### PR TITLE
feat: implement migration for portal schema changes

### DIFF
--- a/packages/db/prisma/migrations/20250319154602_removed_renamed_portal/migration.sql
+++ b/packages/db/prisma/migrations/20250319154602_removed_renamed_portal/migration.sql
@@ -1,0 +1,109 @@
+/*
+  Warnings:
+
+  - You are about to drop the `portal_account` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `portal_session` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `portal_user` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `portal_verification` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Employee" DROP CONSTRAINT "Employee_linkId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "portal_account" DROP CONSTRAINT "portal_account_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "portal_session" DROP CONSTRAINT "portal_session_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "portal_user" DROP CONSTRAINT "portal_user_organizationId_fkey";
+
+-- DropTable
+DROP TABLE "portal_account";
+
+-- DropTable
+DROP TABLE "portal_session";
+
+-- DropTable
+DROP TABLE "portal_user";
+
+-- DropTable
+DROP TABLE "portal_verification";
+
+-- CreateTable
+CREATE TABLE "PortalUser" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "emailVerified" BOOLEAN NOT NULL,
+    "image" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "organizationId" TEXT,
+
+    CONSTRAINT "PortalUser_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PortalSession" (
+    "id" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "token" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "ipAddress" TEXT,
+    "userAgent" TEXT,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "PortalSession_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PortalAccount" (
+    "id" TEXT NOT NULL,
+    "accountId" TEXT NOT NULL,
+    "providerId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "accessToken" TEXT,
+    "refreshToken" TEXT,
+    "idToken" TEXT,
+    "accessTokenExpiresAt" TIMESTAMP(3),
+    "refreshTokenExpiresAt" TIMESTAMP(3),
+    "scope" TEXT,
+    "password" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PortalAccount_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PortalVerification" (
+    "id" TEXT NOT NULL,
+    "identifier" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3),
+    "updatedAt" TIMESTAMP(3),
+
+    CONSTRAINT "PortalVerification_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PortalUser_email_key" ON "PortalUser"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PortalSession_token_key" ON "PortalSession"("token");
+
+-- AddForeignKey
+ALTER TABLE "Employee" ADD CONSTRAINT "Employee_linkId_fkey" FOREIGN KEY ("linkId") REFERENCES "PortalUser"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PortalUser" ADD CONSTRAINT "PortalUser_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PortalSession" ADD CONSTRAINT "PortalSession_userId_fkey" FOREIGN KEY ("userId") REFERENCES "PortalUser"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PortalAccount" ADD CONSTRAINT "PortalAccount_userId_fkey" FOREIGN KEY ("userId") REFERENCES "PortalUser"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema/portal.prisma
+++ b/packages/db/prisma/schema/portal.prisma
@@ -11,8 +11,6 @@ model PortalUser {
   accounts       PortalAccount[]
   sessions       PortalSession[]
   organization   Organization?   @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-
-  @@map("portal_user")
 }
 
 model PortalSession {
@@ -25,8 +23,6 @@ model PortalSession {
   userAgent String?
   userId    String
   user      PortalUser @relation(fields: [userId], references: [id], onDelete: Cascade)
-
-  @@map("portal_session")
 }
 
 model PortalAccount {
@@ -44,8 +40,6 @@ model PortalAccount {
   createdAt             DateTime
   updatedAt             DateTime
   user                  PortalUser @relation(fields: [userId], references: [id], onDelete: Cascade)
-
-  @@map("portal_account")
 }
 
 model PortalVerification {
@@ -55,6 +49,4 @@ model PortalVerification {
   expiresAt  DateTime
   createdAt  DateTime?
   updatedAt  DateTime?
-
-  @@map("portal_verification")
 }


### PR DESCRIPTION
- Added a new migration to drop obsolete portal tables and create updated tables for PortalUser, PortalSession, PortalAccount, and PortalVerification.
- Updated the Prisma schema to reflect the new table names and relationships, removing deprecated mappings for clarity.