### PR TITLE
fix: ensure policy content is always an array in PolicyPageEditor

### DIFF
--- a/apps/app/src/app/[locale]/(app)/(dashboard)/[orgId]/policies/[policyId]/page.tsx
+++ b/apps/app/src/app/[locale]/(app)/(dashboard)/[orgId]/policies/[policyId]/page.tsx
@@ -31,7 +31,7 @@ export default async function PolicyDetails({
       <PolicyOverview policy={policy ?? null} assignees={assignees} />
       <PolicyPageEditor
         policyId={policyId}
-        policyContent={policy?.content as JSONContent[]}
+        policyContent={policy?.content ? (policy.content as JSONContent[]) : []}
       />
     </PageWithBreadcrumb>
   );


### PR DESCRIPTION
- Updated PolicyDetails page to handle cases where policy content may be null, ensuring that an empty array is passed to PolicyPageEditor instead of undefined.