### PR TITLE
refactor: simplify i18n middleware locales configuration

### DIFF
--- a/apps/app/src/components/forms/create-organization-form.tsx
+++ b/apps/app/src/components/forms/create-organization-form.tsx
@@ -49,7 +49,7 @@ export function OnboardingClient() {
 
   const onSubmit = async (data: z.infer<typeof organizationSchema>) => {
     const randomSuffix = Math.floor(100000 + Math.random() * 900000).toString();
-    const slug = `${data.name.toLowerCase().replace(/\s+/g, '-')}-${randomSuffix}`;
+    const slug = `${data.name.toLowerCase().trim().replace(/[^\w\s-]/g, '').replace(/[\s_-]+/g, '-')}-${randomSuffix}`;
 
     await authClient.organization.create({
       name: data.name,

--- a/apps/app/src/middleware.ts
+++ b/apps/app/src/middleware.ts
@@ -9,7 +9,7 @@ export const config = {
 };
 
 const I18nMiddleware = createI18nMiddleware({
-	locales: ["en", "es", "fr", "no", "pt"],
+	locales: ["en"],
 	defaultLocale: "en",
 	urlMappingStrategy: "rewrite",
 });

--- a/apps/portal/src/middleware.ts
+++ b/apps/portal/src/middleware.ts
@@ -2,19 +2,19 @@ import { createI18nMiddleware } from "next-international/middleware";
 import { type NextRequest } from "next/server";
 
 const I18nMiddleware = createI18nMiddleware({
-  locales: ["en", "es", "fr", "no", "pt"],
-  defaultLocale: "en",
-  urlMappingStrategy: "rewrite",
+	locales: ["en"],
+	defaultLocale: "en",
+	urlMappingStrategy: "rewrite",
 });
 
 export async function middleware(request: NextRequest) {
-  const response = I18nMiddleware(request);
+	const response = I18nMiddleware(request);
 
-  return response;
+	return response;
 }
 
 export const config = {
-  matcher: [
-    "/((?!api|_next/static|_next/image|favicon.ico|monitoring|ingest).*)",
-  ],
+	matcher: [
+		"/((?!api|_next/static|_next/image|favicon.ico|monitoring|ingest).*)",
+	],
 };


### PR DESCRIPTION
- Reduced the supported locales in the I18nMiddleware from five to one, streamlining the localization process.
- Maintained default locale and URL mapping strategy for consistent behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The application now offers a single-language interface available exclusively in English. Previously, multiple language options were provided, but this update consolidates the language experience for improved clarity and consistency. Users who previously accessed additional languages should note this shift and plan accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->