### PR TITLE
feat: add RESEND_AUDIENCE_ID to environment and auth middleware

### DIFF
--- a/apps/app/src/env.mjs
+++ b/apps/app/src/env.mjs
@@ -30,6 +30,7 @@ export const env = createEnv({
 		AWS_BUCKET_NAME: z.string(),
 		GROQ_API_KEY: z.string(),
 		NEXT_PUBLIC_PORTAL_URL: z.string(),
+		RESEND_AUDIENCE_ID: z.string().optional(),
 	},
 
 	client: {
@@ -71,6 +72,7 @@ export const env = createEnv({
 		AWS_BUCKET_NAME: process.env.AWS_BUCKET_NAME,
 		GROQ_API_KEY: process.env.GROQ_API_KEY,
 		NEXT_PUBLIC_PORTAL_URL: process.env.NEXT_PUBLIC_PORTAL_URL,
+		RESEND_AUDIENCE_ID: process.env.RESEND_AUDIENCE_ID,
 	},
 
 	skipValidation: !!process.env.CI || !!process.env.SKIP_ENV_VALIDATION,

--- a/turbo.json
+++ b/turbo.json
@@ -41,7 +41,8 @@
         "ANTHROPIC_API_KEY",
         "REVALIDATION_SECRET",
         "GROQ_API_KEY",
-        "SENTRY_AUTH_TOKEN"
+        "SENTRY_AUTH_TOKEN",
+        "RESEND_AUDIENCE_ID"
       ],
       "inputs": ["$TURBO_DEFAULT$", ".env"],
       "dependsOn": ["^build", "^db:generate", "^auth:build", "clean-react"],


### PR DESCRIPTION
## What does this PR do?

- Updated turbo.json to include RESEND_AUDIENCE_ID in environment variables.
- Modified env.mjs to define RESEND_AUDIENCE_ID as an optional environment variable.
- Enhanced auth.ts to utilize RESEND_AUDIENCE_ID in the after hook for session management, integrating with Resend API for contact creation.

- Fixes #394 (GitHub issue number)
- Fixes COMP-95 (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://trycomp.ai/docs). If N/A, write N/A here and check the checkbox.
- [X] I confirm automated tests are in place that prove my fix is effective or that my feature works.