### PR TITLE
feat: add onItemClick prop to MainMenu and MobileMenu

### DIFF
--- a/apps/app/src/components/main-menu.tsx
+++ b/apps/app/src/components/main-menu.tsx
@@ -50,6 +50,7 @@ interface ItemProps {
 	disabled: boolean;
 	organizationId: string;
 	isCollapsed?: boolean;
+	onItemClick?: () => void;
 }
 
 export function MainMenu({
@@ -57,6 +58,7 @@ export function MainMenu({
 	//userIsAdmin,
 	isCollapsed = false,
 	completedOnboarding,
+	onItemClick,
 }: Props) {
 	const t = useI18n();
 	const pathname = usePathname();
@@ -235,6 +237,7 @@ export function MainMenu({
 									disabled={item.disabled}
 									organizationId={organizationId}
 									isCollapsed={isCollapsed}
+									onItemClick={onItemClick}
 								/>
 							);
 						})}
@@ -250,6 +253,7 @@ const Item = ({
 	disabled,
 	organizationId,
 	isCollapsed = false,
+	onItemClick,
 }: ItemProps) => {
 	const Icon = item.icon;
 	const linkDisabled = disabled || item.disabled;
@@ -275,7 +279,7 @@ const Item = ({
 					Coming Soon
 				</div>
 			) : (
-				<Link prefetch href={itemPath}>
+				<Link prefetch href={itemPath} onClick={onItemClick}>
 					<Tooltip>
 						<TooltipTrigger className="w-full">
 							<div
@@ -362,4 +366,5 @@ type Props = {
 	//userIsAdmin: boolean;
 	isCollapsed?: boolean;
 	completedOnboarding: boolean;
+	onItemClick?: () => void;
 };

--- a/apps/app/src/components/mobile-menu.tsx
+++ b/apps/app/src/components/mobile-menu.tsx
@@ -17,6 +17,10 @@ export function MobileMenu({
 }) {
 	const [isOpen, setOpen] = useState(false);
 
+	const handleCloseSheet = () => {
+		setOpen(false);
+	};
+
 	return (
 		<Sheet open={isOpen} onOpenChange={setOpen}>
 			<div>
@@ -37,7 +41,11 @@ export function MobileMenu({
 					<Icons.Logo />
 				</div>
 
-				<MainMenu organizationId={organizationId} completedOnboarding={completedOnboarding} />
+				<MainMenu
+					organizationId={organizationId}
+					completedOnboarding={completedOnboarding}
+					onItemClick={handleCloseSheet}
+				/>
 			</SheetContent>
 		</Sheet>
 	);


### PR DESCRIPTION
## What does this PR do?

- Introduced onItemClick prop in MainMenu and Item components to allow custom click handling.
- Updated MobileMenu to close the sheet when an item is clicked, enhancing user experience.
- Fixes #371 (GitHub issue number)
- Fixes COMP-86 (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] N/A
- [X] I confirm automated tests are in place that prove my fix is effective or that my feature works.