### PR TITLE
fix: update ThemeProvider default theme setting

### DIFF
--- a/apps/app/src/app/[locale]/providers.tsx
+++ b/apps/app/src/app/[locale]/providers.tsx
@@ -20,8 +20,7 @@ export function Providers({ children, locale, session }: ProviderProps) {
 	return (
 		<ThemeProvider
 			attribute="class"
-			enableSystem
-			// forcedTheme="dark"
+			defaultTheme="dark"
 			disableTransitionOnChange
 			scriptProps={{ "data-cfasync": "false" }}
 		>


### PR DESCRIPTION
## What does this PR do?

- Changed ThemeProvider to use `defaultTheme="dark"` instead of `enableSystem` for improved theme management.

## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] N/A
- [X] I confirm automated tests are in place that prove my fix is effective or that my feature works.