### PR TITLE
Fix comment phrasing for ID generation

### DIFF
--- a/apps/app/src/utils/auth.ts
+++ b/apps/app/src/utils/auth.ts
@@ -41,11 +41,11 @@ export const auth = betterAuth({
 		"https://dev.trycomp.ai",
 	],
 	advanced: {
-		database: {
-			// This will enable us to fall back to DB for ID generation.
-			// It's important so we can use customs ID's specified in Prisma Schema.
-			generateId: false,
-		},
+                database: {
+                        // This will enable us to fall back to DB for ID generation.
+                        // It's important so we can use custom IDs specified in Prisma Schema.
+                        generateId: false,
+                },
 	},
 	secret: process.env.AUTH_SECRET!,
 	plugins: [

--- a/apps/framework-editor/app/lib/auth.ts
+++ b/apps/framework-editor/app/lib/auth.ts
@@ -23,11 +23,11 @@ export const auth = betterAuth({
 		provider: "postgresql",
 	}),
 	advanced: {
-		database: {
-			// This will enable us to fall back to DB for ID generation.
-			// It's important so we can use customs ID's specified in Prisma Schema.
-			generateId: false,
-		},
+                database: {
+                        // This will enable us to fall back to DB for ID generation.
+                        // It's important so we can use custom IDs specified in Prisma Schema.
+                        generateId: false,
+                },
 	},
 	secret: process.env.AUTH_SECRET!,
 	plugins: [nextCookies()],

--- a/apps/portal/src/app/lib/auth.ts
+++ b/apps/portal/src/app/lib/auth.ts
@@ -14,7 +14,7 @@ export const auth = betterAuth({
   }),
   advanced: {
     // This will enable us to fall back to DB for ID generation.
-    // It's important so we can use customs ID's specified in Prisma Schema.
+    // It's important so we can use custom IDs specified in Prisma Schema.
     generateId: false,
   },
   secret: process.env.AUTH_SECRET!,


### PR DESCRIPTION
## Summary
- correct comment phrasing for ID generation in auth helpers

## Testing
- `npm run lint` *(fails: turbo not found)*
- `npm test` *(fails: turbo not found)*