### PR TITLE
Fix alert colors for pending policy approval

### DIFF
--- a/apps/app/src/app/[locale]/(app)/(dashboard)/[orgId]/policies/[policyId]/components/PolicyOverview.tsx
+++ b/apps/app/src/app/[locale]/(app)/(dashboard)/[orgId]/policies/[policyId]/components/PolicyOverview.tsx
@@ -105,9 +105,12 @@ export function PolicyOverview({
 
 	return (
 		<div className="space-y-4">
-			{isPendingApproval && (
-				<Alert className="border-red-500 bg-red-50 rounded-sm">
-					<ShieldX className="h-4 w-4" />
+                        {isPendingApproval && (
+                                <Alert
+                                        variant="destructive"
+                                        className="rounded-sm bg-destructive/10 dark:bg-destructive/20"
+                                >
+                                        <ShieldX className="h-4 w-4" />
 					<AlertTitle>
 						{canCurrentUserApprove
 							? "Action Required by You"


### PR DESCRIPTION
## Summary
- fix PolicyOverview pending approval alert styling

## Testing
- `bun test` *(fails: The following filters did not match any test files)*
- `bun run test` *(fails: turbo: command not found)*
- `bun run format` *(fails: biome: command not found)*