### PR TITLE
Fix dashboard timezone parsing

### DIFF
--- a/apps/app/src/app/[locale]/(internal)/internal/dashboard/components/OrganizationsCard.tsx
+++ b/apps/app/src/app/[locale]/(internal)/internal/dashboard/components/OrganizationsCard.tsx
@@ -2,11 +2,12 @@
 
 import { Badge } from "@comp/ui/badge";
 import {
-	type ChartConfig,
-	ChartContainer,
-	ChartTooltip,
-	ChartTooltipContent,
+        type ChartConfig,
+        ChartContainer,
+        ChartTooltip,
+        ChartTooltipContent,
 } from "@comp/ui/chart";
+import { parseUTCDate } from "@/utils/format";
 import { Skeleton } from "@comp/ui/skeleton";
 import { BarChart2, TrendingUp } from "lucide-react";
 import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
@@ -115,13 +116,13 @@ export function OrganizationsCard() {
 								axisLine={false}
 								tickMargin={8}
 								stroke="hsl(var(--muted-foreground))"
-								tickFormatter={(value) => {
-									const date = new Date(value);
-									return date.toLocaleDateString("en-US", {
-										month: "2-digit",
-										day: "2-digit",
-									});
-								}}
+                                                                tickFormatter={(value) => {
+                                                                        const date = parseUTCDate(value as string);
+                                                                        return date.toLocaleDateString(undefined, {
+                                                                                month: "2-digit",
+                                                                                day: "2-digit",
+                                                                        });
+                                                                }}
 								tickCount={10}
 							/>
 							<ChartTooltip

--- a/apps/app/src/app/[locale]/(internal)/internal/dashboard/components/PoliciesCard.tsx
+++ b/apps/app/src/app/[locale]/(internal)/internal/dashboard/components/PoliciesCard.tsx
@@ -7,6 +7,7 @@ import { Calendar, Clock, ShieldCheck, TrendingDown, TrendingUp } from "lucide-r
 import { useMemo } from "react";
 import { Line, LineChart, ResponsiveContainer } from "recharts";
 import { usePoliciesAnalytics } from "../hooks/usePoliciesAnalytics";
+import { parseUTCDate } from "@/utils/format";
 
 // Helper function for formatting numbers
 function formatNumber(value: number | null | undefined): string {
@@ -34,15 +35,15 @@ export function PoliciesCard() {
 			return [];
 		}
 		// Ensure data is sorted chronologically if not already guaranteed by API
-		return [...policiesData.last30DaysTotalByDay]
-			.sort(
-				(a, b) =>
-					new Date(a.date).getTime() - new Date(b.date).getTime(),
-			)
-			.map((item) => ({
-				date: item.date,
-				value: item.count,
-			}));
+                return [...policiesData.last30DaysTotalByDay]
+                        .sort(
+                                (a, b) =>
+                                        parseUTCDate(a.date).getTime() - parseUTCDate(b.date).getTime(),
+                        )
+                        .map((item) => ({
+                                date: item.date,
+                                value: item.count,
+                        }));
 	}, [policiesData?.last30DaysTotalByDay]);
 
 	// Calculate published percentage using all-time data

--- a/apps/app/src/app/[locale]/(internal)/internal/dashboard/components/TaskCard.tsx
+++ b/apps/app/src/app/[locale]/(internal)/internal/dashboard/components/TaskCard.tsx
@@ -7,6 +7,7 @@ import { Calendar, Clock, FileText, TrendingUp } from "lucide-react";
 import { useMemo } from "react";
 import { Area, AreaChart, ResponsiveContainer } from "recharts";
 import { useTaskAnalytics } from "../hooks/useTaskAnalytics";
+import { parseUTCDate } from "@/utils/format";
 
 // Helper function for formatting numbers (assuming it exists or can be added)
 function formatNumber(value: number | null | undefined): string {
@@ -37,15 +38,15 @@ export function TaskCard() {
 			return [];
 		}
 		// Ensure data is sorted chronologically if not already guaranteed by API
-		return [...taskData.last30DaysTotalByDay]
-			.sort(
-				(a, b) =>
-					new Date(a.date).getTime() - new Date(b.date).getTime(),
-			)
-			.map((item) => ({
-				date: item.date,
-				value: item.count,
-			}));
+                return [...taskData.last30DaysTotalByDay]
+                        .sort(
+                                (a, b) =>
+                                        parseUTCDate(a.date).getTime() - parseUTCDate(b.date).getTime(),
+                        )
+                        .map((item) => ({
+                                date: item.date,
+                                value: item.count,
+                        }));
 	}, [taskData?.last30DaysTotalByDay]);
 
 	// Calculate published percentage using all-time data

--- a/apps/app/src/app/[locale]/(internal)/internal/dashboard/components/UsersCard.tsx
+++ b/apps/app/src/app/[locale]/(internal)/internal/dashboard/components/UsersCard.tsx
@@ -7,6 +7,7 @@ import { Calendar, Clock, TrendingDown, TrendingUp, Users } from "lucide-react";
 import { useMemo } from "react";
 import { Area, AreaChart, ResponsiveContainer } from "recharts";
 import { useUsersAnalytics } from "../hooks/useUsersAnalytics";
+import { parseUTCDate } from "@/utils/format";
 
 // Helper function for formatting numbers
 function formatNumber(value: number | null | undefined): string {
@@ -34,15 +35,15 @@ export function UsersCard() {
 			return [];
 		}
 		// Ensure data is sorted chronologically
-		return [...usersData.last30DaysByDay]
-			.sort(
-				(a, b) =>
-					new Date(a.date).getTime() - new Date(b.date).getTime(),
-			)
-			.map((item) => ({
-				date: item.date,
-				value: item.count,
-			}));
+                return [...usersData.last30DaysByDay]
+                        .sort(
+                                (a, b) =>
+                                        parseUTCDate(a.date).getTime() - parseUTCDate(b.date).getTime(),
+                        )
+                        .map((item) => ({
+                                date: item.date,
+                                value: item.count,
+                        }));
 	}, [usersData?.last30DaysByDay]);
 
 	// Calculate active percentage using all-time data

--- a/apps/app/src/utils/format.ts
+++ b/apps/app/src/utils/format.ts
@@ -1,11 +1,13 @@
 import type { TZDate } from "@date-fns/tz";
 import {
-	differenceInDays,
-	differenceInMonths,
-	format,
-	isSameYear,
-	startOfDay,
+        differenceInDays,
+        differenceInMonths,
+        format,
+        isSameYear,
+        parseISO,
+        startOfDay,
 } from "date-fns";
+import { utcToZonedTime } from "@date-fns/tz";
 
 export function formatSize(bytes: number): string {
 	const units = ["byte", "kilobyte", "megabyte", "gigabyte", "terabyte"];
@@ -83,12 +85,25 @@ export function calculateAvgBurnRate(data: BurnRateData[] | null) {
 	return data?.reduce((acc, curr) => acc + curr.value, 0) / data?.length;
 }
 
-export function formatDate(date: string, dateFormat?: string) {
-	if (isSameYear(new Date(), new Date(date))) {
-		return format(new Date(date), "MMM dd, yyyy");
-	}
+export function parseUTCDate(
+        date: string,
+        timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone,
+) {
+        return utcToZonedTime(parseISO(date), timeZone);
+}
 
-	return format(new Date(date), dateFormat ?? "P");
+export function formatDate(
+        date: string,
+        dateFormat?: string,
+        timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone,
+) {
+        const zonedDate = parseUTCDate(date, timeZone);
+
+        if (isSameYear(new Date(), zonedDate)) {
+                return format(zonedDate, "MMM dd, yyyy");
+        }
+
+        return format(zonedDate, dateFormat ?? "P");
 }
 
 export function getInitials(value: string) {


### PR DESCRIPTION
## Summary
- parse UTC dates to local timezone when formatting
- use new timezone-aware parsing in dashboard components

## Testing
- `npm test` *(fails: turbo not found)*
- `npm run lint` *(fails: turbo not found)*
- `npm run format` *(fails: biome not found)*
- `npm run typecheck` *(fails: turbo not found)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.