### PR TITLE
Fix role selection in invite modal

### DIFF
--- a/apps/app/src/app/[locale]/(app)/(dashboard)/[orgId]/people/all/components/MultiRoleCombobox.tsx
+++ b/apps/app/src/app/[locale]/(app)/(dashboard)/[orgId]/people/all/components/MultiRoleCombobox.tsx
@@ -148,8 +148,8 @@ export function MultiRoleCombobox({
 		return label.toLowerCase().includes(searchTerm.toLowerCase());
 	});
 
-	return (
-		<Popover open={open} onOpenChange={setOpen}>
+       return (
+               <Popover open={open} onOpenChange={setOpen} modal={false}>
 			<PopoverTrigger asChild>
 				<Button
 					variant="outline"


### PR DESCRIPTION
## Summary
- ensure popover inside invite dialog is interactive by setting `modal={false}`

## Testing
- `bun run lint` *(fails: turbo not found)*
- `bun run format` *(fails: biome not found)*
- `bun run test` *(fails: turbo not found)*