### PR TITLE
Fix organization dropdown search

### DIFF
--- a/apps/app/src/components/organization-switcher.tsx
+++ b/apps/app/src/components/organization-switcher.tsx
@@ -252,13 +252,13 @@ export function OrganizationSwitcher({
 								{t("common.table.no_results")}
 							</CommandEmpty>
 							<CommandGroup className="max-h-[300px] overflow-y-auto">
-								{organizations.map((org) => (
-									<CommandItem
-										key={org.id}
-										value={org.id}
-										onSelect={() => {
-											if (
-												org.id !==
+                                                                {organizations.map((org) => (
+                                                                        <CommandItem
+                                                                                key={org.id}
+                                                                                value={getDisplayName(org) || org.id}
+                                                                                onSelect={() => {
+                                                                                        if (
+                                                                                                org.id !==
 												currentOrganization?.id
 											) {
 												handleOrgChange(org);


### PR DESCRIPTION
## Summary
- fix search in organization dropdown

## Testing
- `npm test` *(fails: turbo not found)*
- `npm run format` *(fails: biome not found)*
- `npm run lint` *(fails: turbo not found)*
- `npm run typecheck` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b223e3c483209453667b4735a29b