### PR TITLE
Fix organization dropdown search

### DIFF
--- a/apps/app/src/components/organization-switcher.tsx
+++ b/apps/app/src/components/organization-switcher.tsx
@@ -255,7 +255,7 @@ export function OrganizationSwitcher({
 								{organizations.map((org) => (
 									<CommandItem
 										key={org.id}
-										value={org.id}
+										value={`${org.id} ${getDisplayName(org) ?? ""}`}
 										onSelect={() => {
 											if (
 												org.id !==
@@ -268,19 +268,20 @@ export function OrganizationSwitcher({
 										}}
 										disabled={isLoading}
 									>
-										{isLoading && pendingOrgId === org.id ? (
+										{isLoading &&
+										pendingOrgId === org.id ? (
 											<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+										) : !isLoading &&
+											currentOrganization?.id ===
+												org.id ? (
+											<Check
+												className={cn(
+													"mr-2 h-4 w-4",
+													"opacity-100",
+												)}
+											/>
 										) : (
-											!isLoading && currentOrganization?.id === org.id ? (
-												<Check
-													className={cn(
-														"mr-2 h-4 w-4",
-														"opacity-100"
-													)}
-												/>
-											) : (
-												<span className="mr-2 h-4 w-4" />
-											)
+											<span className="mr-2 h-4 w-4" />
 										)}
 										<OrganizationInitialsAvatar
 											name={org.name}


### PR DESCRIPTION
## Summary
- fix search in organization dropdown
- prevent duplicate orgs from collapsing when names match

## Testing
- `npm test` *(fails: Could not find task `test` in project)*
- `npm run lint` *(fails: turbo transitive closures)*
- `npm run typecheck` *(fails: bun typecheck errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841b223e3c483209453667b4735a29b