### PR TITLE
Remove 'Other' option in team work question

### DIFF
--- a/apps/app/src/app/(app)/setup/lib/constants.ts
+++ b/apps/app/src/app/(app)/setup/lib/constants.ts
@@ -100,7 +100,7 @@ export const steps: Step[] = [
     key: 'workLocation',
     question: 'How does your team work?',
     placeholder: 'e.g., Remote',
-    options: ['Fully remote', 'Hybrid (office + remote)', 'Office-based', 'Other'],
+    options: ['Fully remote', 'Hybrid (office + remote)', 'Office-based'],
   },
   {
     key: 'infrastructure',


### PR DESCRIPTION
## Summary
- remove `Other` choice from the `How does your team work?` setup question

## Testing
- `bun run test` *(fails: Could not find task `test` in project)*
- `bun run lint` *(fails: command exited with error)*

------
https://chatgpt.com/codex/tasks/task_e_685ae3d087988320942df711a4ba5f24