### PR TITLE
Fix team size placeholder

### DIFF
--- a/apps/app/src/app/(app)/setup/lib/constants.ts
+++ b/apps/app/src/app/(app)/setup/lib/constants.ts
@@ -52,7 +52,7 @@ export const steps: Step[] = [
   {
     key: 'teamSize',
     question: 'How many employees do you have?',
-    placeholder: 'e.g., 10-50',
+    placeholder: 'e.g., 11-50',
     options: ['1-10', '11-50', '51-200', '201-500', '500+'],
   },
   {


### PR DESCRIPTION
## Summary
- fix inconsistent placeholder for team size in setup form

## Testing
- `bun test` *(fails: The following filters did not match any test files)*
- `bun run test` *(fails: Could not find task `test` in project)*
- `bun run lint` *(fails: Invalid environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_685c317751a88320b5230bbe280b457b