### PR TITLE
feat: linkify comment content

### DIFF
--- a/apps/app/src/components/comments/CommentItem.tsx
+++ b/apps/app/src/components/comments/CommentItem.tsx
@@ -39,6 +39,27 @@ type PendingAttachment = {
   signedUrl: string;
 };
 
+function renderContentWithLinks(text: string): React.ReactNode[] {
+  const regex = /(https?:\/\/[^\s]+|www\.[^\s]+|(?<!@)(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?:\/[^\s]*)?)/gi;
+  return text.split(regex).map((part, index) => {
+    if (/^(https?:\/\/[^\s]+|www\.[^\s]+|(?<!@)(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?:\/[^\s]*)?)$/i.test(part)) {
+      const href = /^https?:\/\//i.test(part) ? part : `https://${part}`;
+      return (
+        <a
+          key={index}
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary underline"
+        >
+          {part}
+        </a>
+      );
+    }
+    return part;
+  });
+}
+
 export function CommentItem({ comment }: { comment: CommentWithAuthor }) {
   const [isEditing, setIsEditing] = useState(false);
   const [editedContent, setEditedContent] = useState(comment.content);
@@ -279,7 +300,9 @@ export function CommentItem({ comment }: { comment: CommentWithAuthor }) {
             </div>
 
             {!isEditing ? (
-              <p className="whitespace-pre-wrap">{comment.content}</p>
+              <p className="whitespace-pre-wrap break-words">
+                {renderContentWithLinks(comment.content)}
+              </p>
             ) : (
               <Textarea
                 value={editedContent}


### PR DESCRIPTION
## Summary
- highlight links in comments and open them in a new tab
- handle links without explicit protocols

## Testing
- `bun run lint` *(fails: Invalid environment variables)*
- `bun run test` *(fails: 17 failed | 1 passed | 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688fca12d2d48320a0ae112b2beac35a