### PR TITLE
fix(docs): Broken contributing guide link in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -38,7 +38,7 @@ A visual demonstration is strongly recommended, for both the original and new ch
 
 <!-- Remove bullet points below that don't apply to you -->
 
-- I haven't read the [contributing guide](https://github.com/trycomp/comp/blob/main/CONTRIBUTING.md)
+- I haven't read the [contributing guide](https://github.com/trycompai/comp/blob/main/CONTRIBUTING.md)
 - My code doesn't follow the style guidelines of this project
 - I haven't commented my code, particularly in hard-to-understand areas
 - I haven't checked if my changes generate no new warnings


### PR DESCRIPTION
## What does this PR do?

Fix broken contributing guide link in the pull request template to point to the correct repo.
