### PR TITLE
chore: update legacy 'docker-compose' command to modern 'docker compo…

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -36,9 +36,9 @@
     "db:push": "prisma db push",
     "db:seed": "prisma db seed",
     "db:studio": "prisma studio",
-    "docker:clean": "docker-compose down -v",
-    "docker:down": "docker-compose down",
-    "docker:up": "docker-compose up -d",
+    "docker:clean": "docker compose down -v",
+    "docker:down": "docker compose down",
+    "docker:up": "docker compose up -d",
     "lint": "prettier --check 'src/**/*.{ts,tsx,js,jsx,json}' 'prisma/**/*.prisma' && tsc --noEmit",
     "prepublishOnly": "bun run build"
   }


### PR DESCRIPTION
### Summary

This PR updates the usage of the deprecated `docker-compose` command to the modern `docker compose` syntax, in line with current Docker best practices.

### Details

- Replaced all instances of `docker-compose` with `docker compose`
- Ensures compatibility with Docker v20.10+ where `docker compose` is the preferred CLI
- No change in behavior or functionality

### Notes

> `docker compose` is now bundled as part of the Docker CLI, whereas `docker-compose` was a standalone Python tool. This change helps ensure future compatibility and avoids reliance on deprecated tooling.

Let me know if this affects any environments still using the old CLI.


