### PR TITLE
Env-ify Better Auth trustedOrigins + refactor Resend sender config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,13 @@
 # Required
 AUTH_SECRET="" # openssl rand -base64 32
 DATABASE_URL="" # Format: "postgresql://postgres:pass@127.0.0.1:5432/comp"
-RESEND_DOMAIN=" # Domain configured in Resend, e.g. mail.trycomp.ai
+RESEND_DOMAIN="" # Domain configured in Resend, e.g. mail.trycomp.ai
 RESEND_API_KEY="" # API key from Resend for email authentication / invites
+RESEND_FROM_MARKETING="Lewis Carhart <lewis@mail.trycomp.ai>"
+RESEND_FROM_SYSTEM="Comp AI <mail@mail.trycomp.ai>"
+RESEND_FROM_DEFAULT="Comp AI <mail@mail.trycomp.ai>"
+RESEND_TO_TEST="mail@mail.trycomp.ai"
+RESEND_REPLY_TO_MARKETING="lewis@mail.trycomp.ai"
 REVALIDATION_SECRET="" # openssl rand -base64 32
 NEXT_PUBLIC_PORTAL_URL="http://localhost:3002" # The employee portal uses port 3002 by default
 
@@ -21,3 +26,4 @@ TRIGGER_SECRET_KEY="" # Secret key from Trigger.dev
 OPENAI_API_KEY="" # AI Chat + Auto Generated Policies, Risks + Vendors
 FIRECRAWL_API_KEY="" # For research, self-host or use cloud-version @ https://firecrawl.dev
 
+AUTH_TRUSTED_ORIGINS=http://localhost:3000,https://*.trycomp.ai,http://localhost:3002

--- a/apps/app/src/utils/auth.ts
+++ b/apps/app/src/utils/auth.ts
@@ -44,7 +44,7 @@ export const auth = betterAuth({
     provider: 'postgresql',
   }),
   baseURL: process.env.NEXT_PUBLIC_BETTER_AUTH_URL,
-  trustedOrigins: ['http://localhost:3000', 'https://*.trycomp.ai', 'http://localhost:3002'],
+  trustedOrigins: process.env.AUTH_TRUSTED_ORIGINS ? process.env.AUTH_TRUSTED_ORIGINS.split(",").map(o => o.trim()) : ['http://localhost:3000', 'https://*.trycomp.ai', 'http://localhost:3002'],  
   emailAndPassword: {
     enabled: true,
   },


### PR DESCRIPTION
## What does this PR do?

Makes Better Auth trustedOrigins configurable via AUTH_TRUSTED_ORIGINS (CSV → array), removing hard-coded origins.
Refactors email sending to use explicit Resend sender envs instead of a single RESEND_DOMAIN.
Updates .env.example with the new variables and safe local defaults.

Primary files touched

`.env.example`
`apps/app/src/utils/auth.ts`
`packages/email/lib/resend.ts`

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://trycomp.ai/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/trycompai/comp/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings
