### PR TITLE
feat: Add PDF view for policies

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/policies/[policyId]/actions/get-policy-pdf-url.ts
+++ b/apps/app/src/app/(app)/[orgId]/policies/[policyId]/actions/get-policy-pdf-url.ts
@@ -1,0 +1,54 @@
+'use server';
+
+import { authActionClient } from '@/actions/safe-action';
+import { BUCKET_NAME, s3Client } from '@/app/s3';
+import { GetObjectCommand } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { db } from '@db';
+import { z } from 'zod';
+
+export const getPolicyPdfUrlAction = authActionClient
+  .inputSchema(z.object({ policyId: z.string() }))
+  .metadata({
+    name: 'get-policy-pdf-url',
+    track: {
+      event: 'get-policy-pdf-url-s3',
+      channel: 'server',
+    },
+  })
+  .action(async ({ parsedInput, ctx }) => {
+    const { policyId } = parsedInput;
+    const { session } = ctx;
+    const organizationId = session.activeOrganizationId;
+
+    if (!organizationId) {
+      return { success: false, error: 'Not authorized' };
+    }
+
+    if (!s3Client || !BUCKET_NAME) {
+      return { success: false, error: 'File storage is not configured.' };
+    }
+
+    try {
+      const policy = await db.policy.findUnique({
+        where: { id: policyId, organizationId },
+        select: { pdfUrl: true },
+      });
+
+      if (!policy?.pdfUrl) {
+        return { success: false, error: 'No PDF found for this policy.' };
+      }
+
+      // Generate a temporary, secure URL for the client to render the PDF from the private bucket.
+      const command = new GetObjectCommand({
+        Bucket: BUCKET_NAME,
+        Key: policy.pdfUrl,
+      });
+      const signedUrl = await getSignedUrl(s3Client, command, { expiresIn: 900 }); // URL is valid for 15 minutes
+
+      return { success: true, data: signedUrl };
+    } catch (error) {
+      console.error('Error generating signed URL for policy PDF:', error);
+      return { success: false, error: 'Could not retrieve PDF.' };
+    }
+  });

--- a/apps/app/src/app/(app)/[orgId]/policies/[policyId]/actions/switch-policy-display-format.ts
+++ b/apps/app/src/app/(app)/[orgId]/policies/[policyId]/actions/switch-policy-display-format.ts
@@ -1,0 +1,62 @@
+'use server';
+
+import { authActionClient } from '@/actions/safe-action';
+import { db, PolicyDisplayFormat } from '@db';
+import { revalidatePath } from 'next/cache';
+import { headers } from 'next/headers';
+import { z } from 'zod';
+
+const switchDisplayFormatSchema = z.object({
+  policyId: z.string(),
+  format: z.enum(['EDITOR', 'PDF']),
+});
+
+export const switchPolicyDisplayFormatAction = authActionClient
+  .inputSchema(switchDisplayFormatSchema)
+  .metadata({
+    name: 'switch-policy-display-format',
+    track: {
+      event: 'switch-policy-display-format',
+      channel: 'server',
+    },
+  })
+  .action(async ({ parsedInput, ctx }) => {
+    const { policyId, format } = parsedInput;
+    const { session } = ctx;
+
+    if (!session.activeOrganizationId) {
+      return { success: false, error: 'Not authorized' };
+    }
+
+    try {
+      const updateData: {
+        displayFormat: PolicyDisplayFormat;
+        pdfUrl?: null;
+        content?: [];
+      } = {
+        displayFormat: format,
+      };
+
+      // When switching, clear the data of the other view to prevent stale data.
+      if (format === 'EDITOR') {
+        updateData.pdfUrl = null;
+      } else if (format === 'PDF') {
+        updateData.content = [];
+      }
+
+      await db.policy.update({
+        where: { id: policyId, organizationId: session.activeOrganizationId },
+        data: updateData,
+      });
+
+      const headersList = await headers();
+      let path = headersList.get('x-pathname') || headersList.get('referer') || '';
+      path = path.replace(/\/[a-z]{2}\//, '/');
+      revalidatePath(path);
+
+      return { success: true };
+    } catch (error) {
+      console.error('Error switching policy display format:', error);
+      return { success: false, error: 'Failed to switch view.' };
+    }
+  });

--- a/apps/app/src/app/(app)/[orgId]/policies/[policyId]/actions/upload-policy-pdf.ts
+++ b/apps/app/src/app/(app)/[orgId]/policies/[policyId]/actions/upload-policy-pdf.ts
@@ -1,0 +1,74 @@
+'use server';
+
+import { authActionClient } from '@/actions/safe-action';
+import { BUCKET_NAME, s3Client } from '@/app/s3';
+import { PutObjectCommand } from '@aws-sdk/client-s3';
+import { db, PolicyDisplayFormat } from '@db';
+import { revalidatePath } from 'next/cache';
+import { headers } from 'next/headers';
+import { z } from 'zod';
+
+const uploadPolicyPdfSchema = z.object({
+  policyId: z.string(),
+  fileName: z.string(),
+  fileType: z.string(),
+  fileData: z.string(), // Base64 encoded file content
+});
+
+export const uploadPolicyPdfAction = authActionClient
+  .inputSchema(uploadPolicyPdfSchema)
+  .metadata({
+    name: 'upload-policy-pdf',
+    track: {
+      event: 'upload-policy-pdf-s3',
+      channel: 'server',
+    },
+  })
+  .action(async ({ parsedInput, ctx }) => {
+    const { policyId, fileName, fileType, fileData } = parsedInput;
+    const { session } = ctx;
+    const organizationId = session.activeOrganizationId;
+
+    if (!organizationId) {
+      return { success: false, error: 'Not authorized' };
+    }
+
+    if (!s3Client || !BUCKET_NAME) {
+      return { success: false, error: 'File storage is not configured.' };
+    }
+
+    const sanitizedFileName = fileName.replace(/[^a-zA-Z0-9.-]/g, '_');
+    const s3Key = `${organizationId}/policies/${policyId}/${Date.now()}-${sanitizedFileName}`;
+
+    try {
+      const fileBuffer = Buffer.from(fileData, 'base64');
+      const command = new PutObjectCommand({
+        Bucket: BUCKET_NAME,
+        Key: s3Key,
+        Body: fileBuffer,
+        ContentType: fileType,
+      });
+
+      await s3Client.send(command);
+
+      // After a successful upload, update the policy to store the S3 Key
+      await db.policy.update({
+        where: { id: policyId, organizationId },
+        data: {
+          pdfUrl: s3Key,
+          displayFormat: PolicyDisplayFormat.PDF,
+          content: [], // Clear any old editor content
+        },
+      });
+
+      const headersList = await headers();
+      let path = headersList.get('x-pathname') || headersList.get('referer') || '';
+      path = path.replace(/\/[a-z]{2}\//, '/');
+      revalidatePath(path);
+
+      return { success: true, data: { s3Key } };
+    } catch (error) {
+      console.error('Error uploading policy PDF to S3:', error);
+      return { success: false, error: 'Failed to upload PDF.' };
+    }
+  });

--- a/apps/app/src/app/(app)/[orgId]/policies/[policyId]/components/PdfViewer.tsx
+++ b/apps/app/src/app/(app)/[orgId]/policies/[policyId]/components/PdfViewer.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { Button } from '@comp/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@comp/ui/card';
+import { Input } from '@comp/ui/input';
+import { FileText, Loader2, UploadCloud } from 'lucide-react';
+import { useAction } from 'next-safe-action/hooks';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { getPolicyPdfUrlAction } from '../actions/get-policy-pdf-url';
+import { uploadPolicyPdfAction } from '../actions/upload-policy-pdf';
+
+interface PdfViewerProps {
+  policyId: string;
+  pdfUrl?: string | null; // This prop contains the S3 Key
+  isPendingApproval: boolean;
+}
+
+export function PdfViewer({ policyId, pdfUrl, isPendingApproval }: PdfViewerProps) {
+  const router = useRouter();
+  const [file, setFile] = useState<File | null>(null);
+  const [signedUrl, setSignedUrl] = useState<string | null>(null);
+  const [isUrlLoading, setUrlLoading] = useState(true);
+
+  const { execute: getUrl } = useAction(getPolicyPdfUrlAction, {
+    onSuccess: (result) => {
+      const url = result?.data?.data ?? null;
+      if (result?.data?.success && url) {
+        setSignedUrl(url);
+      } else {
+        setSignedUrl(null);
+      }
+    },
+    onError: () => toast.error('Could not load the policy document.'),
+    onSettled: () => setUrlLoading(false),
+  });
+
+  // Fetch the secure, temporary URL when the component loads with an S3 key.
+  useEffect(() => {
+    if (pdfUrl) {
+      getUrl({ policyId });
+    } else {
+      setUrlLoading(false);
+    }
+  }, [pdfUrl, policyId, getUrl]);
+
+  const { execute: upload, status: uploadStatus } = useAction(uploadPolicyPdfAction, {
+    onSuccess: () => {
+      toast.success('PDF uploaded successfully.');
+      setFile(null);
+      router.refresh();
+    },
+    onError: (error) => toast.error(error.error.serverError || 'Failed to upload PDF.'),
+  });
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files?.[0]) {
+      setFile(e.target.files[0]);
+    }
+  };
+
+  // The file is read as a base64 string on the client before being sent to the server action.
+  const handleUpload = () => {
+    if (!file) return;
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+    reader.onload = () => {
+      const base64Data = (reader.result as string).split(',')[1];
+      upload({
+        policyId,
+        fileName: file.name,
+        fileType: file.type,
+        fileData: base64Data,
+      });
+    };
+    reader.onerror = () => toast.error('Failed to read the file for uploading.');
+  };
+
+  const isUploading = uploadStatus === 'executing';
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Policy Document (PDF View)</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {pdfUrl ? (
+          <div className="space-y-4">
+            {isUrlLoading ? (
+              <div className="flex h-[800px] w-full items-center justify-center rounded-md border">
+                <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+              </div>
+            ) : signedUrl ? (
+              <iframe
+                key={signedUrl}
+                src={signedUrl}
+                className="h-[800px] w-full rounded-md border"
+                title="Policy PDF"
+              />
+            ) : (
+              <div className="flex h-[800px] w-full flex-col items-center justify-center rounded-md border text-center">
+                <FileText className="h-12 w-12 text-destructive" />
+                <p className="mt-4 font-semibold">Could not load PDF</p>
+                <p className="text-sm text-muted-foreground">
+                  The document might be missing or there was a problem retrieving it.
+                </p>
+              </div>
+            )}
+            {!isPendingApproval && (
+              <p className="text-sm text-muted-foreground">
+                To replace this PDF, you can upload a new one below.
+              </p>
+            )}
+          </div>
+        ) : (
+          <div className="flex flex-col items-center justify-center space-y-4 rounded-md border-2 border-dashed p-12 text-center">
+            <FileText className="h-12 w-12 text-muted-foreground" />
+            <h3 className="text-lg font-semibold">No PDF Uploaded</h3>
+            <p className="text-sm text-muted-foreground">
+              Please upload a PDF document for this policy to continue.
+            </p>
+          </div>
+        )}
+
+        {!isPendingApproval && (
+          <div className="flex items-center gap-4">
+            <Input
+              type="file"
+              accept="application/pdf"
+              onChange={handleFileChange}
+              disabled={isUploading}
+              className="max-w-xs"
+            />
+            <Button onClick={handleUpload} disabled={!file || isUploading}>
+              {isUploading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <UploadCloud className="mr-2 h-4 w-4" />}
+              {pdfUrl ? 'Re-upload' : 'Upload PDF'}
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/app/src/app/(app)/[orgId]/policies/[policyId]/components/PolicyPage.tsx
+++ b/apps/app/src/app/(app)/[orgId]/policies/[policyId]/components/PolicyPage.tsx
@@ -2,7 +2,7 @@ import { Control, Member, Policy, User } from '@db';
 import type { JSONContent } from '@tiptap/react';
 import { Comments } from '../../../../../../components/comments/Comments';
 import { AuditLogWithRelations } from '../data';
-import { PolicyPageEditor } from '../editor/components/PolicyDetails';
+import { PolicyContentDisplay } from '../editor/components/PolicyDetails';
 import { PolicyOverview } from './PolicyOverview';
 import { RecentAuditLogs } from './RecentAuditLogs';
 
@@ -32,10 +32,12 @@ export default function PolicyPage({
         allControls={allControls}
         isPendingApproval={isPendingApproval}
       />
-      <PolicyPageEditor
+      <PolicyContentDisplay
         isPendingApproval={isPendingApproval}
         policyId={policyId}
         policyContent={policy?.content ? (policy.content as JSONContent[]) : []}
+        displayFormat={policy?.displayFormat}
+        pdfUrl={policy?.pdfUrl}
       />
 
       <RecentAuditLogs logs={logs} />

--- a/apps/app/src/app/(app)/[orgId]/policies/[policyId]/editor/components/PolicyDetails.tsx
+++ b/apps/app/src/app/(app)/[orgId]/policies/[policyId]/editor/components/PolicyDetails.tsx
@@ -3,7 +3,9 @@
 import { PolicyEditor } from '@/components/editor/policy-editor';
 import { validateAndFixTipTapContent } from '@comp/ui/editor';
 import '@comp/ui/editor.css';
+import type { PolicyDisplayFormat } from '@db';
 import type { JSONContent } from '@tiptap/react';
+import { PdfViewer } from '../../components/PdfViewer';
 import { updatePolicy } from '../actions/update-policy';
 
 const removeUnsupportedMarks = (node: JSONContent): JSONContent => {
@@ -18,26 +20,32 @@ const removeUnsupportedMarks = (node: JSONContent): JSONContent => {
   return node;
 };
 
-interface PolicyDetailsProps {
+interface PolicyContentDisplayProps {
   policyId: string;
   policyContent: JSONContent | JSONContent[];
   isPendingApproval: boolean;
+  displayFormat?: PolicyDisplayFormat;
+  pdfUrl?: string | null;
 }
 
-export function PolicyPageEditor({
+export function PolicyContentDisplay({
   policyId,
   policyContent,
   isPendingApproval,
-}: PolicyDetailsProps) {
-  const formattedContent = Array.isArray(policyContent)
-    ? policyContent
-    : typeof policyContent === 'object' && policyContent !== null
-      ? [policyContent as JSONContent]
-      : [];
+  displayFormat,
+  pdfUrl,
+}: PolicyContentDisplayProps) {
+  // Conditionally render the PDF viewer or the editor based on the policy's display format.
+  if (displayFormat === 'PDF') {
+    return <PdfViewer policyId={policyId} pdfUrl={pdfUrl} isPendingApproval={isPendingApproval} />;
+  }
+
+  // Default to the rich text editor.
+  const formattedContent = Array.isArray(policyContent) ? policyContent : [policyContent as JSONContent];
   const sanitizedContent = formattedContent.map(removeUnsupportedMarks);
-  // Normalize via validator so editor always receives a clean array
   const validatedDoc = validateAndFixTipTapContent(sanitizedContent);
   const normalizedContent = (validatedDoc.content || []) as JSONContent[];
+
   const handleSavePolicy = async (policyContent: JSONContent[]): Promise<void> => {
     if (!policyId) return;
 

--- a/apps/app/src/app/(app)/[orgId]/policies/[policyId]/page.tsx
+++ b/apps/app/src/app/(app)/[orgId]/policies/[policyId]/page.tsx
@@ -24,7 +24,7 @@ export default async function PolicyDetails({
         { label: 'Policies', href: `/${orgId}/policies/all` },
         { label: policy?.name ?? 'Policy', current: true },
       ]}
-      headerRight={<PolicyHeaderActions policyId={policyId} />}
+      headerRight={<PolicyHeaderActions policy={policy} />}
     >
       <PolicyPage
         policy={policy}

--- a/packages/db/prisma/migrations/20250827202452_add_policy_pdf_view/migration.sql
+++ b/packages/db/prisma/migrations/20250827202452_add_policy_pdf_view/migration.sql
@@ -1,0 +1,6 @@
+-- CreateEnum
+CREATE TYPE "public"."PolicyDisplayFormat" AS ENUM ('EDITOR', 'PDF');
+
+-- AlterTable
+ALTER TABLE "public"."Policy" ADD COLUMN     "displayFormat" "public"."PolicyDisplayFormat" NOT NULL DEFAULT 'EDITOR',
+ADD COLUMN     "pdfUrl" TEXT;

--- a/packages/db/prisma/schema/policy.prisma
+++ b/packages/db/prisma/schema/policy.prisma
@@ -1,15 +1,22 @@
+enum PolicyDisplayFormat {
+  EDITOR
+  PDF
+}
+
 model Policy {
-  id               String       @id @default(dbgenerated("generate_prefixed_cuid('pol'::text)"))
+  id               String              @id @default(dbgenerated("generate_prefixed_cuid('pol'::text)"))
   name             String
   description      String?
-  status           PolicyStatus @default(draft)
+  status           PolicyStatus        @default(draft)
   content          Json[]
   frequency        Frequency?
   department       Departments?
-  isRequiredToSign Boolean      @default(true)
-  signedBy         String[]     @default([])
+  isRequiredToSign Boolean             @default(true)
+  signedBy         String[]            @default([])
   reviewDate       DateTime?
-  isArchived       Boolean      @default(false)
+  isArchived       Boolean             @default(false)
+  displayFormat    PolicyDisplayFormat @default(EDITOR)
+  pdfUrl           String?
 
   // Dates
   createdAt       DateTime  @default(now())


### PR DESCRIPTION
## What does this PR do?

This introduces the ability for users to upload and manage their policies as PDF documents instead of using the rich-text editor.

- Adds `displayFormat` and `pdfUrl` to the Policy schema.
- Creates a `PdfViewer` component to render the PDF via a secure, presigned S3 URL.
- Implements server actions to handle PDF uploads to S3 and to switch between the EDITOR and PDF views.
---
- Fixes #1386

## Visual Demo (For contributors especially)

https://github.com/user-attachments/assets/b148b5f9-4770-4d29-80c7-9c000986713f

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://trycomp.ai/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.
