### PR TITLE
Fix RESEND_DOMAIN variable in .env.example

### DIFF
--- a/apps/app/.env.example
+++ b/apps/app/.env.example
@@ -1,7 +1,7 @@
 # Required
 AUTH_SECRET="" # openssl rand -base64 32
 DATABASE_URL="" # Format: "postgresql://postgres:pass@127.0.0.1:5432/comp"
-RESEND_DOMAIN=" # Domain configured in Resend, e.g. mail.trycomp.ai
+RESEND_DOMAIN="" # Domain configured in Resend, e.g. mail.trycomp.ai
 RESEND_API_KEY="" # API key from Resend for email authentication / invites
 REVALIDATION_SECRET="" # openssl rand -base64 32
 NEXT_PUBLIC_PORTAL_URL="http://localhost:3002" # The employee portal uses port 3002 by default


### PR DESCRIPTION
## What does this PR do?

`apps/app/.env.example` missed a closing quotation mark

## Mandatory Tasks (DO NOT REMOVE)

- [X] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [X] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://trycomp.ai/docs). If N/A, write N/A here and check the checkbox.
- [X] I confirm automated tests are in place that prove my fix is effective or that my feature works.

