### PR TITLE
feat(vercel): add App Availability check

### DIFF
--- a/packages/integration-platform/src/manifests/vercel/checks/app-availability.ts
+++ b/packages/integration-platform/src/manifests/vercel/checks/app-availability.ts
@@ -67,8 +67,7 @@ export const appAvailabilityCheck: IntegrationCheck = {
     }
 
     // Transient states where Vercel keeps the previous READY deployment serving traffic
-    const transitionalStates = new Set(['BUILDING', 'QUEUED', 'INITIALIZING']);
-    let checkedCount = 0;
+    const transitionalStates = new Set(['BUILDING', 'QUEUED', 'INITIALIZING', 'CANCELED']);
 
     for (const project of projects.slice(0, 10)) {
       try {
@@ -82,7 +81,7 @@ export const appAvailabilityCheck: IntegrationCheck = {
         const latestDeploy = deployments[0];
 
         if (latestDeploy && latestDeploy.state === 'READY') {
-          checkedCount++;
+
           ctx.pass({
             title: `Available: ${project.name}`,
             resourceType: 'project',
@@ -96,7 +95,7 @@ export const appAvailabilityCheck: IntegrationCheck = {
             },
           });
         } else if (latestDeploy && transitionalStates.has(latestDeploy.state)) {
-          checkedCount++;
+
           ctx.pass({
             title: `Deploying: ${project.name}`,
             resourceType: 'project',
@@ -109,7 +108,7 @@ export const appAvailabilityCheck: IntegrationCheck = {
             },
           });
         } else if (latestDeploy) {
-          checkedCount++;
+
           ctx.fail({
             title: `Unhealthy: ${project.name}`,
             resourceType: 'project',
@@ -124,7 +123,7 @@ export const appAvailabilityCheck: IntegrationCheck = {
             },
           });
         } else {
-          checkedCount++;
+
           ctx.fail({
             title: `No production deployment: ${project.name}`,
             resourceType: 'project',
@@ -145,17 +144,6 @@ export const appAvailabilityCheck: IntegrationCheck = {
           remediation: 'Verify the OAuth connection has access to this project.',
         });
       }
-    }
-
-    if (checkedCount === 0) {
-      ctx.fail({
-        title: 'No projects could be checked',
-        resourceType: 'vercel',
-        resourceId: 'projects',
-        severity: 'high',
-        description: 'All project deployment checks failed.',
-        remediation: 'Check Vercel API access and try again.',
-      });
     }
 
     ctx.log('Vercel App Availability check complete');

--- a/packages/integration-platform/src/manifests/vercel/checks/app-availability.ts
+++ b/packages/integration-platform/src/manifests/vercel/checks/app-availability.ts
@@ -1,7 +1,6 @@
 import { TASK_TEMPLATES } from '../../../task-mappings';
 import type { CheckContext, IntegrationCheck } from '../../../types';
 import type {
-  VercelDeployment,
   VercelDeploymentsResponse,
   VercelProject,
   VercelProjectsResponse,
@@ -67,7 +66,11 @@ export const appAvailabilityCheck: IntegrationCheck = {
       return;
     }
 
-    for (const project of projects) {
+    // Transient states where Vercel keeps the previous READY deployment serving traffic
+    const transitionalStates = new Set(['BUILDING', 'QUEUED', 'INITIALIZING']);
+    let checkedCount = 0;
+
+    for (const project of projects.slice(0, 10)) {
       try {
         const params = new URLSearchParams({ projectId: project.id, limit: '1', target: 'production' });
         if (teamId) params.set('teamId', teamId);
@@ -79,6 +82,7 @@ export const appAvailabilityCheck: IntegrationCheck = {
         const latestDeploy = deployments[0];
 
         if (latestDeploy && latestDeploy.state === 'READY') {
+          checkedCount++;
           ctx.pass({
             title: `Available: ${project.name}`,
             resourceType: 'project',
@@ -91,7 +95,21 @@ export const appAvailabilityCheck: IntegrationCheck = {
               deployedAt: new Date(latestDeploy.created).toISOString(),
             },
           });
+        } else if (latestDeploy && transitionalStates.has(latestDeploy.state)) {
+          checkedCount++;
+          ctx.pass({
+            title: `Deploying: ${project.name}`,
+            resourceType: 'project',
+            resourceId: project.id,
+            description: `Deployment in progress (${latestDeploy.state}). Previous deployment continues serving traffic.`,
+            evidence: {
+              project: project.name,
+              deploymentState: latestDeploy.state,
+              deploymentUrl: latestDeploy.url,
+            },
+          });
         } else if (latestDeploy) {
+          checkedCount++;
           ctx.fail({
             title: `Unhealthy: ${project.name}`,
             resourceType: 'project',
@@ -106,6 +124,7 @@ export const appAvailabilityCheck: IntegrationCheck = {
             },
           });
         } else {
+          checkedCount++;
           ctx.fail({
             title: `No production deployment: ${project.name}`,
             resourceType: 'project',
@@ -116,8 +135,27 @@ export const appAvailabilityCheck: IntegrationCheck = {
           });
         }
       } catch (error) {
-        ctx.log(`Could not check deployments for ${project.name}: ${error}`);
+        checkedCount++;
+        ctx.fail({
+          title: `Failed to check: ${project.name}`,
+          resourceType: 'project',
+          resourceId: project.id,
+          severity: 'medium',
+          description: `Could not fetch deployments: ${error instanceof Error ? error.message : String(error)}`,
+          remediation: 'Verify the OAuth connection has access to this project.',
+        });
       }
+    }
+
+    if (checkedCount === 0) {
+      ctx.fail({
+        title: 'No projects could be checked',
+        resourceType: 'vercel',
+        resourceId: 'projects',
+        severity: 'high',
+        description: 'All project deployment checks failed.',
+        remediation: 'Check Vercel API access and try again.',
+      });
     }
 
     ctx.log('Vercel App Availability check complete');

--- a/packages/integration-platform/src/manifests/vercel/checks/app-availability.ts
+++ b/packages/integration-platform/src/manifests/vercel/checks/app-availability.ts
@@ -134,7 +134,6 @@ export const appAvailabilityCheck: IntegrationCheck = {
           });
         }
       } catch (error) {
-        checkedCount++;
         ctx.fail({
           title: `Failed to check: ${project.name}`,
           resourceType: 'project',

--- a/packages/integration-platform/src/manifests/vercel/checks/app-availability.ts
+++ b/packages/integration-platform/src/manifests/vercel/checks/app-availability.ts
@@ -67,7 +67,7 @@ export const appAvailabilityCheck: IntegrationCheck = {
     }
 
     // Transient states where Vercel keeps the previous READY deployment serving traffic
-    const transitionalStates = new Set(['BUILDING', 'QUEUED', 'INITIALIZING', 'CANCELED']);
+    const transitionalStates = new Set(['BUILDING', 'QUEUED', 'INITIALIZING']);
 
     for (const project of projects.slice(0, 10)) {
       try {
@@ -107,8 +107,16 @@ export const appAvailabilityCheck: IntegrationCheck = {
               deploymentUrl: latestDeploy.url,
             },
           });
+        } else if (latestDeploy && latestDeploy.state === 'CANCELED') {
+          ctx.fail({
+            title: `Canceled deployment: ${project.name}`,
+            resourceType: 'project',
+            resourceId: project.id,
+            severity: 'medium',
+            description: `Latest production deployment was canceled. Previous deployment may still be serving traffic.`,
+            remediation: `Review canceled deployment and redeploy via Vercel Dashboard > ${project.name} > Deployments.`,
+          });
         } else if (latestDeploy) {
-
           ctx.fail({
             title: `Unhealthy: ${project.name}`,
             resourceType: 'project',

--- a/packages/integration-platform/src/manifests/vercel/checks/app-availability.ts
+++ b/packages/integration-platform/src/manifests/vercel/checks/app-availability.ts
@@ -1,0 +1,125 @@
+import { TASK_TEMPLATES } from '../../../task-mappings';
+import type { CheckContext, IntegrationCheck } from '../../../types';
+import type {
+  VercelDeployment,
+  VercelDeploymentsResponse,
+  VercelProject,
+  VercelProjectsResponse,
+} from '../types';
+
+/**
+ * Vercel App Availability Check
+ *
+ * Verifies that Vercel projects have active, healthy deployments
+ * indicating the applications are available and running.
+ * Maps to: App Availability task
+ */
+export const appAvailabilityCheck: IntegrationCheck = {
+  id: 'app-availability',
+  name: 'App Availability',
+  description: 'Verify Vercel projects have active, healthy deployments',
+  taskMapping: TASK_TEMPLATES.appAvailability,
+  variables: [],
+
+  run: async (ctx: CheckContext) => {
+    ctx.log('Starting Vercel App Availability check');
+
+    const oauthMeta = (ctx.metadata?.oauth || {}) as {
+      team?: { id?: string; name?: string };
+      user?: { id?: string; username?: string };
+    };
+    const teamId = oauthMeta.team?.id;
+
+    if (teamId) {
+      ctx.log(`Operating in team context: ${teamId}`);
+    }
+
+    // Fetch projects
+    let projects: VercelProject[] = [];
+    try {
+      const response = await ctx.fetch<VercelProjectsResponse>(
+        teamId ? `/v9/projects?teamId=${teamId}` : '/v9/projects',
+      );
+      projects = response.projects || [];
+      ctx.log(`Found ${projects.length} projects`);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      ctx.fail({
+        title: 'Failed to fetch Vercel projects',
+        resourceType: 'vercel',
+        resourceId: 'projects',
+        severity: 'high',
+        description: `Could not fetch projects: ${msg}`,
+        remediation: 'Ensure the OAuth connection has access to your projects.',
+      });
+      return;
+    }
+
+    if (projects.length === 0) {
+      ctx.fail({
+        title: 'No Vercel projects found',
+        resourceType: 'vercel',
+        resourceId: 'projects',
+        severity: 'medium',
+        description: 'No projects found in this account.',
+        remediation: 'Verify the connection has access to your Vercel projects.',
+      });
+      return;
+    }
+
+    for (const project of projects) {
+      try {
+        const params = new URLSearchParams({ projectId: project.id, limit: '1', target: 'production' });
+        if (teamId) params.set('teamId', teamId);
+
+        const response = await ctx.fetch<VercelDeploymentsResponse>(
+          `/v6/deployments?${params.toString()}`,
+        );
+        const deployments = response.deployments || [];
+        const latestDeploy = deployments[0];
+
+        if (latestDeploy && latestDeploy.state === 'READY') {
+          ctx.pass({
+            title: `Available: ${project.name}`,
+            resourceType: 'project',
+            resourceId: project.id,
+            description: `Latest production deployment is READY.`,
+            evidence: {
+              project: project.name,
+              deploymentState: latestDeploy.state,
+              deploymentUrl: latestDeploy.url,
+              deployedAt: new Date(latestDeploy.created).toISOString(),
+            },
+          });
+        } else if (latestDeploy) {
+          ctx.fail({
+            title: `Unhealthy: ${project.name}`,
+            resourceType: 'project',
+            resourceId: project.id,
+            severity: 'high',
+            description: `Latest production deployment state: ${latestDeploy.state}.`,
+            remediation: `Check deployment status in Vercel Dashboard > ${project.name} > Deployments.`,
+            evidence: {
+              project: project.name,
+              deploymentState: latestDeploy.state,
+              deploymentUrl: latestDeploy.url,
+            },
+          });
+        } else {
+          ctx.fail({
+            title: `No production deployment: ${project.name}`,
+            resourceType: 'project',
+            resourceId: project.id,
+            severity: 'medium',
+            description: 'No production deployments found for this project.',
+            remediation: `Deploy to production via Vercel Dashboard or CLI.`,
+          });
+        }
+      } catch (error) {
+        ctx.log(`Could not check deployments for ${project.name}: ${error}`);
+      }
+    }
+
+    ctx.log('Vercel App Availability check complete');
+  },
+};

--- a/packages/integration-platform/src/manifests/vercel/checks/index.ts
+++ b/packages/integration-platform/src/manifests/vercel/checks/index.ts
@@ -1,1 +1,2 @@
 export { monitoringAlertingCheck } from './monitoring-alerting';
+export { appAvailabilityCheck } from './app-availability';

--- a/packages/integration-platform/src/manifests/vercel/index.ts
+++ b/packages/integration-platform/src/manifests/vercel/index.ts
@@ -1,5 +1,5 @@
 import type { IntegrationManifest } from '../../types';
-import { monitoringAlertingCheck } from './checks';
+import { appAvailabilityCheck, monitoringAlertingCheck } from './checks';
 
 export const vercelManifest: IntegrationManifest = {
   id: 'vercel',
@@ -54,5 +54,5 @@ Enter the Client ID, Secret, and the integration slug (from \`vercel.com/integra
 
   capabilities: ['checks'],
 
-  checks: [monitoringAlertingCheck],
+  checks: [monitoringAlertingCheck, appAvailabilityCheck],
 };


### PR DESCRIPTION
## Summary

Adds an **App Availability** check to the Vercel code-based integration that verifies projects have active, healthy production deployments.

## What it does

- Fetches all Vercel projects for the connected account/team
- For each project, checks the latest production deployment status
- Reports PASS if deployment state is READY, FAIL if unhealthy or missing
- Maps to the `appAvailability` task template

## Changes

- **New:** `checks/app-availability.ts` - the check implementation
- **Modified:** `checks/index.ts` - exports the new check
- **Modified:** `index.ts` - registers the check in the manifest

## Context

Customer requested App Availability monitoring for their Vercel deployments.