### PR TITLE
feat: admin org activity endpoint

### DIFF
--- a/apps/api/src/admin-organizations/admin-organizations.controller.ts
+++ b/apps/api/src/admin-organizations/admin-organizations.controller.ts
@@ -57,7 +57,7 @@ export class AdminOrganizationsController {
     @Query('limit') limit?: string,
   ) {
     return this.service.getOrgActivity({
-      inactiveDays: Number.isFinite(parseInt(inactiveDays ?? '90', 10)) ? parseInt(inactiveDays ?? '90', 10) : 90,
+      inactiveDays: Math.max(0, Number.isFinite(parseInt(inactiveDays ?? '90', 10)) ? parseInt(inactiveDays ?? '90', 10) : 90),
       hasAccess: hasAccess === 'true' ? true : hasAccess === 'false' ? false : undefined,
       onboarded: onboarded === 'true' ? true : onboarded === 'false' ? false : undefined,
       page: Math.max(1, parseInt(page || '1', 10) || 1),

--- a/apps/api/src/admin-organizations/admin-organizations.controller.ts
+++ b/apps/api/src/admin-organizations/admin-organizations.controller.ts
@@ -42,6 +42,29 @@ export class AdminOrganizationsController {
     });
   }
 
+  @Get('activity')
+  @ApiOperation({ summary: 'Organization activity report - shows last session per org (platform admin)' })
+  @ApiQuery({ name: 'inactiveDays', required: false, description: 'Filter orgs with no session in N days (default: 90)' })
+  @ApiQuery({ name: 'hasAccess', required: false, description: 'Filter by hasAccess (true/false)' })
+  @ApiQuery({ name: 'onboarded', required: false, description: 'Filter by onboardingCompleted (true/false)' })
+  @ApiQuery({ name: 'page', required: false })
+  @ApiQuery({ name: 'limit', required: false })
+  async activity(
+    @Query('inactiveDays') inactiveDays?: string,
+    @Query('hasAccess') hasAccess?: string,
+    @Query('onboarded') onboarded?: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.service.getOrgActivity({
+      inactiveDays: parseInt(inactiveDays || '90', 10) || 90,
+      hasAccess: hasAccess === 'true' ? true : hasAccess === 'false' ? false : undefined,
+      onboarded: onboarded === 'true' ? true : onboarded === 'false' ? false : undefined,
+      page: Math.max(1, parseInt(page || '1', 10) || 1),
+      limit: Math.min(100, Math.max(1, parseInt(limit || '50', 10) || 50)),
+    });
+  }
+
   @Get(':id')
   @ApiOperation({ summary: 'Get organization details (platform admin)' })
   async get(@Param('id') id: string) {

--- a/apps/api/src/admin-organizations/admin-organizations.controller.ts
+++ b/apps/api/src/admin-organizations/admin-organizations.controller.ts
@@ -57,7 +57,7 @@ export class AdminOrganizationsController {
     @Query('limit') limit?: string,
   ) {
     return this.service.getOrgActivity({
-      inactiveDays: parseInt(inactiveDays ?? '90', 10) ?? 90,
+      inactiveDays: Number.isFinite(parseInt(inactiveDays ?? '90', 10)) ? parseInt(inactiveDays ?? '90', 10) : 90,
       hasAccess: hasAccess === 'true' ? true : hasAccess === 'false' ? false : undefined,
       onboarded: onboarded === 'true' ? true : onboarded === 'false' ? false : undefined,
       page: Math.max(1, parseInt(page || '1', 10) || 1),

--- a/apps/api/src/admin-organizations/admin-organizations.controller.ts
+++ b/apps/api/src/admin-organizations/admin-organizations.controller.ts
@@ -57,7 +57,7 @@ export class AdminOrganizationsController {
     @Query('limit') limit?: string,
   ) {
     return this.service.getOrgActivity({
-      inactiveDays: parseInt(inactiveDays || '90', 10) || 90,
+      inactiveDays: parseInt(inactiveDays ?? '90', 10) ?? 90,
       hasAccess: hasAccess === 'true' ? true : hasAccess === 'false' ? false : undefined,
       onboarded: onboarded === 'true' ? true : onboarded === 'false' ? false : undefined,
       page: Math.max(1, parseInt(page || '1', 10) || 1),

--- a/apps/api/src/admin-organizations/admin-organizations.service.ts
+++ b/apps/api/src/admin-organizations/admin-organizations.service.ts
@@ -127,6 +127,7 @@ export class AdminOrganizationsService {
           onboardingCompleted: true,
           _count: { select: { members: true, tasks: true, policies: true, auditLog: true } },
           members: {
+            where: { deactivated: false },
             select: {
               role: true,
               user: {

--- a/apps/api/src/admin-organizations/admin-organizations.service.ts
+++ b/apps/api/src/admin-organizations/admin-organizations.service.ts
@@ -100,6 +100,115 @@ export class AdminOrganizationsService {
     };
   }
 
+  async getOrgActivity(options: {
+    inactiveDays: number;
+    hasAccess?: boolean;
+    onboarded?: boolean;
+    page: number;
+    limit: number;
+  }) {
+    const { inactiveDays, hasAccess, onboarded, page, limit } = options;
+    const skip = (page - 1) * limit;
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - inactiveDays);
+
+    const where: Record<string, unknown> = {};
+    if (hasAccess !== undefined) where.hasAccess = hasAccess;
+    if (onboarded !== undefined) where.onboardingCompleted = onboarded;
+
+    const [organizations, total] = await Promise.all([
+      db.organization.findMany({
+        where,
+        select: {
+          id: true,
+          name: true,
+          createdAt: true,
+          hasAccess: true,
+          onboardingCompleted: true,
+          _count: { select: { members: true } },
+          members: {
+            select: {
+              role: true,
+              user: {
+                select: {
+                  id: true,
+                  name: true,
+                  email: true,
+                  sessions: {
+                    orderBy: { updatedAt: 'desc' as const },
+                    take: 1,
+                    select: { updatedAt: true },
+                  },
+                },
+              },
+            },
+          },
+          auditLog: {
+            orderBy: { timestamp: 'desc' as const },
+            take: 1,
+            select: { timestamp: true },
+          },
+        },
+        orderBy: { createdAt: 'desc' },
+        skip,
+        take: limit,
+      }),
+      db.organization.count({ where }),
+    ]);
+
+    // Post-process to find last activity per org
+    const data = organizations.map((org) => {
+      let lastSession: Date | null = null;
+      let owner: { id: string; name: string; email: string } | null = null;
+
+      for (const member of org.members) {
+        const sess = member.user?.sessions?.[0]?.updatedAt;
+        if (sess && (!lastSession || sess > lastSession)) {
+          lastSession = sess;
+        }
+        if (member.role?.includes('owner') && !owner) {
+          owner = { id: member.user.id, name: member.user.name, email: member.user.email };
+        }
+      }
+
+      const lastAuditLog = org.auditLog?.[0]?.timestamp ?? null;
+      const lastActivity = [lastSession, lastAuditLog]
+        .filter(Boolean)
+        .sort((a, b) => (b as Date).getTime() - (a as Date).getTime())[0] as Date | undefined;
+
+      const isActive = lastActivity ? lastActivity >= cutoff : false;
+
+      return {
+        id: org.id,
+        name: org.name,
+        createdAt: org.createdAt,
+        hasAccess: org.hasAccess,
+        onboardingCompleted: org.onboardingCompleted,
+        memberCount: org._count.members,
+        owner,
+        lastSession: lastSession?.toISOString() ?? null,
+        lastAuditLog: lastAuditLog ? (lastAuditLog as Date).toISOString() : null,
+        lastActivity: lastActivity?.toISOString() ?? null,
+        isActive,
+      };
+    });
+
+    const activeCount = data.filter((d) => d.isActive).length;
+    const inactiveCount = data.filter((d) => !d.isActive).length;
+
+    return {
+      data,
+      total,
+      page,
+      limit,
+      summary: {
+        inactiveDays,
+        activeInPage: activeCount,
+        inactiveInPage: inactiveCount,
+      },
+    };
+  }
+
   async getOrganization(id: string) {
     const org = await db.organization.findUnique({
       where: { id },

--- a/apps/api/src/admin-organizations/admin-organizations.service.ts
+++ b/apps/api/src/admin-organizations/admin-organizations.service.ts
@@ -125,7 +125,7 @@ export class AdminOrganizationsService {
           createdAt: true,
           hasAccess: true,
           onboardingCompleted: true,
-          _count: { select: { members: true, tasks: true, policies: true, auditLog: true } },
+          _count: { select: { members: true, tasks: true, policy: true, auditLog: true } },
           members: {
             where: { deactivated: false },
             select: {
@@ -187,7 +187,7 @@ export class AdminOrganizationsService {
         onboardingCompleted: org.onboardingCompleted,
         memberCount: org._count.members,
         taskCount: org._count.tasks,
-        policyCount: org._count.policies,
+        policyCount: org._count.policy,
         auditLogCount: org._count.auditLog,
         owner,
         lastSession: lastSession?.toISOString() ?? null,

--- a/apps/api/src/admin-organizations/admin-organizations.service.ts
+++ b/apps/api/src/admin-organizations/admin-organizations.service.ts
@@ -125,7 +125,7 @@ export class AdminOrganizationsService {
           createdAt: true,
           hasAccess: true,
           onboardingCompleted: true,
-          _count: { select: { members: true } },
+          _count: { select: { members: true, tasks: true, policies: true, auditLog: true } },
           members: {
             select: {
               role: true,
@@ -185,6 +185,9 @@ export class AdminOrganizationsService {
         hasAccess: org.hasAccess,
         onboardingCompleted: org.onboardingCompleted,
         memberCount: org._count.members,
+        taskCount: org._count.tasks,
+        policyCount: org._count.policies,
+        auditLogCount: org._count.auditLog,
         owner,
         lastSession: lastSession?.toISOString() ?? null,
         lastAuditLog: lastAuditLog ? (lastAuditLog as Date).toISOString() : null,


### PR DESCRIPTION
## Summary

- New endpoint: `GET /v1/admin/organizations/activity`
- Returns per-org activity data: last session, last audit log, last activity (whichever is more recent)
- Supports filtering by `hasAccess`, `onboarded`, `inactiveDays`
- Used for identifying inactive orgs that should be suppressed from email notifications

## Query params

- `inactiveDays` - threshold for marking org inactive (default: 90)
- `hasAccess` - filter by hasAccess (true/false)
- `onboarded` - filter by onboardingCompleted (true/false)
- `page`, `limit` - pagination

## Response

Each org includes: `lastSession`, `lastAuditLog`, `lastActivity`, `isActive`, `owner`, `memberCount`

## Context

Part of P0 domain reputation remediation - need to identify which orgs are truly inactive to suppress email notifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)