### PR TITLE
chore: remove dead Resend client files from app and portal

### DIFF
--- a/apps/app/src/utils/resend.ts
+++ b/apps/app/src/utils/resend.ts
@@ -1,3 +1,0 @@
-import { Resend } from 'resend';
-
-export const resend = new Resend(process.env.RESEND_API_KEY!);

--- a/apps/portal/src/app/lib/resend.ts
+++ b/apps/portal/src/app/lib/resend.ts
@@ -1,4 +1,0 @@
-import { env } from '@/env.mjs';
-import { Resend } from 'resend';
-
-export const resend = new Resend(env.RESEND_API_KEY);


### PR DESCRIPTION
## Summary

- Remove orphaned Resend client initialization from `apps/app/src/utils/resend.ts` and `apps/portal/src/app/lib/resend.ts`
- Neither file was imported by anything - dead code
- All email sending goes through Trigger.dev via the API's `send-email` task
- Part of email infrastructure cleanup for domain reputation remediation

🤖 Generated with [Claude Code](https://claude.com/claude-code)