### PR TITLE
chore: remove syncVercelEnvVars from Trigger configs

### DIFF
--- a/apps/api/trigger.config.ts
+++ b/apps/api/trigger.config.ts
@@ -1,4 +1,3 @@
-import { syncVercelEnvVars } from '@trigger.dev/build/extensions/core';
 import { defineConfig } from '@trigger.dev/sdk';
 import { prismaExtension } from './customPrismaExtension';
 import { emailExtension } from './emailExtension';
@@ -17,7 +16,6 @@ export default defineConfig({
       }),
       integrationPlatformExtension(),
       emailExtension(),
-      syncVercelEnvVars(),
     ],
   },
   retries: {

--- a/apps/app/trigger.config.ts
+++ b/apps/app/trigger.config.ts
@@ -1,5 +1,4 @@
 import { PrismaInstrumentation } from '@prisma/instrumentation';
-import { syncVercelEnvVars } from '@trigger.dev/build/extensions/core';
 import { puppeteer } from '@trigger.dev/build/extensions/puppeteer';
 import { defineConfig } from '@trigger.dev/sdk';
 import { prismaExtension } from './customPrismaExtension';
@@ -17,7 +16,6 @@ export default defineConfig({
         dbPackageVersion: '^2.0.0',
       }),
       puppeteer(),
-      syncVercelEnvVars(),
     ],
   },
   retries: {


### PR DESCRIPTION
## Summary

- Remove `syncVercelEnvVars()` from both app and API Trigger.dev configs
- All required env vars are already set independently in Trigger's dashboard (staging + production)
- Decouples Trigger env from Vercel env for proper isolation

## Why

Trigger should manage its own env vars explicitly, not inherit from Vercel. This is a prerequisite for staging email isolation (separate Resend keys per environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)