### PR TITLE
feat: add List-Unsubscribe headers and throttle email sends

### DIFF
--- a/apps/api/src/email/email.module.ts
+++ b/apps/api/src/email/email.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AuthModule } from '../auth/auth.module';
 import { EmailController } from './email.controller';
+import { UnsubscribeController } from './unsubscribe.controller';
 
 @Module({
   imports: [AuthModule],
-  controllers: [EmailController],
+  controllers: [EmailController, UnsubscribeController],
 })
 export class EmailModule {}

--- a/apps/api/src/email/unsubscribe.controller.ts
+++ b/apps/api/src/email/unsubscribe.controller.ts
@@ -61,6 +61,7 @@ export class UnsubscribeController {
           unassignedItemsNotifications: false,
           taskMentions: false,
           taskAssignments: false,
+          findingNotifications: false,
         },
       },
     });

--- a/apps/api/src/email/unsubscribe.controller.ts
+++ b/apps/api/src/email/unsubscribe.controller.ts
@@ -1,0 +1,63 @@
+import { Controller, Post, Body, Query, HttpCode, BadRequestException } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { db } from '@db';
+import { generateUnsubscribeToken } from '@trycompai/email/lib/unsubscribe';
+
+@ApiTags('Email - Unsubscribe')
+@Controller({ path: 'email/unsubscribe', version: '1' })
+export class UnsubscribeController {
+  /**
+   * RFC 8058 one-click unsubscribe endpoint.
+   * Gmail POSTs to this URL with List-Unsubscribe=One-Click in the body.
+   * Email and token come via query params in the URL.
+   */
+  @Post()
+  @HttpCode(200)
+  @ApiOperation({ summary: 'One-click unsubscribe (RFC 8058)' })
+  async unsubscribe(
+    @Query('email') queryEmail?: string,
+    @Query('token') queryToken?: string,
+    @Body() body?: { email?: string; token?: string },
+  ) {
+    const email = queryEmail || body?.email;
+    const token = queryToken || body?.token;
+
+    if (!email || !token) {
+      throw new BadRequestException('Email and token are required');
+    }
+
+    // Verify HMAC token
+    const expectedToken = generateUnsubscribeToken(email);
+    if (expectedToken !== token) {
+      throw new BadRequestException('Invalid token');
+    }
+
+    // Unsubscribe the user from all email notifications
+    const user = await db.user.findUnique({
+      where: { email },
+      select: { id: true },
+    });
+
+    if (!user) {
+      // Don't reveal user existence - just return success
+      return { success: true };
+    }
+
+    await db.user.update({
+      where: { id: user.id },
+      data: {
+        emailNotificationsUnsubscribed: true,
+        emailPreferences: {
+          policyNotifications: false,
+          taskReminders: false,
+          weeklyTaskDigest: false,
+          unassignedItemsNotifications: false,
+          taskMentions: false,
+          taskAssignments: false,
+        },
+      },
+    });
+
+    return { success: true };
+  }
+}

--- a/apps/api/src/email/unsubscribe.controller.ts
+++ b/apps/api/src/email/unsubscribe.controller.ts
@@ -20,8 +20,11 @@ export class UnsubscribeController {
     @Query('token') queryToken?: string,
     @Body() body?: { email?: string; token?: string },
   ) {
-    const email = queryEmail || body?.email;
-    const token = queryToken || body?.token;
+    // Coerce to string - query params can be arrays if repeated
+    const rawEmail = queryEmail || body?.email;
+    const rawToken = queryToken || body?.token;
+    const email = typeof rawEmail === 'string' ? rawEmail : undefined;
+    const token = typeof rawToken === 'string' ? rawToken : undefined;
 
     if (!email || !token) {
       throw new BadRequestException('Email and token are required');

--- a/apps/api/src/email/unsubscribe.controller.ts
+++ b/apps/api/src/email/unsubscribe.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Post, Body, Query, HttpCode, BadRequestException } from '@n
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { db } from '@db';
 import { generateUnsubscribeToken } from '@trycompai/email/lib/unsubscribe';
+import { timingSafeEqual } from 'node:crypto';
 
 @ApiTags('Email - Unsubscribe')
 @Controller({ path: 'email/unsubscribe', version: '1' })
@@ -26,9 +27,12 @@ export class UnsubscribeController {
       throw new BadRequestException('Email and token are required');
     }
 
-    // Verify HMAC token
+    // Verify HMAC token (timing-safe comparison)
     const expectedToken = generateUnsubscribeToken(email);
-    if (expectedToken !== token) {
+    const tokensMatch =
+      expectedToken.length === token.length &&
+      timingSafeEqual(Buffer.from(expectedToken), Buffer.from(token));
+    if (!tokensMatch) {
       throw new BadRequestException('Invalid token');
     }
 

--- a/apps/api/src/trigger/email/send-email.ts
+++ b/apps/api/src/trigger/email/send-email.ts
@@ -1,7 +1,7 @@
 import { logger, queue, schemaTask } from '@trigger.dev/sdk';
 import { z } from 'zod';
 import { resend } from '../../email/resend';
-import { getUnsubscribeUrl } from '@trycompai/email/lib/unsubscribe';
+import { getUnsubscribeUrl, generateUnsubscribeToken } from '@trycompai/email/lib/unsubscribe';
 
 const emailQueue = queue({
   name: 'send-email',
@@ -52,10 +52,13 @@ export const sendEmailTask = schemaTask({
     }
 
     try {
-      // Build List-Unsubscribe header (mailto + URL for broadest client support)
-      const unsubscribeUrl = getUnsubscribeUrl(params.to);
+      // Build List-Unsubscribe headers for Gmail/RFC 8058 one-click compliance
+      const apiBaseUrl = process.env.NEXT_PUBLIC_API_URL || 'https://api.trycomp.ai';
+      const token = generateUnsubscribeToken(params.to);
+      const oneClickUrl = `${apiBaseUrl}/v1/email/unsubscribe?email=${encodeURIComponent(params.to)}&token=${encodeURIComponent(token)}`;
       const headers: Record<string, string> = {
-        'List-Unsubscribe': `<${unsubscribeUrl}>, <mailto:unsubscribe@mail.trycomp.ai?subject=Unsubscribe&body=${encodeURIComponent(params.to)}>`,
+        'List-Unsubscribe': `<${oneClickUrl}>`,
+        'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
       };
 
       const { data, error } = await resend.emails.send({

--- a/apps/api/src/trigger/email/send-email.ts
+++ b/apps/api/src/trigger/email/send-email.ts
@@ -1,7 +1,7 @@
 import { logger, queue, schemaTask } from '@trigger.dev/sdk';
 import { z } from 'zod';
 import { resend } from '../../email/resend';
-import { getUnsubscribeUrl, generateUnsubscribeToken } from '@trycompai/email/lib/unsubscribe';
+import { generateUnsubscribeToken } from '@trycompai/email/lib/unsubscribe';
 
 const emailQueue = queue({
   name: 'send-email',

--- a/apps/api/src/trigger/email/send-email.ts
+++ b/apps/api/src/trigger/email/send-email.ts
@@ -1,10 +1,11 @@
-import { logger, queue, schemaTask } from '@trigger.dev/sdk';
+import { logger, queue, schemaTask, wait } from '@trigger.dev/sdk';
 import { z } from 'zod';
 import { resend } from '../../email/resend';
+import { getUnsubscribeUrl } from '@trycompai/email/lib/unsubscribe';
 
 const emailQueue = queue({
   name: 'send-email',
-  concurrencyLimit: 30,
+  concurrencyLimit: 10,
 });
 
 export const sendEmailTask = schemaTask({
@@ -51,12 +52,20 @@ export const sendEmailTask = schemaTask({
     }
 
     try {
+      // Build List-Unsubscribe headers for Gmail/RFC 8058 compliance
+      const unsubscribeUrl = getUnsubscribeUrl(toAddress);
+      const headers: Record<string, string> = {
+        'List-Unsubscribe': `<${unsubscribeUrl}>`,
+        'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+      };
+
       const { data, error } = await resend.emails.send({
         from: fromAddress,
         to: toAddress,
         cc: params.cc,
         subject: params.subject,
         html: params.html,
+        headers,
         scheduledAt: params.scheduledAt,
         attachments: params.attachments?.map((att) => ({
           filename: att.filename,
@@ -75,6 +84,9 @@ export const sendEmailTask = schemaTask({
       }
 
       logger.info('Email sent', { to: params.to, id: data?.id });
+
+      // Throttle: wait 1s between sends to avoid email spikes
+      await wait.for({ seconds: 1 });
 
       return { id: data?.id };
     } catch (error) {

--- a/apps/api/src/trigger/email/send-email.ts
+++ b/apps/api/src/trigger/email/send-email.ts
@@ -1,4 +1,4 @@
-import { logger, queue, schemaTask, wait } from '@trigger.dev/sdk';
+import { logger, queue, schemaTask } from '@trigger.dev/sdk';
 import { z } from 'zod';
 import { resend } from '../../email/resend';
 import { getUnsubscribeUrl } from '@trycompai/email/lib/unsubscribe';
@@ -85,8 +85,8 @@ export const sendEmailTask = schemaTask({
 
       logger.info('Email sent', { to: params.to, id: data?.id });
 
-      // Throttle: wait 1s between sends to avoid email spikes
-      await wait.for({ seconds: 1 });
+      // Throttle: hold the concurrency slot for 1s to space out sends
+      await new Promise((r) => setTimeout(r, 1000));
 
       return { id: data?.id };
     } catch (error) {

--- a/apps/api/src/trigger/email/send-email.ts
+++ b/apps/api/src/trigger/email/send-email.ts
@@ -53,7 +53,7 @@ export const sendEmailTask = schemaTask({
 
     try {
       // Build List-Unsubscribe headers for Gmail/RFC 8058 compliance
-      const unsubscribeUrl = getUnsubscribeUrl(toAddress);
+      const unsubscribeUrl = getUnsubscribeUrl(params.to);
       const headers: Record<string, string> = {
         'List-Unsubscribe': `<${unsubscribeUrl}>`,
         'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',

--- a/apps/api/src/trigger/email/send-email.ts
+++ b/apps/api/src/trigger/email/send-email.ts
@@ -52,11 +52,10 @@ export const sendEmailTask = schemaTask({
     }
 
     try {
-      // Build List-Unsubscribe headers for Gmail/RFC 8058 compliance
+      // Build List-Unsubscribe header (mailto + URL for broadest client support)
       const unsubscribeUrl = getUnsubscribeUrl(params.to);
       const headers: Record<string, string> = {
-        'List-Unsubscribe': `<${unsubscribeUrl}>`,
-        'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+        'List-Unsubscribe': `<${unsubscribeUrl}>, <mailto:unsubscribe@mail.trycomp.ai?subject=Unsubscribe&body=${encodeURIComponent(params.to)}>`,
       };
 
       const { data, error } = await resend.emails.send({


### PR DESCRIPTION
## Summary

- Add `List-Unsubscribe` and `List-Unsubscribe-Post` headers to all outbound emails (Gmail/RFC 8058 compliance)
- Reduce email queue concurrency from 30 to 10
- Add 1s delay between sends to spread email volume over time

## Why

Part of domain reputation remediation (P0 SURBL incident). Gmail requires List-Unsubscribe for bulk senders. Email spikes from high concurrency can trigger reputation systems.

## Impact

- With concurrency 10 + 1s delay: ~1000 emails takes ~100s instead of instant blast
- Unsubscribe header uses existing HMAC-signed URL generator

🤖 Generated with [Claude Code](https://claude.com/claude-code)