### PR TITLE
fix: use barrel import for email package (Trigger build fix)

### DIFF
--- a/apps/api/src/email/unsubscribe.controller.ts
+++ b/apps/api/src/email/unsubscribe.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Post, Body, Query, HttpCode, BadRequestException } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { db } from '@db';
-import { generateUnsubscribeToken } from '@trycompai/email/lib/unsubscribe';
+import { generateUnsubscribeToken } from '@trycompai/email';
 import { timingSafeEqual } from 'node:crypto';
 
 @ApiTags('Email - Unsubscribe')

--- a/apps/api/src/trigger/email/send-email.ts
+++ b/apps/api/src/trigger/email/send-email.ts
@@ -1,7 +1,7 @@
 import { logger, queue, schemaTask } from '@trigger.dev/sdk';
 import { z } from 'zod';
 import { resend } from '../../email/resend';
-import { generateUnsubscribeToken } from '@trycompai/email/lib/unsubscribe';
+import { generateUnsubscribeToken } from '@trycompai/email';
 
 const emailQueue = queue({
   name: 'send-email',


### PR DESCRIPTION
## Summary

Fixes Trigger.dev deploy failure caused by deep path import `@trycompai/email/lib/unsubscribe` which resolves to source .ts files that esbuild can't find in dist/. Uses barrel import from `@trycompai/email` instead.

## Error

```
Could not read from file: /runner/_work/comp/comp/packages/email/dist/lib/unsubscribe/index.js
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)