### PR TITLE
feat(github): Add 2FA enforcement check

### DIFF
--- a/packages/integration-platform/src/manifests/github/checks/index.ts
+++ b/packages/integration-platform/src/manifests/github/checks/index.ts
@@ -6,3 +6,4 @@
 export { branchProtectionCheck } from './branch-protection';
 export { dependabotCheck } from './dependabot';
 export { sanitizedInputsCheck } from './sanitized-inputs';
+export { twoFactorAuthCheck } from './two-factor-auth';

--- a/packages/integration-platform/src/manifests/github/checks/two-factor-auth.ts
+++ b/packages/integration-platform/src/manifests/github/checks/two-factor-auth.ts
@@ -3,7 +3,7 @@
  * Verifies that all organization members have 2FA enabled.
  *
  * Uses GET /orgs/{org}/members?filter=2fa_disabled to find members
- * without 2FA. Requires the 'admin:org' OAuth scope.
+ * without 2FA. The filter is only available to organization owners.
  *
  * @see https://docs.github.com/en/rest/orgs/members#list-organization-members
  */
@@ -15,21 +15,46 @@ import type { GitHubOrg } from '../types';
 interface GitHubOrgMember {
   login: string;
   id: number;
-  avatar_url: string;
   html_url: string;
-  type: string;
-  site_admin: boolean;
 }
+
+const MAX_USERNAMES_IN_DESCRIPTION = 20;
+const MAX_USERNAMES_IN_EVIDENCE = 100;
+
+const isOwnerPermissionError = (errorMsg: string): boolean => {
+  const lower = errorMsg.toLowerCase();
+
+  if (lower.includes('403') || lower.includes('forbidden')) return true;
+  if (lower.includes('must be an organization owner') || lower.includes('organization owners')) {
+    return true;
+  }
+
+  // GitHub documents 422 for this endpoint when filter constraints fail.
+  if (lower.includes('422') || lower.includes('unprocessable') || lower.includes('validation failed')) {
+    return true;
+  }
+
+  return false;
+};
+
+const formatUsernamesPreview = (members: GitHubOrgMember[]): string => {
+  const preview = members.slice(0, MAX_USERNAMES_IN_DESCRIPTION).map((member) => `@${member.login}`);
+  const remaining = members.length - preview.length;
+
+  if (remaining > 0) {
+    return `${preview.join(', ')} and ${remaining} more`;
+  }
+  return preview.join(', ');
+};
 
 export const twoFactorAuthCheck: IntegrationCheck = {
   id: 'two_factor_auth',
   name: '2FA Enforcement',
   description:
     'Verify that all GitHub organization members have two-factor authentication enabled',
+  service: 'code-security',
   taskMapping: TASK_TEMPLATES.twoFactorAuth,
   defaultSeverity: 'high',
-
-  variables: [],
 
   run: async (ctx) => {
     // Step 1: Get all orgs the authenticated user belongs to
@@ -70,27 +95,31 @@ export const twoFactorAuthCheck: IntegrationCheck = {
     // Step 2: For each org, check for members without 2FA
     for (const org of orgs) {
       ctx.log(`Checking 2FA for organization: ${org.login}`);
+      const orgSlug = encodeURIComponent(org.login);
+      const checkedAt = new Date().toISOString();
 
       let membersWithout2FA: GitHubOrgMember[];
       try {
         membersWithout2FA = await ctx.fetchAllPages<GitHubOrgMember>(
-          `/orgs/${org.login}/members?filter=2fa_disabled`,
+          `/orgs/${orgSlug}/members?filter=2fa_disabled`,
         );
       } catch (error) {
         const errorMsg = error instanceof Error ? error.message : String(error);
 
-        // 403 usually means the token lacks admin:org scope or user isn't an org owner
-        if (errorMsg.includes('403') || errorMsg.includes('Forbidden')) {
+        // GitHub returns 422 when the caller is not an org owner for 2fa_* filters.
+        if (isOwnerPermissionError(errorMsg)) {
           ctx.warn(
-            `Cannot check 2FA for ${org.login}: insufficient permissions. The admin:org scope and org owner/admin role are required.`,
+            `Cannot check 2FA for ${org.login}: the account must be an organization owner to use the 2FA filter.`,
           );
           ctx.fail({
             title: `Cannot verify 2FA for ${org.login}`,
-            description: `Insufficient permissions to check 2FA status. The filter=2fa_disabled parameter requires the admin:org OAuth scope and the authenticated user must be an organization owner or admin.`,
+            description:
+              'Insufficient permissions to check 2FA status. The `filter=2fa_disabled` parameter is only available to organization owners on GitHub.',
             resourceType: 'organization',
             resourceId: org.login,
             severity: 'medium',
-            remediation: `Reconnect the GitHub integration with an organization owner account. The integration will request the admin:org scope needed to check 2FA status.`,
+            remediation:
+              'Reconnect the GitHub integration with an account that is an owner of this organization.',
           });
           continue;
         }
@@ -108,33 +137,32 @@ export const twoFactorAuthCheck: IntegrationCheck = {
       }
 
       // Step 3: Also fetch total member count for context
-      let totalMembers: GitHubOrgMember[];
+      let totalCount: number | null = null;
       try {
-        totalMembers = await ctx.fetchAllPages<GitHubOrgMember>(
-          `/orgs/${org.login}/members`,
-        );
-      } catch {
+        const totalMembers = await ctx.fetchAllPages<GitHubOrgMember>(`/orgs/${orgSlug}/members`);
+        totalCount = totalMembers.length;
+      } catch (error) {
         // Non-critical: we can still report 2FA findings without total count
-        totalMembers = [];
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        ctx.warn(`Could not fetch total member count for ${org.login}: ${errorMsg}`);
       }
 
-      const totalCount = totalMembers.length;
       const without2FACount = membersWithout2FA.length;
 
       if (without2FACount === 0) {
         ctx.pass({
           title: `All members have 2FA enabled in ${org.login}`,
           description:
-            totalCount > 0
+            typeof totalCount === 'number' && totalCount > 0
               ? `All ${totalCount} members of the ${org.login} organization have two-factor authentication enabled.`
-              : `No members without 2FA found in the ${org.login} organization.`,
+              : `No members without 2FA were returned for ${org.login}.`,
           resourceType: 'organization',
           resourceId: org.login,
           evidence: {
             organization: org.login,
             totalMembers: totalCount,
             membersWithout2FA: 0,
-            checkedAt: new Date().toISOString(),
+            checkedAt,
           },
         });
       } else {
@@ -152,7 +180,7 @@ export const twoFactorAuthCheck: IntegrationCheck = {
               username: member.login,
               userId: member.id,
               profileUrl: member.html_url,
-              checkedAt: new Date().toISOString(),
+              checkedAt,
             },
           });
         }
@@ -160,7 +188,7 @@ export const twoFactorAuthCheck: IntegrationCheck = {
         // Also emit a summary
         ctx.fail({
           title: `${without2FACount} member(s) without 2FA in ${org.login}`,
-          description: `${without2FACount} out of ${totalCount || 'unknown'} members in the ${org.login} organization do not have two-factor authentication enabled: ${membersWithout2FA.map((m) => `@${m.login}`).join(', ')}`,
+          description: `${without2FACount} out of ${totalCount ?? 'unknown'} members in the ${org.login} organization do not have two-factor authentication enabled: ${formatUsernamesPreview(membersWithout2FA)}`,
           resourceType: 'organization',
           resourceId: `${org.login}/2fa-summary`,
           severity: 'high',
@@ -169,8 +197,11 @@ export const twoFactorAuthCheck: IntegrationCheck = {
             organization: org.login,
             totalMembers: totalCount,
             membersWithout2FA: without2FACount,
-            usernames: membersWithout2FA.map((m) => m.login),
-            checkedAt: new Date().toISOString(),
+            sampleUsernames: membersWithout2FA
+              .slice(0, MAX_USERNAMES_IN_EVIDENCE)
+              .map((member) => member.login),
+            usernamesTruncated: membersWithout2FA.length > MAX_USERNAMES_IN_EVIDENCE,
+            checkedAt,
           },
         });
       }

--- a/packages/integration-platform/src/manifests/github/checks/two-factor-auth.ts
+++ b/packages/integration-platform/src/manifests/github/checks/two-factor-auth.ts
@@ -21,20 +21,55 @@ interface GitHubOrgMember {
 const MAX_USERNAMES_IN_DESCRIPTION = 20;
 const MAX_USERNAMES_IN_EVIDENCE = 100;
 
-const isOwnerPermissionError = (errorMsg: string): boolean => {
+const getHttpStatus = (error: unknown): number | null => {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'status' in error &&
+    typeof (error as { status?: unknown }).status === 'number'
+  ) {
+    return (error as { status: number }).status;
+  }
+  return null;
+};
+
+const isOwnerPermissionError = (error: unknown, errorMsg: string): boolean => {
+  const status = getHttpStatus(error);
   const lower = errorMsg.toLowerCase();
 
-  if (lower.includes('403') || lower.includes('forbidden')) return true;
+  // GitHub documents 422 when 2fa_* filters are used in unsupported contexts.
+  if (status === 422) return true;
+
   if (lower.includes('must be an organization owner') || lower.includes('organization owners')) {
     return true;
   }
 
-  // GitHub documents 422 for this endpoint when filter constraints fail.
-  if (lower.includes('422') || lower.includes('unprocessable') || lower.includes('validation failed')) {
+  if (
+    lower.includes('422') ||
+    lower.includes('unprocessable') ||
+    lower.includes('validation failed')
+  ) {
     return true;
   }
 
   return false;
+};
+
+const isSamlSsoError = (errorMsg: string): boolean => {
+  const lower = errorMsg.toLowerCase();
+  return lower.includes('saml') || lower.includes('single sign-on') || lower.includes('sso');
+};
+
+const isRateLimitError = (error: unknown, errorMsg: string): boolean => {
+  const status = getHttpStatus(error);
+  const lower = errorMsg.toLowerCase();
+
+  return (
+    status === 429 ||
+    lower.includes('rate limit') ||
+    lower.includes('abuse detection') ||
+    (status === 403 && lower.includes('secondary rate limit'))
+  );
 };
 
 const formatUsernamesPreview = (members: GitHubOrgMember[]): string => {
@@ -106,8 +141,37 @@ export const twoFactorAuthCheck: IntegrationCheck = {
       } catch (error) {
         const errorMsg = error instanceof Error ? error.message : String(error);
 
+        if (isSamlSsoError(errorMsg)) {
+          ctx.warn(`Cannot check 2FA for ${org.login}: SSO authorization is required.`);
+          ctx.fail({
+            title: `Cannot verify 2FA for ${org.login}`,
+            description:
+              'GitHub organization SSO authorization is required to access organization members.',
+            resourceType: 'organization',
+            resourceId: org.login,
+            severity: 'medium',
+            remediation:
+              'Authorize this OAuth app for your organization SSO, then rerun the check.',
+          });
+          continue;
+        }
+
+        if (isRateLimitError(error, errorMsg)) {
+          ctx.warn(`Rate limit reached while checking 2FA for ${org.login}.`);
+          ctx.fail({
+            title: `Rate limited while checking ${org.login}`,
+            description:
+              'GitHub rate limits prevented completion of this 2FA check for the organization.',
+            resourceType: 'organization',
+            resourceId: org.login,
+            severity: 'low',
+            remediation: 'Wait for the GitHub rate limit to reset, then rerun the check.',
+          });
+          continue;
+        }
+
         // GitHub returns 422 when the caller is not an org owner for 2fa_* filters.
-        if (isOwnerPermissionError(errorMsg)) {
+        if (isOwnerPermissionError(error, errorMsg)) {
           ctx.warn(
             `Cannot check 2FA for ${org.login}: the account must be an organization owner to use the 2FA filter.`,
           );

--- a/packages/integration-platform/src/manifests/github/checks/two-factor-auth.ts
+++ b/packages/integration-platform/src/manifests/github/checks/two-factor-auth.ts
@@ -1,0 +1,179 @@
+/**
+ * Two-Factor Authentication Check
+ * Verifies that all organization members have 2FA enabled.
+ *
+ * Uses GET /orgs/{org}/members?filter=2fa_disabled to find members
+ * without 2FA. Requires the 'admin:org' OAuth scope.
+ *
+ * @see https://docs.github.com/en/rest/orgs/members#list-organization-members
+ */
+
+import { TASK_TEMPLATES } from '../../../task-mappings';
+import type { IntegrationCheck } from '../../../types';
+import type { GitHubOrg } from '../types';
+
+interface GitHubOrgMember {
+  login: string;
+  id: number;
+  avatar_url: string;
+  html_url: string;
+  type: string;
+  site_admin: boolean;
+}
+
+export const twoFactorAuthCheck: IntegrationCheck = {
+  id: 'two_factor_auth',
+  name: '2FA Enforcement',
+  description:
+    'Verify that all GitHub organization members have two-factor authentication enabled',
+  taskMapping: TASK_TEMPLATES.twoFactorAuth,
+  defaultSeverity: 'high',
+
+  variables: [],
+
+  run: async (ctx) => {
+    // Step 1: Get all orgs the authenticated user belongs to
+    let orgs: GitHubOrg[];
+    try {
+      orgs = await ctx.fetchAllPages<GitHubOrg>('/user/orgs');
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      ctx.error(`Failed to fetch organizations: ${errorMsg}`);
+      ctx.fail({
+        title: 'Cannot fetch GitHub organizations',
+        description: `Failed to list organizations: ${errorMsg}`,
+        resourceType: 'organization',
+        resourceId: 'github',
+        severity: 'medium',
+        remediation:
+          'Ensure the GitHub integration has the read:org scope. You may need to reconnect the integration.',
+      });
+      return;
+    }
+
+    if (orgs.length === 0) {
+      ctx.fail({
+        title: 'No GitHub organizations found',
+        description:
+          'The connected GitHub account is not a member of any organizations. 2FA enforcement is an organization-level setting.',
+        resourceType: 'organization',
+        resourceId: 'github',
+        severity: 'low',
+        remediation:
+          'Connect a GitHub account that belongs to at least one organization.',
+      });
+      return;
+    }
+
+    ctx.log(`Found ${orgs.length} organization(s). Checking 2FA status...`);
+
+    // Step 2: For each org, check for members without 2FA
+    for (const org of orgs) {
+      ctx.log(`Checking 2FA for organization: ${org.login}`);
+
+      let membersWithout2FA: GitHubOrgMember[];
+      try {
+        membersWithout2FA = await ctx.fetchAllPages<GitHubOrgMember>(
+          `/orgs/${org.login}/members?filter=2fa_disabled`,
+        );
+      } catch (error) {
+        const errorMsg = error instanceof Error ? error.message : String(error);
+
+        // 403 usually means the token lacks admin:org scope or user isn't an org owner
+        if (errorMsg.includes('403') || errorMsg.includes('Forbidden')) {
+          ctx.warn(
+            `Cannot check 2FA for ${org.login}: insufficient permissions. The admin:org scope and org owner/admin role are required.`,
+          );
+          ctx.fail({
+            title: `Cannot verify 2FA for ${org.login}`,
+            description: `Insufficient permissions to check 2FA status. The filter=2fa_disabled parameter requires the admin:org OAuth scope and the authenticated user must be an organization owner or admin.`,
+            resourceType: 'organization',
+            resourceId: org.login,
+            severity: 'medium',
+            remediation: `Reconnect the GitHub integration with an organization owner account. The integration will request the admin:org scope needed to check 2FA status.`,
+          });
+          continue;
+        }
+
+        ctx.error(`Failed to check 2FA for ${org.login}: ${errorMsg}`);
+        ctx.fail({
+          title: `Error checking 2FA for ${org.login}`,
+          description: `Failed to query members without 2FA: ${errorMsg}`,
+          resourceType: 'organization',
+          resourceId: org.login,
+          severity: 'medium',
+          remediation: 'Check the integration connection and try again.',
+        });
+        continue;
+      }
+
+      // Step 3: Also fetch total member count for context
+      let totalMembers: GitHubOrgMember[];
+      try {
+        totalMembers = await ctx.fetchAllPages<GitHubOrgMember>(
+          `/orgs/${org.login}/members`,
+        );
+      } catch {
+        // Non-critical: we can still report 2FA findings without total count
+        totalMembers = [];
+      }
+
+      const totalCount = totalMembers.length;
+      const without2FACount = membersWithout2FA.length;
+
+      if (without2FACount === 0) {
+        ctx.pass({
+          title: `All members have 2FA enabled in ${org.login}`,
+          description:
+            totalCount > 0
+              ? `All ${totalCount} members of the ${org.login} organization have two-factor authentication enabled.`
+              : `No members without 2FA found in the ${org.login} organization.`,
+          resourceType: 'organization',
+          resourceId: org.login,
+          evidence: {
+            organization: org.login,
+            totalMembers: totalCount,
+            membersWithout2FA: 0,
+            checkedAt: new Date().toISOString(),
+          },
+        });
+      } else {
+        // List each member without 2FA as a separate finding
+        for (const member of membersWithout2FA) {
+          ctx.fail({
+            title: `2FA not enabled: ${member.login}`,
+            description: `GitHub user @${member.login} in the ${org.login} organization does not have two-factor authentication enabled.`,
+            resourceType: 'user',
+            resourceId: `${org.login}/${member.login}`,
+            severity: 'high',
+            remediation: `Ask @${member.login} to enable 2FA in their GitHub account settings (Settings > Password and authentication > Two-factor authentication). Alternatively, enforce 2FA at the organization level in ${org.login}'s settings.`,
+            evidence: {
+              organization: org.login,
+              username: member.login,
+              userId: member.id,
+              profileUrl: member.html_url,
+              checkedAt: new Date().toISOString(),
+            },
+          });
+        }
+
+        // Also emit a summary
+        ctx.fail({
+          title: `${without2FACount} member(s) without 2FA in ${org.login}`,
+          description: `${without2FACount} out of ${totalCount || 'unknown'} members in the ${org.login} organization do not have two-factor authentication enabled: ${membersWithout2FA.map((m) => `@${m.login}`).join(', ')}`,
+          resourceType: 'organization',
+          resourceId: `${org.login}/2fa-summary`,
+          severity: 'high',
+          remediation: `1. Go to https://github.com/organizations/${org.login}/settings/security\n2. Under "Authentication security", check "Require two-factor authentication for everyone"\n3. This will require all existing and future members to enable 2FA`,
+          evidence: {
+            organization: org.login,
+            totalMembers: totalCount,
+            membersWithout2FA: without2FACount,
+            usernames: membersWithout2FA.map((m) => m.login),
+            checkedAt: new Date().toISOString(),
+          },
+        });
+      }
+    }
+  },
+};

--- a/packages/integration-platform/src/manifests/github/checks/two-factor-auth.ts
+++ b/packages/integration-platform/src/manifests/github/checks/two-factor-auth.ts
@@ -18,9 +18,6 @@ interface GitHubOrgMember {
   html_url: string;
 }
 
-const MAX_USERNAMES_IN_DESCRIPTION = 20;
-const MAX_USERNAMES_IN_EVIDENCE = 100;
-
 const getHttpStatus = (error: unknown): number | null => {
   if (
     typeof error === 'object' &&
@@ -72,15 +69,8 @@ const isRateLimitError = (error: unknown, errorMsg: string): boolean => {
   );
 };
 
-const formatUsernamesPreview = (members: GitHubOrgMember[]): string => {
-  const preview = members.slice(0, MAX_USERNAMES_IN_DESCRIPTION).map((member) => `@${member.login}`);
-  const remaining = members.length - preview.length;
-
-  if (remaining > 0) {
-    return `${preview.join(', ')} and ${remaining} more`;
-  }
-  return preview.join(', ');
-};
+const formatUsernames = (members: GitHubOrgMember[]): string =>
+  members.map((member) => `@${member.login}`).join(', ');
 
 export const twoFactorAuthCheck: IntegrationCheck = {
   id: 'two_factor_auth',
@@ -237,7 +227,7 @@ export const twoFactorAuthCheck: IntegrationCheck = {
         // Also emit a summary
         ctx.fail({
           title: `${without2FACount} member(s) without 2FA in ${org.login}`,
-          description: `${without2FACount} member(s) in the ${org.login} organization do not have two-factor authentication enabled: ${formatUsernamesPreview(membersWithout2FA)}`,
+          description: `${without2FACount} member(s) in the ${org.login} organization do not have two-factor authentication enabled: ${formatUsernames(membersWithout2FA)}`,
           resourceType: 'organization',
           resourceId: `${org.login}/2fa-summary`,
           severity: 'high',
@@ -245,10 +235,7 @@ export const twoFactorAuthCheck: IntegrationCheck = {
           evidence: {
             organization: org.login,
             membersWithout2FA: without2FACount,
-            sampleUsernames: membersWithout2FA
-              .slice(0, MAX_USERNAMES_IN_EVIDENCE)
-              .map((member) => member.login),
-            usernamesTruncated: membersWithout2FA.length > MAX_USERNAMES_IN_EVIDENCE,
+            usernames: membersWithout2FA.map((member) => member.login),
             checkedAt,
           },
         });

--- a/packages/integration-platform/src/manifests/github/checks/two-factor-auth.ts
+++ b/packages/integration-platform/src/manifests/github/checks/two-factor-auth.ts
@@ -136,31 +136,16 @@ export const twoFactorAuthCheck: IntegrationCheck = {
         continue;
       }
 
-      // Step 3: Also fetch total member count for context
-      let totalCount: number | null = null;
-      try {
-        const totalMembers = await ctx.fetchAllPages<GitHubOrgMember>(`/orgs/${orgSlug}/members`);
-        totalCount = totalMembers.length;
-      } catch (error) {
-        // Non-critical: we can still report 2FA findings without total count
-        const errorMsg = error instanceof Error ? error.message : String(error);
-        ctx.warn(`Could not fetch total member count for ${org.login}: ${errorMsg}`);
-      }
-
       const without2FACount = membersWithout2FA.length;
 
       if (without2FACount === 0) {
         ctx.pass({
           title: `All members have 2FA enabled in ${org.login}`,
-          description:
-            typeof totalCount === 'number' && totalCount > 0
-              ? `All ${totalCount} members of the ${org.login} organization have two-factor authentication enabled.`
-              : `No members without 2FA were returned for ${org.login}.`,
+          description: `No members without 2FA were returned for ${org.login}.`,
           resourceType: 'organization',
           resourceId: org.login,
           evidence: {
             organization: org.login,
-            totalMembers: totalCount,
             membersWithout2FA: 0,
             checkedAt,
           },
@@ -188,14 +173,13 @@ export const twoFactorAuthCheck: IntegrationCheck = {
         // Also emit a summary
         ctx.fail({
           title: `${without2FACount} member(s) without 2FA in ${org.login}`,
-          description: `${without2FACount} out of ${totalCount ?? 'unknown'} members in the ${org.login} organization do not have two-factor authentication enabled: ${formatUsernamesPreview(membersWithout2FA)}`,
+          description: `${without2FACount} member(s) in the ${org.login} organization do not have two-factor authentication enabled: ${formatUsernamesPreview(membersWithout2FA)}`,
           resourceType: 'organization',
           resourceId: `${org.login}/2fa-summary`,
           severity: 'high',
           remediation: `1. Go to https://github.com/organizations/${org.login}/settings/security\n2. Under "Authentication security", check "Require two-factor authentication for everyone"\n3. This will require all existing and future members to enable 2FA`,
           evidence: {
             organization: org.login,
-            totalMembers: totalCount,
             membersWithout2FA: without2FACount,
             sampleUsernames: membersWithout2FA
               .slice(0, MAX_USERNAMES_IN_EVIDENCE)

--- a/packages/integration-platform/src/manifests/github/index.ts
+++ b/packages/integration-platform/src/manifests/github/index.ts
@@ -32,7 +32,7 @@ export const manifest: IntegrationManifest = {
     config: {
       authorizeUrl: 'https://github.com/login/oauth/authorize',
       tokenUrl: 'https://github.com/login/oauth/access_token',
-      scopes: ['admin:org', 'repo', 'read:user'],
+      scopes: ['read:org', 'repo', 'read:user'],
       pkce: false,
       clientAuthMethod: 'body',
       revoke: {

--- a/packages/integration-platform/src/manifests/github/index.ts
+++ b/packages/integration-platform/src/manifests/github/index.ts
@@ -9,6 +9,7 @@ import type { IntegrationManifest } from '../../types';
 import { branchProtectionCheck } from './checks/branch-protection';
 import { dependabotCheck } from './checks/dependabot';
 import { sanitizedInputsCheck } from './checks/sanitized-inputs';
+import { twoFactorAuthCheck } from './checks/two-factor-auth';
 
 export const manifest: IntegrationManifest = {
   id: 'github',
@@ -31,7 +32,7 @@ export const manifest: IntegrationManifest = {
     config: {
       authorizeUrl: 'https://github.com/login/oauth/authorize',
       tokenUrl: 'https://github.com/login/oauth/access_token',
-      scopes: ['read:org', 'repo', 'read:user'],
+      scopes: ['admin:org', 'repo', 'read:user'],
       pkce: false,
       clientAuthMethod: 'body',
       revoke: {
@@ -81,7 +82,7 @@ export const manifest: IntegrationManifest = {
   ],
 
   // Compliance checks that run daily and can auto-complete tasks
-  checks: [branchProtectionCheck, dependabotCheck, sanitizedInputsCheck],
+  checks: [branchProtectionCheck, dependabotCheck, sanitizedInputsCheck, twoFactorAuthCheck],
 
   isActive: true,
 };


### PR DESCRIPTION
## What
Adds a new **2FA Enforcement** check to the GitHub integration that verifies all organization members have two-factor authentication enabled.

## How it works
1. Fetches all organizations the connected GitHub user belongs to
2. For each org, calls `GET /orgs/{org}/members?filter=2fa_disabled`
3. Emits a **PASS** per org if all members have 2FA
4. Emits a **FAIL** per member without 2FA + an org-level summary with remediation steps
5. Handles 403 gracefully (guides user to reconnect with proper scope)

## Changes
- New check: `packages/integration-platform/src/manifests/github/checks/two-factor-auth.ts`
- Updated `index.ts`: added check to manifest, upgraded OAuth scope `read:org` -> `admin:org`

## Scope change
The `admin:org` scope is required by GitHub to use the `filter=2fa_disabled` parameter. This is a superset of `read:org`, so existing functionality (branch protection, dependabot, sanitized inputs) continues to work. **Existing connections will need to be reconnected** to grant the new scope - the check handles the missing scope gracefully with a clear remediation message.

## Task mapping
Maps to `TASK_TEMPLATES.twoFactorAuth` (`frk_tt_68406cd9dde2d8cd4c463fe0`)