### PR TITLE
fix(api): use relative path for dynamic import of S3 presigner

### DIFF
--- a/apps/api/src/policies/policies.controller.ts
+++ b/apps/api/src/policies/policies.controller.ts
@@ -316,7 +316,7 @@ export class PoliciesController {
 
     // Generate signed URL
     const { S3Client, GetObjectCommand } = await import('@aws-sdk/client-s3');
-    const { getSignedUrl } = await import('@/app/s3');
+    const { getSignedUrl } = await import('../app/s3');
     const bucketName = process.env.APP_AWS_BUCKET_NAME;
 
     if (!bucketName) {
@@ -480,7 +480,7 @@ export class PoliciesController {
     if (!pdfUrl) return { url: null };
 
     const { S3Client, GetObjectCommand } = await import('@aws-sdk/client-s3');
-    const { getSignedUrl } = await import('@/app/s3');
+    const { getSignedUrl } = await import('../app/s3');
     const bucketName = process.env.APP_AWS_BUCKET_NAME;
     if (!bucketName) return { url: null };
 


### PR DESCRIPTION
## Summary
- Fixes API Docker/CodeBuild build failure (`TS2307: Cannot find module '@/app/s3'`)
- Dynamic `import()` doesn't resolve `@/` path aliases in `nest build` — changed to relative `../app/s3`
- Follow-up to #2520 which centralized the S3 presigner wrapper but missed this edge case

## Changes
- `apps/api/src/policies/policies.controller.ts` — 2 lines: `await import('@/app/s3')` → `await import('../app/s3')`

## Test plan
- [ ] Verify API Docker build passes (CodeBuild)

🤖 Generated with [Claude Code](https://claude.com/claude-code)