### PR TITLE
fix(app): clarify integration setup flow CTAs and guard empty forms

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/EmptyStateOnboarding.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/EmptyStateOnboarding.test.tsx
@@ -1,0 +1,124 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EmptyStateOnboarding } from './EmptyStateOnboarding';
+
+const mockCreateConnection = vi.fn();
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+
+vi.mock('@/hooks/use-integration-platform', () => ({
+  useIntegrationMutations: () => ({
+    createConnection: mockCreateConnection,
+  }),
+}));
+
+vi.mock('@/components/integrations/CloudShellSetup', () => ({
+  CloudShellSetup: () => <div data-testid="cloud-shell-setup" />,
+}));
+
+vi.mock('@/components/integrations/CredentialInput', () => ({
+  CredentialInput: ({ field, value, onChange }: any) => (
+    <input
+      aria-label={field.label}
+      value={Array.isArray(value) ? value.join(',') : (value ?? '')}
+      onChange={(event) => onChange(event.target.value)}
+    />
+  ),
+}));
+
+vi.mock('@trycompai/design-system', () => ({
+  Button: ({ children, disabled, loading, onClick }: any) => (
+    <button disabled={disabled || loading} onClick={onClick} type="button">
+      {children}
+    </button>
+  ),
+  Label: ({ children, htmlFor }: any) => <label htmlFor={htmlFor}>{children}</label>,
+}));
+
+vi.mock('lucide-react', () => ({
+  ArrowRight: () => <span data-testid="arrow-right-icon" />,
+  Shield: () => <span data-testid="shield-icon" />,
+}));
+
+vi.mock('@trycompai/integration-platform', () => ({
+  awsRemediationScript: '',
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+describe('EmptyStateOnboarding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('allows connecting dynamic custom integrations with no credential fields', async () => {
+    mockCreateConnection.mockResolvedValue({ success: true });
+    const onConnected = vi.fn();
+
+    render(
+      <EmptyStateOnboarding
+        provider={{
+          id: 'dynamic-security',
+          slug: 'dynamic-security',
+          name: 'Dynamic Security',
+          description: 'Dynamic integration',
+          category: 'Security',
+          logoUrl: '',
+          authType: 'custom',
+          capabilities: ['checks'],
+          isActive: true,
+          docsUrl: 'https://example.com/docs',
+        } as any}
+        orgId="org_1"
+        onConnected={onConnected}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /connect account/i }));
+
+    await waitFor(() => {
+      expect(mockCreateConnection).toHaveBeenCalledWith('dynamic-security', {});
+    });
+    expect(onConnected).toHaveBeenCalled();
+    expect(mockToastSuccess).toHaveBeenCalledWith('Dynamic Security connected!');
+  });
+
+  it('uses API key fallback field when credential fields are missing', async () => {
+    mockCreateConnection.mockResolvedValue({ success: true });
+
+    render(
+      <EmptyStateOnboarding
+        provider={{
+          id: 'dynamic-api',
+          slug: 'dynamic-api',
+          name: 'Dynamic API',
+          description: 'Dynamic API integration',
+          category: 'Security',
+          logoUrl: '',
+          authType: 'api_key',
+          capabilities: ['checks'],
+          isActive: true,
+        } as any}
+        orgId="org_1"
+        onConnected={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /connect account/i }));
+    expect(screen.getByText('API Key is required')).toBeInTheDocument();
+    expect(mockCreateConnection).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByLabelText('API Key'), { target: { value: 'secret' } });
+    fireEvent.click(screen.getByRole('button', { name: /connect account/i }));
+
+    await waitFor(() => {
+      expect(mockCreateConnection).toHaveBeenCalledWith('dynamic-api', { api_key: 'secret' });
+    });
+  });
+});
+

--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/EmptyStateOnboarding.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/EmptyStateOnboarding.tsx
@@ -346,11 +346,6 @@ function CredentialSetup({
   };
 
   const handleConnect = useCallback(async () => {
-    if (!hasConfigurableFields) {
-      toast.error('This integration setup is not configured yet.');
-      return;
-    }
-
     const newErrors: Record<string, string> = {};
     for (const field of fields) {
       const value = credentials[field.id];
@@ -381,7 +376,7 @@ function CredentialSetup({
     } finally {
       setConnecting(false);
     }
-  }, [fields, credentials, createConnection, hasConfigurableFields, provider, onConnected]);
+  }, [fields, credentials, createConnection, provider, onConnected]);
 
   return (
     <div className="py-6 space-y-6">
@@ -408,7 +403,7 @@ function CredentialSetup({
               ))
             ) : (
               <div className="rounded-lg border border-dashed border-muted-foreground/30 bg-muted/30 px-3 py-3 text-xs text-muted-foreground">
-                Setup fields are not configured for this integration yet.
+                No additional setup fields are required for this integration.
                 {provider.docsUrl ? (
                   <>
                     {' '}
@@ -427,8 +422,8 @@ function CredentialSetup({
             )}
           </div>
           <div className="border-t bg-muted/30 px-6 py-5 rounded-b-xl">
-            <Button onClick={handleConnect} disabled={connecting || !hasConfigurableFields} loading={connecting}>
-              {connecting ? 'Connecting...' : !hasConfigurableFields ? 'Setup unavailable' : (
+            <Button onClick={handleConnect} disabled={connecting} loading={connecting}>
+              {connecting ? 'Connecting...' : (
                 <>
                   Connect account
                   <ArrowRight className="ml-1.5 h-3.5 w-3.5" />

--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/EmptyStateOnboarding.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/EmptyStateOnboarding.tsx
@@ -296,7 +296,43 @@ function CredentialSetup({
   const [credentials, setCredentials] = useState<Record<string, string | string[]>>({});
   const [errors, setErrors] = useState<Record<string, string>>({});
 
-  const fields = provider.credentialFields ?? [];
+  const fields = useMemo(() => {
+    const configuredFields = provider.credentialFields ?? [];
+
+    if (provider.authType === 'basic' && configuredFields.length === 0) {
+      return [
+        {
+          id: 'username',
+          label: 'Username',
+          type: 'text' as const,
+          required: true,
+          placeholder: 'Enter username',
+        },
+        {
+          id: 'password',
+          label: 'Password',
+          type: 'password' as const,
+          required: true,
+          placeholder: 'Enter password',
+        },
+      ];
+    }
+
+    if (provider.authType === 'api_key' && configuredFields.length === 0) {
+      return [
+        {
+          id: 'api_key',
+          label: 'API Key',
+          type: 'password' as const,
+          required: true,
+          placeholder: 'Enter your API key',
+        },
+      ];
+    }
+
+    return configuredFields;
+  }, [provider.authType, provider.credentialFields]);
+  const hasConfigurableFields = fields.length > 0;
 
   const updateCredential = (fieldId: string, value: string | string[]) => {
     setCredentials((prev) => ({ ...prev, [fieldId]: value }));
@@ -310,6 +346,11 @@ function CredentialSetup({
   };
 
   const handleConnect = useCallback(async () => {
+    if (!hasConfigurableFields) {
+      toast.error('This integration setup is not configured yet.');
+      return;
+    }
+
     const newErrors: Record<string, string> = {};
     for (const field of fields) {
       const value = credentials[field.id];
@@ -340,7 +381,7 @@ function CredentialSetup({
     } finally {
       setConnecting(false);
     }
-  }, [fields, credentials, createConnection, provider, onConnected]);
+  }, [fields, credentials, createConnection, hasConfigurableFields, provider, onConnected]);
 
   return (
     <div className="py-6 space-y-6">
@@ -355,21 +396,41 @@ function CredentialSetup({
         {/* Main form */}
         <div className="rounded-xl border bg-background shadow-sm">
           <div className="p-6 space-y-4">
-            {fields.map((field) => (
-              <FieldRow
-                key={field.id}
-                field={field}
-                value={credentials[field.id] || (field.type === 'multi-select' ? [] : '')}
-                error={errors[field.id]}
-                onChange={(v) => updateCredential(field.id, v)}
-              />
-            ))}
+            {hasConfigurableFields ? (
+              fields.map((field) => (
+                <FieldRow
+                  key={field.id}
+                  field={field}
+                  value={credentials[field.id] || (field.type === 'multi-select' ? [] : '')}
+                  error={errors[field.id]}
+                  onChange={(v) => updateCredential(field.id, v)}
+                />
+              ))
+            ) : (
+              <div className="rounded-lg border border-dashed border-muted-foreground/30 bg-muted/30 px-3 py-3 text-xs text-muted-foreground">
+                Setup fields are not configured for this integration yet.
+                {provider.docsUrl ? (
+                  <>
+                    {' '}
+                    <a
+                      href={provider.docsUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="font-medium text-primary hover:underline"
+                    >
+                      Open docs
+                    </a>
+                    .
+                  </>
+                ) : null}
+              </div>
+            )}
           </div>
           <div className="border-t bg-muted/30 px-6 py-5 rounded-b-xl">
-            <Button onClick={handleConnect} disabled={connecting} loading={connecting}>
-              {connecting ? 'Connecting...' : (
+            <Button onClick={handleConnect} disabled={connecting || !hasConfigurableFields} loading={connecting}>
+              {connecting ? 'Connecting...' : !hasConfigurableFields ? 'Setup unavailable' : (
                 <>
-                  Connect
+                  Connect account
                   <ArrowRight className="ml-1.5 h-3.5 w-3.5" />
                 </>
               )}

--- a/apps/app/src/app/(app)/[orgId]/integrations/components/PlatformIntegrations.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/components/PlatformIntegrations.tsx
@@ -620,7 +620,7 @@ export function PlatformIntegrations({ className, taskTemplates }: PlatformInteg
                                 Connecting...
                               </>
                             ) : (
-                              'Connect'
+                              provider.authType === 'oauth2' ? 'Connect' : 'Set up'
                             )}
                           </Button>
                         ) : null}


### PR DESCRIPTION
Summary:
- rename disconnected non-OAuth CTA on integrations list from Connect to Set up
- keep OAuth CTA as Connect
- add safe credential-field fallback for basic and api_key integrations on detail page
- prevent empty credential screens from showing actionable connect by displaying Setup unavailable state with docs link

Why:
- list page Connect currently opens details for non-OAuth providers, which is confusing because actual connect happens inside details
- some dynamic integrations can have missing credential fields, resulting in a blank setup form with a misleading Connect button

Validation:
- bun run test -- src/components/integrations/ConnectIntegrationDialog.test.tsx --run
- bun run test -- src/app/(app)/[orgId]/integrations/[slug]/components/connection-display.test.ts --run
- bun run typecheck (fails with many pre-existing unrelated errors in this branch/worktree)
