### PR TITLE
fix(app): repair GCP reconnect flow from integration detail

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/ProviderDetailView.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/ProviderDetailView.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ConnectIntegrationDialog } from '@/components/integrations/ConnectIntegrationDialog';
 import {
   useConnectionServices,
   useIntegrationConnections,
@@ -35,10 +36,11 @@ interface ProviderDetailViewProps {
 
 export function ProviderDetailView({ provider, initialConnections }: ProviderDetailViewProps) {
   const { orgId } = useParams<{ orgId: string }>();
-  const { connections: allConnections } = useIntegrationConnections();
+  const { connections: allConnections, refresh: refreshConnections } = useIntegrationConnections();
   const { startOAuth } = useIntegrationMutations();
   const [showAddAccount, setShowAddAccount] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [reconnectDialogOpen, setReconnectDialogOpen] = useState(false);
 
   const connections = useMemo(() => {
     const live = allConnections.filter((c) => c.providerSlug === provider.id);
@@ -158,12 +160,15 @@ export function ProviderDetailView({ provider, initialConnections }: ProviderDet
   }, [isCloudProvider, isConnected, selectedConnection?.id, refreshServices]);
 
   const handleConnect = useCallback(async () => {
-    if (provider.authType === 'oauth2' && provider.oauthConfigured) {
+    if (provider.authType === 'oauth2') {
       const redirectUrl = `${window.location.origin}/${orgId}/integrations/${provider.id}?success=true`;
       const result = await startOAuth(provider.id, redirectUrl);
       if (result?.authorizationUrl) {
         window.location.href = result.authorizationUrl;
+      } else {
+        toast.error(result.error || 'Failed to start connection');
       }
+      return;
     } else {
       // For non-OAuth, show the inline add-account form
       setShowAddAccount(true);
@@ -202,7 +207,7 @@ export function ProviderDetailView({ provider, initialConnections }: ProviderDet
                 This connection was created before {CLOUD_RECONNECT_CUTOFF_LABEL}. Reconnect it to keep scans and remediation fully reliable.
               </p>
             </div>
-            <Button size="sm" variant="outline" onClick={() => void handleConnect()}>
+            <Button size="sm" variant="outline" onClick={() => setReconnectDialogOpen(true)}>
               Reconnect
             </Button>
           </div>
@@ -274,6 +279,22 @@ export function ProviderDetailView({ provider, initialConnections }: ProviderDet
           orgId={orgId}
           onConnected={() => setShowAddAccount(false)}
           onOAuthConnect={handleConnect}
+        />
+      )}
+
+      {selectedConnectionRequiresReconnect && (
+        <ConnectIntegrationDialog
+          open={reconnectDialogOpen}
+          onOpenChange={setReconnectDialogOpen}
+          integrationId={provider.id}
+          integrationName={provider.name}
+          integrationLogoUrl={provider.logoUrl}
+          initialView="list"
+          onConnected={() => {
+            setReconnectDialogOpen(false);
+            setShowAddAccount(false);
+            refreshConnections();
+          }}
         />
       )}
     </>


### PR DESCRIPTION
## Summary
- fix integrations detail reconnect path for OAuth providers where oauthConfigured is absent in provider detail payload
- make reconnect CTA open Manage Connections dialog (same flow as Cloud Tests) so users can delete and re-add cleanly
- add toast on OAuth start failures instead of silent no-op

## User impact fixed
- clicking reconnect from integration detail no longer shows a dead-end Connect card
- reconnect now follows the working delete/re-add flow and can clear reconnect warning after re-adding

## Verification
- bun run test -- 'src/components/integrations/ConnectIntegrationDialog.test.tsx' 'src/app/(app)/[orgId]/integrations/[slug]/components/EmptyStateOnboarding.test.tsx' 'src/app/(app)/[orgId]/cloud-tests/components/TestsLayout.test.tsx' 'src/lib/cloud-reconnect-policy.test.ts' --run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the GCP/OAuth reconnect flow from the integration detail page by sending users to the Manage Connections dialog instead of the dead-end Connect card. Also handles OAuth start when `oauthConfigured` is missing and shows a toast on failure.

- **Bug Fixes**
  - Always start OAuth for `oauth2` providers; show an error toast if it fails.
  - “Reconnect” now opens `ConnectIntegrationDialog` for delete-and-readd flow.
  - Refresh connections after a successful reconnect.

<sup>Written for commit fd9e041ef53523797e8cb376634665d8698c6c56. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

