### PR TITLE
chore(release): cherry-pick PCI DSS Level 1 framework badge support

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/frameworks/components/FrameworksTable.tsx
+++ b/apps/app/src/app/(app)/[orgId]/frameworks/components/FrameworksTable.tsx
@@ -41,6 +41,18 @@ const FRAMEWORK_BADGES: Record<string, string> = {
   'ISO 9001': '/badges/iso9001.svg',
 };
 
+function getFrameworkBadge(name: string): string | null {
+  const directMatch = FRAMEWORK_BADGES[name];
+  if (directMatch) return directMatch;
+
+  const normalizedName = name.trim().toLowerCase();
+  if (normalizedName.includes('pci dss')) {
+    return '/badges/pci-dss.svg';
+  }
+
+  return null;
+}
+
 function getFrameworkStatus(complianceScore: number): {
   label: string;
   variant: 'default' | 'secondary' | 'destructive';
@@ -197,7 +209,7 @@ export function FrameworksTable({
               const score = complianceMap[fw.id] ?? 0;
               const roundedScore = Math.round(score);
               const status = getFrameworkStatus(score);
-              const badgeSrc = FRAMEWORK_BADGES[fw.framework.name] ?? null;
+              const badgeSrc = getFrameworkBadge(fw.framework.name);
 
               return (
                 <TableRow

--- a/apps/app/src/app/(app)/[orgId]/frameworks/components/FrameworksTable.tsx
+++ b/apps/app/src/app/(app)/[orgId]/frameworks/components/FrameworksTable.tsx
@@ -36,6 +36,7 @@ const FRAMEWORK_BADGES: Record<string, string> = {
   'HIPAA': '/badges/hipaa.svg',
   'GDPR': '/badges/gdpr.svg',
   'PCI DSS': '/badges/pci-dss.svg',
+  'PCI DSS Level 1': '/badges/pci-dss.svg',
   'NEN 7510': '/badges/nen7510.svg',
   'ISO 9001': '/badges/iso9001.svg',
 };

--- a/apps/app/src/app/(app)/[orgId]/overview/components/FrameworksOverview.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/overview/components/FrameworksOverview.test.tsx
@@ -95,4 +95,29 @@ describe('FrameworksOverview permission gating', () => {
     const badge = screen.getByAltText('PCI DSS Level 1');
     expect(badge).toHaveAttribute('src', '/badges/pci-dss.svg');
   });
+
+  it('renders PCI DSS badge for PCI DSS framework name variants', () => {
+    setMockPermissions({});
+
+    render(
+      <FrameworksOverview
+        {...baseProps}
+        overallComplianceScore={0}
+        frameworksWithControls={[
+          {
+            id: 'fi_pci_variant',
+            controls: [],
+            framework: {
+              id: 'fw_pci_variant',
+              name: 'PCI DSS v4.0 Level 1',
+              description: 'PCI DSS framework variant',
+            },
+          } as any,
+        ]}
+      />,
+    );
+
+    const badge = screen.getByAltText('PCI DSS v4.0 Level 1');
+    expect(badge).toHaveAttribute('src', '/badges/pci-dss.svg');
+  });
 });

--- a/apps/app/src/app/(app)/[orgId]/overview/components/FrameworksOverview.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/overview/components/FrameworksOverview.test.tsx
@@ -28,6 +28,10 @@ vi.mock('@trycompai/ui/scroll-area', () => ({
   ),
 }));
 
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ orgId: 'org_123' }),
+}));
+
 vi.mock('next/image', () => ({
   default: (props: Record<string, unknown>) => (
     // eslint-disable-next-line @next/next/no-img-element
@@ -65,5 +69,30 @@ describe('FrameworksOverview permission gating', () => {
     setMockPermissions({});
     render(<FrameworksOverview {...baseProps} />);
     expect(screen.queryByRole('button', { name: /add framework/i })).not.toBeInTheDocument();
+  });
+
+  it('renders PCI DSS badge for PCI DSS Level 1 framework instances', () => {
+    setMockPermissions({});
+
+    render(
+      <FrameworksOverview
+        {...baseProps}
+        overallComplianceScore={0}
+        frameworksWithControls={[
+          {
+            id: 'fi_pci_level_1',
+            controls: [],
+            framework: {
+              id: 'fw_pci_level_1',
+              name: 'PCI DSS Level 1',
+              description: 'Payment Card Industry Data Security Standard Level 1',
+            },
+          } as any,
+        ]}
+      />,
+    );
+
+    const badge = screen.getByAltText('PCI DSS Level 1');
+    expect(badge).toHaveAttribute('src', '/badges/pci-dss.svg');
   });
 });

--- a/apps/app/src/app/(app)/[orgId]/overview/components/FrameworksOverview.tsx
+++ b/apps/app/src/app/(app)/[orgId]/overview/components/FrameworksOverview.tsx
@@ -24,38 +24,38 @@ export interface FrameworksOverviewProps {
 }
 
 export function mapFrameworkToBadge(framework: FrameworkInstanceWithControls) {
-  if (framework.framework.name === 'SOC 2') {
+  const frameworkName = framework.framework.name.trim();
+  const normalizedName = frameworkName.toLowerCase();
+
+  if (frameworkName === 'SOC 2') {
     return '/badges/soc2.svg';
   }
 
-  if (framework.framework.name === 'ISO 27001') {
+  if (frameworkName === 'ISO 27001') {
     return '/badges/iso27001.svg';
   }
 
-  if (framework.framework.name === 'ISO 42001') {
+  if (frameworkName === 'ISO 42001') {
     return '/badges/iso42001.svg';
   }
 
-  if (framework.framework.name === 'HIPAA') {
+  if (frameworkName === 'HIPAA') {
     return '/badges/hipaa.svg';
   }
 
-  if (framework.framework.name === 'GDPR') {
+  if (frameworkName === 'GDPR') {
     return '/badges/gdpr.svg';
   }
 
-  if (
-    framework.framework.name === 'PCI DSS' ||
-    framework.framework.name === 'PCI DSS Level 1'
-  ) {
+  if (normalizedName.includes('pci dss')) {
     return '/badges/pci-dss.svg';
   }
 
-  if (framework.framework.name === 'NEN 7510') {
+  if (frameworkName === 'NEN 7510') {
     return '/badges/nen7510.svg';
   }
 
-  if (framework.framework.name === 'ISO 9001') {
+  if (frameworkName === 'ISO 9001') {
     return '/badges/iso9001.svg';
   }
 

--- a/apps/app/src/app/(app)/[orgId]/overview/components/FrameworksOverview.tsx
+++ b/apps/app/src/app/(app)/[orgId]/overview/components/FrameworksOverview.tsx
@@ -44,7 +44,10 @@ export function mapFrameworkToBadge(framework: FrameworkInstanceWithControls) {
     return '/badges/gdpr.svg';
   }
 
-  if (framework.framework.name === 'PCI DSS') {
+  if (
+    framework.framework.name === 'PCI DSS' ||
+    framework.framework.name === 'PCI DSS Level 1'
+  ) {
     return '/badges/pci-dss.svg';
   }
 


### PR DESCRIPTION
## Summary
- cherry-pick PR #2529 changes onto release
- includes PCI DSS Level 1 badge mapping and name variant support

## Cherry-picked commits
- 4f1c2d0615c3714fbd7712ddebd734a9ee68f980
- d30fdae069f09ff21dce1f81de7bc70bc22b871e

## Notes
- Could not run the overview test in this worktree because vitest is not available in PATH.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds PCI DSS Level 1 badge support and name variant matching so PCI frameworks consistently show the PCI badge in Frameworks Overview and Frameworks Table.

- **Bug Fixes**
  - Map "PCI DSS Level 1" and any name containing "PCI DSS" to `/badges/pci-dss.svg`.
  - Use normalized badge lookup via `getFrameworkBadge` in `FrameworksTable.tsx`.
  - Add tests covering Level 1 and variant names in `FrameworksOverview`.

<sup>Written for commit 24fe953974779f7a985a69aa731df094754dea4a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

