### PR TITLE
fix(cloud): clear reconnect warning after successful OAuth reconnect

### DIFF
--- a/apps/api/src/cloud-security/cloud-security-query.service.ts
+++ b/apps/api/src/cloud-security/cloud-security-query.service.ts
@@ -17,6 +17,7 @@ export interface CloudProvider {
   status: string;
   createdAt: Date;
   updatedAt: Date;
+  reconnectedAt?: Date;
   isLegacy: boolean;
   variables: Record<string, unknown> | null;
   requiredVariables: string[];
@@ -96,6 +97,12 @@ export class CloudSecurityQueryService {
     const newProviders: CloudProvider[] = newConnections.map((conn) => {
       const metadata = (conn.metadata || {}) as Record<string, unknown>;
       const manifest = getManifest(conn.provider.slug);
+      const reconnectMarker = metadata.reconnectedAt;
+      const reconnectedAt =
+        typeof reconnectMarker === 'string' &&
+        !Number.isNaN(new Date(reconnectMarker).getTime())
+          ? new Date(reconnectMarker)
+          : undefined;
       return {
         id: conn.id,
         integrationId: conn.provider.slug,
@@ -109,6 +116,7 @@ export class CloudSecurityQueryService {
         status: conn.status,
         createdAt: conn.createdAt,
         updatedAt: conn.updatedAt,
+        reconnectedAt,
         isLegacy: false,
         variables: (conn.variables as Record<string, unknown>) ?? null,
         requiredVariables: getRequiredVariables(conn.provider.slug),

--- a/apps/api/src/integration-platform/controllers/oauth.controller.ts
+++ b/apps/api/src/integration-platform/controllers/oauth.controller.ts
@@ -315,6 +315,23 @@ export class OAuthController {
 
       // Store tokens and mark connection as active
       await this.credentialVaultService.storeOAuthTokens(connection.id, tokens);
+
+      // Mark cloud OAuth reconnect completion so reconnect banners clear after successful OAuth.
+      if (manifest.category === 'Cloud') {
+        const metadata =
+          connection.metadata &&
+          typeof connection.metadata === 'object' &&
+          !Array.isArray(connection.metadata)
+            ? (connection.metadata as Record<string, unknown>)
+            : {};
+        connection = await this.connectionRepository.update(connection.id, {
+          metadata: {
+            ...metadata,
+            reconnectedAt: new Date().toISOString(),
+          },
+        });
+      }
+
       await this.connectionService.activateConnection(connection.id);
 
       // Provider-specific post-OAuth actions

--- a/apps/app/src/app/(app)/[orgId]/cloud-tests/components/TestsLayout.tsx
+++ b/apps/app/src/app/(app)/[orgId]/cloud-tests/components/TestsLayout.tsx
@@ -108,6 +108,7 @@ export function TestsLayout({ initialFindings, initialProviders, orgId }: TestsL
         requiresCloudReconnect({
           providerId: provider.integrationId,
           createdAt: provider.createdAt,
+          reconnectedAt: provider.reconnectedAt,
           isLegacy: provider.isLegacy,
           status: provider.status,
         }),
@@ -331,6 +332,7 @@ export function TestsLayout({ initialFindings, initialProviders, orgId }: TestsL
           requiresCloudReconnect({
             providerId: provider.integrationId,
             createdAt: provider.createdAt,
+            reconnectedAt: provider.reconnectedAt,
             isLegacy: provider.isLegacy,
             status: provider.status,
           })

--- a/apps/app/src/app/(app)/[orgId]/cloud-tests/types.ts
+++ b/apps/app/src/app/(app)/[orgId]/cloud-tests/types.ts
@@ -23,6 +23,7 @@ export interface Provider {
   status: string;
   createdAt: Date;
   updatedAt: Date;
+  reconnectedAt?: Date | string | null;
   isLegacy?: boolean;
   variables?: Record<string, unknown> | null;
   requiredVariables?: string[];

--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/ProviderDetailView.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/ProviderDetailView.tsx
@@ -71,9 +71,12 @@ export function ProviderDetailView({ provider, initialConnections }: ProviderDet
   const isCloudProvider = provider.category === 'Cloud';
   const selectedConnectionRequiresReconnect = useMemo(() => {
     if (!isCloudProvider || !selectedConnection) return false;
+    const metadata = (selectedConnection.metadata || {}) as Record<string, unknown>;
     return requiresCloudReconnect({
       providerId: provider.id,
       createdAt: selectedConnection.createdAt,
+      reconnectedAt:
+        typeof metadata.reconnectedAt === 'string' ? metadata.reconnectedAt : null,
       status: selectedConnection.status,
     });
   }, [isCloudProvider, provider.id, selectedConnection]);

--- a/apps/app/src/lib/cloud-reconnect-policy.test.ts
+++ b/apps/app/src/lib/cloud-reconnect-policy.test.ts
@@ -74,4 +74,26 @@ describe('requiresCloudReconnect', () => {
       }),
     ).toBe(true);
   });
+
+  it('returns false when connection was reconnected after cutoff', () => {
+    expect(
+      requiresCloudReconnect({
+        providerId: 'gcp',
+        createdAt: '2026-04-12T12:00:00.000Z',
+        reconnectedAt: '2026-04-13T20:00:00.000Z',
+        status: 'active',
+      }),
+    ).toBe(false);
+  });
+
+  it('returns true when reconnect marker is before cutoff', () => {
+    expect(
+      requiresCloudReconnect({
+        providerId: 'azure',
+        createdAt: '2026-04-10T12:00:00.000Z',
+        reconnectedAt: '2026-04-13T17:00:00.000Z',
+        status: 'active',
+      }),
+    ).toBe(true);
+  });
 });

--- a/apps/app/src/lib/cloud-reconnect-policy.ts
+++ b/apps/app/src/lib/cloud-reconnect-policy.ts
@@ -12,6 +12,7 @@ const CLOUD_RECONNECT_CUTOFF_MS = new Date(CLOUD_RECONNECT_CUTOFF_ISO_UTC).getTi
 type ReconnectCandidate = {
   providerId: string;
   createdAt?: Date | string | null;
+  reconnectedAt?: Date | string | null;
   isLegacy?: boolean;
   status?: string | null;
 };
@@ -25,6 +26,13 @@ export function requiresCloudReconnect(candidate: ReconnectCandidate): boolean {
 
   // Legacy cloud connections come from the old integration table and should be re-added.
   if (candidate.isLegacy) return true;
+
+  if (candidate.reconnectedAt) {
+    const reconnectedAt = new Date(candidate.reconnectedAt);
+    if (!Number.isNaN(reconnectedAt.getTime())) {
+      return reconnectedAt.getTime() < CLOUD_RECONNECT_CUTOFF_MS;
+    }
+  }
 
   if (!candidate.createdAt) return false;
 


### PR DESCRIPTION
Summary:\n- store reconnect timestamp after successful cloud OAuth reconnect\n- use reconnect timestamp in cloud reconnect policy so warning clears correctly\n- pass reconnect timestamp through cloud providers and integration detail reconnect checks\n- add reconnect policy tests for reconnect marker behavior\n\nValidation:\n- apps/app vitest cloud reconnect policy and tests layout\n- apps/api bun run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cloud OAuth reconnect banners not clearing. We now record a reconnect timestamp and use it in the reconnect policy and UI so the warning disappears after a successful reconnect.

- **Bug Fixes**
  - On cloud OAuth success, save `reconnectedAt` in connection metadata in `apps/api` `OAuthController`.
  - Expose `reconnectedAt` from the API and into the app (`CloudSecurityQueryService`, app provider types).
  - Update `requiresCloudReconnect` to consider `reconnectedAt` against the cutoff; add unit tests.
  - Pass `reconnectedAt` into UI checks in cloud tests and provider detail views to clear the banner.

<sup>Written for commit 4faab4001988e4934fec98cca1f5c7427ae07b09. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

