### PR TITLE
CS-222: Preserve custom favicon through trust access token flows

### DIFF
--- a/apps/api/src/trust-portal/trust-access.service.spec.ts
+++ b/apps/api/src/trust-portal/trust-access.service.spec.ts
@@ -1,0 +1,177 @@
+import { GetObjectCommand } from '@aws-sdk/client-s3';
+import { db } from '@db';
+import { getSignedUrl } from '../app/s3';
+import { TrustAccessService } from './trust-access.service';
+
+jest.mock('@db', () => ({
+  db: {
+    trust: {
+      findUnique: jest.fn(),
+      findFirst: jest.fn(),
+      upsert: jest.fn(),
+    },
+    trustNDAAgreement: {
+      findUnique: jest.fn(),
+    },
+    trustAccessGrant: {
+      findUnique: jest.fn(),
+    },
+  },
+  Prisma: {
+    PrismaClientKnownRequestError: class PrismaClientKnownRequestError extends Error {
+      code: string;
+
+      constructor(code: string) {
+        super();
+        this.code = code;
+      }
+    },
+  },
+  TrustFramework: {
+    iso_27001: 'iso_27001',
+    iso_42001: 'iso_42001',
+    gdpr: 'gdpr',
+    hipaa: 'hipaa',
+    soc2_type1: 'soc2_type1',
+    soc2_type2: 'soc2_type2',
+    pci_dss: 'pci_dss',
+    nen_7510: 'nen_7510',
+    iso_9001: 'iso_9001',
+  },
+}));
+
+jest.mock('../app/s3', () => ({
+  APP_AWS_ORG_ASSETS_BUCKET: 'org-assets',
+  s3Client: { send: jest.fn() },
+  getSignedUrl: jest.fn(),
+}));
+
+const mockDb = db as unknown as {
+  trust: {
+    findUnique: jest.Mock;
+    findFirst: jest.Mock;
+    upsert: jest.Mock;
+  };
+  trustNDAAgreement: {
+    findUnique: jest.Mock;
+  };
+  trustAccessGrant: {
+    findUnique: jest.Mock;
+  };
+};
+
+const mockGetSignedUrl = getSignedUrl as jest.MockedFunction<
+  typeof getSignedUrl
+>;
+
+describe('TrustAccessService favicon branding', () => {
+  const service = new TrustAccessService(
+    {
+      getSignedUrl: jest.fn(),
+    } as any,
+    {} as any,
+    {} as any,
+    {} as any,
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('falls back to organizationId lookup when getPublicFavicon route id is not a friendlyUrl', async () => {
+    mockDb.trust.findUnique.mockResolvedValue(null);
+    mockDb.trust.findFirst.mockResolvedValue({
+      favicon: 'org_123/trust/favicon/icon.png',
+    });
+    mockGetSignedUrl.mockResolvedValue('https://cdn.example.com/favicon.png');
+
+    const result = await service.getPublicFavicon('org_123');
+
+    expect(mockDb.trust.findUnique).toHaveBeenCalledWith({
+      where: { friendlyUrl: 'org_123' },
+      select: { favicon: true },
+    });
+    expect(mockDb.trust.findFirst).toHaveBeenCalledWith({
+      where: { organizationId: 'org_123' },
+      select: { favicon: true },
+    });
+    expect(result).toBe('https://cdn.example.com/favicon.png');
+    expect(mockGetSignedUrl).toHaveBeenCalledTimes(1);
+    expect(mockGetSignedUrl.mock.calls[0][1]).toBeInstanceOf(GetObjectCommand);
+  });
+
+  it('includes friendlyUrl and faviconUrl in getGrantByAccessToken response', async () => {
+    const futureDate = new Date(Date.now() + 60 * 60 * 1000);
+
+    mockDb.trustAccessGrant.findUnique.mockResolvedValue({
+      id: 'grant_1',
+      status: 'active',
+      expiresAt: futureDate,
+      accessTokenExpiresAt: futureDate,
+      subjectEmail: 'alice@example.com',
+      accessRequest: {
+        organizationId: 'org_123',
+        name: 'Alice',
+        organization: {
+          name: 'Acme Security',
+        },
+      },
+      ndaAgreement: null,
+    });
+    mockDb.trust.findUnique.mockResolvedValue({
+      friendlyUrl: 'acme-security',
+      favicon: 'org_123/trust/favicon/icon.png',
+    });
+    mockGetSignedUrl.mockResolvedValue('https://cdn.example.com/favicon.png');
+
+    const result = await service.getGrantByAccessToken('grant-token');
+
+    expect(result).toMatchObject({
+      organizationName: 'Acme Security',
+      friendlyUrl: 'acme-security',
+      faviconUrl: 'https://cdn.example.com/favicon.png',
+      subjectEmail: 'alice@example.com',
+    });
+  });
+
+  it('includes friendlyUrl and faviconUrl in getNdaByToken response', async () => {
+    const futureDate = new Date(Date.now() + 60 * 60 * 1000);
+
+    mockDb.trustNDAAgreement.findUnique.mockResolvedValue({
+      id: 'nda_1',
+      organizationId: 'org_123',
+      signTokenExpiresAt: futureDate,
+      status: 'pending',
+      accessRequest: {
+        name: 'Alice',
+        email: 'alice@example.com',
+        organization: {
+          name: 'Acme Security',
+        },
+      },
+      grant: null,
+    });
+    mockDb.trust.findUnique
+      .mockResolvedValueOnce({
+        domain: null,
+        domainVerified: false,
+        friendlyUrl: 'acme-security',
+      })
+      .mockResolvedValueOnce({
+        friendlyUrl: 'acme-security',
+        favicon: 'org_123/trust/favicon/icon.png',
+      });
+    mockGetSignedUrl.mockResolvedValue('https://cdn.example.com/favicon.png');
+
+    const result = await service.getNdaByToken('nda-token');
+
+    expect(result).toMatchObject({
+      id: 'nda_1',
+      status: 'pending',
+      organizationName: 'Acme Security',
+      friendlyUrl: 'acme-security',
+      faviconUrl: 'https://cdn.example.com/favicon.png',
+    });
+    expect(result.portalUrl).toContain('/acme-security');
+  });
+});

--- a/apps/api/src/trust-portal/trust-access.service.spec.ts
+++ b/apps/api/src/trust-portal/trust-access.service.spec.ts
@@ -7,7 +7,6 @@ jest.mock('@db', () => ({
   db: {
     trust: {
       findUnique: jest.fn(),
-      findFirst: jest.fn(),
       upsert: jest.fn(),
     },
     trustNDAAgreement: {
@@ -49,7 +48,6 @@ jest.mock('../app/s3', () => ({
 const mockDb = db as unknown as {
   trust: {
     findUnique: jest.Mock;
-    findFirst: jest.Mock;
     upsert: jest.Mock;
   };
   trustNDAAgreement: {
@@ -79,19 +77,18 @@ describe('TrustAccessService favicon branding', () => {
   });
 
   it('falls back to organizationId lookup when getPublicFavicon route id is not a friendlyUrl', async () => {
-    mockDb.trust.findUnique.mockResolvedValue(null);
-    mockDb.trust.findFirst.mockResolvedValue({
+    mockDb.trust.findUnique.mockResolvedValueOnce(null).mockResolvedValueOnce({
       favicon: 'org_123/trust/favicon/icon.png',
     });
     mockGetSignedUrl.mockResolvedValue('https://cdn.example.com/favicon.png');
 
     const result = await service.getPublicFavicon('org_123');
 
-    expect(mockDb.trust.findUnique).toHaveBeenCalledWith({
+    expect(mockDb.trust.findUnique).toHaveBeenNthCalledWith(1, {
       where: { friendlyUrl: 'org_123' },
       select: { favicon: true },
     });
-    expect(mockDb.trust.findFirst).toHaveBeenCalledWith({
+    expect(mockDb.trust.findUnique).toHaveBeenNthCalledWith(2, {
       where: { organizationId: 'org_123' },
       select: { favicon: true },
     });

--- a/apps/api/src/trust-portal/trust-access.service.ts
+++ b/apps/api/src/trust-portal/trust-access.service.ts
@@ -986,10 +986,15 @@ export class TrustAccessService {
       organizationId: nda.organizationId,
       organizationName: nda.accessRequest.organization.name,
     });
+    const branding = await this.getTrustBrandingByOrganizationId(
+      nda.organizationId,
+    );
 
     const baseResponse = {
       id: nda.id,
       organizationName: nda.accessRequest.organization.name,
+      friendlyUrl: branding.friendlyUrl,
+      faviconUrl: branding.faviconUrl,
       requesterName: nda.accessRequest.name,
       requesterEmail: nda.accessRequest.email,
       expiresAt: nda.signTokenExpiresAt,
@@ -1434,13 +1439,46 @@ export class TrustAccessService {
     const ndaPdfUrl = grant.ndaAgreement?.pdfSignedKey
       ? await this.ndaPdfService.getSignedUrl(grant.ndaAgreement.pdfSignedKey)
       : null;
+    const branding = await this.getTrustBrandingByOrganizationId(
+      grant.accessRequest.organizationId,
+    );
 
     return {
       organizationName: grant.accessRequest.organization.name,
+      friendlyUrl: branding.friendlyUrl,
+      faviconUrl: branding.faviconUrl,
       expiresAt: grant.expiresAt,
       subjectEmail: grant.subjectEmail,
       ndaPdfUrl,
     };
+  }
+
+  private async getTrustBrandingByOrganizationId(
+    organizationId: string,
+  ): Promise<{ friendlyUrl: string; faviconUrl: string | null }> {
+    const trust = await db.trust.findUnique({
+      where: { organizationId },
+      select: { friendlyUrl: true, favicon: true },
+    });
+
+    const friendlyUrl = trust?.friendlyUrl ?? organizationId;
+
+    if (!trust?.favicon || !s3Client || !APP_AWS_ORG_ASSETS_BUCKET) {
+      return { friendlyUrl, faviconUrl: null };
+    }
+
+    try {
+      const command = new GetObjectCommand({
+        Bucket: APP_AWS_ORG_ASSETS_BUCKET,
+        Key: trust.favicon,
+      });
+      const faviconUrl = await getSignedUrl(s3Client, command, {
+        expiresIn: 86400,
+      });
+      return { friendlyUrl, faviconUrl };
+    } catch {
+      return { friendlyUrl, faviconUrl: null };
+    }
   }
 
   async validateAccessTokenAndGetOrganizationId(
@@ -2428,10 +2466,17 @@ export class TrustAccessService {
   }
 
   async getPublicFavicon(friendlyUrl: string): Promise<string | null> {
-    const trust = await db.trust.findUnique({
+    let trust = await db.trust.findUnique({
       where: { friendlyUrl },
       select: { favicon: true },
     });
+
+    if (!trust) {
+      trust = await db.trust.findFirst({
+        where: { organizationId: friendlyUrl },
+        select: { favicon: true },
+      });
+    }
 
     if (!trust?.favicon || !s3Client || !APP_AWS_ORG_ASSETS_BUCKET) {
       return null;

--- a/apps/api/src/trust-portal/trust-access.service.ts
+++ b/apps/api/src/trust-portal/trust-access.service.ts
@@ -1462,22 +1462,28 @@ export class TrustAccessService {
     });
 
     const friendlyUrl = trust?.friendlyUrl ?? organizationId;
+    const faviconUrl = trust?.favicon
+      ? await this.getFaviconSignedUrl(trust.favicon)
+      : null;
 
-    if (!trust?.favicon || !s3Client || !APP_AWS_ORG_ASSETS_BUCKET) {
-      return { friendlyUrl, faviconUrl: null };
+    return { friendlyUrl, faviconUrl };
+  }
+
+  private async getFaviconSignedUrl(
+    faviconKey: string,
+  ): Promise<string | null> {
+    if (!s3Client || !APP_AWS_ORG_ASSETS_BUCKET) {
+      return null;
     }
 
     try {
       const command = new GetObjectCommand({
         Bucket: APP_AWS_ORG_ASSETS_BUCKET,
-        Key: trust.favicon,
+        Key: faviconKey,
       });
-      const faviconUrl = await getSignedUrl(s3Client, command, {
-        expiresIn: 86400,
-      });
-      return { friendlyUrl, faviconUrl };
+      return await getSignedUrl(s3Client, command, { expiresIn: 86400 }); // 24 hours
     } catch {
-      return { friendlyUrl, faviconUrl: null };
+      return null;
     }
   }
 
@@ -2472,25 +2478,17 @@ export class TrustAccessService {
     });
 
     if (!trust) {
-      trust = await db.trust.findFirst({
+      trust = await db.trust.findUnique({
         where: { organizationId: friendlyUrl },
         select: { favicon: true },
       });
     }
 
-    if (!trust?.favicon || !s3Client || !APP_AWS_ORG_ASSETS_BUCKET) {
+    if (!trust?.favicon) {
       return null;
     }
 
-    try {
-      const command = new GetObjectCommand({
-        Bucket: APP_AWS_ORG_ASSETS_BUCKET,
-        Key: trust.favicon,
-      });
-      return await getSignedUrl(s3Client, command, { expiresIn: 86400 }); // 24 hours
-    } catch {
-      return null;
-    }
+    return this.getFaviconSignedUrl(trust.favicon);
   }
 
   async getPublicVendors(friendlyUrl: string) {


### PR DESCRIPTION
## Summary
- enrich trust access token/NDA token payloads with friendlyUrl and faviconUrl branding data
- add organizationId fallback in public favicon lookup when friendly URL is not present
- add focused tests for branding fields and favicon fallback behavior

## Testing
- test execution in this environment is limited by missing local jest/ts-jest workspace dependencies
- validated patch scope and diff cleanliness

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CS-222 by preserving custom favicons during NDA signing and Access flows on the Trust portal. Adds `friendlyUrl` and signed `faviconUrl` to token responses and improves public favicon lookup with an `organizationId` fallback.

- **Bug Fixes**
  - Return `friendlyUrl` and `faviconUrl` from `getGrantByAccessToken` and `getNdaByToken` (signed via shared S3 helper).
  - Add `getPublicFavicon` fallback to `organizationId` when no `friendlyUrl` match.
  - Add focused tests for branding fields and favicon fallback behavior.

<sup>Written for commit 2e5cf0fbefeebaca83e0aab7e1fd43659f44fd19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

