### PR TITLE
CS-241: Add all frameworks to finding type dropdown

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/findings/CreateFindingSheet.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/findings/CreateFindingSheet.test.tsx
@@ -32,6 +32,15 @@ vi.mock('@/hooks/use-findings-api', () => ({
     },
   ],
   FINDING_CATEGORY_LABELS: { general: 'General' },
+  FINDING_TYPE_FRAMEWORK_OPTIONS: [
+    { value: 'soc2', label: 'SOC 2' },
+    { value: 'iso27001', label: 'ISO 27001' },
+    { value: 'pci_dss', label: 'PCI DSS' },
+    { value: 'hipaa', label: 'HIPAA' },
+    { value: 'gdpr', label: 'GDPR' },
+    { value: 'iso9001', label: 'ISO 9001' },
+    { value: 'iso42001', label: 'ISO 42001' },
+  ],
   FINDING_TYPE_LABELS: { soc2: 'SOC 2', iso27001: 'ISO 27001' },
   useFindingActions: () => ({
     createFinding: vi.fn(),
@@ -99,7 +108,14 @@ vi.mock('@trycompai/design-system', () => ({
   Select: ({ children }: any) => <div>{children}</div>,
   SelectContent: ({ children }: any) => <div>{children}</div>,
   SelectGroup: ({ children }: any) => <div>{children}</div>,
-  SelectItem: ({ children }: any) => <div>{children}</div>,
+  SelectItem: ({ children, value, disabled }: any) => (
+    <div
+      data-testid={`select-item-${value}`}
+      data-disabled={disabled ? 'true' : 'false'}
+    >
+      {children}
+    </div>
+  ),
   SelectLabel: ({ children }: any) => <div>{children}</div>,
   SelectTrigger: ({ children }: any) => <button>{children}</button>,
   Sheet: ({ children, open }: any) => (open ? <div data-testid="sheet">{children}</div> : null),
@@ -188,5 +204,33 @@ describe('CreateFindingSheet permission gating', () => {
     render(<CreateFindingSheet {...defaultProps} open={false} />);
 
     expect(screen.queryByTestId('sheet')).not.toBeInTheDocument();
+  });
+
+  it('shows all required frameworks in finding type dropdown options', () => {
+    setMockPermissions(ADMIN_PERMISSIONS);
+
+    render(<CreateFindingSheet {...defaultProps} />);
+
+    expect(screen.getByText('SOC 2')).toBeInTheDocument();
+    expect(screen.getByText('ISO 27001')).toBeInTheDocument();
+    expect(screen.getByText('PCI DSS')).toBeInTheDocument();
+    expect(screen.getByText('HIPAA')).toBeInTheDocument();
+    expect(screen.getByText('GDPR')).toBeInTheDocument();
+    expect(screen.getByText('ISO 9001')).toBeInTheDocument();
+    expect(screen.getByText('ISO 42001')).toBeInTheDocument();
+  });
+
+  it('only enables framework options currently supported by FindingType enum', () => {
+    setMockPermissions(ADMIN_PERMISSIONS);
+
+    render(<CreateFindingSheet {...defaultProps} />);
+
+    expect(screen.getByTestId('select-item-soc2')).toHaveAttribute('data-disabled', 'false');
+    expect(screen.getByTestId('select-item-iso27001')).toHaveAttribute('data-disabled', 'false');
+    expect(screen.getByTestId('select-item-pci_dss')).toHaveAttribute('data-disabled', 'true');
+    expect(screen.getByTestId('select-item-hipaa')).toHaveAttribute('data-disabled', 'true');
+    expect(screen.getByTestId('select-item-gdpr')).toHaveAttribute('data-disabled', 'true');
+    expect(screen.getByTestId('select-item-iso9001')).toHaveAttribute('data-disabled', 'true');
+    expect(screen.getByTestId('select-item-iso42001')).toHaveAttribute('data-disabled', 'true');
   });
 });

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/findings/CreateFindingSheet.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/findings/CreateFindingSheet.tsx
@@ -3,6 +3,7 @@
 import {
   DEFAULT_FINDING_TEMPLATES,
   FINDING_CATEGORY_LABELS,
+  FINDING_TYPE_FRAMEWORK_OPTIONS,
   FINDING_TYPE_LABELS,
   useFindingActions,
   useFindingTemplates,
@@ -68,6 +69,7 @@ export function CreateFindingSheet({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { hasPermission } = usePermissions();
   const canCreateFinding = hasPermission('finding', 'create');
+  const supportedFindingTypes = new Set(Object.values(FindingType));
 
   const { data: templatesData } = useFindingTemplates();
   const { createFinding } = useFindingActions();
@@ -165,8 +167,12 @@ export function CreateFindingSheet({
               <Select value={field.value} onValueChange={field.onChange}>
                 <SelectTrigger>{FINDING_TYPE_LABELS[field.value as FindingType]}</SelectTrigger>
                 <SelectContent>
-                  {Object.entries(FINDING_TYPE_LABELS).map(([value, label]) => (
-                    <SelectItem key={value} value={value}>
+                  {FINDING_TYPE_FRAMEWORK_OPTIONS.map(({ value, label }) => (
+                    <SelectItem
+                      key={value}
+                      value={value}
+                      disabled={!supportedFindingTypes.has(value as FindingType)}
+                    >
                       {label}
                     </SelectItem>
                   ))}

--- a/apps/app/src/hooks/use-findings-api.ts
+++ b/apps/app/src/hooks/use-findings-api.ts
@@ -396,6 +396,19 @@ export const FINDING_STATUS_CONFIG: Record<
 };
 
 /**
+ * Framework options shown in finding type selectors
+ */
+export const FINDING_TYPE_FRAMEWORK_OPTIONS = [
+  { value: 'soc2', label: 'SOC 2' },
+  { value: 'iso27001', label: 'ISO 27001' },
+  { value: 'pci_dss', label: 'PCI DSS' },
+  { value: 'hipaa', label: 'HIPAA' },
+  { value: 'gdpr', label: 'GDPR' },
+  { value: 'iso9001', label: 'ISO 9001' },
+  { value: 'iso42001', label: 'ISO 42001' },
+] as const;
+
+/**
  * Finding type labels
  */
 export const FINDING_TYPE_LABELS: Record<FindingType, string> = {


### PR DESCRIPTION
## Summary
- add framework option list for finding type selector: SOC 2, ISO 27001, PCI DSS, HIPAA, GDPR, ISO 9001, ISO 42001
- update Create Finding sheet to render full framework option list
- keep currently unsupported enum values disabled to avoid backend/API breakage
- add tests covering option visibility and enabled/disabled behavior

## Testing
- could not run full vitest suite in this environment due missing local test dependencies
- validated diff integrity with git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds all frameworks to the Finding Type dropdown in Create Finding, per CS-241. Shows SOC 2, ISO 27001, PCI DSS, HIPAA, GDPR, ISO 9001, and ISO 42001; unsupported types are visible but disabled to avoid API errors.

- **New Features**
  - Introduced `FINDING_TYPE_FRAMEWORK_OPTIONS` as the single source for framework options.
  - Updated `CreateFindingSheet` to render the full list and disable options not in `FindingType`.
  - Added tests for option visibility and enabled/disabled states.

<sup>Written for commit e31be9b95086e5e6b7217c26d3715d07ea85925b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

