### PR TITLE
fix(integrations): tooltip on +N more badge + hide AI Agent integrations

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/integrations/components/PlatformIntegrations.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/components/PlatformIntegrations.tsx
@@ -22,6 +22,7 @@ import {
   DialogTitle,
 } from '@trycompai/ui/dialog';
 import { Skeleton } from '@trycompai/ui/skeleton';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@trycompai/ui/tooltip';
 import {
   AlertCircle,
   AlertTriangle,
@@ -679,12 +680,24 @@ export function PlatformIntegrations({ className, taskTemplates }: PlatformInteg
                               );
                             })}
                             {provider.mappedTasks.length > 3 && (
-                              <Badge
-                                variant="outline"
-                                className="text-[10px] px-1.5 py-0.5 font-normal"
-                              >
-                                +{provider.mappedTasks.length - 3} more
-                              </Badge>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <Badge
+                                    variant="outline"
+                                    className="text-[10px] px-1.5 py-0.5 font-normal cursor-default"
+                                  >
+                                    +{provider.mappedTasks.length - 3} more
+                                  </Badge>
+                                </TooltipTrigger>
+                                <TooltipContent side="bottom" className="max-w-xs">
+                                  <p className="text-xs">
+                                    {provider.mappedTasks
+                                      .slice(3)
+                                      .map((t) => t.name)
+                                      .join(', ')}
+                                  </p>
+                                </TooltipContent>
+                              </Tooltip>
                             )}
                           </div>
                         )}

--- a/apps/app/src/app/(app)/[orgId]/integrations/components/PlatformIntegrations.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/components/PlatformIntegrations.tsx
@@ -279,12 +279,8 @@ export function PlatformIntegrations({ className, taskTemplates }: PlatformInteg
         return a.provider.name.localeCompare(b.provider.name);
       });
 
-    const customIntegrations: UnifiedIntegration[] = INTEGRATIONS.map((integration) => ({
-      type: 'custom' as const,
-      integration,
-    }));
-
-    const allIntegrations = [...platformIntegrations, ...customIntegrations];
+    // AI Agent integrations are hidden — they are not real integrations
+    const allIntegrations = [...platformIntegrations];
     if (vendorNames.size === 0) {
       return allIntegrations;
     }


### PR DESCRIPTION
## Summary
- Add tooltip to "+N more" badge on integration cards — hovering shows all remaining task names
- Hide AI Agent integrations (GitHub, Datadog, etc.) from the integrations list — they are not real integrations with OAuth connections

## Test plan
- [ ] Integration card with 3+ mapped tasks shows "+N more" badge
- [ ] Hovering "+N more" shows tooltip with remaining task names
- [ ] AI Agent integrations (GitHub, Datadog, Slack, etc.) no longer appear in the list
- [ ] Platform integrations (AWS, GCP, Azure, Google Workspace, etc.) still show correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a tooltip to the "+N more" badge on integration cards to show remaining task names. Also hid AI Agent integrations (GitHub, Datadog, Slack, etc.) so only real platform integrations are shown.

<sup>Written for commit f25649dee4c3feb4f3280cb6a80c4117fdd40e3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

