### PR TITLE
fix: wrap Tooltip in TooltipProvider to prevent runtime error

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/integrations/components/PlatformIntegrations.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/components/PlatformIntegrations.tsx
@@ -22,7 +22,7 @@ import {
   DialogTitle,
 } from '@trycompai/ui/dialog';
 import { Skeleton } from '@trycompai/ui/skeleton';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@trycompai/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@trycompai/ui/tooltip';
 import {
   AlertCircle,
   AlertTriangle,
@@ -676,6 +676,7 @@ export function PlatformIntegrations({ className, taskTemplates }: PlatformInteg
                               );
                             })}
                             {provider.mappedTasks.length > 3 && (
+                              <TooltipProvider>
                               <Tooltip>
                                 <TooltipTrigger asChild>
                                   <Badge
@@ -694,6 +695,7 @@ export function PlatformIntegrations({ className, taskTemplates }: PlatformInteg
                                   </p>
                                 </TooltipContent>
                               </Tooltip>
+                              </TooltipProvider>
                             )}
                           </div>
                         )}


### PR DESCRIPTION
## Summary
- Fixes `Tooltip must be used within TooltipProvider` runtime error on the integrations page
- Wraps the "+N more" badge tooltip in its own `TooltipProvider`

## Test plan
- [ ] Integrations page loads without errors
- [ ] Hovering "+N more" badge shows tooltip with task names

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the "Tooltip must be used within TooltipProvider" runtime error on the Integrations page. Adds a local `TooltipProvider` around the "+N more" badge `Tooltip` so the page loads and the hover tooltip renders correctly.

<sup>Written for commit 1813085c6c52a9b7f52f896e65264f1536c675a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

