### PR TITLE
fix(integrations): sort connected integrations to top of the list

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/integrations/components/PlatformIntegrations.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/components/PlatformIntegrations.tsx
@@ -305,7 +305,22 @@ export function PlatformIntegrations({ className, taskTemplates }: PlatformInteg
       }
     });
 
-    return [...vendorListedIntegrations, ...otherIntegrations];
+    // Connected integrations always appear first, then vendor-listed, then others
+    const sortByConnection = (list: UnifiedIntegration[]) =>
+      list.sort((a, b) => {
+        const aConnected =
+          a.type === 'platform' &&
+          a.connection?.status === 'active'
+            ? 0
+            : 1;
+        const bConnected =
+          b.type === 'platform' &&
+          b.connection?.status === 'active'
+            ? 0
+            : 1;
+        return aConnected - bConnected;
+      });
+    return sortByConnection([...vendorListedIntegrations, ...otherIntegrations]);
   }, [providers, connectionsByProvider, vendorNames]);
 
   // Get all unique categories

--- a/apps/app/src/app/(app)/[orgId]/integrations/components/PlatformIntegrations.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/components/PlatformIntegrations.tsx
@@ -702,12 +702,23 @@ export function PlatformIntegrations({ className, taskTemplates }: PlatformInteg
                                   </Badge>
                                 </TooltipTrigger>
                                 <TooltipContent side="bottom" className="max-w-xs">
-                                  <p className="text-xs">
-                                    {provider.mappedTasks
-                                      .slice(3)
-                                      .map((t) => t.name)
-                                      .join(', ')}
-                                  </p>
+                                  <div className="flex flex-wrap gap-1">
+                                    {provider.mappedTasks.slice(3).map((t) => {
+                                      const tid = templateToTaskMap.get(t.id);
+                                      return tid ? (
+                                        <Link
+                                          key={t.id}
+                                          href={`/${orgId}/tasks/${tid}`}
+                                          className="text-xs text-primary hover:underline"
+                                          onClick={(e) => e.stopPropagation()}
+                                        >
+                                          {t.name}
+                                        </Link>
+                                      ) : (
+                                        <span key={t.id} className="text-xs">{t.name}</span>
+                                      );
+                                    })}
+                                  </div>
                                 </TooltipContent>
                               </Tooltip>
                               </TooltipProvider>

--- a/apps/app/src/app/(app)/[orgId]/integrations/components/PlatformIntegrations.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/components/PlatformIntegrations.tsx
@@ -306,16 +306,19 @@ export function PlatformIntegrations({ className, taskTemplates }: PlatformInteg
     });
 
     // Connected integrations always appear first, then vendor-listed, then others
+    const ESTABLISHED_STATUSES = new Set(['active', 'pending', 'error', 'paused']);
     const sortByConnection = (list: UnifiedIntegration[]) =>
       list.sort((a, b) => {
         const aConnected =
           a.type === 'platform' &&
-          a.connection?.status === 'active'
+          a.connection?.status &&
+          ESTABLISHED_STATUSES.has(a.connection.status)
             ? 0
             : 1;
         const bConnected =
           b.type === 'platform' &&
-          b.connection?.status === 'active'
+          b.connection?.status &&
+          ESTABLISHED_STATUSES.has(b.connection.status)
             ? 0
             : 1;
         return aConnected - bConnected;


### PR DESCRIPTION
## Summary
Connected integrations now always appear before disconnected ones, regardless of vendor list matching.

## Test plan
- [ ] Connected integrations (GCP, Google Workspace, etc.) appear at the top
- [ ] Disconnected integrations appear below

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Connected integrations now appear at the top of the Integrations list; active, pending, error, and paused are treated as established. The "+N more" tooltip links each task to its task page.

- **Bug Fixes**
  - Updated sorting in `PlatformIntegrations` to place established connections (active/pending/error/paused) ahead of vendor-listed and other items, matching `platformSortTier` behavior.
  - Made task names in the "+N more" tooltip clickable links to their task pages.

<sup>Written for commit d13e81d41372b2d7841af2e93ea29e0c6b2da639. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

