### PR TITLE
fix(cloud-tests): move single-finding remediation to Trigger.dev

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/cloud-tests/actions/single-fix.ts
+++ b/apps/app/src/app/(app)/[orgId]/cloud-tests/actions/single-fix.ts
@@ -1,0 +1,45 @@
+'use server';
+
+import { auth as triggerAuth, tasks } from '@trigger.dev/sdk';
+import { auth } from '@/utils/auth';
+import { headers } from 'next/headers';
+
+interface SingleFixInput {
+  connectionId: string;
+  organizationId: string;
+  checkResultId: string;
+  remediationKey: string;
+  acknowledgment?: string;
+}
+
+export async function startSingleFix(
+  input: SingleFixInput,
+): Promise<{ data?: { runId: string; accessToken: string }; error?: string }> {
+  try {
+    const session = await auth.api.getSession({
+      headers: await headers(),
+    });
+
+    if (!session?.user?.id) {
+      return { error: 'Unauthorized' };
+    }
+
+    const handle = await tasks.trigger('remediate-single', {
+      connectionId: input.connectionId,
+      organizationId: input.organizationId,
+      checkResultId: input.checkResultId,
+      remediationKey: input.remediationKey,
+      userId: session.user.id,
+      acknowledgment: input.acknowledgment,
+    });
+
+    const accessToken = await triggerAuth.createPublicToken({
+      scopes: { read: { runs: [handle.id] } },
+    });
+
+    return { data: { runId: handle.id, accessToken } };
+  } catch (err) {
+    console.error('Failed to start single fix:', err);
+    return { error: err instanceof Error ? err.message : 'Failed to start fix' };
+  }
+}

--- a/apps/app/src/app/(app)/[orgId]/cloud-tests/components/RemediationDialog.tsx
+++ b/apps/app/src/app/(app)/[orgId]/cloud-tests/components/RemediationDialog.tsx
@@ -10,11 +10,21 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@trycompai/ui/dialog';
+import { useRealtimeRun } from '@trigger.dev/react-hooks';
 import { AlertTriangle, ListOrdered, Loader2, RotateCcw } from 'lucide-react';
+import { useParams } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
+import { startSingleFix } from '../actions/single-fix';
 import { AcknowledgmentPanel } from './AcknowledgmentPanel';
 import { PermissionErrorPanel } from './PermissionErrorPanel';
+
+interface SingleFixProgress {
+  phase: 'executing' | 'success' | 'failed' | 'needs_permissions';
+  error?: string;
+  actionId?: string;
+  permissionError?: { missingActions: string[]; fixScript?: string };
+}
 
 interface RemediationDialogProps {
   open: boolean;
@@ -259,6 +269,7 @@ export function RemediationDialog({
   onComplete,
 }: RemediationDialogProps) {
   const api = useApi();
+  const { orgId } = useParams<{ orgId: string }>();
   const [preview, setPreview] = useState<PreviewData | null>(null);
   const [isLoadingPreview, setIsLoadingPreview] = useState(false);
   const [isExecuting, setIsExecuting] = useState(false);
@@ -267,6 +278,50 @@ export function RemediationDialog({
   const [error, setError] = useState<string | null>(null);
   const [permissionError, setPermissionError] = useState<{ missingActions: string[]; fixScript?: string } | null>(null);
   const [acknowledgment, setAcknowledgment] = useState<string | null>(null);
+
+  // Trigger.dev state for async execution
+  const [runId, setRunId] = useState<string | null>(null);
+  const [triggerAccessToken, setTriggerAccessToken] = useState<string | null>(null);
+
+  const { run } = useRealtimeRun(runId ?? '', {
+    accessToken: triggerAccessToken ?? undefined,
+    enabled: Boolean(runId && triggerAccessToken),
+  });
+
+  // Watch task progress and update dialog state
+  useEffect(() => {
+    const progress = (run?.metadata as { progress?: SingleFixProgress } | undefined)?.progress;
+    if (!progress || progress.phase === 'executing') return;
+
+    if (progress.phase === 'success') {
+      setIsExecuting(false);
+      setPreview(null);
+      setError(null);
+      setSucceeded(true);
+      toast.success('Fix applied successfully');
+      onComplete?.();
+      setTimeout(() => {
+        onOpenChange(false);
+        setSucceeded(false);
+        setRunId(null);
+        setTriggerAccessToken(null);
+      }, 4000);
+    } else if (progress.phase === 'failed') {
+      setIsExecuting(false);
+      setError(progress.error || 'Remediation failed');
+      setRunId(null);
+      setTriggerAccessToken(null);
+    } else if (progress.phase === 'needs_permissions') {
+      setIsExecuting(false);
+      setError(progress.error || 'Missing permissions');
+      if (progress.permissionError) {
+        setPermissionError(progress.permissionError);
+      }
+      setRunId(null);
+      setTriggerAccessToken(null);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [run?.metadata]);
 
   // Ref to store permissions across rechecks (avoids stale closure in useCallback)
   const permissionsRef = useRef<string[] | undefined>(undefined);
@@ -313,6 +368,9 @@ export function RemediationDialog({
     setError(null);
     setPermissionError(null);
     setAcknowledgment(null);
+    setRunId(null);
+    setTriggerAccessToken(null);
+    setSucceeded(false);
 
     // Guided-only: skip API call, use local data
     if (guidedOnly && guidedSteps) {
@@ -339,45 +397,23 @@ export function RemediationDialog({
     setError(null);
     setPermissionError(null);
     try {
-      const response = await api.post<{
-        status: string;
-        error?: string;
-        permissionError?: { missingActions: string[]; fixScript?: string };
-      }>(
-        '/v1/cloud-security/remediation/execute',
-        { connectionId, checkResultId, remediationKey, acknowledgment },
-      );
-      if (response.error) {
-        const msg =
-          typeof response.error === 'string'
-            ? response.error
-            : 'Remediation failed';
-        setError(msg);
+      const result = await startSingleFix({
+        connectionId,
+        organizationId: orgId,
+        checkResultId,
+        remediationKey,
+        acknowledgment: acknowledgment ?? undefined,
+      });
+      if (result.error || !result.data) {
+        setError(result.error || 'Failed to start fix');
+        setIsExecuting(false);
         return;
       }
-
-      const data = response.data;
-      if (data?.status === 'success') {
-        setPreview(null);
-        setError(null);
-        setSucceeded(true);
-        toast.success('Fix applied successfully');
-        // Trigger re-scan, then close dialog after user sees confirmation
-        onComplete?.();
-        setTimeout(() => {
-          onOpenChange(false);
-          setSucceeded(false);
-        }, 4000);
-      } else {
-        const msg = data?.error || 'Remediation failed';
-        setError(msg);
-        if (data?.permissionError) {
-          setPermissionError(data.permissionError);
-        }
-      }
+      // Task started — useRealtimeRun effect handles the rest
+      setRunId(result.data.runId);
+      setTriggerAccessToken(result.data.accessToken);
     } catch {
-      setError('Remediation failed. Please try again.');
-    } finally {
+      setError('Failed to start fix');
       setIsExecuting(false);
     }
   };

--- a/apps/app/src/trigger/tasks/cloud-security/remediate-batch.ts
+++ b/apps/app/src/trigger/tasks/cloud-security/remediate-batch.ts
@@ -135,7 +135,7 @@ async function persistProgress(batchId: string, progress: BatchProgress) {
 
 export const remediateBatch = task({
   id: 'remediate-batch',
-  maxDuration: 1000 * 60 * 30,
+  maxDuration: 60 * 30, // 30 minutes (seconds, not ms)
   retry: { maxAttempts: 1 },
   run: async (payload: {
     batchId: string;

--- a/apps/app/src/trigger/tasks/cloud-security/remediate-single.ts
+++ b/apps/app/src/trigger/tasks/cloud-security/remediate-single.ts
@@ -1,0 +1,107 @@
+import { logger, metadata, task } from '@trigger.dev/sdk';
+
+interface SingleFixProgress {
+  phase: 'executing' | 'success' | 'failed' | 'needs_permissions';
+  error?: string;
+  actionId?: string;
+  permissionError?: { missingActions: string[]; fixScript?: string };
+}
+
+const getApiBaseUrl = () =>
+  process.env.NEXT_PUBLIC_API_URL || process.env.API_BASE_URL || 'http://localhost:3333';
+
+function makeHeaders(organizationId: string, userId?: string): Record<string, string> {
+  return {
+    'Content-Type': 'application/json',
+    'x-service-token': process.env.SERVICE_TOKEN_TRIGGER!,
+    'x-organization-id': organizationId,
+    ...(userId && { 'x-user-id': userId }),
+  };
+}
+
+function sync(progress: SingleFixProgress) {
+  metadata.set('progress', JSON.parse(JSON.stringify(progress)));
+}
+
+interface ExecuteResult {
+  actionId?: string;
+  status: string;
+  error?: string;
+  permissionError?: { missingActions: string[]; fixScript?: string };
+}
+
+export const remediateSingle = task({
+  id: 'remediate-single',
+  maxDuration: 1000 * 60 * 5,
+  retry: { maxAttempts: 1 },
+  run: async (payload: {
+    connectionId: string;
+    organizationId: string;
+    checkResultId: string;
+    remediationKey: string;
+    userId: string;
+    acknowledgment?: string;
+  }) => {
+    const { connectionId, organizationId, checkResultId, remediationKey, userId, acknowledgment } = payload;
+
+    logger.info(`Single fix: ${remediationKey} on ${checkResultId} (user: ${userId})`);
+
+    const progress: SingleFixProgress = { phase: 'executing' };
+    sync(progress);
+
+    try {
+      const url = `${getApiBaseUrl()}/v1/cloud-security/remediation/execute`;
+      const resp = await fetch(url, {
+        method: 'POST',
+        headers: makeHeaders(organizationId, userId),
+        body: JSON.stringify({
+          connectionId,
+          checkResultId,
+          remediationKey,
+          acknowledgment: acknowledgment ?? 'acknowledged',
+        }),
+      });
+
+      const json = (await resp.json()) as ExecuteResult;
+
+      if (!resp.ok) {
+        const errorMsg = (json as { message?: string }).message ?? `HTTP ${resp.status}`;
+        progress.phase = 'failed';
+        progress.error = errorMsg;
+        sync(progress);
+        logger.error(`Single fix failed: ${errorMsg}`);
+        return { success: false, error: errorMsg };
+      }
+
+      if (json.status === 'success') {
+        progress.phase = 'success';
+        progress.actionId = json.actionId;
+        sync(progress);
+        logger.info(`Single fix succeeded: ${json.actionId}`);
+        return { success: true, actionId: json.actionId };
+      }
+
+      if (json.permissionError) {
+        progress.phase = 'needs_permissions';
+        progress.error = json.error ?? 'Missing permissions';
+        progress.permissionError = json.permissionError;
+        sync(progress);
+        logger.warn(`Single fix needs permissions: ${json.permissionError.missingActions.join(', ')}`);
+        return { success: false, needsPermissions: true, permissionError: json.permissionError };
+      }
+
+      progress.phase = 'failed';
+      progress.error = json.error ?? 'Remediation failed';
+      sync(progress);
+      logger.error(`Single fix failed: ${json.error}`);
+      return { success: false, error: json.error };
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      progress.phase = 'failed';
+      progress.error = errorMsg;
+      sync(progress);
+      logger.error(`Single fix exception: ${errorMsg}`);
+      return { success: false, error: errorMsg };
+    }
+  },
+});

--- a/apps/app/src/trigger/tasks/cloud-security/remediate-single.ts
+++ b/apps/app/src/trigger/tasks/cloud-security/remediate-single.ts
@@ -32,7 +32,7 @@ interface ExecuteResult {
 
 export const remediateSingle = task({
   id: 'remediate-single',
-  maxDuration: 1000 * 60 * 5,
+  maxDuration: 60 * 5, // 5 minutes (seconds, not ms)
   retry: { maxAttempts: 1 },
   run: async (payload: {
     connectionId: string;


### PR DESCRIPTION
## Summary

- Single-finding auto-fix previously ran entirely within one HTTP request (3-5 LLM calls + cloud API reads/writes + verification = **5-45 seconds**), risking browser timeouts
- Batch remediation already uses Trigger.dev correctly — this applies the same pattern to single fixes
- **Preview stays synchronous** (needed for UI display, within browser limits)
- **Execute moves to Trigger.dev** background task with real-time progress via `useRealtimeRun`

## Changes

| File | What |
|------|------|
| `remediate-single.ts` (new) | Trigger.dev task — calls existing `/v1/cloud-security/remediation/execute` endpoint via service token, reports progress via metadata |
| `single-fix.ts` (new) | Server action — gets userId from session, triggers task, returns runId + access token |
| `RemediationDialog.tsx` | Replaced synchronous `api.post('/execute')` with `startSingleFix()` + `useRealtimeRun` hook to watch task progress |

## Edge cases handled

- **Permission errors** → task reports `needs_permissions` phase → PermissionErrorPanel shown → user fixes permissions → Retry triggers new task (also async)
- **Dialog closed during execution** → task continues in background, fix still applies
- **Guided-only mode** → untouched (no execute step)
- **Success with re-scan** → task reports `success` → `onComplete()` fires → dialog auto-closes after 4s
- **IAM propagation retry** → 10s frontend wait before triggering new task
- **State cleanup** → runId/accessToken reset on dialog open/close

## Test plan

- [ ] Open a cloud finding → click Fix → preview loads (synchronous, same as before) → click Apply Fix → spinner shows → task runs in background → success shown via real-time progress
- [ ] Test permission error flow: fix fails on permissions → PermissionErrorPanel shown → add permissions → Retry → new task → success
- [ ] Close dialog while executing → no crash, task completes in background
- [ ] Guided-only findings still show manual steps without execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves single-finding remediation to a `Trigger.dev` background task to avoid browser timeouts and show real-time progress. Preview stays synchronous; apply runs async with live updates in the dialog. Also fixes `maxDuration` to use seconds for both single and batch tasks.

- **Refactors**
  - Added `remediate-single` task that calls `/v1/cloud-security/remediation/execute` with a service token and emits progress (`executing`, `success`, `failed`, `needs_permissions`).
  - Added `startSingleFix` server action that triggers the task and returns `{ runId, accessToken }` via `@trigger.dev/sdk`.
  - Updated `RemediationDialog` to start the task and subscribe with `useRealtimeRun` from `@trigger.dev/react-hooks`; preserves permission error flow, retries, and background completion.

- **Bug Fixes**
  - Corrected `maxDuration` units (seconds) for Trigger.dev tasks: `remediate-single` 5 minutes, `remediate-batch` 30 minutes.

<sup>Written for commit c85f2b3e404d92fcc268b158804832d3ae55d1ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

