### PR TITLE
fix(cloud-tests): derive organizationId from session, remove acknowledgment default

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/cloud-tests/actions/single-fix.ts
+++ b/apps/app/src/app/(app)/[orgId]/cloud-tests/actions/single-fix.ts
@@ -6,7 +6,6 @@ import { headers } from 'next/headers';
 
 interface SingleFixInput {
   connectionId: string;
-  organizationId: string;
   checkResultId: string;
   remediationKey: string;
   acknowledgment?: string;
@@ -24,9 +23,14 @@ export async function startSingleFix(
       return { error: 'Unauthorized' };
     }
 
+    const organizationId = session.session?.activeOrganizationId;
+    if (!organizationId) {
+      return { error: 'No active organization' };
+    }
+
     const handle = await tasks.trigger('remediate-single', {
       connectionId: input.connectionId,
-      organizationId: input.organizationId,
+      organizationId,
       checkResultId: input.checkResultId,
       remediationKey: input.remediationKey,
       userId: session.user.id,

--- a/apps/app/src/app/(app)/[orgId]/cloud-tests/components/RemediationDialog.tsx
+++ b/apps/app/src/app/(app)/[orgId]/cloud-tests/components/RemediationDialog.tsx
@@ -12,7 +12,6 @@ import {
 } from '@trycompai/ui/dialog';
 import { useRealtimeRun } from '@trigger.dev/react-hooks';
 import { AlertTriangle, ListOrdered, Loader2, RotateCcw } from 'lucide-react';
-import { useParams } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { startSingleFix } from '../actions/single-fix';
@@ -269,7 +268,6 @@ export function RemediationDialog({
   onComplete,
 }: RemediationDialogProps) {
   const api = useApi();
-  const { orgId } = useParams<{ orgId: string }>();
   const [preview, setPreview] = useState<PreviewData | null>(null);
   const [isLoadingPreview, setIsLoadingPreview] = useState(false);
   const [isExecuting, setIsExecuting] = useState(false);
@@ -399,7 +397,6 @@ export function RemediationDialog({
     try {
       const result = await startSingleFix({
         connectionId,
-        organizationId: orgId,
         checkResultId,
         remediationKey,
         acknowledgment: acknowledgment ?? undefined,

--- a/apps/app/src/trigger/tasks/cloud-security/remediate-single.ts
+++ b/apps/app/src/trigger/tasks/cloud-security/remediate-single.ts
@@ -58,7 +58,7 @@ export const remediateSingle = task({
           connectionId,
           checkResultId,
           remediationKey,
-          acknowledgment: acknowledgment ?? 'acknowledged',
+          acknowledgment,
         }),
       });
 


### PR DESCRIPTION
## Summary

- **Security**: `organizationId` is now derived from `session.activeOrganizationId` instead of being passed from the client. Prevents a user from triggering remediation on a different organization's connection.
- **Correctness**: Removed `'acknowledged'` default for missing acknowledgment in the Trigger.dev task. The execute endpoint should receive exactly what the user provided — silently defaulting bypasses explicit confirmation semantics for infrastructure-changing actions.

## Changes

| File | What |
|------|------|
| `single-fix.ts` (action) | Removed `organizationId` from input, derive from session instead. Added check for active organization. |
| `remediate-single.ts` (task) | Pass `acknowledgment` as-is instead of defaulting to `'acknowledged'` |
| `RemediationDialog.tsx` | Removed `organizationId` from `startSingleFix` call, removed unused `useParams` import |

## Test plan

- [ ] Click Fix on a finding → preview loads → Apply Fix → task runs successfully (organizationId correctly derived from session)
- [ ] Verify acknowledgment value arrives at the execute endpoint unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secure the single-fix flow by deriving `organizationId` from the server session and sending the user's `acknowledgment` value as-is with no defaults. Prevents cross-organization remediation and preserves explicit confirmation.

- **Bug Fixes**
  - Action: read `session.activeOrganizationId`; return an error if missing.
  - UI: stop passing `organizationId` from `RemediationDialog`; remove unused `useParams`.
  - Task: forward `acknowledgment` unchanged (no `'acknowledged'` default).

<sup>Written for commit 69a170d84d4c227ca8fbf392f995a7f6ee24797c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

