### PR TITLE
fix(pdf): render Tiptap tables in policy PDF exports (CS-221)

### DIFF
--- a/apps/api/src/trust-portal/policy-pdf-renderer.service.spec.ts
+++ b/apps/api/src/trust-portal/policy-pdf-renderer.service.spec.ts
@@ -455,6 +455,73 @@ describe('PolicyPdfRendererService', () => {
       expect(result.length).toBeGreaterThan(0);
     });
 
+    it('separates text from multi-paragraph cells with newlines', () => {
+      // Regression test for the CS-221 review comment: cells with multiple
+      // block children (paragraphs, hardBreaks) used to be concatenated
+      // without a separator, so "Retention Period" + "30 days" rendered as
+      // "Retention Period30 days". extractCellText joins top-level blocks
+      // with \n so splitTextToSize wraps them correctly.
+      const result = service.renderPoliciesPdfBuffer(
+        [
+          {
+            name: 'Multi-paragraph Cell Policy',
+            content: {
+              type: 'doc',
+              content: [
+                {
+                  type: 'table',
+                  content: [
+                    {
+                      type: 'tableRow',
+                      content: [
+                        {
+                          type: 'tableCell',
+                          content: [
+                            {
+                              type: 'paragraph',
+                              content: [
+                                { type: 'text', text: 'Retention Period' },
+                              ],
+                            },
+                            {
+                              type: 'paragraph',
+                              content: [{ type: 'text', text: '30 days' }],
+                            },
+                          ],
+                        },
+                        {
+                          type: 'tableCell',
+                          content: [
+                            {
+                              type: 'paragraph',
+                              content: [
+                                { type: 'text', text: 'Line one' },
+                                { type: 'hardBreak' },
+                                { type: 'text', text: 'Line two' },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+        'Test Org',
+      );
+
+      expect(result).toBeInstanceOf(Buffer);
+      expect(result.length).toBeGreaterThan(0);
+
+      // The concatenated-without-separator strings must NOT appear in the PDF.
+      const pdfText = result.toString('latin1');
+      expect(pdfText).not.toContain('Retention Period30 days');
+      expect(pdfText).not.toContain('Line oneLine two');
+    });
+
     it('handles empty tables without crashing', () => {
       const result = service.renderPoliciesPdfBuffer(
         [

--- a/apps/api/src/trust-portal/policy-pdf-renderer.service.spec.ts
+++ b/apps/api/src/trust-portal/policy-pdf-renderer.service.spec.ts
@@ -522,14 +522,111 @@ describe('PolicyPdfRendererService', () => {
       expect(pdfText).not.toContain('Line oneLine two');
     });
 
-    it('separates bullet list items inside a cell with newlines', () => {
+    it('renders bullet and numbered list items inside a cell with markers', () => {
       // A cell whose only block is a bulletList used to concatenate items
       // (e.g. "AlphaBeta") because extractInlineText didn't recognize list
-      // containers as line-break boundaries.
-      const result = service.renderPoliciesPdfBuffer(
+      // containers as line-break boundaries. After the fix, items must
+      // also carry the same bullet/number prefix as the top-level list
+      // renderer so they read as a list rather than plain-text lines.
+
+      // Helper: pull every (text)Tj token from a jsPDF buffer, with
+      // non-ASCII bytes spelled out as \xNN (jsPDF emits the bullet
+      // character U+2022 as WinAnsi byte 0x95 in its own Tj command).
+      const tokensFrom = (buf: Buffer): string[] => {
+        const raw = buf.toString('binary');
+        const out: string[] = [];
+        const re = /\((.*?)\)\s*Tj/g;
+        let m: RegExpExecArray | null;
+        while ((m = re.exec(raw)) !== null) {
+          const bytes = Buffer.from(m[1], 'binary');
+          out.push(
+            Array.from(bytes)
+              .map((b) =>
+                b < 0x20 || b > 0x7e
+                  ? `\\x${b.toString(16).padStart(2, '0')}`
+                  : String.fromCharCode(b),
+              )
+              .join(''),
+          );
+        }
+        return out;
+      };
+
+      const orderedResult = service.renderPoliciesPdfBuffer(
         [
           {
-            name: 'List-in-Cell Policy',
+            name: 'Ordered List in Cell',
+            content: {
+              type: 'doc',
+              content: [
+                {
+                  type: 'table',
+                  content: [
+                    {
+                      type: 'tableRow',
+                      content: [
+                        {
+                          type: 'tableCell',
+                          content: [
+                            {
+                              type: 'orderedList',
+                              content: [
+                                {
+                                  type: 'listItem',
+                                  content: [
+                                    {
+                                      type: 'paragraph',
+                                      content: [
+                                        { type: 'text', text: 'First step' },
+                                      ],
+                                    },
+                                  ],
+                                },
+                                {
+                                  type: 'listItem',
+                                  content: [
+                                    {
+                                      type: 'paragraph',
+                                      content: [
+                                        { type: 'text', text: 'Second step' },
+                                      ],
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+        'Test Org',
+      );
+
+      expect(orderedResult).toBeInstanceOf(Buffer);
+      const orderedTokens = tokensFrom(orderedResult);
+      // Numbered prefixes and their item text must both be present.
+      // jsPDF may emit the prefix and item text as separate adjacent Tj
+      // commands (e.g. "1." + "First step"); accept either form.
+      const orderedHas = (needle: string): boolean =>
+        orderedTokens.some((t) => t.includes(needle));
+      expect(orderedHas('1.')).toBe(true);
+      expect(orderedHas('2.')).toBe(true);
+      expect(orderedHas('First step')).toBe(true);
+      expect(orderedHas('Second step')).toBe(true);
+      // The concatenated-without-markers string must NOT appear.
+      const orderedRaw = orderedResult.toString('latin1');
+      expect(orderedRaw).not.toContain('First stepSecond step');
+
+      const bulletResult = service.renderPoliciesPdfBuffer(
+        [
+          {
+            name: 'Bullet List in Cell',
             content: {
               type: 'doc',
               content: [
@@ -582,8 +679,19 @@ describe('PolicyPdfRendererService', () => {
         'Test Org',
       );
 
-      const pdfText = result.toString('latin1');
-      expect(pdfText).not.toContain('AlphaBeta');
+      const bulletTokens = tokensFrom(bulletResult);
+      // jsPDF emits the bullet character U+2022 as WinAnsi byte 0x95. The
+      // whole line '• Alpha' may show up as one token '\x95 Alpha', or as
+      // two adjacent tokens '\x95' + ' Alpha' depending on jsPDF's text
+      // layout. Accept both.
+      const contains = (needle: string): boolean =>
+        bulletTokens.some((t) => t.includes(needle));
+      expect(contains('Alpha')).toBe(true);
+      expect(contains('Beta')).toBe(true);
+      expect(contains('\\x95')).toBe(true);
+      // The concatenated-without-separator string must NOT appear.
+      const bulletRaw = bulletResult.toString('latin1');
+      expect(bulletRaw).not.toContain('AlphaBeta');
     });
 
     it('renders very long cell text across wrapped lines', () => {

--- a/apps/api/src/trust-portal/policy-pdf-renderer.service.spec.ts
+++ b/apps/api/src/trust-portal/policy-pdf-renderer.service.spec.ts
@@ -522,6 +522,247 @@ describe('PolicyPdfRendererService', () => {
       expect(pdfText).not.toContain('Line oneLine two');
     });
 
+    it('separates bullet list items inside a cell with newlines', () => {
+      // A cell whose only block is a bulletList used to concatenate items
+      // (e.g. "AlphaBeta") because extractInlineText didn't recognize list
+      // containers as line-break boundaries.
+      const result = service.renderPoliciesPdfBuffer(
+        [
+          {
+            name: 'List-in-Cell Policy',
+            content: {
+              type: 'doc',
+              content: [
+                {
+                  type: 'table',
+                  content: [
+                    {
+                      type: 'tableRow',
+                      content: [
+                        {
+                          type: 'tableCell',
+                          content: [
+                            {
+                              type: 'bulletList',
+                              content: [
+                                {
+                                  type: 'listItem',
+                                  content: [
+                                    {
+                                      type: 'paragraph',
+                                      content: [
+                                        { type: 'text', text: 'Alpha' },
+                                      ],
+                                    },
+                                  ],
+                                },
+                                {
+                                  type: 'listItem',
+                                  content: [
+                                    {
+                                      type: 'paragraph',
+                                      content: [
+                                        { type: 'text', text: 'Beta' },
+                                      ],
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+        'Test Org',
+      );
+
+      const pdfText = result.toString('latin1');
+      expect(pdfText).not.toContain('AlphaBeta');
+    });
+
+    it('renders very long cell text across wrapped lines', () => {
+      // Stress test: a single cell with text much longer than the column
+      // width. Must not throw, must produce a valid PDF, and must grow the
+      // row height (so lines don't overlap).
+      const longText =
+        'This is a very long cell value that should wrap across multiple lines inside the cell. '.repeat(
+          4,
+        );
+      const result = service.renderPoliciesPdfBuffer(
+        [
+          {
+            name: 'Long Text Policy',
+            content: {
+              type: 'doc',
+              content: [
+                {
+                  type: 'table',
+                  content: [
+                    {
+                      type: 'tableRow',
+                      content: [
+                        {
+                          type: 'tableCell',
+                          content: [
+                            {
+                              type: 'paragraph',
+                              content: [{ type: 'text', text: longText }],
+                            },
+                          ],
+                        },
+                        {
+                          type: 'tableCell',
+                          content: [
+                            {
+                              type: 'paragraph',
+                              content: [{ type: 'text', text: 'short' }],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+        'Test Org',
+      );
+
+      expect(result).toBeInstanceOf(Buffer);
+      expect(result.length).toBeGreaterThan(0);
+      expect(result.subarray(0, 5).toString()).toBe('%PDF-');
+    });
+
+    it('inserts a page break when a table row does not fit the current page', () => {
+      // 50 rows forces at least one page break mid-table. Must not throw.
+      const rows = Array.from({ length: 50 }, (_, i) => ({
+        type: 'tableRow' as const,
+        content: [
+          {
+            type: 'tableCell' as const,
+            content: [
+              {
+                type: 'paragraph' as const,
+                content: [{ type: 'text' as const, text: `Row ${i + 1}` }],
+              },
+            ],
+          },
+          {
+            type: 'tableCell' as const,
+            content: [
+              {
+                type: 'paragraph' as const,
+                content: [{ type: 'text' as const, text: `Value ${i + 1}` }],
+              },
+            ],
+          },
+        ],
+      }));
+
+      const result = service.renderPoliciesPdfBuffer(
+        [
+          {
+            name: 'Long Table Policy',
+            content: {
+              type: 'doc',
+              content: [
+                {
+                  type: 'table',
+                  content: [
+                    {
+                      type: 'tableRow',
+                      content: [
+                        {
+                          type: 'tableHeader',
+                          content: [
+                            {
+                              type: 'paragraph',
+                              content: [{ type: 'text', text: 'Row' }],
+                            },
+                          ],
+                        },
+                        {
+                          type: 'tableHeader',
+                          content: [
+                            {
+                              type: 'paragraph',
+                              content: [{ type: 'text', text: 'Value' }],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    ...rows,
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+        'Test Org',
+      );
+
+      expect(result).toBeInstanceOf(Buffer);
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('renders content that follows a table on the same page', () => {
+      // yPosition must advance past the table so following content doesn't
+      // overlap it.
+      const result = service.renderPoliciesPdfBuffer(
+        [
+          {
+            name: 'Table Then Paragraph',
+            content: {
+              type: 'doc',
+              content: [
+                {
+                  type: 'table',
+                  content: [
+                    {
+                      type: 'tableRow',
+                      content: [
+                        {
+                          type: 'tableCell',
+                          content: [
+                            {
+                              type: 'paragraph',
+                              content: [{ type: 'text', text: 'Cell' }],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  type: 'paragraph',
+                  content: [
+                    {
+                      type: 'text',
+                      text: 'Paragraph after the table renders normally.',
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+        'Test Org',
+      );
+
+      expect(result).toBeInstanceOf(Buffer);
+      expect(result.length).toBeGreaterThan(0);
+    });
+
     it('handles empty tables without crashing', () => {
       const result = service.renderPoliciesPdfBuffer(
         [

--- a/apps/api/src/trust-portal/policy-pdf-renderer.service.spec.ts
+++ b/apps/api/src/trust-portal/policy-pdf-renderer.service.spec.ts
@@ -286,6 +286,193 @@ describe('PolicyPdfRendererService', () => {
       expect(result.length).toBeGreaterThan(0);
     });
 
+    it('renders tables with header row and data cells (CS-221)', () => {
+      // Regression test for CS-221: tables in policy content rendered as
+      // stacked text in PDFs because there was no 'table' case in processContent.
+      const result = service.renderPoliciesPdfBuffer(
+        [
+          {
+            name: 'Data Retention Policy',
+            content: {
+              type: 'doc',
+              content: [
+                {
+                  type: 'heading',
+                  attrs: { level: 2 },
+                  content: [{ type: 'text', text: 'Appendix A' }],
+                },
+                {
+                  type: 'table',
+                  content: [
+                    {
+                      type: 'tableRow',
+                      content: [
+                        {
+                          type: 'tableHeader',
+                          content: [
+                            {
+                              type: 'paragraph',
+                              content: [{ type: 'text', text: 'Data Type' }],
+                            },
+                          ],
+                        },
+                        {
+                          type: 'tableHeader',
+                          content: [
+                            {
+                              type: 'paragraph',
+                              content: [
+                                { type: 'text', text: 'Retention Period' },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    {
+                      type: 'tableRow',
+                      content: [
+                        {
+                          type: 'tableCell',
+                          content: [
+                            {
+                              type: 'paragraph',
+                              content: [{ type: 'text', text: 'User logs' }],
+                            },
+                          ],
+                        },
+                        {
+                          type: 'tableCell',
+                          content: [
+                            {
+                              type: 'paragraph',
+                              content: [{ type: 'text', text: '90 days' }],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    {
+                      type: 'tableRow',
+                      content: [
+                        {
+                          type: 'tableCell',
+                          content: [
+                            {
+                              type: 'paragraph',
+                              content: [
+                                { type: 'text', text: 'Billing records' },
+                              ],
+                            },
+                          ],
+                        },
+                        {
+                          type: 'tableCell',
+                          content: [
+                            {
+                              type: 'paragraph',
+                              content: [{ type: 'text', text: '7 years' }],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+        'Test Org',
+      );
+
+      expect(result).toBeInstanceOf(Buffer);
+      expect(result.length).toBeGreaterThan(0);
+      expect(result.subarray(0, 5).toString()).toBe('%PDF-');
+    });
+
+    it('renders tables with cell colspan', () => {
+      const result = service.renderPoliciesPdfBuffer(
+        [
+          {
+            name: 'Colspan Policy',
+            content: {
+              type: 'doc',
+              content: [
+                {
+                  type: 'table',
+                  content: [
+                    {
+                      type: 'tableRow',
+                      content: [
+                        {
+                          type: 'tableHeader',
+                          attrs: { colspan: 2 },
+                          content: [
+                            {
+                              type: 'paragraph',
+                              content: [
+                                { type: 'text', text: 'Merged header' },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    {
+                      type: 'tableRow',
+                      content: [
+                        {
+                          type: 'tableCell',
+                          content: [
+                            {
+                              type: 'paragraph',
+                              content: [{ type: 'text', text: 'Left' }],
+                            },
+                          ],
+                        },
+                        {
+                          type: 'tableCell',
+                          content: [
+                            {
+                              type: 'paragraph',
+                              content: [{ type: 'text', text: 'Right' }],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+        'Test Org',
+      );
+
+      expect(result).toBeInstanceOf(Buffer);
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('handles empty tables without crashing', () => {
+      const result = service.renderPoliciesPdfBuffer(
+        [
+          {
+            name: 'Empty Table Policy',
+            content: {
+              type: 'doc',
+              content: [{ type: 'table', content: [] }],
+            },
+          },
+        ],
+        'Test Org',
+      );
+
+      expect(result).toBeInstanceOf(Buffer);
+      expect(result.length).toBeGreaterThan(0);
+    });
+
     it('applies custom primary color', () => {
       const result = service.renderPoliciesPdfBuffer(
         [

--- a/apps/api/src/trust-portal/policy-pdf-renderer.service.ts
+++ b/apps/api/src/trust-portal/policy-pdf-renderer.service.ts
@@ -448,10 +448,10 @@ export class PolicyPdfRendererService {
         const isHeader = cell.type === 'tableHeader';
         const colspan = cell.attrs?.colspan ?? 1;
         const width = colWidth * colspan;
-        const rawText = cell.content
-          ? this.extractTextFromContent(cell.content)
-          : '';
+        const rawText = this.extractCellText(cell.content ?? []);
         const cleanText = this.cleanTextForPDF(rawText);
+        // splitTextToSize respects embedded \n, so multi-paragraph cells
+        // wrap into separate visual rows within the same cell.
         const lines = config.doc.splitTextToSize(
           cleanText || ' ',
           width - cellPadding * 2,
@@ -502,6 +502,30 @@ export class PolicyPdfRendererService {
     }
 
     config.yPosition += config.lineHeight * 0.5;
+  }
+
+  /**
+   * Extract display text from a table cell's block-level content.
+   *
+   * Tiptap cells wrap their content in block nodes (one `paragraph` per line,
+   * plus the occasional `hardBreak`). Joining top-level blocks with '\n'
+   * preserves the visual separation a user sees in the editor so that
+   * splitTextToSize wraps each intended line separately — without it, two
+   * paragraphs like "Retention Period" and "30 days" would render as the
+   * single concatenated string "Retention Period30 days".
+   */
+  private extractCellText(cellContent: JSONContent[]): string {
+    return cellContent
+      .map((block) => this.extractInlineText(block))
+      .filter((s) => s.length > 0)
+      .join('\n');
+  }
+
+  private extractInlineText(node: JSONContent): string {
+    if (node.type === 'hardBreak') return '\n';
+    if (node.text) return node.text;
+    if (!node.content) return '';
+    return node.content.map((child) => this.extractInlineText(child)).join('');
   }
 
   renderPoliciesPdfBuffer(

--- a/apps/api/src/trust-portal/policy-pdf-renderer.service.ts
+++ b/apps/api/src/trust-portal/policy-pdf-renderer.service.ts
@@ -401,12 +401,107 @@ export class PolicyPdfRendererService {
           config.yPosition += config.lineHeight;
           break;
 
+        case 'table':
+          this.renderTable(config, node);
+          break;
+
         default:
           if (node.content) {
             this.processContent(config, node.content);
           }
       }
     }
+  }
+
+  private renderTable(config: PDFConfig, tableNode: JSONContent): void {
+    const rows = tableNode.content;
+    if (!rows || rows.length === 0) return;
+
+    const firstRow = rows[0];
+    if (!firstRow.content || firstRow.content.length === 0) return;
+
+    // Count columns (including colspans) from the first row
+    let columnCount = 0;
+    for (const cell of firstRow.content) {
+      columnCount += cell.attrs?.colspan ?? 1;
+    }
+    if (columnCount === 0) return;
+
+    const colWidth = config.contentWidth / columnCount;
+    const cellPadding = 2;
+    const minCellHeight = config.lineHeight + cellPadding * 2;
+
+    config.doc.setFontSize(config.defaultFontSize);
+
+    for (const row of rows) {
+      if (row.type !== 'tableRow' || !row.content) continue;
+
+      // Pre-compute wrapped lines per cell to determine row height
+      const cellsInRow: Array<{
+        isHeader: boolean;
+        lines: string[];
+        width: number;
+      }> = [];
+
+      for (const cell of row.content) {
+        if (cell.type !== 'tableCell' && cell.type !== 'tableHeader') continue;
+        const isHeader = cell.type === 'tableHeader';
+        const colspan = cell.attrs?.colspan ?? 1;
+        const width = colWidth * colspan;
+        const rawText = cell.content
+          ? this.extractTextFromContent(cell.content)
+          : '';
+        const cleanText = this.cleanTextForPDF(rawText);
+        const lines = config.doc.splitTextToSize(
+          cleanText || ' ',
+          width - cellPadding * 2,
+        ) as string[];
+        cellsInRow.push({ isHeader, lines, width });
+      }
+
+      if (cellsInRow.length === 0) continue;
+
+      const rowHeight = Math.max(
+        minCellHeight,
+        ...cellsInRow.map(
+          (c) => c.lines.length * config.lineHeight + cellPadding * 2,
+        ),
+      );
+
+      this.checkPageBreak(config, rowHeight);
+
+      const rowY = config.yPosition;
+      let xOffset = 0;
+      for (const cell of cellsInRow) {
+        const x = config.margin + xOffset;
+
+        if (cell.isHeader) {
+          config.doc.setFillColor(240, 240, 240);
+          config.doc.rect(x, rowY, cell.width, rowHeight, 'F');
+        }
+
+        config.doc.setDrawColor(180, 180, 180);
+        config.doc.setLineWidth(0.2);
+        config.doc.rect(x, rowY, cell.width, rowHeight);
+
+        config.doc.setFont('helvetica', cell.isHeader ? 'bold' : 'normal');
+        config.doc.setTextColor(0, 0, 0);
+        cell.lines.forEach((line, li) => {
+          config.doc.text(
+            line,
+            x + cellPadding,
+            rowY + cellPadding + config.lineHeight * (li + 0.75),
+          );
+        });
+
+        xOffset += cell.width;
+      }
+
+      config.doc.setFont('helvetica', 'normal');
+      config.yPosition = rowY + rowHeight;
+    }
+
+    config.yPosition += config.lineHeight * 0.5;
   }
 
   renderPoliciesPdfBuffer(

--- a/apps/api/src/trust-portal/policy-pdf-renderer.service.ts
+++ b/apps/api/src/trust-portal/policy-pdf-renderer.service.ts
@@ -507,25 +507,48 @@ export class PolicyPdfRendererService {
   /**
    * Extract display text from a table cell's block-level content.
    *
-   * Tiptap cells wrap their content in block nodes (one `paragraph` per line,
-   * plus the occasional `hardBreak`). Joining top-level blocks with '\n'
-   * preserves the visual separation a user sees in the editor so that
-   * splitTextToSize wraps each intended line separately — without it, two
-   * paragraphs like "Retention Period" and "30 days" would render as the
-   * single concatenated string "Retention Period30 days".
+   * Tiptap cells wrap their content in block nodes — most commonly one
+   * `paragraph` per visual line, plus the occasional `hardBreak` inside a
+   * paragraph or a `bulletList`/`orderedList`. We need to preserve the visual
+   * line boundaries the user sees in the editor so that `splitTextToSize`
+   * wraps each intended line separately. Without this, a cell with two
+   * paragraphs "Retention Period" and "30 days" renders as the single
+   * concatenated string "Retention Period30 days".
+   *
+   * Block boundaries that insert a newline:
+   *  - top-level children of the cell (paragraph, bulletList, etc.)
+   *  - each list item inside a bulletList/orderedList
+   *  - `hardBreak` nodes
+   *
+   * Inline marks (bold, italic, link) are flattened to their text — we lose
+   * the formatting but the content is complete.
    */
   private extractCellText(cellContent: JSONContent[]): string {
     return cellContent
-      .map((block) => this.extractInlineText(block))
+      .map((block) => this.blockText(block))
       .filter((s) => s.length > 0)
       .join('\n');
   }
 
-  private extractInlineText(node: JSONContent): string {
+  private blockText(node: JSONContent): string {
+    if (node.type === 'bulletList' || node.type === 'orderedList') {
+      if (!node.content) return '';
+      return node.content
+        .map((item) => this.blockText(item))
+        .filter((s) => s.length > 0)
+        .join('\n');
+    }
+    if (node.type === 'listItem') {
+      if (!node.content) return '';
+      return node.content
+        .map((child) => this.blockText(child))
+        .filter((s) => s.length > 0)
+        .join('\n');
+    }
     if (node.type === 'hardBreak') return '\n';
     if (node.text) return node.text;
     if (!node.content) return '';
-    return node.content.map((child) => this.extractInlineText(child)).join('');
+    return node.content.map((child) => this.blockText(child)).join('');
   }
 
   renderPoliciesPdfBuffer(

--- a/apps/api/src/trust-portal/policy-pdf-renderer.service.ts
+++ b/apps/api/src/trust-portal/policy-pdf-renderer.service.ts
@@ -531,14 +531,22 @@ export class PolicyPdfRendererService {
   }
 
   private blockText(node: JSONContent): string {
-    if (node.type === 'bulletList' || node.type === 'orderedList') {
+    if (node.type === 'bulletList') {
       if (!node.content) return '';
       return node.content
-        .map((item) => this.blockText(item))
+        .map((item) => this.renderListItem(item, '•'))
+        .filter((s) => s.length > 0)
+        .join('\n');
+    }
+    if (node.type === 'orderedList') {
+      if (!node.content) return '';
+      return node.content
+        .map((item, i) => this.renderListItem(item, `${i + 1}.`))
         .filter((s) => s.length > 0)
         .join('\n');
     }
     if (node.type === 'listItem') {
+      // Bare listItem without a parent list (unusual); render without prefix.
       if (!node.content) return '';
       return node.content
         .map((child) => this.blockText(child))
@@ -549,6 +557,16 @@ export class PolicyPdfRendererService {
     if (node.text) return node.text;
     if (!node.content) return '';
     return node.content.map((child) => this.blockText(child)).join('');
+  }
+
+  private renderListItem(itemNode: JSONContent, prefix: string): string {
+    if (!itemNode.content) return '';
+    const body = itemNode.content
+      .map((child) => this.blockText(child))
+      .filter((s) => s.length > 0)
+      .join('\n');
+    if (!body) return '';
+    return `${prefix} ${body}`;
   }
 
   renderPoliciesPdfBuffer(

--- a/apps/app/src/lib/pdf-generator.ts
+++ b/apps/app/src/lib/pdf-generator.ts
@@ -303,6 +303,23 @@ const processContent = (config: PDFConfig, content: JSONContent[], level: number
   }
 };
 
+// Extract display text from a table cell's block-level content.
+// See renderTable-in-sync note below: joins top-level blocks with '\n' so
+// splitTextToSize wraps multi-paragraph cells correctly instead of producing
+// a concatenated "Retention Period30 days".
+const extractInlineText = (node: JSONContent): string => {
+  if (node.type === 'hardBreak') return '\n';
+  if (node.text) return node.text;
+  if (!node.content) return '';
+  return node.content.map((child) => extractInlineText(child)).join('');
+};
+
+const extractCellText = (cellContent: JSONContent[]): string =>
+  cellContent
+    .map((block) => extractInlineText(block))
+    .filter((s) => s.length > 0)
+    .join('\n');
+
 // Render a Tiptap table node as a jsPDF grid with borders and header fill.
 // NOTE: Keep in sync with apps/api/src/trust-portal/policy-pdf-renderer.service.ts renderTable
 const renderTable = (config: PDFConfig, tableNode: JSONContent) => {
@@ -338,8 +355,10 @@ const renderTable = (config: PDFConfig, tableNode: JSONContent) => {
       const isHeader = cell.type === 'tableHeader';
       const colspan = cell.attrs?.colspan ?? 1;
       const width = colWidth * colspan;
-      const rawText = cell.content ? extractTextFromContent(cell.content) : '';
+      const rawText = extractCellText(cell.content ?? []);
       const cleanText = cleanTextForPDF(rawText);
+      // splitTextToSize respects embedded \n, so multi-paragraph cells
+      // wrap into separate visual rows within the same cell.
       const lines = config.doc.splitTextToSize(
         cleanText || ' ',
         width - cellPadding * 2,

--- a/apps/app/src/lib/pdf-generator.ts
+++ b/apps/app/src/lib/pdf-generator.ts
@@ -271,13 +271,13 @@ const processContent = (config: PDFConfig, content: JSONContent[], level: number
             if (listItem.type === 'listItem' && listItem.content) {
               const listText = extractTextFromContent(listItem.content);
               checkPageBreak(config);
-              
+
               // Add number with consistent font
               config.doc.setFontSize(config.defaultFontSize);
               config.doc.setFont('helvetica', 'normal');
               config.doc.setTextColor(0, 0, 0); // Ensure number is black
               config.doc.text(`${itemNumber}.`, config.margin + level * 10, config.yPosition);
-              
+
               // Add indented text with proper font reset
               config.doc.setFontSize(config.defaultFontSize);
               config.doc.setFont('helvetica', 'normal');
@@ -295,8 +295,101 @@ const processContent = (config: PDFConfig, content: JSONContent[], level: number
           }
         }
         break;
+
+      case 'table':
+        renderTable(config, item);
+        break;
     }
   }
+};
+
+// Render a Tiptap table node as a jsPDF grid with borders and header fill.
+// NOTE: Keep in sync with apps/api/src/trust-portal/policy-pdf-renderer.service.ts renderTable
+const renderTable = (config: PDFConfig, tableNode: JSONContent) => {
+  const rows = tableNode.content;
+  if (!rows || rows.length === 0) return;
+
+  const firstRow = rows[0];
+  if (!firstRow.content || firstRow.content.length === 0) return;
+
+  let columnCount = 0;
+  for (const cell of firstRow.content) {
+    columnCount += cell.attrs?.colspan ?? 1;
+  }
+  if (columnCount === 0) return;
+
+  const colWidth = config.contentWidth / columnCount;
+  const cellPadding = 2;
+  const minCellHeight = config.lineHeight + cellPadding * 2;
+
+  config.doc.setFontSize(config.defaultFontSize);
+
+  for (const row of rows) {
+    if (row.type !== 'tableRow' || !row.content) continue;
+
+    const cellsInRow: Array<{
+      isHeader: boolean;
+      lines: string[];
+      width: number;
+    }> = [];
+
+    for (const cell of row.content) {
+      if (cell.type !== 'tableCell' && cell.type !== 'tableHeader') continue;
+      const isHeader = cell.type === 'tableHeader';
+      const colspan = cell.attrs?.colspan ?? 1;
+      const width = colWidth * colspan;
+      const rawText = cell.content ? extractTextFromContent(cell.content) : '';
+      const cleanText = cleanTextForPDF(rawText);
+      const lines = config.doc.splitTextToSize(
+        cleanText || ' ',
+        width - cellPadding * 2,
+      ) as string[];
+      cellsInRow.push({ isHeader, lines, width });
+    }
+
+    if (cellsInRow.length === 0) continue;
+
+    const rowHeight = Math.max(
+      minCellHeight,
+      ...cellsInRow.map(
+        (c) => c.lines.length * config.lineHeight + cellPadding * 2,
+      ),
+    );
+
+    checkPageBreak(config, rowHeight);
+
+    const rowY = config.yPosition;
+    let xOffset = 0;
+    for (const cell of cellsInRow) {
+      const x = config.margin + xOffset;
+
+      if (cell.isHeader) {
+        config.doc.setFillColor(240, 240, 240);
+        config.doc.rect(x, rowY, cell.width, rowHeight, 'F');
+      }
+
+      config.doc.setDrawColor(180, 180, 180);
+      config.doc.setLineWidth(0.2);
+      config.doc.rect(x, rowY, cell.width, rowHeight);
+
+      config.doc.setFont('helvetica', cell.isHeader ? 'bold' : 'normal');
+      config.doc.setTextColor(0, 0, 0);
+      cell.lines.forEach((line: string, li: number) => {
+        config.doc.text(
+          line,
+          x + cellPadding,
+          rowY + cellPadding + config.lineHeight * (li + 0.75),
+        );
+      });
+
+      xOffset += cell.width;
+    }
+
+    config.doc.setFont('helvetica', 'normal');
+    config.yPosition = rowY + rowHeight;
+  }
+
+  config.yPosition += config.lineHeight * 0.5;
 };
 
 // Function to add audit logs table

--- a/apps/app/src/lib/pdf-generator.ts
+++ b/apps/app/src/lib/pdf-generator.ts
@@ -309,15 +309,33 @@ const processContent = (config: PDFConfig, content: JSONContent[], level: number
 // concatenated "Retention Period30 days" or "AlphaBeta".
 //
 // NOTE: Keep in sync with apps/api/src/trust-portal/policy-pdf-renderer.service.ts
+const renderListItem = (itemNode: JSONContent, prefix: string): string => {
+  if (!itemNode.content) return '';
+  const body = itemNode.content
+    .map((child) => blockText(child))
+    .filter((s) => s.length > 0)
+    .join('\n');
+  if (!body) return '';
+  return `${prefix} ${body}`;
+};
+
 const blockText = (node: JSONContent): string => {
-  if (node.type === 'bulletList' || node.type === 'orderedList') {
+  if (node.type === 'bulletList') {
     if (!node.content) return '';
     return node.content
-      .map((item) => blockText(item))
+      .map((item) => renderListItem(item, '•'))
+      .filter((s) => s.length > 0)
+      .join('\n');
+  }
+  if (node.type === 'orderedList') {
+    if (!node.content) return '';
+    return node.content
+      .map((item, i) => renderListItem(item, `${i + 1}.`))
       .filter((s) => s.length > 0)
       .join('\n');
   }
   if (node.type === 'listItem') {
+    // Bare listItem without a parent list (unusual); render without prefix.
     if (!node.content) return '';
     return node.content
       .map((child) => blockText(child))

--- a/apps/app/src/lib/pdf-generator.ts
+++ b/apps/app/src/lib/pdf-generator.ts
@@ -304,19 +304,35 @@ const processContent = (config: PDFConfig, content: JSONContent[], level: number
 };
 
 // Extract display text from a table cell's block-level content.
-// See renderTable-in-sync note below: joins top-level blocks with '\n' so
-// splitTextToSize wraps multi-paragraph cells correctly instead of producing
-// a concatenated "Retention Period30 days".
-const extractInlineText = (node: JSONContent): string => {
+// Joins top-level blocks and list items with '\n' so splitTextToSize wraps
+// multi-paragraph/multi-list-item cells correctly instead of producing a
+// concatenated "Retention Period30 days" or "AlphaBeta".
+//
+// NOTE: Keep in sync with apps/api/src/trust-portal/policy-pdf-renderer.service.ts
+const blockText = (node: JSONContent): string => {
+  if (node.type === 'bulletList' || node.type === 'orderedList') {
+    if (!node.content) return '';
+    return node.content
+      .map((item) => blockText(item))
+      .filter((s) => s.length > 0)
+      .join('\n');
+  }
+  if (node.type === 'listItem') {
+    if (!node.content) return '';
+    return node.content
+      .map((child) => blockText(child))
+      .filter((s) => s.length > 0)
+      .join('\n');
+  }
   if (node.type === 'hardBreak') return '\n';
   if (node.text) return node.text;
   if (!node.content) return '';
-  return node.content.map((child) => extractInlineText(child)).join('');
+  return node.content.map((child) => blockText(child)).join('');
 };
 
 const extractCellText = (cellContent: JSONContent[]): string =>
   cellContent
-    .map((block) => extractInlineText(block))
+    .map((block) => blockText(block))
     .filter((s) => s.length > 0)
     .join('\n');
 


### PR DESCRIPTION
## Summary

Fixes [CS-221](https://linear.app/compai/issue/CS-221/policy-table-formatting-is-lost-in-saved-pdfs) — policy tables (e.g. the Data Retention "Appendix A" table) were losing all formatting when exported to PDF.

**Root cause:** Neither PDF renderer handled Tiptap table nodes.

- `apps/api/src/trust-portal/policy-pdf-renderer.service.ts` (trust portal + all-policies bundle) fell through to a default case that rendered each cell as a stacked, left-aligned paragraph.
- `apps/app/src/lib/pdf-generator.ts` (single policy Download-as-PDF) had no default case at all, so table nodes were silently dropped.

**Fix:** Added a `renderTable` helper to both renderers that draws a jsPDF grid with borders, a shaded header row, cell padding, wrapped text, and colspan support. Kept logic in sync between the two files (matching the existing convention and the `NOTE: Keep in sync` comments already there for `cleanTextForPDF`).

**Coverage:** This affects all policy PDF paths:
- Single policy "Download as PDF" button (`PolicyHeaderActions.tsx`)
- "Download all policies" bundle (`policies.service.ts`)
- Trust portal policy downloads (`trust-access.service.ts`)

## Test plan

- [x] New unit tests in `policy-pdf-renderer.service.spec.ts` cover:
  - Header row + data cells (CS-221 regression test)
  - Cells with `colspan: 2`
  - Empty tables (no crash)
- [x] All 13 tests pass (`cd apps/api && npx jest src/trust-portal/policy-pdf-renderer.service`)
- [ ] Manual: open a policy with a table (e.g. Data Retention), click Download as PDF, confirm table has borders + shaded header + aligned columns
- [ ] Manual: same from trust portal download
- [ ] Manual: same from "Download all policies" bundle

## Notes

- Rowspan is **not** supported in this PR. No evidence of rowspan in our seeded policies; spanning cells will render as normal cells in their row and the subsequent rows will have empty slots where the spanned cell would continue. Can be added if we hit a real case.
- `generatePolicyPDFFromHTML` in `pdf-generator.ts` (the HTML/print-dialog fallback) is exported but not called anywhere — left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CS-221 by rendering Tiptap tables in policy PDFs and preserving line breaks in cell content, including lists with proper bullet/number markers and hard breaks.

- **Bug Fixes**
  - Added `renderTable` to the server (`policy-pdf-renderer.service.ts`) and client (`pdf-generator.ts`) to draw a grid with borders, shaded header, padding, wrapped text, `colspan`, and mid-table page breaks.
  - New cell text extraction joins paragraphs, list items, and `hardBreak` with `\n`; prefixes list items with bullets/numbers so lists read correctly.
  - Advances layout after tables so following content renders in the right position.
  - Applies to single policy downloads, trust portal downloads, and the “download all policies” bundle.
  - Tests cover header/data rows, `colspan`, empty tables, list markers, long cell wrapping, and page breaks; `rowspan` not supported yet.

<sup>Written for commit 9dea98a74e232fccc912cf43084a8ec4f9fb9a1c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

