### PR TITLE
fix(api): accept MIME types with parameters or whitespace (CS-217)

### DIFF
--- a/apps/api/src/attachments/upload-attachment.dto.ts
+++ b/apps/api/src/attachments/upload-attachment.dto.ts
@@ -6,25 +6,8 @@ import {
   IsOptional,
   IsString,
   MaxLength,
-  Matches,
 } from 'class-validator';
-
-// Block dangerous MIME types that could execute code
-const BLOCKED_MIME_TYPES = [
-  'application/x-msdownload', // .exe
-  'application/x-msdos-program',
-  'application/x-executable',
-  'application/x-sh', // Shell scripts
-  'application/x-bat', // Batch files
-  'text/x-sh',
-  'text/x-python',
-  'text/x-perl',
-  'text/x-ruby',
-  'application/x-httpd-php', // PHP files
-  'application/x-javascript', // Executable JS (not JSON)
-  'application/javascript',
-  'text/javascript',
-];
+import { IsMimeTypeField } from '../utils/mime-type.validator';
 
 export class UploadAttachmentDto {
   @ApiProperty({
@@ -42,11 +25,7 @@ export class UploadAttachmentDto {
     description: 'MIME type of the file',
     example: 'application/pdf',
   })
-  @IsString()
-  @IsNotEmpty()
-  @Matches(/^[a-zA-Z0-9\-]+\/[a-zA-Z0-9\-\+\.]+$/, {
-    message: 'Invalid MIME type format',
-  })
+  @IsMimeTypeField()
   fileType: string;
 
   @ApiProperty({

--- a/apps/api/src/org-chart/dto/upload-org-chart.dto.ts
+++ b/apps/api/src/org-chart/dto/upload-org-chart.dto.ts
@@ -1,5 +1,6 @@
-import { IsNotEmpty, IsString, Matches } from 'class-validator';
+import { IsNotEmpty, IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsMimeTypeField } from '../../utils/mime-type.validator';
 
 export class UploadOrgChartDto {
   @ApiProperty({ description: 'Original file name' })
@@ -8,11 +9,7 @@ export class UploadOrgChartDto {
   fileName: string;
 
   @ApiProperty({ description: 'MIME type of the file (e.g. image/png)' })
-  @IsString()
-  @IsNotEmpty()
-  @Matches(/^[a-zA-Z0-9\-]+\/[a-zA-Z0-9\-\+\.]+$/, {
-    message: 'Invalid MIME type format',
-  })
+  @IsMimeTypeField()
   fileType: string;
 
   @ApiProperty({ description: 'Base64-encoded file data' })

--- a/apps/api/src/task-management/dto/upload-task-item-attachment.dto.ts
+++ b/apps/api/src/task-management/dto/upload-task-item-attachment.dto.ts
@@ -3,13 +3,12 @@ import { Transform } from 'class-transformer';
 import {
   IsBase64,
   IsNotEmpty,
-  IsOptional,
   IsString,
   MaxLength,
-  Matches,
   IsEnum,
 } from 'class-validator';
 import { TaskItemEntityType } from '@db';
+import { IsMimeTypeField } from '../../utils/mime-type.validator';
 
 export class UploadTaskItemAttachmentDto {
   @ApiProperty({
@@ -27,11 +26,7 @@ export class UploadTaskItemAttachmentDto {
     description: 'MIME type of the file',
     example: 'application/pdf',
   })
-  @IsString()
-  @IsNotEmpty()
-  @Matches(/^[a-zA-Z0-9\-]+\/[a-zA-Z0-9\-\+\.]+$/, {
-    message: 'Invalid MIME type format',
-  })
+  @IsMimeTypeField()
   fileType: string;
 
   @ApiProperty({

--- a/apps/api/src/tasks/dto/upload-attachment.dto.ts
+++ b/apps/api/src/tasks/dto/upload-attachment.dto.ts
@@ -6,25 +6,8 @@ import {
   IsOptional,
   IsString,
   MaxLength,
-  Matches,
 } from 'class-validator';
-
-// Block dangerous MIME types that could execute code
-const BLOCKED_MIME_TYPES = [
-  'application/x-msdownload', // .exe
-  'application/x-msdos-program',
-  'application/x-executable',
-  'application/x-sh', // Shell scripts
-  'application/x-bat', // Batch files
-  'text/x-sh',
-  'text/x-python',
-  'text/x-perl',
-  'text/x-ruby',
-  'application/x-httpd-php', // PHP files
-  'application/x-javascript', // Executable JS (not JSON)
-  'application/javascript',
-  'text/javascript',
-];
+import { IsMimeTypeField } from '../../utils/mime-type.validator';
 
 export class UploadAttachmentDto {
   @ApiProperty({
@@ -42,11 +25,7 @@ export class UploadAttachmentDto {
     description: 'MIME type of the file',
     example: 'application/pdf',
   })
-  @IsString()
-  @IsNotEmpty()
-  @Matches(/^[a-zA-Z0-9\-]+\/[a-zA-Z0-9\-\+\.]+$/, {
-    message: 'Invalid MIME type format',
-  })
+  @IsMimeTypeField()
   fileType: string;
 
   @ApiProperty({

--- a/apps/api/src/utils/mime-type.validator.spec.ts
+++ b/apps/api/src/utils/mime-type.validator.spec.ts
@@ -1,0 +1,126 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { IsMimeTypeField, normalizeMimeType } from './mime-type.validator';
+
+class TestDto {
+  @IsMimeTypeField()
+  fileType!: string;
+}
+
+const expectValid = async (input: unknown, expectedNormalized: string) => {
+  const instance = plainToInstance(TestDto, { fileType: input });
+  const errors = await validate(instance);
+  expect(errors).toEqual([]);
+  expect(instance.fileType).toBe(expectedNormalized);
+};
+
+const expectInvalid = async (input: unknown) => {
+  const instance = plainToInstance(TestDto, { fileType: input });
+  const errors = await validate(instance);
+  expect(errors.length).toBeGreaterThan(0);
+};
+
+describe('normalizeMimeType', () => {
+  it('returns non-strings unchanged', () => {
+    expect(normalizeMimeType(undefined)).toBe(undefined);
+    expect(normalizeMimeType(null)).toBe(null);
+    expect(normalizeMimeType(123)).toBe(123);
+  });
+
+  it('strips parameters, whitespace, and lowercases', () => {
+    expect(normalizeMimeType('application/pdf')).toBe('application/pdf');
+    expect(normalizeMimeType('application/pdf;charset=utf-8')).toBe(
+      'application/pdf',
+    );
+    expect(normalizeMimeType('application/pdf; charset=utf-8')).toBe(
+      'application/pdf',
+    );
+    expect(normalizeMimeType('  application/PDF  ')).toBe('application/pdf');
+    expect(normalizeMimeType('application/pdf\n')).toBe('application/pdf');
+  });
+});
+
+describe('IsMimeTypeField', () => {
+  describe('valid inputs (CS-217 regression)', () => {
+    it('accepts application/pdf', async () => {
+      await expectValid('application/pdf', 'application/pdf');
+    });
+
+    it('accepts the xlsx vendor type', async () => {
+      await expectValid(
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      );
+    });
+
+    it('accepts application/pdf with charset parameter', async () => {
+      await expectValid(
+        'application/pdf;charset=utf-8',
+        'application/pdf',
+      );
+    });
+
+    it('accepts xlsx with charset parameter', async () => {
+      await expectValid(
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;charset=utf-8',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      );
+    });
+
+    it('accepts trailing whitespace', async () => {
+      await expectValid('application/pdf ', 'application/pdf');
+    });
+
+    it('accepts trailing newline', async () => {
+      await expectValid('application/pdf\n', 'application/pdf');
+    });
+
+    it('accepts uppercase', async () => {
+      await expectValid('APPLICATION/PDF', 'application/pdf');
+    });
+
+    it('accepts structured syntax suffix (e.g. +json)', async () => {
+      await expectValid(
+        'application/vnd.api+json',
+        'application/vnd.api+json',
+      );
+    });
+
+    it('accepts image/svg+xml', async () => {
+      await expectValid('image/svg+xml', 'image/svg+xml');
+    });
+  });
+
+  describe('invalid inputs', () => {
+    it('rejects empty string', async () => {
+      await expectInvalid('');
+    });
+
+    it('rejects missing slash', async () => {
+      await expectInvalid('applicationpdf');
+    });
+
+    it('rejects leading slash', async () => {
+      await expectInvalid('/pdf');
+    });
+
+    it('rejects trailing slash', async () => {
+      await expectInvalid('application/');
+    });
+
+    it('rejects spaces inside type/subtype', async () => {
+      await expectInvalid('application /pdf');
+      await expectInvalid('application/ pdf');
+    });
+
+    it('rejects multiple slashes', async () => {
+      await expectInvalid('application/foo/bar');
+    });
+
+    it('rejects non-string values', async () => {
+      await expectInvalid(123);
+      await expectInvalid(null);
+      await expectInvalid(undefined);
+    });
+  });
+});

--- a/apps/api/src/utils/mime-type.validator.ts
+++ b/apps/api/src/utils/mime-type.validator.ts
@@ -1,0 +1,32 @@
+import { applyDecorators } from '@nestjs/common';
+import { Transform } from 'class-transformer';
+import { IsNotEmpty, IsString, Matches } from 'class-validator';
+
+// RFC 6838 restricted-name-chars set (alpha, digit, !, #, $, &, -, ^, _, ., +)
+// First char must be alpha/digit.
+const MIME_TYPE_REGEX =
+  /^[a-z0-9][a-z0-9!#$&^_.+-]*\/[a-z0-9][a-z0-9!#$&^_.+-]*$/i;
+
+/**
+ * Normalize a Content-Type / MIME value to its bare `type/subtype` form:
+ * strips optional `;parameters` (RFC 7231) and surrounding whitespace,
+ * and lowercases the result.
+ */
+export const normalizeMimeType = (value: unknown): unknown => {
+  if (typeof value !== 'string') return value;
+  const bare = value.split(';')[0]?.trim().toLowerCase() ?? '';
+  return bare;
+};
+
+/**
+ * Decorator for DTO fields that accept a file MIME type.
+ * Normalizes the value (strip parameters, trim, lowercase) before validating
+ * it against the RFC 6838 restricted-name-chars grammar.
+ */
+export const IsMimeTypeField = (): PropertyDecorator =>
+  applyDecorators(
+    IsString(),
+    IsNotEmpty(),
+    Transform(({ value }) => normalizeMimeType(value)),
+    Matches(MIME_TYPE_REGEX, { message: 'Invalid MIME type format' }),
+  );


### PR DESCRIPTION
## Summary

Fixes [CS-217](https://linear.app/compai/issue/CS-217/invalid-mime-type-format-error-in-api) — customer file upload endpoints returning `400 Invalid MIME type format` for legitimate `application/pdf` and `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` values.

**Root cause:** Four DTOs (`attachments`, `tasks/dto`, `task-management/dto`, `org-chart/dto`) each declared `@Matches(/^[a-zA-Z0-9\-]+\/[a-zA-Z0-9\-\+\.]+$/)` with no trim or parameter strip. So the regex itself accepts bare `application/pdf`, but the customer's HTTP client is almost certainly sending the Content-Type with a parameter (e.g. `application/pdf;charset=utf-8`) or trailing whitespace/newline, which the regex rejects.

**Fix:** Extracted a shared `IsMimeTypeField` decorator + `normalizeMimeType` helper in `apps/api/src/utils/mime-type.validator.ts`. It:
- Strips RFC 7231 media-type parameters (`;...`) and whitespace before validation
- Lowercases the value
- Validates against the RFC 6838 `restricted-name-chars` grammar

Applied the new decorator to all four DTOs and removed the now-duplicated inline regex. Also removed dead `BLOCKED_MIME_TYPES` constants from two DTOs — the real enforcement lives in `attachments.service.ts` and always operated on the lowercased value.

## Test plan

- [x] 18 unit tests in `mime-type.validator.spec.ts` cover:
  - Regression: `application/pdf`, `application/pdf;charset=utf-8`, the full xlsx vendor type, trailing whitespace/newline, uppercase, `application/vnd.api+json`, `image/svg+xml`
  - Negative: empty, missing slash, leading/trailing slash, spaces inside type, multiple slashes, non-strings
- [x] `cd apps/api && npx jest src/utils/mime-type.validator` → 18/18 pass
- [x] Full API typecheck: no new errors on changed files (pre-existing unrelated failures only)
- [ ] Manual: re-run customer's failing upload (`application/pdf;charset=utf-8`) against staging — should succeed
- [ ] Manual: attempt to upload `application/javascript;charset=utf-8` — should still be rejected by `attachments.service.ts` blocklist

## Notes

- The customer's report says uploads "worked previously". The current regex has been in place since Nov 20, 2025 (commit 6c2844beb replaced an `@IsIn` allow-list with it). So the "worked previously" timeframe predates the regex; likely the customer's HTTP client changed recently and began including `;charset=...` parameters in the `fileType` field.
- No schema changes. No new DB fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CS-217 by accepting MIME types with parameters or whitespace in file upload requests. Adds a shared `IsMimeTypeField` validator to normalize and validate values, preventing 400s for legitimate types like `application/pdf;charset=utf-8`.

- **Bug Fixes**
  - Added `IsMimeTypeField` with `normalizeMimeType` to strip parameters/whitespace, lowercase, and validate per RFC 6838.
  - Replaced inline regex in four DTOs (attachments, tasks, task-management, org-chart); removed unused `BLOCKED_MIME_TYPES` constants (blocklist stays in `attachments.service.ts`).
  - Added 18 unit tests covering regressions (`application/pdf`, vendor xlsx type, `+json`, case/whitespace) and invalid inputs.

<sup>Written for commit 911a790a872cff2c938c61ca44b80f6b31e5d359. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

