### PR TITLE
fix(integrations): clear stale task status after connection disconnect (CS-166)

### DIFF
--- a/apps/api/src/integration-platform/repositories/check-run.repository.ts
+++ b/apps/api/src/integration-platform/repositories/check-run.repository.ts
@@ -124,11 +124,18 @@ export class CheckRunRepository {
   }
 
   /**
-   * Get check runs for a task
+   * Get check runs for a task.
+   *
+   * CS-166: excludes runs from disconnected connections so the task's UI
+   * panels don't render stale "failed" history after a user disconnects the
+   * integration. The rows remain in the DB for audit.
    */
   async findByTask(taskId: string, limit = 10) {
     return db.integrationCheckRun.findMany({
-      where: { taskId },
+      where: {
+        taskId,
+        connection: { status: { not: 'disconnected' } },
+      },
       include: {
         results: true,
         connection: {

--- a/apps/api/src/integration-platform/services/connection.service.spec.ts
+++ b/apps/api/src/integration-platform/services/connection.service.spec.ts
@@ -141,9 +141,6 @@ describe('ConnectionService', () => {
         {
           id: 'tsk_4',
           evidenceAutomations: [],
-          // Mock comes pre-sorted desc by createdAt to match the service's
-          // orderBy. Latest run for check_a is success; check_b is only one
-          // run and it's success.
           integrationCheckRuns: [
             {
               checkId: 'check_a',
@@ -170,6 +167,53 @@ describe('ConnectionService', () => {
         where: { id: 'tsk_4' },
         data: { status: 'done' },
       });
+    });
+
+    it('picks the latest run per checkId even when the input is reverse-sorted', async () => {
+      // Defensive test: if a future change breaks the query's orderBy,
+      // the logic must still pick the newest run per checkId.
+      findRuns.mockResolvedValue([{ taskId: 'tsk_reorder' }]);
+      findTasks.mockResolvedValue([
+        {
+          id: 'tsk_reorder',
+          evidenceAutomations: [],
+          // Oldest first — the opposite of the query's orderBy desc.
+          integrationCheckRuns: [
+            {
+              checkId: 'check_a',
+              status: 'failed',
+              createdAt: new Date('2026-04-01'),
+            },
+            {
+              checkId: 'check_a',
+              status: 'success',
+              createdAt: new Date('2026-04-05'),
+            },
+          ],
+        },
+      ]);
+
+      await service.disconnectConnection(CONNECTION_ID);
+
+      // Latest run for check_a (2026-04-05) is success → task should become
+      // done. If we naively picked the first-seen run, it would be failed
+      // and the task would stay at 'failed'.
+      expect(updateTask).toHaveBeenCalledWith({
+        where: { id: 'tsk_reorder' },
+        data: { status: 'done' },
+      });
+    });
+
+    it('swallows errors from the re-evaluation step so disconnect still succeeds', async () => {
+      // The primary disconnect has already succeeded by the time re-evaluation
+      // runs. A DB hiccup in the cleanup path must not surface to the caller.
+      findRuns.mockRejectedValue(new Error('transient DB failure'));
+
+      await expect(
+        service.disconnectConnection(CONNECTION_ID),
+      ).resolves.toEqual(
+        expect.objectContaining({ id: CONNECTION_ID, status: 'disconnected' }),
+      );
     });
 
     it('does not touch a task that is not currently failed', async () => {

--- a/apps/api/src/integration-platform/services/connection.service.spec.ts
+++ b/apps/api/src/integration-platform/services/connection.service.spec.ts
@@ -1,0 +1,211 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConnectionService } from './connection.service';
+import { ConnectionRepository } from '../repositories/connection.repository';
+import { ProviderRepository } from '../repositories/provider.repository';
+import { ConnectionAuthTeardownService } from './connection-auth-teardown.service';
+
+jest.mock('@db', () => ({
+  db: {
+    integrationCheckRun: {
+      findMany: jest.fn(),
+    },
+    task: {
+      findMany: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('@trycompai/integration-platform', () => ({
+  getManifest: jest.fn(),
+}));
+
+import { db } from '@db';
+
+const findRuns = (db.integrationCheckRun as unknown as { findMany: jest.Mock })
+  .findMany;
+const findTasks = (db.task as unknown as { findMany: jest.Mock }).findMany;
+const updateTask = (db.task as unknown as { update: jest.Mock }).update;
+
+describe('ConnectionService', () => {
+  let service: ConnectionService;
+
+  const mockConnectionRepository = {
+    update: jest.fn(),
+  };
+  const mockProviderRepository = {};
+  const mockTeardown = {
+    teardown: jest.fn(),
+  };
+
+  const CONNECTION_ID = 'icn_1';
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ConnectionService,
+        { provide: ConnectionRepository, useValue: mockConnectionRepository },
+        { provide: ProviderRepository, useValue: mockProviderRepository },
+        { provide: ConnectionAuthTeardownService, useValue: mockTeardown },
+      ],
+    }).compile();
+
+    service = module.get(ConnectionService);
+
+    mockConnectionRepository.update.mockResolvedValue({
+      id: CONNECTION_ID,
+      status: 'disconnected',
+    });
+    mockTeardown.teardown.mockResolvedValue(undefined);
+  });
+
+  describe('disconnectConnection (CS-166)', () => {
+    it('re-evaluates failed tasks to "todo" when the only automation source was the disconnected connection', async () => {
+      findRuns.mockResolvedValue([{ taskId: 'tsk_1' }]);
+      findTasks.mockResolvedValue([
+        {
+          id: 'tsk_1',
+          evidenceAutomations: [],
+          integrationCheckRuns: [], // filtered query returns no active runs
+        },
+      ]);
+
+      await service.disconnectConnection(CONNECTION_ID);
+
+      expect(findRuns).toHaveBeenCalledWith({
+        where: { connectionId: CONNECTION_ID, taskId: { not: null } },
+        select: { taskId: true },
+        distinct: ['taskId'],
+      });
+      expect(findTasks).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: { in: ['tsk_1'] }, status: 'failed' },
+        }),
+      );
+      expect(updateTask).toHaveBeenCalledWith({
+        where: { id: 'tsk_1' },
+        data: { status: 'todo' },
+      });
+    });
+
+    it('re-evaluates failed task to "done" when remaining active automations are passing', async () => {
+      findRuns.mockResolvedValue([{ taskId: 'tsk_2' }]);
+      findTasks.mockResolvedValue([
+        {
+          id: 'tsk_2',
+          evidenceAutomations: [],
+          integrationCheckRuns: [
+            {
+              checkId: 'other_check',
+              status: 'success',
+              createdAt: new Date('2026-04-01'),
+            },
+          ],
+        },
+      ]);
+
+      await service.disconnectConnection(CONNECTION_ID);
+
+      expect(updateTask).toHaveBeenCalledWith({
+        where: { id: 'tsk_2' },
+        data: { status: 'done' },
+      });
+    });
+
+    it('leaves the task at "failed" when another active automation is still failing', async () => {
+      findRuns.mockResolvedValue([{ taskId: 'tsk_3' }]);
+      findTasks.mockResolvedValue([
+        {
+          id: 'tsk_3',
+          evidenceAutomations: [],
+          integrationCheckRuns: [
+            {
+              checkId: 'other_check',
+              status: 'failed',
+              createdAt: new Date('2026-04-01'),
+            },
+          ],
+        },
+      ]);
+
+      await service.disconnectConnection(CONNECTION_ID);
+
+      expect(updateTask).not.toHaveBeenCalled();
+    });
+
+    it('picks the latest run per checkId when multiple exist', async () => {
+      findRuns.mockResolvedValue([{ taskId: 'tsk_4' }]);
+      findTasks.mockResolvedValue([
+        {
+          id: 'tsk_4',
+          evidenceAutomations: [],
+          // Mock comes pre-sorted desc by createdAt to match the service's
+          // orderBy. Latest run for check_a is success; check_b is only one
+          // run and it's success.
+          integrationCheckRuns: [
+            {
+              checkId: 'check_a',
+              status: 'success',
+              createdAt: new Date('2026-04-05'),
+            },
+            {
+              checkId: 'check_a',
+              status: 'failed',
+              createdAt: new Date('2026-04-01'),
+            },
+            {
+              checkId: 'check_b',
+              status: 'success',
+              createdAt: new Date('2026-04-03'),
+            },
+          ],
+        },
+      ]);
+
+      await service.disconnectConnection(CONNECTION_ID);
+
+      expect(updateTask).toHaveBeenCalledWith({
+        where: { id: 'tsk_4' },
+        data: { status: 'done' },
+      });
+    });
+
+    it('does not touch a task that is not currently failed', async () => {
+      findRuns.mockResolvedValue([{ taskId: 'tsk_5' }]);
+      // findTasks filters by status: 'failed', so non-failed tasks are not returned
+      findTasks.mockResolvedValue([]);
+
+      await service.disconnectConnection(CONNECTION_ID);
+
+      expect(updateTask).not.toHaveBeenCalled();
+    });
+
+    it('skips re-evaluation when no runs exist for the connection', async () => {
+      findRuns.mockResolvedValue([]);
+
+      await service.disconnectConnection(CONNECTION_ID);
+
+      expect(findTasks).not.toHaveBeenCalled();
+      expect(updateTask).not.toHaveBeenCalled();
+    });
+
+    it('handles evidenceAutomations — task with failing custom automation stays failed', async () => {
+      findRuns.mockResolvedValue([{ taskId: 'tsk_6' }]);
+      findTasks.mockResolvedValue([
+        {
+          id: 'tsk_6',
+          evidenceAutomations: [
+            { runs: [{ evaluationStatus: 'fail' }] },
+          ],
+          integrationCheckRuns: [],
+        },
+      ]);
+
+      await service.disconnectConnection(CONNECTION_ID);
+
+      expect(updateTask).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/integration-platform/services/connection.service.ts
+++ b/apps/api/src/integration-platform/services/connection.service.ts
@@ -2,8 +2,10 @@ import {
   Injectable,
   NotFoundException,
   ConflictException,
+  Logger,
 } from '@nestjs/common';
 import { getManifest } from '@trycompai/integration-platform';
+import { db } from '@db';
 import { ConnectionRepository } from '../repositories/connection.repository';
 import { ProviderRepository } from '../repositories/provider.repository';
 import { ConnectionAuthTeardownService } from './connection-auth-teardown.service';
@@ -18,6 +20,8 @@ export interface CreateConnectionInput {
 
 @Injectable()
 export class ConnectionService {
+  private readonly logger = new Logger(ConnectionService.name);
+
   constructor(
     private readonly connectionRepository: ConnectionRepository,
     private readonly providerRepository: ProviderRepository,
@@ -135,11 +139,15 @@ export class ConnectionService {
   ): Promise<IntegrationConnection> {
     await this.connectionAuthTeardownService.teardown({ connectionId });
 
-    return this.connectionRepository.update(connectionId, {
+    const connection = await this.connectionRepository.update(connectionId, {
       status: 'disconnected',
       errorMessage: null,
       activeCredentialVersionId: null,
     });
+
+    await this.reevaluateFailedTasksAfterDisconnect(connectionId);
+
+    return connection;
   }
 
   async deleteConnection(connectionId: string): Promise<void> {
@@ -153,6 +161,109 @@ export class ConnectionService {
       activeCredentialVersionId: null,
       errorMessage: null,
     });
+
+    await this.reevaluateFailedTasksAfterDisconnect(connectionId);
+  }
+
+  /**
+   * CS-166: After a connection is disconnected, tasks whose status was set to
+   * 'failed' by check runs from that connection can end up stuck — the
+   * historical runs remain in the DB but no new runs will clear them.
+   *
+   * We preserve the check run rows for audit (see deleteConnection doc above)
+   * and instead fix the UX by re-deriving each affected task's target status
+   * from its remaining, non-disconnected automation state. Only 'failed' tasks
+   * are considered; 'done' or 'todo' tasks are left alone.
+   */
+  private async reevaluateFailedTasksAfterDisconnect(
+    connectionId: string,
+  ): Promise<void> {
+    const runs = await db.integrationCheckRun.findMany({
+      where: { connectionId, taskId: { not: null } },
+      select: { taskId: true },
+      distinct: ['taskId'],
+    });
+
+    const taskIds = runs
+      .map((r) => r.taskId)
+      .filter((id): id is string => id !== null);
+
+    if (taskIds.length === 0) return;
+
+    const tasks = await db.task.findMany({
+      where: { id: { in: taskIds }, status: 'failed' },
+      select: {
+        id: true,
+        evidenceAutomations: {
+          where: { isEnabled: true },
+          select: {
+            runs: {
+              orderBy: { createdAt: 'desc' },
+              take: 1,
+              select: { evaluationStatus: true },
+            },
+          },
+        },
+        integrationCheckRuns: {
+          where: { connection: { status: { not: 'disconnected' } } },
+          orderBy: { createdAt: 'desc' },
+          select: { checkId: true, status: true, createdAt: true },
+        },
+      },
+    });
+
+    for (const task of tasks) {
+      const target = this.deriveTargetStatusForTask(task);
+      if (target === 'failed') continue;
+      await db.task.update({
+        where: { id: task.id },
+        data: { status: target },
+      });
+      this.logger.log(
+        `Task ${task.id} re-evaluated to '${target}' after connection ${connectionId} disconnect`,
+      );
+    }
+  }
+
+  /**
+   * Mirror of the scheduler's getTargetStatus (see apps/app/src/trigger/tasks/
+   * task/task-schedule-helpers.ts), scoped to the fields we fetch above.
+   */
+  private deriveTargetStatusForTask(task: {
+    evidenceAutomations: Array<{
+      runs: Array<{ evaluationStatus: string | null }>;
+    }>;
+    integrationCheckRuns: Array<{
+      checkId: string;
+      status: string;
+      createdAt: Date;
+    }>;
+  }): 'done' | 'todo' | 'failed' {
+    const hasCustom = task.evidenceAutomations.length > 0;
+    const customPassing =
+      hasCustom &&
+      task.evidenceAutomations.every(
+        (a) => a.runs[0]?.evaluationStatus === 'pass',
+      );
+
+    const hasApp = task.integrationCheckRuns.length > 0;
+    let appPassing = false;
+    if (hasApp) {
+      const latestByCheckId = new Map<string, { status: string }>();
+      for (const run of task.integrationCheckRuns) {
+        const existing = latestByCheckId.get(run.checkId);
+        if (!existing) latestByCheckId.set(run.checkId, run);
+      }
+      appPassing = Array.from(latestByCheckId.values()).every(
+        (r) => r.status === 'success',
+      );
+    }
+
+    if (!hasCustom && !hasApp) return 'todo';
+
+    const allPassing =
+      (!hasCustom || customPassing) && (!hasApp || appPassing);
+    return allPassing ? 'done' : 'failed';
   }
 
   async updateLastSync(connectionId: string): Promise<IntegrationConnection> {

--- a/apps/api/src/integration-platform/services/connection.service.ts
+++ b/apps/api/src/integration-platform/services/connection.service.ts
@@ -145,7 +145,16 @@ export class ConnectionService {
       activeCredentialVersionId: null,
     });
 
-    await this.reevaluateFailedTasksAfterDisconnect(connectionId);
+    // Best-effort task status cleanup. The primary disconnect already
+    // succeeded above; a failure here must not surface to the caller.
+    try {
+      await this.reevaluateFailedTasksAfterDisconnect(connectionId);
+    } catch (error) {
+      this.logger.error(
+        `Failed to re-evaluate task statuses after disconnecting ${connectionId}`,
+        error instanceof Error ? error.stack : String(error),
+      );
+    }
 
     return connection;
   }
@@ -162,7 +171,15 @@ export class ConnectionService {
       errorMessage: null,
     });
 
-    await this.reevaluateFailedTasksAfterDisconnect(connectionId);
+    // Best-effort task status cleanup (see disconnectConnection for rationale).
+    try {
+      await this.reevaluateFailedTasksAfterDisconnect(connectionId);
+    } catch (error) {
+      this.logger.error(
+        `Failed to re-evaluate task statuses after deleting ${connectionId}`,
+        error instanceof Error ? error.stack : String(error),
+      );
+    }
   }
 
   /**
@@ -249,10 +266,18 @@ export class ConnectionService {
     const hasApp = task.integrationCheckRuns.length > 0;
     let appPassing = false;
     if (hasApp) {
-      const latestByCheckId = new Map<string, { status: string }>();
+      // Order-independent latest-per-checkId selection. Matches the scheduler's
+      // getTargetStatus so behavior doesn't silently depend on whether the
+      // caller's query ordered runs by createdAt.
+      const latestByCheckId = new Map<
+        string,
+        { status: string; createdAt: Date }
+      >();
       for (const run of task.integrationCheckRuns) {
         const existing = latestByCheckId.get(run.checkId);
-        if (!existing) latestByCheckId.set(run.checkId, run);
+        if (!existing || run.createdAt > existing.createdAt) {
+          latestByCheckId.set(run.checkId, run);
+        }
       }
       appPassing = Array.from(latestByCheckId.values()).every(
         (r) => r.status === 'success',

--- a/apps/app/src/trigger/tasks/task/task-schedule.ts
+++ b/apps/app/src/trigger/tasks/task/task-schedule.ts
@@ -69,8 +69,11 @@ export const taskSchedule = schedules.task({
             },
           },
         },
-        // Include App Automations (IntegrationCheckRun) - get all runs to group by checkId
+        // Include App Automations (IntegrationCheckRun) - get all runs to group by checkId.
+        // CS-166: exclude runs from disconnected connections — their historical
+        // "failed" state must not drive scheduled status changes.
         integrationCheckRuns: {
+          where: { connection: { status: { not: 'disconnected' } } },
           orderBy: { createdAt: 'desc' },
           select: {
             checkId: true,


### PR DESCRIPTION
## Summary

Fixes [CS-166](https://linear.app/compai/issue/CS-166/bug-github-integration-has-been-disconnected-however-still-showing) — after a customer disconnected their GitHub integration, related tasks were stuck on "failed" status and the task detail page kept showing historical failed automation runs.

## Root cause

`ConnectionService.disconnectConnection()` soft-deletes the connection (sets `status: 'disconnected'`, clears credentials) but does not touch `Task.status` or the `IntegrationCheckRun` audit rows. Three independent gaps result:

- **Defect A — stuck task status**: when a check from the now-disconnected connection had set `Task.status = 'failed'`, nothing re-evaluates it. The task is pinned to failed indefinitely, because the 12-hour scheduler only processes `done` tasks.
- **Defect B — stale "App Automations" UI**: `CheckRunRepository.findByTask` returned runs regardless of connection status, so the task detail panel still surfaced old failed runs under the active-integrations summary.
- **Defect C — scheduler re-marks done→failed**: `apps/app/src/trigger/tasks/task/task-schedule.ts` pulls `integrationCheckRuns` with no connection filter. For a `done` task whose review window has elapsed, a stale failed run from the disconnected connection would flip the task to `failed` on the next tick.

## Fix

Minimal, read-side filters + one re-evaluation on disconnect. No schema changes. Check run rows are preserved (matches the existing soft-delete design for `IntegrationConnection`).

1. **`ConnectionService.disconnectConnection` and `deleteConnection`** now call `reevaluateFailedTasksAfterDisconnect(connectionId)`. For each failed task that had runs from this connection, it re-derives the target status from only active (non-disconnected) automations. Uses a local mirror of the scheduler's `getTargetStatus` — same 3-way logic (no automations → `todo`, all passing → `done`, else `failed`).
2. **`CheckRunRepository.findByTask`** filters out runs whose connection is `disconnected`.
3. **`task-schedule.ts`** adds the same filter on its `integrationCheckRuns` include.

## Test plan

- [x] `cd apps/api && npx jest src/integration-platform/services/connection.service` → 7/7 new tests pass:
  - Task with no other active automations → `todo`
  - Task with other passing app automations → `done`
  - Task with another failing automation → stays `failed`
  - Latest-run-per-checkId selection works
  - Non-failed tasks untouched
  - No runs from connection → no re-evaluation
  - Failing custom automation keeps task failed
- [x] Full API typecheck: no new errors on changed files
- [ ] Manual: connect GitHub, run a failing check, disconnect → task status returns to `todo`; task detail "App Automations" panel no longer shows old runs
- [ ] Manual: with a second active integration passing, disconnect GitHub → task transitions to `done`

## Notes

- Only re-evaluates tasks currently at `status: 'failed'`. We don't demote `done` or `todo` tasks — those transitions already have dedicated flows.
- The 3-way status helper is inlined in `ConnectionService` rather than extracted. The scheduler's `getTargetStatus` lives in `apps/app` and can't be imported from `apps/api`; a shared package move would be a larger refactor than this bug requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears stale “failed” task states when an integration (e.g., GitHub) is disconnected and hides runs from disconnected connections so the UI and scheduler ignore outdated failures. Fixes CS-166.

- **Bug Fixes**
  - On `disconnectConnection`/`deleteConnection`, re-derive each affected failed task’s status from active automations only (`todo` if none, `done` if all passing; otherwise unchanged). Latest-per-`checkId` selection is order-independent, and the cleanup is best-effort (wrapped in try/catch) so disconnect/delete still succeed. Audit rows stay.
  - Exclude runs from `disconnected` connections in `CheckRunRepository.findByTask` and `apps/app/src/trigger/tasks/task/task-schedule.ts` so stale failures don’t affect the "App Automations" panel or scheduled status.

<sup>Written for commit 9f140e1213f1c3f8335c63733152017e824fce8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

