### PR TITLE
fix(automations): show schedule in UTC and next run in user tz (CS-97)

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/automations/[automationId]/overview/components/MetricsSection.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/automations/[automationId]/overview/components/MetricsSection.test.tsx
@@ -4,7 +4,9 @@ import { MetricsSection } from './MetricsSection';
 
 describe('MetricsSection (CS-97)', () => {
   beforeEach(() => {
-    vi.useFakeTimers();
+    // shouldAdvanceTime lets React effects flush on their normal tick
+    // while still letting us pin `new Date()` with vi.setSystemTime.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
   });
 
   afterEach(() => {
@@ -17,21 +19,37 @@ describe('MetricsSection (CS-97)', () => {
     expect(screen.getByText('Every day at 9:00 AM UTC')).toBeInTheDocument();
   });
 
-  it('renders the next run as a concrete weekday + time rather than the old hardcoded "Tomorrow 9:00 AM"', () => {
+  it('uses an SSR-safe placeholder for the next run (defers date formatting to post-mount)', () => {
+    // Verify the initial JSX does NOT synchronously format a Date — that's
+    // the property that keeps SSR and hydration outputs identical. We
+    // simulate "server-side" rendering with renderToString and assert the
+    // next-run cell contains the em-dash placeholder rather than a formatted
+    // weekday/time.
+    const { renderToString } = require('react-dom/server') as typeof import('react-dom/server');
+    vi.setSystemTime(new Date('2026-04-16T07:00:00Z'));
+    const html = renderToString(
+      <MetricsSection initialVersions={[]} initialRuns={[]} />,
+    );
+    expect(html).not.toMatch(/Mon|Tue|Wed|Thu|Fri|Sat|Sun/);
+    expect(html).toContain('—');
+  });
+
+  it('fills in the next-run label after mount with a concrete weekday + time', async () => {
     vi.setSystemTime(new Date('2026-04-16T07:00:00Z'));
     render(<MetricsSection initialVersions={[]} initialRuns={[]} />);
 
-    // The old hardcoded literals must be gone.
+    // Old hardcoded literals must never appear.
     expect(screen.queryByText('Every Day 9:00 AM')).not.toBeInTheDocument();
     expect(screen.queryByText('Tomorrow 9:00 AM')).not.toBeInTheDocument();
 
-    // The next-run line should be a real locale string formatted as
-    // "Weekday H:MM AM/PM", which is NOT the word "Tomorrow".
-    const nextRunLabels = screen.getAllByText(/\d{1,2}:\d{2}\s(AM|PM)$/);
+    // After mount the effect runs and the real label shows up.
+    const nextRunLabels = await screen.findAllByText(
+      /\d{1,2}:\d{2}\s(AM|PM)$/,
+    );
     expect(nextRunLabels.length).toBeGreaterThan(0);
   });
 
-  it('picks today (UTC) when the current time is before 09:00 UTC', () => {
+  it('picks today (UTC) when the current time is before 09:00 UTC', async () => {
     // 2026-04-16 07:00 UTC → next run is 2026-04-16 09:00 UTC (same day).
     vi.setSystemTime(new Date('2026-04-16T07:00:00Z'));
     render(<MetricsSection initialVersions={[]} initialRuns={[]} />);
@@ -45,10 +63,10 @@ describe('MetricsSection (CS-97)', () => {
         hour12: true,
       },
     );
-    expect(screen.getByText(expected)).toBeInTheDocument();
+    expect(await screen.findByText(expected)).toBeInTheDocument();
   });
 
-  it('picks the next day (UTC) when the current time is past 09:00 UTC', () => {
+  it('picks the next day (UTC) when the current time is past 09:00 UTC', async () => {
     // 2026-04-16 10:00 UTC → today's run already happened, next is 2026-04-17 09:00 UTC.
     vi.setSystemTime(new Date('2026-04-16T10:00:00Z'));
     render(<MetricsSection initialVersions={[]} initialRuns={[]} />);
@@ -62,6 +80,6 @@ describe('MetricsSection (CS-97)', () => {
         hour12: true,
       },
     );
-    expect(screen.getByText(expected)).toBeInTheDocument();
+    expect(await screen.findByText(expected)).toBeInTheDocument();
   });
 });

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/automations/[automationId]/overview/components/MetricsSection.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/automations/[automationId]/overview/components/MetricsSection.test.tsx
@@ -23,18 +23,28 @@ describe('MetricsSection (CS-97)', () => {
     // Verify the initial JSX does NOT synchronously format a Date — that's
     // the property that keeps SSR and hydration outputs identical. We
     // simulate "server-side" rendering with renderToString and assert the
-    // next-run cell contains the em-dash placeholder rather than a formatted
-    // weekday/time.
+    // Next Run cell specifically contains the em-dash placeholder rather
+    // than a formatted weekday/time. We scope the assertion to the Next Run
+    // card because Success Rate also renders `—` when there are no runs.
     const { renderToString } = require('react-dom/server') as typeof import('react-dom/server');
     vi.setSystemTime(new Date('2026-04-16T07:00:00Z'));
     const html = renderToString(
       <MetricsSection initialVersions={[]} initialRuns={[]} />,
     );
+
+    // No weekday should appear anywhere in SSR output.
     expect(html).not.toMatch(/Mon|Tue|Wed|Thu|Fri|Sat|Sun/);
-    expect(html).toContain('—');
+
+    // Locate the Next Run cell and assert its value paragraph contains `—`.
+    // Matches: <p ...>Next Run</p><p class="...">—</p>
+    const nextRunCellMatch = html.match(
+      /Next Run[^<]*<\/p>\s*<p[^>]*>([^<]*)<\/p>/,
+    );
+    expect(nextRunCellMatch).not.toBeNull();
+    expect(nextRunCellMatch?.[1]).toBe('—');
   });
 
-  it('fills in the next-run label after mount with a concrete weekday + time', async () => {
+  it('fills in the next-run label after mount with a concrete weekday, time, and timezone', async () => {
     vi.setSystemTime(new Date('2026-04-16T07:00:00Z'));
     render(<MetricsSection initialVersions={[]} initialRuns={[]} />);
 
@@ -42,9 +52,12 @@ describe('MetricsSection (CS-97)', () => {
     expect(screen.queryByText('Every Day 9:00 AM')).not.toBeInTheDocument();
     expect(screen.queryByText('Tomorrow 9:00 AM')).not.toBeInTheDocument();
 
-    // After mount the effect runs and the real label shows up.
+    // After mount the effect runs and the real label shows up. It must
+    // include an explicit timezone so it's not confused with the UTC
+    // Schedule card next to it — e.g. "Thu 9:00 AM UTC" or "Thu, 12:00 PM EST".
+    // Node/browser locales may insert a comma after the weekday; allow both.
     const nextRunLabels = await screen.findAllByText(
-      /\d{1,2}:\d{2}\s(AM|PM)$/,
+      /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun),?\s\d{1,2}:\d{2}\s(AM|PM)\s.+/,
     );
     expect(nextRunLabels.length).toBeGreaterThan(0);
   });
@@ -61,6 +74,7 @@ describe('MetricsSection (CS-97)', () => {
         hour: 'numeric',
         minute: '2-digit',
         hour12: true,
+        timeZoneName: 'short',
       },
     );
     expect(await screen.findByText(expected)).toBeInTheDocument();
@@ -78,6 +92,7 @@ describe('MetricsSection (CS-97)', () => {
         hour: 'numeric',
         minute: '2-digit',
         hour12: true,
+        timeZoneName: 'short',
       },
     );
     expect(await screen.findByText(expected)).toBeInTheDocument();

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/automations/[automationId]/overview/components/MetricsSection.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/automations/[automationId]/overview/components/MetricsSection.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MetricsSection } from './MetricsSection';
+
+describe('MetricsSection (CS-97)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('labels the schedule as 9:00 AM UTC (no ambiguous local time)', () => {
+    vi.setSystemTime(new Date('2026-04-16T07:00:00Z'));
+    render(<MetricsSection initialVersions={[]} initialRuns={[]} />);
+    expect(screen.getByText('Every day at 9:00 AM UTC')).toBeInTheDocument();
+  });
+
+  it('renders the next run as a concrete weekday + time rather than the old hardcoded "Tomorrow 9:00 AM"', () => {
+    vi.setSystemTime(new Date('2026-04-16T07:00:00Z'));
+    render(<MetricsSection initialVersions={[]} initialRuns={[]} />);
+
+    // The old hardcoded literals must be gone.
+    expect(screen.queryByText('Every Day 9:00 AM')).not.toBeInTheDocument();
+    expect(screen.queryByText('Tomorrow 9:00 AM')).not.toBeInTheDocument();
+
+    // The next-run line should be a real locale string formatted as
+    // "Weekday H:MM AM/PM", which is NOT the word "Tomorrow".
+    const nextRunLabels = screen.getAllByText(/\d{1,2}:\d{2}\s(AM|PM)$/);
+    expect(nextRunLabels.length).toBeGreaterThan(0);
+  });
+
+  it('picks today (UTC) when the current time is before 09:00 UTC', () => {
+    // 2026-04-16 07:00 UTC → next run is 2026-04-16 09:00 UTC (same day).
+    vi.setSystemTime(new Date('2026-04-16T07:00:00Z'));
+    render(<MetricsSection initialVersions={[]} initialRuns={[]} />);
+
+    const expected = new Date('2026-04-16T09:00:00Z').toLocaleString(
+      undefined,
+      {
+        weekday: 'short',
+        hour: 'numeric',
+        minute: '2-digit',
+        hour12: true,
+      },
+    );
+    expect(screen.getByText(expected)).toBeInTheDocument();
+  });
+
+  it('picks the next day (UTC) when the current time is past 09:00 UTC', () => {
+    // 2026-04-16 10:00 UTC → today's run already happened, next is 2026-04-17 09:00 UTC.
+    vi.setSystemTime(new Date('2026-04-16T10:00:00Z'));
+    render(<MetricsSection initialVersions={[]} initialRuns={[]} />);
+
+    const expected = new Date('2026-04-17T09:00:00Z').toLocaleString(
+      undefined,
+      {
+        weekday: 'short',
+        hour: 'numeric',
+        minute: '2-digit',
+        hour12: true,
+      },
+    );
+    expect(screen.getByText(expected)).toBeInTheDocument();
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/automations/[automationId]/overview/components/MetricsSection.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/automations/[automationId]/overview/components/MetricsSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { EvidenceAutomationRun, EvidenceAutomationVersion } from '@db';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 interface MetricsSectionProps {
   initialVersions: EvidenceAutomationVersion[];
@@ -33,7 +33,16 @@ export function MetricsSection({
   // comp-private/apps/enterprise-api/src/trigger/automation/run-automations-schedule.ts).
   // Render the schedule explicitly in UTC and the next run in the user's
   // local timezone so the label matches when it actually fires.
-  const nextRun = useMemo(() => {
+  //
+  // The next-run label is computed on the client only (useState + useEffect
+  // instead of useMemo) to avoid a hydration mismatch: Node.js renders in
+  // the server's timezone + locale (typically UTC) while the browser renders
+  // in the user's, and `new Date()` can also tick across 09:00 UTC between
+  // the two renders and produce a different weekday. We render `—` during
+  // SSR and fill it in once mounted.
+  const [nextRunLabel, setNextRunLabel] = useState<string | null>(null);
+
+  useEffect(() => {
     const now = new Date();
     const next = new Date(
       Date.UTC(
@@ -49,7 +58,14 @@ export function MetricsSection({
     if (next.getTime() <= now.getTime()) {
       next.setUTCDate(next.getUTCDate() + 1);
     }
-    return next;
+    setNextRunLabel(
+      next.toLocaleString(undefined, {
+        weekday: 'short',
+        hour: 'numeric',
+        minute: '2-digit',
+        hour12: true,
+      }),
+    );
   }, []);
 
   return (
@@ -69,14 +85,7 @@ export function MetricsSection({
 
       <div className="px-4">
         <p className="text-xs text-muted-foreground mb-1">Next Run</p>
-        <p className="text-sm font-medium">
-          {nextRun.toLocaleString(undefined, {
-            weekday: 'short',
-            hour: 'numeric',
-            minute: '2-digit',
-            hour12: true,
-          })}
-        </p>
+        <p className="text-sm font-medium">{nextRunLabel ?? '—'}</p>
       </div>
 
       <div className="px-4">

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/automations/[automationId]/overview/components/MetricsSection.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/automations/[automationId]/overview/components/MetricsSection.tsx
@@ -58,12 +58,15 @@ export function MetricsSection({
     if (next.getTime() <= now.getTime()) {
       next.setUTCDate(next.getUTCDate() + 1);
     }
+    // Include timeZoneName so the label is unambiguous alongside the UTC
+    // Schedule card — otherwise "Fri 12:00 PM" could be mistaken for UTC.
     setNextRunLabel(
       next.toLocaleString(undefined, {
         weekday: 'short',
         hour: 'numeric',
         minute: '2-digit',
         hour12: true,
+        timeZoneName: 'short',
       }),
     );
   }, []);

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/automations/[automationId]/overview/components/MetricsSection.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/automations/[automationId]/overview/components/MetricsSection.tsx
@@ -29,6 +29,29 @@ export function MetricsSection({
   const successRateColor = successRate >= 90 ? 'text-primary' : successRate >= 60 ? 'text-warning' : 'text-destructive';
   const latestRun = initialRuns[0];
 
+  // Automations run daily at 09:00 UTC (see
+  // comp-private/apps/enterprise-api/src/trigger/automation/run-automations-schedule.ts).
+  // Render the schedule explicitly in UTC and the next run in the user's
+  // local timezone so the label matches when it actually fires.
+  const nextRun = useMemo(() => {
+    const now = new Date();
+    const next = new Date(
+      Date.UTC(
+        now.getUTCFullYear(),
+        now.getUTCMonth(),
+        now.getUTCDate(),
+        9,
+        0,
+        0,
+        0,
+      ),
+    );
+    if (next.getTime() <= now.getTime()) {
+      next.setUTCDate(next.getUTCDate() + 1);
+    }
+    return next;
+  }, []);
+
   return (
     <div className="grid grid-cols-2 md:grid-cols-4 divide-x border-y py-4">
       <div className="px-4">
@@ -41,12 +64,19 @@ export function MetricsSection({
 
       <div className="px-4">
         <p className="text-xs text-muted-foreground mb-1">Schedule</p>
-        <p className="text-sm font-medium">Every Day 9:00 AM</p>
+        <p className="text-sm font-medium">Every day at 9:00 AM UTC</p>
       </div>
 
       <div className="px-4">
         <p className="text-xs text-muted-foreground mb-1">Next Run</p>
-        <p className="text-sm font-medium">Tomorrow 9:00 AM</p>
+        <p className="text-sm font-medium">
+          {nextRun.toLocaleString(undefined, {
+            weekday: 'short',
+            hour: 'numeric',
+            minute: '2-digit',
+            hour12: true,
+          })}
+        </p>
       </div>
 
       <div className="px-4">


### PR DESCRIPTION
## Summary

Fixes [CS-97](https://linear.app/compai/issue/CS-97) — automation overview page showed `Every Day 9:00 AM` and `Tomorrow 9:00 AM` with no timezone label, so a UTC+3 customer saw the automation actually fire at noon local while the UI insisted it was 9 AM.

**Root cause (verified):** Two hardcoded JSX literals in `MetricsSection.tsx`:
- Line 44: `<p>Every Day 9:00 AM</p>`
- Line 49: `<p>Tomorrow 9:00 AM</p>`

Backend cron is `0 9 * * *` (UTC) in `comp-private/apps/enterprise-api/src/trigger/automation/run-automations-schedule.ts` — no per-org timezone config exists, and no automation-level schedule is stored. The "Tomorrow" literal was also wrong whenever today's 09:00 UTC hadn't happened yet.

## Fix

- Schedule label → `Every day at 9:00 AM UTC` (matches the pattern used by Cloud Tests' `ScheduledScanPopover`).
- Next Run → compute the next 09:00 UTC occurrence as a real `Date`, render with `toLocaleString({ weekday, hour, minute })` so each user sees it in their own TZ. Matches the pattern in `BrowserAutomationsList`.

No schema changes. No new fields.

## Test plan

- [x] 4 new Vitest tests in `MetricsSection.test.tsx`:
  - UTC label is present on the schedule card
  - Old hardcoded literals are gone
  - Before 09:00 UTC → next run is today (UTC)
  - After 09:00 UTC → next run is tomorrow (UTC)
- [x] Run: `cd apps/app && npx vitest run MetricsSection.test` — 4/4 pass
- [x] Typecheck clean on touched files
- [ ] Manual: open an automation overview page, confirm the Schedule card shows `Every day at 9:00 AM UTC` and the Next Run card shows the local time (e.g. `Fri 12:00 PM` for a UTC+3 viewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CS-97 by labeling the schedule in UTC and showing the next run in the viewer’s local time with an explicit timezone. Defers the next-run label to post-mount to avoid SSR hydration mismatches.

- **Bug Fixes**
  - Schedule: “Every day at 9:00 AM UTC”.
  - Next Run: compute next 09:00 UTC and render locally with weekday/time and short timezone (e.g., “Thu, 5:00 AM EDT”); compute on mount with an em-dash placeholder during SSR.
  - Tests: remove hardcoded literals; add 5 Vitest tests, including a scoped SSR-placeholder check for the Next Run cell and a TZ-included label assertion.

<sup>Written for commit 6e7429be627991d8cb081fcc10ccbf470018def3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

