### PR TITLE
fix(tasks): render task description markdown in the main app (CS-98)

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/SingleTask.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/SingleTask.tsx
@@ -2,6 +2,7 @@
 
 import { SelectAssignee } from '@/components/SelectAssignee';
 import { RecentAuditLogs } from '@/components/RecentAuditLogs';
+import { MarkdownRenderer } from '../automation/[automationId]/components/markdown-renderer/markdown-renderer';
 import { useAuditLogs } from '@/hooks/use-audit-logs';
 import { useOrganizationMembers } from '@/hooks/use-organization-members';
 import { downloadTaskEvidenceZip } from '@/lib/evidence-download';
@@ -289,15 +290,21 @@ export function SingleTask({
             autoFocus
           />
         ) : (
-          <Text
-            size="sm"
-            variant="muted"
-            as="p"
+          // CS-98: descriptions authored in the Framework Editor use markdown
+          // (bullets, bold, headings). Plain-text rendering with whiteSpace:
+          // pre-line preserved newlines but showed raw "**" and "- " syntax.
+          // Render through the shared MarkdownRenderer so the app matches
+          // what admins see in the editor preview.
+          <div
             onClick={startEditingDescription}
-            style={{ cursor: 'pointer', whiteSpace: 'pre-line' }}
+            className="text-sm text-muted-foreground cursor-pointer"
           >
-            {task.description || 'Add a description...'}
-          </Text>
+            {task.description ? (
+              <MarkdownRenderer content={task.description} />
+            ) : (
+              'Add a description...'
+            )}
+          </div>
         )}
       </Stack>
 


### PR DESCRIPTION
## Summary

Fixes [CS-98](https://linear.app/compai/issue/CS-98) — task descriptions authored in the Framework Editor showed up as a plain wall of text in the main app, with literal `**` and `- ` characters instead of rendered markdown.

## Investigation

- The **Framework Editor** (`comp-private/apps/framework-editor/app/components/table/MarkdownCell.tsx`) stores descriptions as markdown and renders them via `ReactMarkdown` + `remarkGfm`.
- The DB column is a plain `String` — markdown is preserved 1:1 when a framework is applied to an org or a task is regenerated.
- The **main app renderer** at `SingleTask.tsx:291-301` used a `<Text>` with `whiteSpace: 'pre-line'`. That CSS preserves literal `\n` (PR #2327 added this) but does **not** parse markdown syntax — bullets stay as `- `, bold stays as `**text**`.
- The `MarkdownRenderer` component already exists in the app and is used by the task automation chat (with `remark-gfm`, `rehype-raw`, `rehype-sanitize`).

## Fix

Swap the plain `<Text>` for `<MarkdownRenderer content={task.description} />`. Click-to-edit behavior is preserved by wrapping in a clickable `<div>`. No schema changes.

## Test plan

- [x] Typecheck clean on touched files
- [ ] Manual: open a task whose description contains bullets / `**bold**` / `## headings` — confirm they render as formatted markdown, matching what admins see in the Framework Editor preview
- [ ] Manual: click the description → edit mode still opens
- [ ] Manual: empty description still shows `"Add a description..."` placeholder

## Notes

- The existing `SingleTask.test.tsx` (7 tests) was already broken on `main` before this change — verified by reproducing the failure on main. Not introduced here.
- Didn't relocate `MarkdownRenderer` to a shared location even though it's now imported from a peer component tree; that refactor is out of scope for this bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render task descriptions as markdown in the main app so bullets, bold, quotes, and headings display correctly, matching the Framework Editor preview (CS-98). Keeps readability while preserving click-to-edit.

- **Bug Fixes**
  - Replaced plain `<Text>` + `whiteSpace: 'pre-line'` with `MarkdownRenderer` in `SingleTask.tsx` to parse and render markdown.
  - Kept edit-on-click by wrapping in a clickable `div`; empty state still shows “Add a description…”.

<sup>Written for commit fb68a367f08cded117b3ba86fd52e1e0f7621e95. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

