### PR TITLE
fix(policies): restore AI-tailoring UI on the Policies page (ENG-108)

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/policies/(overview)/hooks/use-policy-onboarding-status.ts
+++ b/apps/app/src/app/(app)/[orgId]/policies/(overview)/hooks/use-policy-onboarding-status.ts
@@ -1,0 +1,95 @@
+'use client';
+
+import { useRealtimeRun } from '@trigger.dev/react-hooks';
+import { useMemo } from 'react';
+import type { PolicyTailoringStatus } from '../../all/components/policy-tailoring-context';
+
+export interface PolicyOnboardingItemInfo {
+  id: string;
+  name: string;
+}
+
+/**
+ * Subscribe to the onboarding trigger.dev run and derive per-policy tailoring
+ * status plus overall progress. Mirrors use-onboarding-status in risk/ and
+ * vendors/ but handles the `policies` → `policy_<id>_status` singular
+ * conversion correctly (the shared hook's `itemType.slice(0, -1)` would
+ * produce `policie_`).
+ */
+export function usePolicyOnboardingStatus(
+  onboardingRunId: string | null | undefined,
+) {
+  const shouldSubscribe = Boolean(onboardingRunId);
+  const { run } = useRealtimeRun(shouldSubscribe ? onboardingRunId! : '', {
+    enabled: shouldSubscribe,
+  });
+
+  const itemStatuses = useMemo<Record<string, PolicyTailoringStatus>>(() => {
+    if (!run?.metadata) return {};
+
+    const meta = run.metadata as Record<string, unknown>;
+    const itemsInfo =
+      (meta.policiesInfo as Array<{ id: string; name: string }>) || [];
+
+    return itemsInfo.reduce<Record<string, PolicyTailoringStatus>>(
+      (acc, item) => {
+        const status = meta[`policy_${item.id}_status`];
+        if (
+          status === 'queued' ||
+          status === 'pending' ||
+          status === 'processing' ||
+          status === 'completed'
+        ) {
+          acc[item.id] = status;
+        }
+        return acc;
+      },
+      {},
+    );
+  }, [run?.metadata]);
+
+  const progress = useMemo(() => {
+    if (!run?.metadata) return null;
+
+    const meta = run.metadata as Record<string, unknown>;
+    const total = typeof meta.policiesTotal === 'number' ? meta.policiesTotal : 0;
+    const completed =
+      typeof meta.policiesCompleted === 'number' ? meta.policiesCompleted : 0;
+
+    if (total === 0) return null;
+    return { total, completed };
+  }, [run?.metadata]);
+
+  const itemsInfo = useMemo<PolicyOnboardingItemInfo[]>(() => {
+    if (!run?.metadata) return [];
+    const meta = run.metadata as Record<string, unknown>;
+    return (meta.policiesInfo as Array<{ id: string; name: string }>) || [];
+  }, [run?.metadata]);
+
+  // Active if any item is not yet completed
+  const hasActiveItems = useMemo(
+    () =>
+      Object.values(itemStatuses).some(
+        (status) => status !== 'completed' && status !== undefined,
+      ),
+    [itemStatuses],
+  );
+
+  const isRunActive = useMemo(() => {
+    if (!run) return false;
+    return ['EXECUTING', 'QUEUED', 'WAITING'].includes(run.status);
+  }, [run]);
+
+  const hasActiveProgress =
+    progress !== null && progress.completed < progress.total;
+  const isActive = isRunActive || hasActiveProgress || hasActiveItems;
+
+  return {
+    itemStatuses,
+    progress,
+    itemsInfo,
+    isActive,
+    isLoading: shouldSubscribe && !run,
+    runStatus: run?.status,
+  };
+}

--- a/apps/app/src/app/(app)/[orgId]/policies/(overview)/page.tsx
+++ b/apps/app/src/app/(app)/[orgId]/policies/(overview)/page.tsx
@@ -3,7 +3,6 @@ import type { Policy } from '@db';
 import { PageHeader, PageLayout, Stack } from '@trycompai/design-system';
 import type { Metadata } from 'next';
 import { Suspense } from 'react';
-import { PolicyTailoringProvider } from '../all/components/policy-tailoring-context';
 import { PolicyFilters } from '../all/components/PolicyFilters';
 import { PolicyPageActions } from '../all/components/PolicyPageActions';
 import { PolicyChartsClient } from './components/PolicyChartsClient';
@@ -21,9 +20,18 @@ interface PoliciesPageProps {
 export default async function PoliciesPage({ params }: PoliciesPageProps) {
   const { orgId } = await params;
 
-  const policiesRes = await serverApi.get<{ data: PolicyWithAssignee[] }>(
-    '/v1/policies',
-  );
+  // ENG-108: fetch the active onboarding run id alongside policies so the
+  // client-side filters component can subscribe and surface "tailoring your
+  // policies…" status during first-run AI generation. Mirrors the pattern
+  // used by the risks and vendors pages.
+  const [policiesRes, onboardingRes] = await Promise.all([
+    serverApi.get<{ data: PolicyWithAssignee[] }>('/v1/policies'),
+    serverApi.get<{
+      triggerJobId: string | null;
+      triggerJobCompleted: boolean;
+    } | null>('/v1/organization/onboarding'),
+  ]);
+
   const policies = Array.isArray(policiesRes.data?.data)
     ? policiesRes.data.data
     : [];
@@ -49,9 +57,10 @@ export default async function PoliciesPage({ params }: PoliciesPageProps) {
         <Suspense fallback={<Loading />}>
           <PolicyChartsClient organizationId={orgId} initialData={initialOverview} />
         </Suspense>
-        <PolicyTailoringProvider statuses={{}}>
-          <PolicyFilters policies={policies} />
-        </PolicyTailoringProvider>
+        <PolicyFilters
+          policies={policies}
+          onboardingRunId={onboardingRes.data?.triggerJobId ?? null}
+        />
       </Stack>
     </PageLayout>
   );

--- a/apps/app/src/app/(app)/[orgId]/policies/all/components/PolicyFilters.tsx
+++ b/apps/app/src/app/(app)/[orgId]/policies/all/components/PolicyFilters.tsx
@@ -14,12 +14,16 @@ import {
   Stack,
 } from '@trycompai/design-system';
 import { Search } from '@trycompai/design-system/icons';
+import { Loader2 } from 'lucide-react';
 import { useMemo, useState } from 'react';
+import { usePolicyOnboardingStatus } from '../../(overview)/hooks/use-policy-onboarding-status';
 import { PoliciesTableDS } from './PoliciesTableDS';
+import { PolicyTailoringProvider } from './policy-tailoring-context';
 import { comparePoliciesByName } from './policy-name-sort';
 
 interface PolicyFiltersProps {
   policies: Policy[];
+  onboardingRunId?: string | null;
 }
 
 const STATUS_OPTIONS: { value: PolicyStatus | 'all' | 'archived'; label: string }[] = [
@@ -30,12 +34,20 @@ const STATUS_OPTIONS: { value: PolicyStatus | 'all' | 'archived'; label: string 
   { value: 'archived', label: 'Archived' },
 ];
 
-export function PolicyFilters({ policies }: PolicyFiltersProps) {
+export function PolicyFilters({ policies, onboardingRunId }: PolicyFiltersProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<PolicyStatus | 'all' | 'archived'>('all');
   const [departmentFilter, setDepartmentFilter] = useState<string>('all');
   const [sortColumn, setSortColumn] = useState<'name' | 'status' | 'updatedAt'>('name');
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
+
+  // ENG-108: subscribe to the onboarding run so PoliciesTableDS can surface
+  // per-row "Tailoring/Queued/Preparing" state and we can render the banner
+  // while AI is still personalizing the policy pack. Mirrors the existing
+  // pattern in RisksTable/VendorsTable.
+  const { itemStatuses, progress, isActive } = usePolicyOnboardingStatus(onboardingRunId);
+  const hasActivePolicies = policies.length > 0;
+  const showTailoringBanner = isActive && hasActivePolicies && progress !== null;
 
   // Get unique departments from policies
   const departments = useMemo(() => {
@@ -103,63 +115,78 @@ export function PolicyFilters({ policies }: PolicyFiltersProps) {
     departmentFilter === 'all' ? 'All Departments' : formatDepartment(departmentFilter);
 
   return (
-    <Stack gap="md">
-      <div className="flex flex-col gap-3 md:flex-row md:items-end">
-        {/* Search - full width on mobile, constrained on desktop */}
-        <div className="w-full md:max-w-[300px]">
-          <InputGroup>
-            <InputGroupAddon>
-              <Search size={16} />
-            </InputGroupAddon>
-            <InputGroupInput
-              placeholder="Search policies..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-            />
-          </InputGroup>
-        </div>
-        {/* Filters - side by side on mobile, inline with search on desktop */}
-        <div className="flex gap-2">
-          <div className="flex-1 md:w-[160px] md:flex-none">
-            <Select
-              value={statusFilter}
-              onValueChange={(v) => setStatusFilter((v ?? 'all') as PolicyStatus | 'all' | 'archived')}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Status">{statusLabel}</SelectValue>
-              </SelectTrigger>
-              <SelectContent>
-                {STATUS_OPTIONS.map((opt) => (
-                  <SelectItem key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+    <PolicyTailoringProvider statuses={itemStatuses}>
+      <Stack gap="md">
+        <div className="flex flex-col gap-3 md:flex-row md:items-end">
+          {/* Search - full width on mobile, constrained on desktop */}
+          <div className="w-full md:max-w-[300px]">
+            <InputGroup>
+              <InputGroupAddon>
+                <Search size={16} />
+              </InputGroupAddon>
+              <InputGroupInput
+                placeholder="Search policies..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+              />
+            </InputGroup>
           </div>
-          <div className="flex-1 md:w-[160px] md:flex-none">
-            <Select value={departmentFilter} onValueChange={(v) => setDepartmentFilter(v ?? 'all')}>
-              <SelectTrigger>
-                <SelectValue placeholder="Department">{departmentLabel}</SelectValue>
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All Departments</SelectItem>
-                {departments.map((dept) => (
-                  <SelectItem key={dept} value={dept}>
-                    {formatDepartment(dept)}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+          {/* Filters - side by side on mobile, inline with search on desktop */}
+          <div className="flex gap-2">
+            <div className="flex-1 md:w-[160px] md:flex-none">
+              <Select
+                value={statusFilter}
+                onValueChange={(v) => setStatusFilter((v ?? 'all') as PolicyStatus | 'all' | 'archived')}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Status">{statusLabel}</SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  {STATUS_OPTIONS.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex-1 md:w-[160px] md:flex-none">
+              <Select value={departmentFilter} onValueChange={(v) => setDepartmentFilter(v ?? 'all')}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Department">{departmentLabel}</SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All Departments</SelectItem>
+                  {departments.map((dept) => (
+                    <SelectItem key={dept} value={dept}>
+                      {formatDepartment(dept)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
           </div>
         </div>
-      </div>
-      <PoliciesTableDS
-        policies={filteredPolicies}
-        sortColumn={sortColumn}
-        sortDirection={sortDirection}
-        onSort={handleSort}
-      />
-    </Stack>
+        {showTailoringBanner && progress !== null && (
+          <div className="flex items-center gap-3 rounded-xl border border-primary/20 bg-linear-to-r from-primary/10 via-primary/5 to-transparent px-4 py-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/15 text-primary">
+              <Loader2 className="h-5 w-5 animate-spin" />
+            </div>
+            <div className="flex flex-col">
+              <span className="text-sm font-medium text-primary">Tailoring your policies</span>
+              <span className="text-xs text-muted-foreground">
+                Personalized {progress.completed}/{progress.total} policies
+              </span>
+            </div>
+          </div>
+        )}
+        <PoliciesTableDS
+          policies={filteredPolicies}
+          sortColumn={sortColumn}
+          sortDirection={sortDirection}
+          onSort={handleSort}
+        />
+      </Stack>
+    </PolicyTailoringProvider>
   );
 }


### PR DESCRIPTION
## Summary

Fixes [ENG-108](https://linear.app/compai/issue/ENG-108) — during first-run onboarding, the \"AI is tailoring your policies\" banner and per-row tailoring status disappeared from the Policies page. Vendors and Risks already got their equivalent restored; Policies was the last holdout.

## Root cause

Commit `8974418c6` (Jan 2026 design-system migration) replaced the old `PoliciesTable` with `PoliciesTableDS`. The new flow wraps `<PolicyFilters>` in `<PolicyTailoringProvider statuses={{}}>` with an empty map, so `PoliciesTableDS`'s existing per-row \"Tailoring/Queued/Preparing\" rendering had no data to show. The page also never fetched the onboarding `triggerJobId`, so there was nothing to subscribe to.

## Fix

No trigger.dev pipeline changes — the backend still emits `policiesTotal` / `policiesCompleted` / `policy_<id>_status` exactly as before. Only the frontend wiring:

1. **New hook**: `apps/app/.../policies/(overview)/hooks/use-policy-onboarding-status.ts` — mirrors the existing risks/vendors `useOnboardingStatus` but handles the singular/plural correctly (the shared hook's `itemType.slice(0, -1)` would have produced `policie_`, not `policy_`).

2. **`policies/(overview)/page.tsx`**: fetch `/v1/organization/onboarding` alongside `/v1/policies` and pass the `triggerJobId` into `PolicyFilters`. Moved `PolicyTailoringProvider` out of the server component (where it had empty statuses) into `PolicyFilters` (client) where the realtime data lives.

3. **`PolicyFilters.tsx`**: accept `onboardingRunId`, subscribe via the new hook, wrap children in `PolicyTailoringProvider` with live statuses, render the \"Tailoring your policies — Personalized N/M\" banner while the run is active.

## Scope

- No schema changes, no new DB fields.
- No changes to the trigger.dev tasks or API endpoints.
- The orphaned `apps/app/.../policies/all/components/policies-table.tsx` (pre-migration legacy table, imported by nothing) is **left in place** to keep this PR focused; it's a follow-up cleanup candidate.

## Test plan

- [x] Typecheck clean on all touched files
- [ ] Manual: trigger a fresh org onboarding and confirm:
  - Banner appears: \"Tailoring your policies — Personalized X/Y policies\"
  - Each row in the table shows \"Tailoring\" / \"Queued\" / \"Preparing\" badges per row (via existing `PoliciesTableDS` rendering)
  - When onboarding completes, the banner disappears and rows show normal status
- [ ] Regression: on an org without an active onboarding run, the page renders exactly as before (no banner, no extra state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the “Tailoring your policies” banner and per-row tailoring badges on the Policies page during onboarding, addressing ENG-108. The page now streams onboarding progress so users see real-time status until completion.

- **Bug Fixes**
  - Added `usePolicyOnboardingStatus` using `@trigger.dev/react-hooks` to expose `policiesTotal`, `policiesCompleted`, and `policy_<id>_status`.
  - Updated `policies/(overview)/page.tsx` to fetch `/v1/organization/onboarding` and pass `onboardingRunId` to `PolicyFilters`.
  - Moved `PolicyTailoringProvider` into `PolicyFilters`; added a progress banner; `PoliciesTableDS` now shows live per-row statuses.
  - No backend, API, or schema changes.

<sup>Written for commit 6d2434ce4b9c29b77d1a6459842cd643b6e963ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

