### PR TITLE
fix(digest): inline compliance filter to avoid trigger.dev bundle fai…

### DIFF
--- a/apps/app/src/trigger/tasks/task/policy-acknowledgment-digest-helpers.test.ts
+++ b/apps/app/src/trigger/tasks/task/policy-acknowledgment-digest-helpers.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   computePendingPolicies,
+  filterDigestMembersByCompliance,
   type DigestMember,
   type DigestPolicy,
 } from './policy-acknowledgment-digest-helpers';
@@ -65,5 +66,63 @@ describe('computePendingPolicies', () => {
 
   it('returns empty array when there are no policies', () => {
     expect(computePendingPolicies(alice, [])).toEqual([]);
+  });
+});
+
+describe('filterDigestMembersByCompliance', () => {
+  const mockDb = {
+    organizationRole: { findMany: vi.fn() },
+  };
+
+  beforeEach(() => {
+    mockDb.organizationRole.findMany.mockReset();
+    mockDb.organizationRole.findMany.mockResolvedValue([]);
+  });
+
+  it('keeps members whose built-in role has the compliance obligation', async () => {
+    const member: DigestMember = {
+      id: 'm1', role: 'employee', department: 'it',
+      user: { id: 'u1', name: 'A', email: 'a@x', role: null },
+    };
+    const result = await filterDigestMembersByCompliance(mockDb, [member], 'org_1');
+    expect(result).toEqual([member]);
+  });
+
+  it('drops members whose only role lacks the compliance obligation', async () => {
+    const member: DigestMember = {
+      id: 'm2', role: 'auditor', department: null,
+      user: { id: 'u2', name: 'B', email: 'b@x', role: null },
+    };
+    const result = await filterDigestMembersByCompliance(mockDb, [member], 'org_1');
+    expect(result).toEqual([]);
+  });
+
+  it('drops platform admins even when member role has the obligation', async () => {
+    const member: DigestMember = {
+      id: 'm3', role: 'employee', department: 'it',
+      user: { id: 'u3', name: 'C', email: 'c@x', role: 'admin' },
+    };
+    const result = await filterDigestMembersByCompliance(mockDb, [member], 'org_1');
+    expect(result).toEqual([]);
+  });
+
+  it('resolves custom-role obligations via organizationRole lookup', async () => {
+    mockDb.organizationRole.findMany.mockResolvedValueOnce([
+      { name: 'contributor', obligations: { compliance: true } },
+    ]);
+    const keeper: DigestMember = {
+      id: 'm4', role: 'contributor', department: 'hr',
+      user: { id: 'u4', name: 'D', email: 'd@x', role: null },
+    };
+    const dropper: DigestMember = {
+      id: 'm5', role: 'observer', department: 'hr',
+      user: { id: 'u5', name: 'E', email: 'e@x', role: null },
+    };
+    const result = await filterDigestMembersByCompliance(
+      mockDb,
+      [keeper, dropper],
+      'org_1',
+    );
+    expect(result.map((m) => m.id)).toEqual(['m4']);
   });
 });

--- a/apps/app/src/trigger/tasks/task/policy-acknowledgment-digest-helpers.ts
+++ b/apps/app/src/trigger/tasks/task/policy-acknowledgment-digest-helpers.ts
@@ -4,6 +4,83 @@
  */
 import type { Departments, PolicyVisibility } from '@db';
 
+// Inlined from @trycompai/auth to avoid pulling that package into the Trigger.dev bundle.
+// Keep in sync with packages/auth/src/permissions.ts BUILT_IN_ROLE_OBLIGATIONS.
+const BUILT_IN_ROLE_OBLIGATIONS: Record<string, { compliance?: boolean }> = {
+  owner: { compliance: true },
+  admin: { compliance: true },
+  auditor: {},
+  employee: { compliance: true },
+  contractor: { compliance: true },
+};
+const BUILT_IN_ROLE_NAMES = new Set(Object.keys(BUILT_IN_ROLE_OBLIGATIONS));
+
+export interface ComplianceFilterDb {
+  organizationRole: {
+    findMany: (args: {
+      where: { organizationId: string; name: { in: string[] } };
+      select: { name: true; obligations: true };
+    }) => Promise<Array<{ name: string; obligations: unknown }>>;
+  };
+}
+
+/**
+ * Filter members to only those with the compliance obligation.
+ * Inlined equivalent of apps/app/src/lib/compliance.ts#filterComplianceMembers
+ * so this file has no transitive dependency on @trycompai/auth (which cannot
+ * be bundled by the Trigger.dev deploy pipeline).
+ */
+export async function filterDigestMembersByCompliance<T extends DigestMember>(
+  db: ComplianceFilterDb,
+  members: T[],
+  organizationId: string,
+): Promise<T[]> {
+  if (members.length === 0) return [];
+
+  const customRoleNames = new Set<string>();
+  const parsed = members.map((member) => {
+    const roleNames = member.role
+      .split(',')
+      .map((r) => r.trim())
+      .filter(Boolean);
+    for (const name of roleNames) {
+      if (!BUILT_IN_ROLE_NAMES.has(name)) customRoleNames.add(name);
+    }
+    return { member, roleNames };
+  });
+
+  let customObligationMap: Record<string, { compliance?: boolean }> = {};
+  if (customRoleNames.size > 0) {
+    const customRoles = await db.organizationRole.findMany({
+      where: { organizationId, name: { in: [...customRoleNames] } },
+      select: { name: true, obligations: true },
+    });
+    customObligationMap = Object.fromEntries(
+      customRoles.map((r) => {
+        const obligations =
+          typeof r.obligations === 'string'
+            ? JSON.parse(r.obligations)
+            : r.obligations || {};
+        return [r.name, obligations as { compliance?: boolean }];
+      }),
+    );
+  }
+
+  return parsed
+    .filter(({ member, roleNames }) => {
+      // Platform admins are excluded — matches the @/lib/compliance behavior.
+      if (member.user?.role === 'admin') return false;
+      for (const name of roleNames) {
+        const builtIn = BUILT_IN_ROLE_OBLIGATIONS[name];
+        if (builtIn?.compliance) return true;
+        const custom = customObligationMap[name];
+        if (custom?.compliance) return true;
+      }
+      return false;
+    })
+    .map(({ member }) => member);
+}
+
 export interface DigestPolicy {
   id: string;
   name: string;

--- a/apps/app/src/trigger/tasks/task/policy-acknowledgment-digest.test.ts
+++ b/apps/app/src/trigger/tasks/task/policy-acknowledgment-digest.test.ts
@@ -6,9 +6,13 @@ vi.mock('@db/server', () => ({
   },
 }));
 
-vi.mock('@/lib/compliance', () => ({
-  filterComplianceMembers: vi.fn(),
-}));
+vi.mock('./policy-acknowledgment-digest-helpers', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('./policy-acknowledgment-digest-helpers')>();
+  return {
+    ...mod,
+    filterDigestMembersByCompliance: vi.fn().mockImplementation(async (_db: unknown, members: unknown[]) => members),
+  };
+});
 
 vi.mock('../../lib/send-email-via-api', () => ({
   sendEmailViaApi: vi.fn(),
@@ -26,7 +30,7 @@ vi.mock('@trigger.dev/sdk', () => ({
 }));
 
 import { db } from '@db/server';
-import { filterComplianceMembers } from '@/lib/compliance';
+import { filterDigestMembersByCompliance } from './policy-acknowledgment-digest-helpers';
 import { sendEmailViaApi } from '../../lib/send-email-via-api';
 import { getUnsubscribedEmails } from '@trycompai/email/lib/check-unsubscribe';
 import { policyAcknowledgmentDigest } from './policy-acknowledgment-digest';
@@ -35,7 +39,7 @@ const mockDb = db as unknown as {
   organization: { findMany: ReturnType<typeof vi.fn> };
 };
 const mockFindMany = mockDb.organization.findMany;
-const mockFilterComplianceMembers = vi.mocked(filterComplianceMembers);
+const mockFilterDigestMembersByCompliance = vi.mocked(filterDigestMembersByCompliance);
 const mockSendEmailViaApi = vi.mocked(sendEmailViaApi);
 const mockGetUnsubscribedEmails = vi.mocked(getUnsubscribedEmails);
 
@@ -54,7 +58,7 @@ const taskUnderTest = policyAcknowledgmentDigest as unknown as {
 describe('policyAcknowledgmentDigest', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockFilterComplianceMembers.mockImplementation(async (members) => members);
+    mockFilterDigestMembersByCompliance.mockImplementation(async (_db, members) => members);
     mockSendEmailViaApi.mockResolvedValue({ taskId: 'run_fake' });
     mockGetUnsubscribedEmails.mockResolvedValue(new Set<string>());
   });
@@ -176,7 +180,7 @@ describe('policyAcknowledgmentDigest', () => {
         ],
       },
     ]);
-    mockFilterComplianceMembers.mockResolvedValueOnce([]);
+    mockFilterDigestMembersByCompliance.mockResolvedValueOnce([]);
 
     const result = await taskUnderTest.run({
       timestamp: new Date(),

--- a/apps/app/src/trigger/tasks/task/policy-acknowledgment-digest.ts
+++ b/apps/app/src/trigger/tasks/task/policy-acknowledgment-digest.ts
@@ -1,13 +1,14 @@
 import { db } from '@db/server';
 import { logger, schedules } from '@trigger.dev/sdk';
 
-import { filterComplianceMembers } from '@/lib/compliance';
 import { PolicyAcknowledgmentDigestEmail } from '@trycompai/email';
 import { getUnsubscribedEmails } from '@trycompai/email/lib/check-unsubscribe';
 
 import { sendEmailViaApi } from '../../lib/send-email-via-api';
 import {
   computePendingPolicies,
+  filterDigestMembersByCompliance,
+  type ComplianceFilterDb,
   type DigestMember,
 } from './policy-acknowledgment-digest-helpers';
 
@@ -90,7 +91,8 @@ export const policyAcknowledgmentDigest = schedules.task({
 
     for (const org of organizations) {
       orgsProcessed += 1;
-      const complianceMembers = await filterComplianceMembers<DigestMember>(
+      const complianceMembers = await filterDigestMembersByCompliance(
+        db as unknown as ComplianceFilterDb,
         org.members,
         org.id,
       );


### PR DESCRIPTION
…lure

The Trigger.dev deploy pipeline cannot resolve @trycompai/auth because its dist is not built during the CI deploy step. Remove the transitive dependency by inlining the compliance-obligation filter directly in the helpers file, keeping identical behaviour.

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #XXXX (GitHub issue number)
- Fixes COMP-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://trycomp.ai/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/trycompai/comp/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inlined the compliance-role filter in the digest helpers to remove the transitive dependency on `@trycompai/auth` that broke Trigger.dev bundling. Behavior is unchanged and deploys succeed again.

- **Bug Fixes**
  - Replaced `filterComplianceMembers` with local `filterDigestMembersByCompliance`.
  - Inlined built-in role obligations and resolved custom roles via `organizationRole` lookup.
  - Excludes platform admins as before; output set remains the same.
  - Updated task to use the local filter and added focused unit tests for filtering logic.

<sup>Written for commit b1ac2a877aaf1cc970bba77579a026990a9e39f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

