### PR TITLE
fix(devices): flag stale device agents as non-compliant + CSV export

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -81,6 +81,7 @@
         "@trycompai/db": "workspace:*",
         "@trycompai/email": "workspace:*",
         "@trycompai/integration-platform": "workspace:*",
+        "@trycompai/utils": "workspace:*",
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.34.2",
         "@upstash/vector": "^1.2.2",
@@ -167,7 +168,8 @@
             "^@trycompai/company$": "<rootDir>/../../../packages/company/src/index.ts",
             "^@trycompai/db$": "@prisma/client",
             "^@trycompai/email$": "<rootDir>/../../../packages/email/index.ts",
-            "^@trycompai/integration-platform$": "<rootDir>/../../../packages/integration-platform/src/index.ts"
+            "^@trycompai/integration-platform$": "<rootDir>/../../../packages/integration-platform/src/index.ts",
+            "^@trycompai/utils/(.*)$": "<rootDir>/../../../packages/utils/src/$1.ts"
         }
     },
     "license": "UNLICENSED",

--- a/apps/api/src/devices/devices.service.ts
+++ b/apps/api/src/devices/devices.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, NotFoundException, Logger } from '@nestjs/common';
 import { db } from '@db';
+import { getDeviceComplianceStatus } from '@trycompai/utils/devices';
 import { FleetService } from '../lib/fleet.service';
 import { DeviceResponseDto } from './dto/device-responses.dto';
 import type { MemberResponseDto } from './dto/member-responses.dto';
@@ -331,7 +332,14 @@ export class DevicesService {
     dto.updated_at = device.updatedAt.toISOString();
     dto.display_name = device.name;
     dto.display_text = device.name;
-    dto.status = device.isCompliant ? 'compliant' : 'non-compliant';
+    const complianceStatus = getDeviceComplianceStatus({
+      isCompliant: device.isCompliant,
+      lastCheckIn: device.lastCheckIn,
+    });
+    // Keep the existing string shape ('compliant' | 'non-compliant' | 'stale') so
+    // downstream API consumers see a predictable value.
+    dto.status =
+      complianceStatus === 'non_compliant' ? 'non-compliant' : complianceStatus;
     dto.disk_encryption_enabled = device.diskEncryptionEnabled;
     dto.source = 'device_agent';
     // Default empty values for FleetDM-specific fields

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/page.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/page.tsx
@@ -11,6 +11,10 @@ import { db } from '@db/server';
 import type { Metadata } from 'next';
 import { headers } from 'next/headers';
 import { notFound, redirect } from 'next/navigation';
+import {
+  daysSinceCheckIn,
+  getDeviceComplianceStatus,
+} from '@trycompai/utils/devices';
 import type { CheckDetails, DeviceWithChecks } from '../devices/types';
 import { Employee } from './components/Employee';
 
@@ -287,6 +291,11 @@ const getMemberDevice = async (
     return null;
   }
 
+  const complianceStatus = getDeviceComplianceStatus({
+    isCompliant: device.isCompliant,
+    lastCheckIn: device.lastCheckIn,
+  });
+
   return {
     id: device.id,
     name: device.name,
@@ -309,5 +318,7 @@ const getMemberDevice = async (
       email: device.member.user.email,
     },
     source: 'device_agent' as const,
+    complianceStatus,
+    daysSinceLastCheckIn: daysSinceCheckIn(device.lastCheckIn),
   };
 };

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceAgentDevicesList.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceAgentDevicesList.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { DeviceWithChecks } from '../types';
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ orgId: 'org_1' }),
+}));
+
+vi.mock('../lib/devices-csv', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../lib/devices-csv')>();
+  return {
+    ...mod,
+    downloadDevicesCsv: vi.fn(),
+  };
+});
+
+import { DeviceAgentDevicesList } from './DeviceAgentDevicesList';
+import { downloadDevicesCsv } from '../lib/devices-csv';
+
+const mockDownload = vi.mocked(downloadDevicesCsv);
+
+function makeDevice(overrides: Partial<DeviceWithChecks> = {}): DeviceWithChecks {
+  return {
+    id: 'dev_1',
+    name: 'Mac',
+    hostname: 'mac',
+    platform: 'macos',
+    osVersion: '14.0',
+    serialNumber: 'SN1',
+    hardwareModel: 'MBP',
+    isCompliant: true,
+    diskEncryptionEnabled: true,
+    antivirusEnabled: true,
+    passwordPolicySet: true,
+    screenLockEnabled: true,
+    checkDetails: null,
+    lastCheckIn: new Date().toISOString(),
+    agentVersion: '1.0.0',
+    installedAt: new Date().toISOString(),
+    memberId: 'mem_1',
+    user: { name: 'Jane', email: 'jane@example.com' },
+    source: 'device_agent',
+    complianceStatus: 'compliant',
+    daysSinceLastCheckIn: 0,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('DeviceAgentDevicesList', () => {
+  it('renders "Yes" for a compliant device', () => {
+    render(<DeviceAgentDevicesList devices={[makeDevice()]} />);
+    expect(screen.getByText('Yes')).toBeInTheDocument();
+  });
+
+  it('renders "No" for a non-compliant fresh device', () => {
+    render(
+      <DeviceAgentDevicesList
+        devices={[makeDevice({ isCompliant: false, complianceStatus: 'non_compliant' })]}
+      />,
+    );
+    expect(screen.getByText('No')).toBeInTheDocument();
+  });
+
+  it('renders "Stale (Nd)" for a stale device and shows em-dash check badges', () => {
+    render(
+      <DeviceAgentDevicesList
+        devices={[
+          makeDevice({
+            complianceStatus: 'stale',
+            daysSinceLastCheckIn: 34,
+            diskEncryptionEnabled: true,
+            antivirusEnabled: true,
+            passwordPolicySet: true,
+            screenLockEnabled: true,
+          }),
+        ]}
+      />,
+    );
+    expect(screen.getByText('Stale (34d)')).toBeInTheDocument();
+    // All four check badges should show em-dash when stale.
+    const dashBadges = screen.getAllByText('—');
+    expect(dashBadges.length).toBe(4);
+  });
+
+  it('renders "Stale" with no day count when lastCheckIn is null', () => {
+    render(
+      <DeviceAgentDevicesList
+        devices={[
+          makeDevice({
+            lastCheckIn: null,
+            complianceStatus: 'stale',
+            daysSinceLastCheckIn: null,
+          }),
+        ]}
+      />,
+    );
+    expect(screen.getByText('Stale')).toBeInTheDocument();
+  });
+
+  it('shows the Export CSV button when devices are present', () => {
+    render(<DeviceAgentDevicesList devices={[makeDevice()]} />);
+    expect(screen.getByRole('button', { name: /export csv/i })).toBeInTheDocument();
+  });
+
+  it('calls the CSV download with the built rows when clicked', () => {
+    render(
+      <DeviceAgentDevicesList
+        devices={[
+          makeDevice({ name: 'Alpha', id: 'a' }),
+          makeDevice({ name: 'Beta', id: 'b', complianceStatus: 'stale', daysSinceLastCheckIn: 10 }),
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /export csv/i }));
+    expect(mockDownload).toHaveBeenCalledTimes(1);
+    const [filename, contents] = mockDownload.mock.calls[0];
+    expect(filename).toMatch(/^devices-org_1-\d{4}-\d{2}-\d{2}\.csv$/);
+    expect(contents).toContain('Alpha');
+    expect(contents).toContain('Beta');
+    expect(contents).toContain('stale');
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceAgentDevicesList.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceAgentDevicesList.tsx
@@ -2,6 +2,7 @@
 
 import {
   Badge,
+  Button,
   Empty,
   EmptyDescription,
   EmptyHeader,
@@ -18,11 +19,16 @@ import {
   TableRow,
   Text,
 } from '@trycompai/design-system';
-import { Search } from '@trycompai/design-system/icons';
+import { Download, Search } from '@trycompai/design-system/icons';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { useMemo, useState } from 'react';
 import type { DeviceWithChecks } from '../types';
+import {
+  buildDevicesCsv,
+  devicesCsvFilename,
+  downloadDevicesCsv,
+} from '../lib/devices-csv';
 import { DeviceDetails } from './DeviceDetails';
 
 export interface DeviceAgentDevicesListProps {
@@ -62,6 +68,10 @@ function isDeviceOnline(lastCheckIn: string | null): boolean {
   return diffMs < 2 * 60 * 60 * 1000;
 }
 
+function staleLabel(daysSinceLastCheckIn: number | null): string {
+  return daysSinceLastCheckIn === null ? 'Stale' : `Stale (${daysSinceLastCheckIn}d)`;
+}
+
 function UserNameCell({ device }: { device: DeviceWithChecks }) {
   const params = useParams();
   const orgId = params?.orgId as string;
@@ -90,7 +100,41 @@ function UserNameCell({ device }: { device: DeviceWithChecks }) {
   );
 }
 
+function CompliantBadge({ device }: { device: DeviceWithChecks }) {
+  if (device.complianceStatus === 'stale') {
+    return <Badge variant="secondary">{staleLabel(device.daysSinceLastCheckIn)}</Badge>;
+  }
+  if (device.complianceStatus === 'compliant') {
+    return <Badge variant="default">Yes</Badge>;
+  }
+  return <Badge variant="destructive">No</Badge>;
+}
+
+function CheckBadges({ device }: { device: DeviceWithChecks }) {
+  if (device.complianceStatus === 'stale') {
+    return (
+      <div className="flex flex-wrap gap-1">
+        {CHECK_FIELDS.map(({ key, label }) => (
+          <Badge key={key} variant="secondary" title={`${label} — unknown (device is stale)`}>
+            —
+          </Badge>
+        ))}
+      </div>
+    );
+  }
+  return (
+    <div className="flex flex-wrap gap-1">
+      {CHECK_FIELDS.map(({ key, label }) => (
+        <Badge key={key} variant={device[key] ? 'default' : 'destructive'}>
+          {label}
+        </Badge>
+      ))}
+    </div>
+  );
+}
+
 export const DeviceAgentDevicesList = ({ devices }: DeviceAgentDevicesListProps) => {
+  const { orgId } = useParams<{ orgId: string }>();
   const [selectedDevice, setSelectedDevice] = useState<DeviceWithChecks | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [page, setPage] = useState(1);
@@ -114,6 +158,12 @@ export const DeviceAgentDevicesList = ({ devices }: DeviceAgentDevicesListProps)
     return filteredDevices.slice(start, start + perPage);
   }, [filteredDevices, page, perPage]);
 
+  function handleExport() {
+    const contents = buildDevicesCsv(devices);
+    const filename = devicesCsvFilename({ orgId });
+    downloadDevicesCsv(filename, contents);
+  }
+
   if (selectedDevice) {
     return <DeviceDetails device={selectedDevice} onClose={() => setSelectedDevice(null)} />;
   }
@@ -124,20 +174,26 @@ export const DeviceAgentDevicesList = ({ devices }: DeviceAgentDevicesListProps)
 
   return (
     <Stack gap="4">
-      <div className="w-full md:max-w-[300px]">
-        <InputGroup>
-          <InputGroupAddon>
-            <Search size={16} />
-          </InputGroupAddon>
-          <InputGroupInput
-            placeholder="Search devices..."
-            value={searchQuery}
-            onChange={(e) => {
-              setSearchQuery(e.target.value);
-              setPage(1);
-            }}
-          />
-        </InputGroup>
+      <div className="flex w-full flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <div className="w-full md:max-w-[300px]">
+          <InputGroup>
+            <InputGroupAddon>
+              <Search size={16} />
+            </InputGroupAddon>
+            <InputGroupInput
+              placeholder="Search devices..."
+              value={searchQuery}
+              onChange={(e) => {
+                setSearchQuery(e.target.value);
+                setPage(1);
+              }}
+            />
+          </InputGroup>
+        </div>
+        <Button variant="outline" onClick={handleExport}>
+          <Download size={16} />
+          Export CSV
+        </Button>
       </div>
 
       {filteredDevices.length === 0 ? (
@@ -209,21 +265,10 @@ export const DeviceAgentDevicesList = ({ devices }: DeviceAgentDevicesListProps)
                   <Text size="sm">{formatTimeAgo(device.lastCheckIn)}</Text>
                 </TableCell>
                 <TableCell>
-                  <div className="flex flex-wrap gap-1">
-                    {CHECK_FIELDS.map(({ key, label }) => (
-                      <Badge
-                        key={key}
-                        variant={device[key] ? 'default' : 'destructive'}
-                      >
-                        {label}
-                      </Badge>
-                    ))}
-                  </div>
+                  <CheckBadges device={device} />
                 </TableCell>
                 <TableCell>
-                  <Badge variant={device.isCompliant ? 'default' : 'destructive'}>
-                    {device.isCompliant ? 'Yes' : 'No'}
-                  </Badge>
+                  <CompliantBadge device={device} />
                 </TableCell>
               </TableRow>
             ))}

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceAgentDevicesList.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceAgentDevicesList.tsx
@@ -72,9 +72,7 @@ function staleLabel(daysSinceLastCheckIn: number | null): string {
   return daysSinceLastCheckIn === null ? 'Stale' : `Stale (${daysSinceLastCheckIn}d)`;
 }
 
-function UserNameCell({ device }: { device: DeviceWithChecks }) {
-  const params = useParams();
-  const orgId = params?.orgId as string;
+function UserNameCell({ device, orgId }: { device: DeviceWithChecks; orgId: string }) {
   const memberId = device.memberId;
 
   if (!memberId) {
@@ -102,7 +100,18 @@ function UserNameCell({ device }: { device: DeviceWithChecks }) {
 
 function CompliantBadge({ device }: { device: DeviceWithChecks }) {
   if (device.complianceStatus === 'stale') {
-    return <Badge variant="secondary">{staleLabel(device.daysSinceLastCheckIn)}</Badge>;
+    return (
+      <Badge
+        variant="secondary"
+        title={
+          device.daysSinceLastCheckIn === null
+            ? 'No check-ins recorded'
+            : `No check-in in ${device.daysSinceLastCheckIn} days`
+        }
+      >
+        {staleLabel(device.daysSinceLastCheckIn)}
+      </Badge>
+    );
   }
   if (device.complianceStatus === 'compliant') {
     return <Badge variant="default">Yes</Badge>;
@@ -251,7 +260,7 @@ export const DeviceAgentDevicesList = ({ devices }: DeviceAgentDevicesListProps)
                   </div>
                 </TableCell>
                 <TableCell>
-                  <UserNameCell device={device} />
+                  <UserNameCell device={device} orgId={orgId} />
                 </TableCell>
                 <TableCell>
                   <div className="flex flex-col">

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceAgentDevicesList.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceAgentDevicesList.tsx
@@ -199,8 +199,7 @@ export const DeviceAgentDevicesList = ({ devices }: DeviceAgentDevicesListProps)
             />
           </InputGroup>
         </div>
-        <Button variant="outline" onClick={handleExport}>
-          <Download size={16} />
+        <Button variant="outline" iconLeft={<Download />} onClick={handleExport}>
           Export CSV
         </Button>
       </div>

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceComplianceChart.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceComplianceChart.test.tsx
@@ -48,6 +48,8 @@ function makeAgentDevice(overrides: Partial<DeviceWithChecks> = {}): DeviceWithC
     installedAt: new Date().toISOString(),
     user: { name: 'Test User', email: 'test@example.com' },
     source: 'device_agent',
+    complianceStatus: 'compliant',
+    daysSinceLastCheckIn: 0,
     ...overrides,
   };
 }

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceComplianceChart.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceComplianceChart.test.tsx
@@ -142,11 +142,25 @@ describe('DeviceComplianceChart', () => {
   it('counts agent devices correctly — mixed compliance', () => {
     const devices = [
       makeAgentDevice({ isCompliant: true }),
-      makeAgentDevice({ isCompliant: false }),
+      makeAgentDevice({ isCompliant: false, complianceStatus: 'non_compliant' }),
     ];
 
     render(<DeviceComplianceChart fleetDevices={[]} agentDevices={devices} />);
     expect(screen.getByText('Compliant (1)')).toBeInTheDocument();
+    expect(screen.getByText('Non-Compliant (1)')).toBeInTheDocument();
+  });
+
+  it('counts stale agent devices as Non-Compliant (chart stays binary)', () => {
+    const devices = [
+      makeAgentDevice({
+        isCompliant: true,
+        complianceStatus: 'stale',
+        daysSinceLastCheckIn: 30,
+      }),
+    ];
+
+    render(<DeviceComplianceChart fleetDevices={[]} agentDevices={devices} />);
+    expect(screen.getByText('Compliant (0)')).toBeInTheDocument();
     expect(screen.getByText('Non-Compliant (1)')).toBeInTheDocument();
   });
 
@@ -183,7 +197,7 @@ describe('DeviceComplianceChart', () => {
   it('combines agent and fleet devices in total count', () => {
     const agentDevices = [
       makeAgentDevice({ isCompliant: true }),
-      makeAgentDevice({ isCompliant: false }),
+      makeAgentDevice({ isCompliant: false, complianceStatus: 'non_compliant' }),
     ];
     const fleetDevices = [
       makeFleetDevice({

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceComplianceChart.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceComplianceChart.tsx
@@ -31,9 +31,10 @@ export function DeviceComplianceChart({ fleetDevices, agentDevices }: DeviceComp
     let compliantCount = 0;
     let nonCompliantCount = 0;
 
-    // Count device-agent devices
+    // Count device-agent devices. Stale devices (no check-in for >= 7 days)
+    // count as non-compliant to match the table's three-state rendering.
     for (const device of agentDevices ?? []) {
-      if (device.isCompliant) {
+      if (device.complianceStatus === 'compliant') {
         compliantCount++;
       } else {
         nonCompliantCount++;

--- a/apps/app/src/app/(app)/[orgId]/people/devices/lib/devices-csv.test.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/lib/devices-csv.test.ts
@@ -133,6 +133,41 @@ describe('buildDevicesCsv', () => {
     expect(lines[1].startsWith('Alpha,')).toBe(true);
     expect(lines[2].startsWith('Beta,')).toBe(true);
   });
+
+  describe('formula injection neutralization', () => {
+    function firstCell(csv: string): string {
+      const body = stripBom(csv);
+      const row = body.slice(0, -2).split('\r\n')[1];
+      return row.split(',')[0];
+    }
+
+    it('prefixes cells starting with "=" with an apostrophe', () => {
+      const csv = buildDevicesCsv([makeDevice({ name: '=CMD(A1)' })]);
+      expect(firstCell(csv)).toBe("'=CMD(A1)");
+    });
+
+    it('prefixes cells starting with "+" with an apostrophe', () => {
+      const csv = buildDevicesCsv([makeDevice({ name: '+1234' })]);
+      expect(firstCell(csv)).toBe("'+1234");
+    });
+
+    it('prefixes cells starting with "-" with an apostrophe', () => {
+      const csv = buildDevicesCsv([makeDevice({ name: '-5' })]);
+      expect(firstCell(csv)).toBe("'-5");
+    });
+
+    it('prefixes cells starting with "@" with an apostrophe', () => {
+      const csv = buildDevicesCsv([makeDevice({ name: '@somewhere' })]);
+      expect(firstCell(csv)).toBe("'@somewhere");
+    });
+
+    it('prefixes and double-quotes cells with a leading trigger AND an embedded comma', () => {
+      const csv = buildDevicesCsv([makeDevice({ name: '=EVIL,' })]);
+      const body = stripBom(csv);
+      const rowsPart = body.slice(0, -2).split('\r\n').slice(1).join('\r\n');
+      expect(rowsPart.startsWith('"\'=EVIL,"')).toBe(true);
+    });
+  });
 });
 
 describe('devicesCsvFilename', () => {

--- a/apps/app/src/app/(app)/[orgId]/people/devices/lib/devices-csv.test.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/lib/devices-csv.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import type { DeviceWithChecks } from '../types';
+import { buildDevicesCsv, DEVICES_CSV_HEADER } from './devices-csv';
+
+function makeDevice(overrides: Partial<DeviceWithChecks> = {}): DeviceWithChecks {
+  return {
+    id: 'dev_1',
+    name: 'MacBook',
+    hostname: 'macbook',
+    platform: 'macos',
+    osVersion: '14.0',
+    serialNumber: 'SN1',
+    hardwareModel: 'MBP',
+    isCompliant: true,
+    diskEncryptionEnabled: true,
+    antivirusEnabled: true,
+    passwordPolicySet: true,
+    screenLockEnabled: true,
+    checkDetails: null,
+    lastCheckIn: '2026-04-17T12:00:00.000Z',
+    agentVersion: '1.2.0',
+    installedAt: '2026-01-01T00:00:00.000Z',
+    memberId: 'mem_1',
+    user: { name: 'Jane Doe', email: 'jane@example.com' },
+    source: 'device_agent',
+    complianceStatus: 'compliant',
+    daysSinceLastCheckIn: 0,
+    ...overrides,
+  };
+}
+
+describe('buildDevicesCsv', () => {
+  it('emits the fixed header row', () => {
+    const csv = buildDevicesCsv([]);
+    expect(csv).toBe(DEVICES_CSV_HEADER + '\n');
+  });
+
+  it('renders a compliant device in column order', () => {
+    const csv = buildDevicesCsv([makeDevice()]);
+    const [header, row] = csv.trim().split('\n');
+    expect(header).toBe(DEVICES_CSV_HEADER);
+    expect(row).toBe(
+      [
+        'MacBook',
+        'Jane Doe',
+        'jane@example.com',
+        'macos',
+        '14.0',
+        '1.2.0',
+        '2026-04-17T12:00:00.000Z',
+        '0',
+        'compliant',
+        'yes',
+        'yes',
+        'yes',
+        'yes',
+      ].join(','),
+    );
+  });
+
+  it('uses "no" for failing checks and stale status when applicable', () => {
+    const csv = buildDevicesCsv([
+      makeDevice({
+        complianceStatus: 'stale',
+        daysSinceLastCheckIn: 51,
+        diskEncryptionEnabled: false,
+        antivirusEnabled: false,
+      }),
+    ]);
+    const row = csv.trim().split('\n')[1];
+    const cells = row.split(',');
+    expect(cells).toContain('stale');
+    expect(cells[7]).toBe('51'); // days since sync
+    expect(cells.slice(-4)).toEqual(['no', 'no', 'yes', 'yes']);
+  });
+
+  it('represents never-synced devices with empty last-check-in and empty days', () => {
+    const csv = buildDevicesCsv([
+      makeDevice({
+        lastCheckIn: null,
+        daysSinceLastCheckIn: null,
+        complianceStatus: 'stale',
+      }),
+    ]);
+    const cells = csv.trim().split('\n')[1].split(',');
+    expect(cells[6]).toBe(''); // last check-in
+    expect(cells[7]).toBe(''); // days since sync
+    expect(cells[8]).toBe('stale');
+  });
+
+  it('escapes commas, quotes, and newlines per RFC 4180', () => {
+    const csv = buildDevicesCsv([
+      makeDevice({
+        name: 'Device, "quoted"',
+        user: { name: 'Line1\nLine2', email: 'x@y.com' },
+      }),
+    ]);
+    const row = csv.trim().split('\n').slice(1).join('\n'); // multi-line row is still one row
+    expect(row.startsWith('"Device, ""quoted"""')).toBe(true);
+    expect(row).toContain('"Line1\nLine2"');
+  });
+
+  it('handles multiple rows', () => {
+    const csv = buildDevicesCsv([
+      makeDevice({ id: 'a', name: 'Alpha' }),
+      makeDevice({ id: 'b', name: 'Beta', complianceStatus: 'non_compliant' }),
+    ]);
+    const lines = csv.trim().split('\n');
+    expect(lines).toHaveLength(3);
+    expect(lines[1].startsWith('Alpha,')).toBe(true);
+    expect(lines[2].startsWith('Beta,')).toBe(true);
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/people/devices/lib/devices-csv.test.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/lib/devices-csv.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { DeviceWithChecks } from '../types';
-import { buildDevicesCsv, DEVICES_CSV_HEADER } from './devices-csv';
+import {
+  buildDevicesCsv,
+  DEVICES_CSV_HEADER,
+  devicesCsvFilename,
+  downloadDevicesCsv,
+} from './devices-csv';
 
 function makeDevice(overrides: Partial<DeviceWithChecks> = {}): DeviceWithChecks {
   return {
@@ -29,15 +34,27 @@ function makeDevice(overrides: Partial<DeviceWithChecks> = {}): DeviceWithChecks
   };
 }
 
+function stripBom(csv: string): string {
+  return csv.replace(/^\uFEFF/, '');
+}
+
 describe('buildDevicesCsv', () => {
-  it('emits the fixed header row', () => {
+  it('prepends a UTF-8 BOM so Excel renders non-ASCII correctly', () => {
     const csv = buildDevicesCsv([]);
-    expect(csv).toBe(DEVICES_CSV_HEADER + '\n');
+    expect(csv.charCodeAt(0)).toBe(0xfeff);
   });
 
-  it('renders a compliant device in column order', () => {
+  it('emits the fixed header row with CRLF terminator', () => {
+    const csv = buildDevicesCsv([]);
+    expect(stripBom(csv)).toBe(DEVICES_CSV_HEADER + '\r\n');
+  });
+
+  it('renders a compliant device in column order using CRLF line endings', () => {
     const csv = buildDevicesCsv([makeDevice()]);
-    const [header, row] = csv.trim().split('\n');
+    const body = stripBom(csv);
+    // Trim only the trailing terminator to keep any embedded CRLFs intact.
+    expect(body.endsWith('\r\n')).toBe(true);
+    const [header, row] = body.slice(0, -2).split('\r\n');
     expect(header).toBe(DEVICES_CSV_HEADER);
     expect(row).toBe(
       [
@@ -67,7 +84,8 @@ describe('buildDevicesCsv', () => {
         antivirusEnabled: false,
       }),
     ]);
-    const row = csv.trim().split('\n')[1];
+    const body = stripBom(csv);
+    const row = body.slice(0, -2).split('\r\n')[1];
     const cells = row.split(',');
     expect(cells).toContain('stale');
     expect(cells[7]).toBe('51'); // days since sync
@@ -82,7 +100,8 @@ describe('buildDevicesCsv', () => {
         complianceStatus: 'stale',
       }),
     ]);
-    const cells = csv.trim().split('\n')[1].split(',');
+    const body = stripBom(csv);
+    const cells = body.slice(0, -2).split('\r\n')[1].split(',');
     expect(cells[6]).toBe(''); // last check-in
     expect(cells[7]).toBe(''); // days since sync
     expect(cells[8]).toBe('stale');
@@ -95,19 +114,136 @@ describe('buildDevicesCsv', () => {
         user: { name: 'Line1\nLine2', email: 'x@y.com' },
       }),
     ]);
-    const row = csv.trim().split('\n').slice(1).join('\n'); // multi-line row is still one row
-    expect(row.startsWith('"Device, ""quoted"""')).toBe(true);
-    expect(row).toContain('"Line1\nLine2"');
+    const body = stripBom(csv);
+    // The embedded newline is inside a quoted cell, so split on CRLF (record sep)
+    // and take everything after the header row.
+    const rowsPart = body.slice(0, -2).split('\r\n').slice(1).join('\r\n');
+    expect(rowsPart.startsWith('"Device, ""quoted"""')).toBe(true);
+    expect(rowsPart).toContain('"Line1\nLine2"');
   });
 
-  it('handles multiple rows', () => {
+  it('handles multiple rows separated by CRLF', () => {
     const csv = buildDevicesCsv([
       makeDevice({ id: 'a', name: 'Alpha' }),
       makeDevice({ id: 'b', name: 'Beta', complianceStatus: 'non_compliant' }),
     ]);
-    const lines = csv.trim().split('\n');
+    const body = stripBom(csv);
+    const lines = body.slice(0, -2).split('\r\n');
     expect(lines).toHaveLength(3);
     expect(lines[1].startsWith('Alpha,')).toBe(true);
     expect(lines[2].startsWith('Beta,')).toBe(true);
+  });
+});
+
+describe('devicesCsvFilename', () => {
+  const now = new Date('2026-04-20T10:00:00Z');
+
+  it('uses orgSlug when present', () => {
+    expect(devicesCsvFilename({ orgSlug: 'acme', orgId: 'org_123', now })).toBe(
+      'devices-acme-2026-04-20.csv',
+    );
+  });
+
+  it('falls back to orgId when slug is empty', () => {
+    expect(devicesCsvFilename({ orgSlug: '', orgId: 'org_123', now })).toBe(
+      'devices-org_123-2026-04-20.csv',
+    );
+  });
+
+  it('sanitizes special characters from slug', () => {
+    expect(devicesCsvFilename({ orgSlug: 'acme/test', orgId: 'org_123', now })).toBe(
+      'devices-acme-test-2026-04-20.csv',
+    );
+  });
+
+  it('sanitizes orgId with unsafe characters', () => {
+    expect(devicesCsvFilename({ orgSlug: '', orgId: 'org/123 evil\\name', now })).toBe(
+      'devices-org-123-evil-name-2026-04-20.csv',
+    );
+  });
+});
+
+describe('downloadDevicesCsv', () => {
+  const createdUrl = 'blob:mock-url';
+  const createObjectURL = vi.fn<(blob: Blob) => string>();
+  const revokeObjectURL = vi.fn<(url: string) => void>();
+  const clickSpy = vi.fn<() => void>();
+  let appendedNodes: Node[] = [];
+  let removedNodes: Node[] = [];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    createObjectURL.mockReset().mockReturnValue(createdUrl);
+    revokeObjectURL.mockReset();
+    clickSpy.mockReset();
+    appendedNodes = [];
+    removedNodes = [];
+
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL,
+      revokeObjectURL,
+    });
+
+    vi.spyOn(document.body, 'appendChild').mockImplementation(<T extends Node>(node: T): T => {
+      appendedNodes.push(node);
+      return node;
+    });
+    vi.spyOn(document.body, 'removeChild').mockImplementation(<T extends Node>(node: T): T => {
+      removedNodes.push(node);
+      return node;
+    });
+
+    // Intercept anchor elements so we can assert on props and mock click().
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation(((
+      tag: string,
+      options?: ElementCreationOptions,
+    ) => {
+      const el = originalCreateElement(tag, options);
+      if (tag === 'a') {
+        (el as HTMLAnchorElement).click = clickSpy;
+      }
+      return el;
+    }) as typeof document.createElement);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('creates an anchor with filename and blob URL, then clicks and cleans up', () => {
+    downloadDevicesCsv('devices-acme-2026-04-20.csv', 'header\r\nrow\r\n');
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(appendedNodes).toHaveLength(1);
+    const appendedNode = appendedNodes[0] as HTMLAnchorElement;
+    expect(appendedNode.tagName).toBe('A');
+    expect(appendedNode.download).toBe('devices-acme-2026-04-20.csv');
+    expect(appendedNode.href).toContain(createdUrl);
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(removedNodes).toHaveLength(1);
+    expect(removedNodes[0]).toBe(appendedNode);
+
+    // revoke should be deferred via setTimeout
+    expect(revokeObjectURL).not.toHaveBeenCalled();
+    vi.runAllTimers();
+    expect(revokeObjectURL).toHaveBeenCalledWith(createdUrl);
+  });
+
+  it('no-ops when document is undefined (SSR)', () => {
+    // Simulate SSR by temporarily removing the document global.
+    const globalWithDoc = globalThis as { document?: Document };
+    const originalDocument = globalWithDoc.document;
+    delete globalWithDoc.document;
+    try {
+      expect(() => downloadDevicesCsv('x.csv', 'data')).not.toThrow();
+      expect(createObjectURL).not.toHaveBeenCalled();
+    } finally {
+      globalWithDoc.document = originalDocument;
+    }
   });
 });

--- a/apps/app/src/app/(app)/[orgId]/people/devices/lib/devices-csv.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/lib/devices-csv.ts
@@ -1,0 +1,77 @@
+import type { DeviceWithChecks } from '../types';
+
+export const DEVICES_CSV_HEADER = [
+  'Device Name',
+  'User Name',
+  'Email',
+  'Platform',
+  'OS Version',
+  'Agent Version',
+  'Last Check-in (ISO)',
+  'Days Since Sync',
+  'Status',
+  'Disk Encryption',
+  'Antivirus',
+  'Password Policy',
+  'Screen Lock',
+].join(',');
+
+function escapeCell(value: string | number | null | undefined): string {
+  if (value === null || value === undefined) return '';
+  const str = String(value);
+  if (/[",\r\n]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+function yesNo(value: boolean): 'yes' | 'no' {
+  return value ? 'yes' : 'no';
+}
+
+export function buildDevicesCsv(devices: DeviceWithChecks[]): string {
+  const rows = devices.map((d) =>
+    [
+      escapeCell(d.name),
+      escapeCell(d.user.name),
+      escapeCell(d.user.email),
+      escapeCell(d.platform),
+      escapeCell(d.osVersion),
+      escapeCell(d.agentVersion ?? ''),
+      escapeCell(d.lastCheckIn ?? ''),
+      escapeCell(d.daysSinceLastCheckIn ?? ''),
+      escapeCell(d.complianceStatus),
+      escapeCell(yesNo(d.diskEncryptionEnabled)),
+      escapeCell(yesNo(d.antivirusEnabled)),
+      escapeCell(yesNo(d.passwordPolicySet)),
+      escapeCell(yesNo(d.screenLockEnabled)),
+    ].join(','),
+  );
+  return [DEVICES_CSV_HEADER, ...rows].join('\n') + '\n';
+}
+
+export function downloadDevicesCsv(filename: string, contents: string): void {
+  const blob = new Blob([contents], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+export function devicesCsvFilename({
+  orgSlug,
+  orgId,
+  now = new Date(),
+}: {
+  orgSlug?: string;
+  orgId: string;
+  now?: Date;
+}): string {
+  const date = now.toISOString().slice(0, 10);
+  const slug = orgSlug && orgSlug.length > 0 ? orgSlug : orgId;
+  return `devices-${slug}-${date}.csv`;
+}

--- a/apps/app/src/app/(app)/[orgId]/people/devices/lib/devices-csv.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/lib/devices-csv.ts
@@ -47,10 +47,13 @@ export function buildDevicesCsv(devices: DeviceWithChecks[]): string {
       escapeCell(yesNo(d.screenLockEnabled)),
     ].join(','),
   );
-  return [DEVICES_CSV_HEADER, ...rows].join('\n') + '\n';
+  // RFC 4180: records separated by CRLF; trailing CRLF after the final record.
+  // Prepend a UTF-8 BOM so Excel correctly detects UTF-8 encoding for non-ASCII data.
+  return '\uFEFF' + [DEVICES_CSV_HEADER, ...rows].join('\r\n') + '\r\n';
 }
 
 export function downloadDevicesCsv(filename: string, contents: string): void {
+  if (typeof document === 'undefined') return;
   const blob = new Blob([contents], { type: 'text/csv;charset=utf-8;' });
   const url = URL.createObjectURL(blob);
   const link = document.createElement('a');
@@ -59,7 +62,12 @@ export function downloadDevicesCsv(filename: string, contents: string): void {
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
-  URL.revokeObjectURL(url);
+  // Defer revoke so the browser can finish dispatching the download first.
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
+function sanitizeFilenamePart(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]+/g, '-');
 }
 
 export function devicesCsvFilename({
@@ -72,6 +80,7 @@ export function devicesCsvFilename({
   now?: Date;
 }): string {
   const date = now.toISOString().slice(0, 10);
-  const slug = orgSlug && orgSlug.length > 0 ? orgSlug : orgId;
-  return `devices-${slug}-${date}.csv`;
+  const raw = orgSlug && orgSlug.length > 0 ? orgSlug : orgId;
+  const safe = sanitizeFilenamePart(raw);
+  return `devices-${safe}-${date}.csv`;
 }

--- a/apps/app/src/app/(app)/[orgId]/people/devices/lib/devices-csv.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/lib/devices-csv.ts
@@ -16,9 +16,14 @@ export const DEVICES_CSV_HEADER = [
   'Screen Lock',
 ].join(',');
 
+const FORMULA_TRIGGER = /^[=+\-@\t\r]/;
+
 function escapeCell(value: string | number | null | undefined): string {
   if (value === null || value === undefined) return '';
-  const str = String(value);
+  let str = String(value);
+  if (FORMULA_TRIGGER.test(str)) {
+    str = `'${str}`;
+  }
   if (/[",\r\n]/.test(str)) {
     return `"${str.replace(/"/g, '""')}"`;
   }

--- a/apps/app/src/app/(app)/[orgId]/people/devices/types/index.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/types/index.ts
@@ -1,3 +1,5 @@
+import type { DeviceComplianceStatus } from '@trycompai/utils/devices';
+
 export type CheckDetailEntry = {
   method?: string;
   raw?: string;
@@ -33,6 +35,10 @@ export interface DeviceWithChecks {
   };
   /** Indicates which system reported this device */
   source: 'device_agent' | 'fleet';
+  /** Derived on the server; 'stale' = no check-in for >= 7 days. */
+  complianceStatus: DeviceComplianceStatus;
+  /** Whole days since last check-in, or null when never synced. */
+  daysSinceLastCheckIn: number | null;
 }
 
 export interface FleetPolicy {

--- a/apps/app/src/app/api/people/agent-devices/route.test.ts
+++ b/apps/app/src/app/api/people/agent-devices/route.test.ts
@@ -1,0 +1,119 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/utils/auth', () => ({
+  auth: {
+    api: {
+      getSession: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('next/headers', () => ({
+  headers: vi.fn(async () => new Headers()),
+}));
+
+vi.mock('@db/server', () => ({
+  db: {
+    device: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+import { auth } from '@/utils/auth';
+import { db } from '@db/server';
+import { GET } from './route';
+
+const mockedGetSession = vi.mocked(auth.api.getSession);
+const mockedFindMany = vi.mocked(
+  (db as unknown as { device: { findMany: ReturnType<typeof vi.fn> } }).device.findMany,
+);
+
+// Freeze "now" so day math is deterministic.
+const FIXED_NOW = new Date('2026-04-17T12:00:00.000Z');
+
+beforeAll(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(FIXED_NOW);
+});
+
+afterAll(() => {
+  vi.useRealTimers();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedGetSession.mockResolvedValue({
+    session: { activeOrganizationId: 'org_1' },
+  } as unknown as Awaited<ReturnType<typeof auth.api.getSession>>);
+});
+
+function deviceRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'dev_1',
+    name: 'Mac',
+    hostname: 'mac',
+    platform: 'macos',
+    osVersion: '14.0',
+    serialNumber: 'SN1',
+    hardwareModel: 'MBP',
+    isCompliant: true,
+    diskEncryptionEnabled: true,
+    antivirusEnabled: true,
+    passwordPolicySet: true,
+    screenLockEnabled: true,
+    checkDetails: null,
+    lastCheckIn: new Date(FIXED_NOW),
+    agentVersion: '1.0.0',
+    installedAt: new Date('2026-01-01T00:00:00.000Z'),
+    memberId: 'mem_1',
+    member: { user: { name: 'A', email: 'a@example.com' } },
+    ...overrides,
+  };
+}
+
+describe('GET /api/people/agent-devices', () => {
+  it('returns 401 when no organization is active', async () => {
+    mockedGetSession.mockResolvedValue({ session: {} } as never);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it('marks a fresh + isCompliant device as compliant', async () => {
+    mockedFindMany.mockResolvedValue([deviceRow({ lastCheckIn: new Date(FIXED_NOW) })]);
+    const res = await GET();
+    const body = await res.json();
+    expect(body.data[0].complianceStatus).toBe('compliant');
+    expect(body.data[0].daysSinceLastCheckIn).toBe(0);
+  });
+
+  it('marks a fresh + !isCompliant device as non_compliant', async () => {
+    mockedFindMany.mockResolvedValue([
+      deviceRow({
+        isCompliant: false,
+        diskEncryptionEnabled: false,
+        lastCheckIn: new Date(FIXED_NOW),
+      }),
+    ]);
+    const res = await GET();
+    const body = await res.json();
+    expect(body.data[0].complianceStatus).toBe('non_compliant');
+  });
+
+  it('marks a device with lastCheckIn >= 7 days ago as stale', async () => {
+    const eightDaysAgo = new Date(FIXED_NOW.getTime() - 8 * 24 * 60 * 60 * 1000);
+    mockedFindMany.mockResolvedValue([deviceRow({ lastCheckIn: eightDaysAgo })]);
+    const res = await GET();
+    const body = await res.json();
+    expect(body.data[0].complianceStatus).toBe('stale');
+    expect(body.data[0].daysSinceLastCheckIn).toBe(8);
+  });
+
+  it('marks a device with null lastCheckIn as stale', async () => {
+    mockedFindMany.mockResolvedValue([deviceRow({ lastCheckIn: null })]);
+    const res = await GET();
+    const body = await res.json();
+    expect(body.data[0].complianceStatus).toBe('stale');
+    expect(body.data[0].daysSinceLastCheckIn).toBeNull();
+  });
+});

--- a/apps/app/src/app/api/people/agent-devices/route.ts
+++ b/apps/app/src/app/api/people/agent-devices/route.ts
@@ -2,6 +2,10 @@ import { auth } from '@/utils/auth';
 import { db } from '@db/server';
 import { headers } from 'next/headers';
 import { NextResponse } from 'next/server';
+import {
+  daysSinceCheckIn,
+  getDeviceComplianceStatus,
+} from '@trycompai/utils/devices';
 import type { CheckDetails, DeviceWithChecks } from '@/app/(app)/[orgId]/people/devices/types';
 
 export async function GET() {
@@ -30,30 +34,38 @@ export async function GET() {
     orderBy: { installedAt: 'desc' },
   });
 
-  const data: DeviceWithChecks[] = devices.map((device) => ({
-    id: device.id,
-    name: device.name,
-    hostname: device.hostname,
-    platform: device.platform as 'macos' | 'windows' | 'linux',
-    osVersion: device.osVersion,
-    serialNumber: device.serialNumber,
-    hardwareModel: device.hardwareModel,
-    isCompliant: device.isCompliant,
-    diskEncryptionEnabled: device.diskEncryptionEnabled,
-    antivirusEnabled: device.antivirusEnabled,
-    passwordPolicySet: device.passwordPolicySet,
-    screenLockEnabled: device.screenLockEnabled,
-    checkDetails: (device.checkDetails as CheckDetails) ?? null,
-    lastCheckIn: device.lastCheckIn?.toISOString() ?? null,
-    agentVersion: device.agentVersion,
-    installedAt: device.installedAt.toISOString(),
-    memberId: device.memberId,
-    user: {
-      name: device.member.user.name,
-      email: device.member.user.email,
-    },
-    source: 'device_agent' as const,
-  }));
+  const data: DeviceWithChecks[] = devices.map((device) => {
+    const complianceStatus = getDeviceComplianceStatus({
+      isCompliant: device.isCompliant,
+      lastCheckIn: device.lastCheckIn,
+    });
+    return {
+      id: device.id,
+      name: device.name,
+      hostname: device.hostname,
+      platform: device.platform as 'macos' | 'windows' | 'linux',
+      osVersion: device.osVersion,
+      serialNumber: device.serialNumber,
+      hardwareModel: device.hardwareModel,
+      isCompliant: device.isCompliant,
+      diskEncryptionEnabled: device.diskEncryptionEnabled,
+      antivirusEnabled: device.antivirusEnabled,
+      passwordPolicySet: device.passwordPolicySet,
+      screenLockEnabled: device.screenLockEnabled,
+      checkDetails: (device.checkDetails as CheckDetails) ?? null,
+      lastCheckIn: device.lastCheckIn?.toISOString() ?? null,
+      agentVersion: device.agentVersion,
+      installedAt: device.installedAt.toISOString(),
+      memberId: device.memberId,
+      user: {
+        name: device.member.user.name,
+        email: device.member.user.email,
+      },
+      source: 'device_agent' as const,
+      complianceStatus,
+      daysSinceLastCheckIn: daysSinceCheckIn(device.lastCheckIn),
+    };
+  });
 
   return NextResponse.json({ data });
 }

--- a/apps/app/src/trigger/tasks/device/flag-stale-devices.test.ts
+++ b/apps/app/src/trigger/tasks/device/flag-stale-devices.test.ts
@@ -25,6 +25,7 @@ const task = flagStaleDevices as unknown as {
     success: boolean;
     flaggedCount: number;
     threshold: Date;
+    error?: string;
   }>;
 };
 
@@ -95,5 +96,6 @@ describe('flagStaleDevices', () => {
 
     expect(result.success).toBe(false);
     expect(result.flaggedCount).toBe(0);
+    expect(result.error).toBe('db down');
   });
 });

--- a/apps/app/src/trigger/tasks/device/flag-stale-devices.test.ts
+++ b/apps/app/src/trigger/tasks/device/flag-stale-devices.test.ts
@@ -1,0 +1,99 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@db/server', () => ({
+  db: {
+    device: {
+      updateMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@trigger.dev/sdk', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  schedules: {
+    task: (config: { run: (payload: unknown) => Promise<unknown> }) => config,
+  },
+}));
+
+import { db } from '@db/server';
+import { flagStaleDevices } from './flag-stale-devices';
+
+const FIXED_NOW = new Date('2026-04-17T12:00:00.000Z');
+
+const task = flagStaleDevices as unknown as {
+  run: (payload: unknown) => Promise<{
+    success: boolean;
+    flaggedCount: number;
+    threshold: Date;
+  }>;
+};
+
+const mockUpdateMany = vi.mocked(
+  (db as unknown as { device: { updateMany: ReturnType<typeof vi.fn> } }).device.updateMany,
+);
+
+beforeAll(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(FIXED_NOW);
+});
+
+afterAll(() => {
+  vi.useRealTimers();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('flagStaleDevices', () => {
+  it('flips compliant devices older than 7 days to isCompliant = false', async () => {
+    mockUpdateMany.mockResolvedValue({ count: 3 });
+
+    const result = await task.run({});
+
+    expect(mockUpdateMany).toHaveBeenCalledTimes(1);
+    const call = mockUpdateMany.mock.calls[0][0] as {
+      where: {
+        isCompliant: boolean;
+        OR: Array<{ lastCheckIn: null | { lt: Date } }>;
+      };
+      data: { isCompliant: boolean };
+    };
+
+    expect(call.where.isCompliant).toBe(true);
+    expect(call.data).toEqual({ isCompliant: false });
+
+    // Threshold is 7 days before FIXED_NOW.
+    const expectedThreshold = new Date(FIXED_NOW.getTime() - 7 * 24 * 60 * 60 * 1000);
+    const ltClause = call.where.OR.find((c) => c.lastCheckIn && 'lt' in c.lastCheckIn);
+    expect(ltClause).toBeDefined();
+    expect((ltClause!.lastCheckIn as { lt: Date }).lt.toISOString()).toBe(
+      expectedThreshold.toISOString(),
+    );
+
+    // Null-lastCheckIn clause is also present.
+    const nullClause = call.where.OR.find((c) => c.lastCheckIn === null);
+    expect(nullClause).toBeDefined();
+
+    expect(result.success).toBe(true);
+    expect(result.flaggedCount).toBe(3);
+  });
+
+  it('reports zero when nothing matches', async () => {
+    mockUpdateMany.mockResolvedValue({ count: 0 });
+
+    const result = await task.run({});
+
+    expect(result.success).toBe(true);
+    expect(result.flaggedCount).toBe(0);
+  });
+
+  it('returns success: false when the update throws', async () => {
+    mockUpdateMany.mockRejectedValue(new Error('db down'));
+
+    const result = await task.run({});
+
+    expect(result.success).toBe(false);
+    expect(result.flaggedCount).toBe(0);
+  });
+});

--- a/apps/app/src/trigger/tasks/device/flag-stale-devices.ts
+++ b/apps/app/src/trigger/tasks/device/flag-stale-devices.ts
@@ -8,7 +8,12 @@ export const flagStaleDevices = schedules.task({
   id: 'flag-stale-devices',
   cron: '0 6 * * *', // Daily at 06:00 UTC (~01:00 US/Eastern)
   maxDuration: 1000 * 60 * 5, // 5 minutes
-  run: async () => {
+  run: async (): Promise<{
+    success: boolean;
+    flaggedCount: number;
+    threshold: Date;
+    error?: string;
+  }> => {
     const threshold = new Date(
       Date.now() - STALE_DEVICE_THRESHOLD_DAYS * MS_PER_DAY,
     );
@@ -32,13 +37,14 @@ export const flagStaleDevices = schedules.task({
         threshold,
       };
     } catch (error) {
-      logger.error(
-        `flag-stale-devices failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
+      logger.error('flag-stale-devices failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
       return {
         success: false,
         flaggedCount: 0,
         threshold,
+        error: error instanceof Error ? error.message : String(error),
       };
     }
   },

--- a/apps/app/src/trigger/tasks/device/flag-stale-devices.ts
+++ b/apps/app/src/trigger/tasks/device/flag-stale-devices.ts
@@ -1,0 +1,45 @@
+import { db } from '@db/server';
+import { logger, schedules } from '@trigger.dev/sdk';
+import { STALE_DEVICE_THRESHOLD_DAYS } from '@trycompai/utils/devices';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export const flagStaleDevices = schedules.task({
+  id: 'flag-stale-devices',
+  cron: '0 6 * * *', // Daily at 06:00 UTC (~01:00 US/Eastern)
+  maxDuration: 1000 * 60 * 5, // 5 minutes
+  run: async () => {
+    const threshold = new Date(
+      Date.now() - STALE_DEVICE_THRESHOLD_DAYS * MS_PER_DAY,
+    );
+
+    try {
+      const result = await db.device.updateMany({
+        where: {
+          isCompliant: true,
+          OR: [{ lastCheckIn: null }, { lastCheckIn: { lt: threshold } }],
+        },
+        data: { isCompliant: false },
+      });
+
+      logger.info(
+        `Flagged ${result.count} stale device(s) as non-compliant (threshold ${threshold.toISOString()})`,
+      );
+
+      return {
+        success: true,
+        flaggedCount: result.count,
+        threshold,
+      };
+    } catch (error) {
+      logger.error(
+        `flag-stale-devices failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return {
+        success: false,
+        flaggedCount: 0,
+        threshold,
+      };
+    }
+  },
+});

--- a/apps/app/src/trigger/tasks/device/flag-stale-devices.ts
+++ b/apps/app/src/trigger/tasks/device/flag-stale-devices.ts
@@ -7,7 +7,7 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 export const flagStaleDevices = schedules.task({
   id: 'flag-stale-devices',
   cron: '0 6 * * *', // Daily at 06:00 UTC (~01:00 US/Eastern)
-  maxDuration: 1000 * 60 * 5, // 5 minutes
+  maxDuration: 60 * 5, // 5 minutes (trigger.dev expects seconds)
   run: async (): Promise<{
     success: boolean;
     flaggedCount: number;

--- a/bun.lock
+++ b/bun.lock
@@ -148,6 +148,7 @@
         "@trycompai/db": "workspace:*",
         "@trycompai/email": "workspace:*",
         "@trycompai/integration-platform": "workspace:*",
+        "@trycompai/utils": "workspace:*",
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.34.2",
         "@upstash/vector": "^1.2.2",

--- a/packages/utils/src/devices.test.ts
+++ b/packages/utils/src/devices.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import {
+  STALE_DEVICE_THRESHOLD_DAYS,
+  daysSinceCheckIn,
+  isDeviceStale,
+  getDeviceComplianceStatus,
+} from './devices';
+
+// Fri 2026-04-17 12:00:00 UTC — a fixed "now" for deterministic math.
+const FIXED_NOW = new Date('2026-04-17T12:00:00.000Z');
+
+const originalDateNow = Date.now;
+
+beforeEach(() => {
+  Date.now = () => FIXED_NOW.getTime();
+});
+
+afterEach(() => {
+  Date.now = originalDateNow;
+});
+
+function daysAgo(days: number): Date {
+  return new Date(FIXED_NOW.getTime() - days * 24 * 60 * 60 * 1000);
+}
+
+describe('STALE_DEVICE_THRESHOLD_DAYS', () => {
+  it('is 7 days', () => {
+    expect(STALE_DEVICE_THRESHOLD_DAYS).toBe(7);
+  });
+});
+
+describe('daysSinceCheckIn', () => {
+  it('returns null when lastCheckIn is null', () => {
+    expect(daysSinceCheckIn(null)).toBeNull();
+  });
+
+  it('returns 0 for just now', () => {
+    expect(daysSinceCheckIn(FIXED_NOW)).toBe(0);
+  });
+
+  it('returns whole days (floored) for past timestamps', () => {
+    expect(daysSinceCheckIn(daysAgo(1))).toBe(1);
+    expect(daysSinceCheckIn(daysAgo(6))).toBe(6);
+    expect(daysSinceCheckIn(daysAgo(7))).toBe(7);
+    expect(daysSinceCheckIn(daysAgo(51))).toBe(51);
+  });
+
+  it('accepts ISO strings', () => {
+    expect(daysSinceCheckIn(daysAgo(3).toISOString())).toBe(3);
+  });
+});
+
+describe('isDeviceStale', () => {
+  it('treats never-synced devices as stale', () => {
+    expect(isDeviceStale(null)).toBe(true);
+  });
+
+  it('is false for a check-in 6 days ago', () => {
+    expect(isDeviceStale(daysAgo(6))).toBe(false);
+  });
+
+  it('is true exactly at the 7-day boundary', () => {
+    expect(isDeviceStale(daysAgo(7))).toBe(true);
+  });
+
+  it('is true for a check-in 51 days ago', () => {
+    expect(isDeviceStale(daysAgo(51))).toBe(true);
+  });
+});
+
+describe('getDeviceComplianceStatus', () => {
+  it('returns "stale" regardless of isCompliant when never synced', () => {
+    expect(getDeviceComplianceStatus({ isCompliant: true, lastCheckIn: null })).toBe('stale');
+    expect(getDeviceComplianceStatus({ isCompliant: false, lastCheckIn: null })).toBe('stale');
+  });
+
+  it('returns "stale" regardless of isCompliant when beyond threshold', () => {
+    expect(
+      getDeviceComplianceStatus({ isCompliant: true, lastCheckIn: daysAgo(8) }),
+    ).toBe('stale');
+    expect(
+      getDeviceComplianceStatus({ isCompliant: false, lastCheckIn: daysAgo(51) }),
+    ).toBe('stale');
+  });
+
+  it('returns "compliant" for fresh + isCompliant true', () => {
+    expect(
+      getDeviceComplianceStatus({ isCompliant: true, lastCheckIn: daysAgo(1) }),
+    ).toBe('compliant');
+  });
+
+  it('returns "non_compliant" for fresh + isCompliant false', () => {
+    expect(
+      getDeviceComplianceStatus({ isCompliant: false, lastCheckIn: daysAgo(1) }),
+    ).toBe('non_compliant');
+  });
+
+  it('honors the 7-day boundary: day 6 fresh, day 7 stale', () => {
+    expect(
+      getDeviceComplianceStatus({ isCompliant: true, lastCheckIn: daysAgo(6) }),
+    ).toBe('compliant');
+    expect(
+      getDeviceComplianceStatus({ isCompliant: true, lastCheckIn: daysAgo(7) }),
+    ).toBe('stale');
+  });
+});

--- a/packages/utils/src/devices.test.ts
+++ b/packages/utils/src/devices.test.ts
@@ -2,8 +2,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import {
   STALE_DEVICE_THRESHOLD_DAYS,
   daysSinceCheckIn,
-  isDeviceStale,
   getDeviceComplianceStatus,
+  isDeviceStale,
 } from './devices';
 
 // Fri 2026-04-17 12:00:00 UTC — a fixed "now" for deterministic math.
@@ -75,32 +75,28 @@ describe('getDeviceComplianceStatus', () => {
   });
 
   it('returns "stale" regardless of isCompliant when beyond threshold', () => {
-    expect(
-      getDeviceComplianceStatus({ isCompliant: true, lastCheckIn: daysAgo(8) }),
-    ).toBe('stale');
-    expect(
-      getDeviceComplianceStatus({ isCompliant: false, lastCheckIn: daysAgo(51) }),
-    ).toBe('stale');
+    expect(getDeviceComplianceStatus({ isCompliant: true, lastCheckIn: daysAgo(8) })).toBe('stale');
+    expect(getDeviceComplianceStatus({ isCompliant: false, lastCheckIn: daysAgo(51) })).toBe(
+      'stale',
+    );
   });
 
   it('returns "compliant" for fresh + isCompliant true', () => {
-    expect(
-      getDeviceComplianceStatus({ isCompliant: true, lastCheckIn: daysAgo(1) }),
-    ).toBe('compliant');
+    expect(getDeviceComplianceStatus({ isCompliant: true, lastCheckIn: daysAgo(1) })).toBe(
+      'compliant',
+    );
   });
 
   it('returns "non_compliant" for fresh + isCompliant false', () => {
-    expect(
-      getDeviceComplianceStatus({ isCompliant: false, lastCheckIn: daysAgo(1) }),
-    ).toBe('non_compliant');
+    expect(getDeviceComplianceStatus({ isCompliant: false, lastCheckIn: daysAgo(1) })).toBe(
+      'non_compliant',
+    );
   });
 
   it('honors the 7-day boundary: day 6 fresh, day 7 stale', () => {
-    expect(
-      getDeviceComplianceStatus({ isCompliant: true, lastCheckIn: daysAgo(6) }),
-    ).toBe('compliant');
-    expect(
-      getDeviceComplianceStatus({ isCompliant: true, lastCheckIn: daysAgo(7) }),
-    ).toBe('stale');
+    expect(getDeviceComplianceStatus({ isCompliant: true, lastCheckIn: daysAgo(6) })).toBe(
+      'compliant',
+    );
+    expect(getDeviceComplianceStatus({ isCompliant: true, lastCheckIn: daysAgo(7) })).toBe('stale');
   });
 });

--- a/packages/utils/src/devices.test.ts
+++ b/packages/utils/src/devices.test.ts
@@ -48,6 +48,11 @@ describe('daysSinceCheckIn', () => {
   it('accepts ISO strings', () => {
     expect(daysSinceCheckIn(daysAgo(3).toISOString())).toBe(3);
   });
+
+  it('returns null for invalid date strings', () => {
+    expect(daysSinceCheckIn('not-a-date')).toBeNull();
+    expect(daysSinceCheckIn('')).toBeNull();
+  });
 });
 
 describe('isDeviceStale', () => {
@@ -65,6 +70,10 @@ describe('isDeviceStale', () => {
 
   it('is true for a check-in 51 days ago', () => {
     expect(isDeviceStale(daysAgo(51))).toBe(true);
+  });
+
+  it('treats invalid date strings as stale', () => {
+    expect(isDeviceStale('not-a-date')).toBe(true);
   });
 });
 
@@ -98,5 +107,14 @@ describe('getDeviceComplianceStatus', () => {
       'compliant',
     );
     expect(getDeviceComplianceStatus({ isCompliant: true, lastCheckIn: daysAgo(7) })).toBe('stale');
+  });
+
+  it('returns "stale" for invalid date strings regardless of isCompliant', () => {
+    expect(getDeviceComplianceStatus({ isCompliant: true, lastCheckIn: 'not-a-date' })).toBe(
+      'stale',
+    );
+    expect(getDeviceComplianceStatus({ isCompliant: false, lastCheckIn: 'not-a-date' })).toBe(
+      'stale',
+    );
   });
 });

--- a/packages/utils/src/devices.ts
+++ b/packages/utils/src/devices.ts
@@ -52,6 +52,7 @@ function toDate(value: Date | string): Date {
 export function daysSinceCheckIn(lastCheckIn: Date | string | null): number | null {
   if (lastCheckIn === null) return null;
   const then = toDate(lastCheckIn).getTime();
+  if (Number.isNaN(then)) return null;
   return Math.floor((Date.now() - then) / MS_PER_DAY);
 }
 

--- a/packages/utils/src/devices.ts
+++ b/packages/utils/src/devices.ts
@@ -33,3 +33,49 @@ export function mergeDeviceLists<T>(
 
   return [...priorityDevices, ...uniqueSecondaryDevices];
 }
+
+/** How long without a check-in before a device is considered stale. */
+export const STALE_DEVICE_THRESHOLD_DAYS = 7;
+
+export type DeviceComplianceStatus = 'compliant' | 'non_compliant' | 'stale';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function toDate(value: Date | string): Date {
+  return value instanceof Date ? value : new Date(value);
+}
+
+/**
+ * Whole days since `lastCheckIn`. Returns null when the device has never
+ * checked in. Uses `Date.now()` so tests can freeze time.
+ */
+export function daysSinceCheckIn(lastCheckIn: Date | string | null): number | null {
+  if (lastCheckIn === null) return null;
+  const then = toDate(lastCheckIn).getTime();
+  return Math.floor((Date.now() - then) / MS_PER_DAY);
+}
+
+/**
+ * True when a device hasn't checked in within STALE_DEVICE_THRESHOLD_DAYS.
+ * A device that has never synced is always stale.
+ */
+export function isDeviceStale(lastCheckIn: Date | string | null): boolean {
+  const days = daysSinceCheckIn(lastCheckIn);
+  if (days === null) return true;
+  return days >= STALE_DEVICE_THRESHOLD_DAYS;
+}
+
+/**
+ * Three-state compliance status. Stale wins over the stored `isCompliant`
+ * because old check-in data cannot be trusted.
+ */
+export function getDeviceComplianceStatus({
+  isCompliant,
+  lastCheckIn,
+}: {
+  isCompliant: boolean;
+  lastCheckIn: Date | string | null;
+}): DeviceComplianceStatus {
+  if (isDeviceStale(lastCheckIn)) return 'stale';
+  return isCompliant ? 'compliant' : 'non_compliant';
+}


### PR DESCRIPTION
## Summary

- Fixes "outdated CompAI device agents stop syncing yet still display as fully compliant" — a security blind spot where 34–51 day old check-ins were rendered green.
- Adds a 7-day staleness threshold. Devices past it are derived as a third state (`stale`) in the API and the UI, and a daily trigger.dev cron flips `isCompliant = false` in the DB so direct queries stay honest.
- Device list gains a client-side CSV export (RFC 4180 with CRLF, UTF-8 BOM, sanitized filename) so IT can pull a worklist of non-syncing devices for agent-update campaigns.

## What changed

- `packages/utils/src/devices.ts` — pure helpers: `STALE_DEVICE_THRESHOLD_DAYS`, `daysSinceCheckIn`, `isDeviceStale`, `getDeviceComplianceStatus`.
- `apps/app/src/app/api/people/agent-devices/route.ts` + NestJS `DevicesService.mapAgentDeviceToDto` — both derive `complianceStatus` on read.
- `apps/app/src/trigger/tasks/device/flag-stale-devices.ts` — daily cron at `0 6 * * *` UTC.
- `DeviceAgentDevicesList.tsx` — three-state compliant badge (Yes / No / Stale (Nd)); stale rows render check badges as neutral em-dashes; new Export CSV button.
- `DeviceComplianceChart.tsx` — now counts stale devices toward Non-Compliant (matches the table).

## Test plan

- [ ] Navigate to `/<orgId>/people` → Devices tab.
- [ ] Confirm fresh compliant devices still show green "Yes".
- [ ] Confirm non-compliant fresh devices still show red "No".
- [ ] For a device with `lastCheckIn` older than 7 days (tweak via Prisma Studio if needed), confirm the row shows a muted "Stale (Nd)" badge and neutral em-dash check badges.
- [ ] Click "Export CSV" — file downloads as `devices-<orgId>-<YYYY-MM-DD>.csv`, opens cleanly in Excel, non-ASCII device names render correctly.
- [ ] Confirm the compliance pie chart treats stale devices as Non-Compliant (no disagreement with the table).
- [ ] Verify the `flag-stale-devices` trigger.dev schedule appears in the Trigger.dev dashboard and runs successfully on its first invocation.

## Notes

- No Prisma migration. Threshold is a hardcoded 7 days — promote to an org setting later if requested.
- The hyphenated `'non-compliant'` vocabulary on `/v1/devices.status` is preserved for external API consumers; internal code uses underscore form.
- `DeviceComplianceChart` stays binary (stale counts toward Non-Compliant) rather than adding a third slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flags device agents that haven’t checked in for 7+ days as a new “stale” state across API and UI, and adds a hardened CSV export for the devices list to support update campaigns. Stale devices are treated as non‑compliant in charts and the external API now returns `'stale'`.

- **New Features**
  - Three-state compliance in `@trycompai/utils` (`compliant`, `non_compliant`, `stale`) with helpers; `/api/people/agent-devices` returns `complianceStatus` and `daysSinceLastCheckIn`; v1 devices DTO exposes `'compliant' | 'non-compliant' | 'stale'`.
  - Devices list shows a “Stale (Nd)” badge with em‑dash check badges; export CSV button using RFC 4180 (CRLF) with UTF‑8 BOM and sanitized filename `devices-<org|slug>-<YYYY-MM-DD>.csv`; escapes quotes/newlines and neutralizes CSV injection by prefixing leading `= + - @` (tab/CR) with `'`.
  - Device compliance chart stays binary and counts stale as Non‑Compliant.

- **Bug Fixes**
  - Stale/never‑checked‑in devices no longer appear compliant; a daily `@trigger.dev/sdk` task flips them to `isCompliant = false`.
  - `daysSinceCheckIn` guards invalid `lastCheckIn` strings (treated as stale).
  - External API keeps hyphenated `'non-compliant'` while internal code uses underscores.

<sup>Written for commit dba59ff52f2e343577e184f0b98296c7f96f742d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

