### PR TITLE
fix(policies): remove stray brace breaking nest build

### DIFF
--- a/apps/api/src/policies/policies.service.ts
+++ b/apps/api/src/policies/policies.service.ts
@@ -1043,7 +1043,6 @@ export class PoliciesService {
           'This policy has no pending changes to approve. The stale approval request has been cleared — please ask the policy owner to re-submit if a new approval is needed.',
         );
       }
-      }
       throw new BadRequestException('No pending version to approve');
     }
 


### PR DESCRIPTION
## Summary
- Commit 91c6debc2 added the approver-id authorization check to `approveChanges` but left an extra `}` after the inner `if` block, prematurely closing the outer `!policy.pendingVersionId` guard and the method itself.
- Every subsequent method (`denyChanges`, `getMemberId`, `hexToRgb`, `downloadAllPoliciesPdf`, `isUniqueConstraintError`, …) ended up at class-statement scope, cascading into 131 tsc errors and breaking the production Docker build (`bunx nest build`).
- This PR deletes the single stray brace. No behaviour change.

## Test plan
- [x] `bunx nest build` locally: 131 errors → 1 pre-existing unrelated `better-auth` type error on `auth.server.ts:430`
- [ ] CI build passes and ECR push succeeds

## Follow-up
- `denyChanges` has the same stale-state cleanup pattern as `approveChanges` and still needs the matching `dto.approverId === policy.approverId` guard to fully address the original cubic P2. Will do that in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove an extra closing brace in `PoliciesService.approveChanges` that pushed subsequent methods to class scope, causing 131 TypeScript errors and failing `bunx nest build`. Restores the build; no behavior change.

<sup>Written for commit fde65bfaec7f2d2c85de04d9283dcfccb0852292. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

