### PR TITLE
fix(api,app): unblock onboarding frameworks list for users without active org

### DIFF
--- a/apps/api/src/auth/auth-context.decorator.ts
+++ b/apps/api/src/auth/auth-context.decorator.ts
@@ -1,4 +1,8 @@
-import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import {
+  createParamDecorator,
+  ExecutionContext,
+  InternalServerErrorException,
+} from '@nestjs/common';
 import { AuthContext as AuthContextType, AuthenticatedRequest } from './types';
 
 /**
@@ -46,7 +50,10 @@ export const AuthContext = createParamDecorator(
 );
 
 /**
- * Parameter decorator to extract just the organization ID
+ * Parameter decorator to extract just the organization ID.
+ * Throws when no active organization is present on the request — only use this
+ * on endpoints that require an active organization. For endpoints decorated
+ * with @SkipOrgCheck() (e.g. onboarding), use @OrganizationIdOptional() instead.
  */
 export const OrganizationId = createParamDecorator(
   (data: unknown, ctx: ExecutionContext): string => {
@@ -54,12 +61,25 @@ export const OrganizationId = createParamDecorator(
     const { organizationId } = request;
 
     if (!organizationId) {
-      throw new Error(
-        'Organization ID not found. Ensure HybridAuthGuard is applied.',
+      throw new InternalServerErrorException(
+        'Organization ID missing on request. If this endpoint is @SkipOrgCheck()-decorated, use @OrganizationIdOptional() instead.',
       );
     }
 
     return organizationId;
+  },
+);
+
+/**
+ * Parameter decorator to extract the organization ID when it may be absent.
+ * Returns `undefined` instead of throwing when no active organization is
+ * present. Use this on endpoints decorated with @SkipOrgCheck() where the
+ * user may not yet have an active organization (e.g. during onboarding).
+ */
+export const OrganizationIdOptional = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext): string | undefined => {
+    const request = ctx.switchToHttp().getRequest<AuthenticatedRequest>();
+    return request.organizationId || undefined;
   },
 );
 

--- a/apps/api/src/frameworks/frameworks.controller.spec.ts
+++ b/apps/api/src/frameworks/frameworks.controller.spec.ts
@@ -15,6 +15,7 @@ describe('FrameworksController', () => {
 
   const mockService = {
     findAll: jest.fn(),
+    findAvailable: jest.fn(),
     delete: jest.fn(),
   };
 
@@ -65,6 +66,32 @@ describe('FrameworksController', () => {
       const result = await controller.findAll('org_1');
 
       expect(result).toEqual({ data: [], count: 0 });
+    });
+  });
+
+  describe('findAvailable', () => {
+    // Regression test for the onboarding 500 bug: this endpoint must not throw
+    // when the authenticated user has no active organization yet (fresh signups
+    // hitting the first onboarding step). Previously used @OrganizationId(),
+    // which threw when organizationId was empty → HTTP 500.
+    it('should return frameworks when user has no active organization', async () => {
+      const mockFrameworks = [
+        { id: 'frk_1', name: 'soc2', visible: true, isCustom: false },
+      ];
+      mockService.findAvailable.mockResolvedValue(mockFrameworks);
+
+      const result = await controller.findAvailable(undefined);
+
+      expect(result).toEqual({ data: mockFrameworks, count: 1 });
+      expect(service.findAvailable).toHaveBeenCalledWith(undefined);
+    });
+
+    it('should pass organizationId to service when user has an active org', async () => {
+      mockService.findAvailable.mockResolvedValue([]);
+
+      await controller.findAvailable('org_1');
+
+      expect(service.findAvailable).toHaveBeenCalledWith('org_1');
     });
   });
 

--- a/apps/api/src/frameworks/frameworks.controller.ts
+++ b/apps/api/src/frameworks/frameworks.controller.ts
@@ -18,7 +18,11 @@ import { HybridAuthGuard } from '../auth/hybrid-auth.guard';
 import { PermissionGuard } from '../auth/permission.guard';
 import { RequirePermission } from '../auth/require-permission.decorator';
 import { SkipOrgCheck } from '../auth/skip-org-check.decorator';
-import { AuthContext, OrganizationId } from '../auth/auth-context.decorator';
+import {
+  AuthContext,
+  OrganizationId,
+  OrganizationIdOptional,
+} from '../auth/auth-context.decorator';
 import type { AuthContext as AuthContextType } from '../auth/types';
 import { FrameworksService } from './frameworks.service';
 import { AddFrameworksDto } from './dto/add-frameworks.dto';
@@ -57,7 +61,7 @@ export class FrameworksController {
     summary:
       'List available frameworks (requires session, no active org needed — used during onboarding)',
   })
-  async findAvailable(@OrganizationId() organizationId?: string) {
+  async findAvailable(@OrganizationIdOptional() organizationId?: string) {
     const data = await this.frameworksService.findAvailable(organizationId);
     return { data, count: data.length };
   }

--- a/apps/app/src/app/(app)/setup/components/FrameworkSelection.tsx
+++ b/apps/app/src/app/(app)/setup/components/FrameworkSelection.tsx
@@ -19,11 +19,22 @@ export function FrameworkSelection({ value, onChange, onLoadingChange }: Framewo
   const onChangeRef = useRef(onChange);
   const valueRef = useRef(value);
 
-  const { data: frameworks = [], isLoading } = useSWR<Framework[]>(
+  const {
+    data: frameworks = [],
+    isLoading,
+    error,
+    mutate,
+  } = useSWR<Framework[]>(
     '/v1/frameworks/available',
     async (endpoint: string) => {
       const response = await api.get<{ data: Framework[] }>(endpoint);
-      return Array.isArray(response.data?.data) ? response.data.data : [];
+      if (response.error || !response.data) {
+        throw new Error(
+          response.error ||
+            `Failed to load frameworks (HTTP ${response.status})`,
+        );
+      }
+      return Array.isArray(response.data.data) ? response.data.data : [];
     },
   );
 
@@ -50,6 +61,25 @@ export function FrameworkSelection({ value, onChange, onLoadingChange }: Framewo
 
   if (isLoading) {
     return null;
+  }
+
+  if (error) {
+    const message =
+      error instanceof Error ? error.message : 'Something went wrong.';
+    return (
+      <div className="flex flex-col items-start gap-2">
+        <p className="text-sm text-destructive">
+          We couldn't load the compliance frameworks. {message}
+        </p>
+        <button
+          type="button"
+          onClick={() => mutate()}
+          className="text-sm underline hover:no-underline"
+        >
+          Try again
+        </button>
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary

Fresh signups hitting the first onboarding step (\"Which compliance frameworks do you need?\") have been seeing an empty screen with a disabled Continue button. Customer [Daniel Cooke reported](https://app.slack.com) a 500 on `https://api.trycomp.ai/v1/frameworks/available`, and I reproduced it in incognito with a brand-new email.

### Root cause

- **2026-04-17 (commit `a81af3efb7`)** — The `/v1/frameworks/available` endpoint's signature was changed from `findAvailable()` to `findAvailable(@OrganizationId() organizationId?: string)` so custom frameworks could be scoped per-org.
- `@OrganizationId()` **throws a plain `Error`** when `request.organizationId` is falsy.
- `@SkipOrgCheck()` (already on this endpoint) correctly allows session-auth'd users with no active org through — `HybridAuthGuard` sets `request.organizationId = ''` in that case.
- Empty string is falsy → `@OrganizationId()` throws → NestJS converts the generic `Error` to **HTTP 500**.
- The `?: string` in the signature shows the intent was optional, but the decorator didn't honor it — that contract isn't visible in the decorator's type signature.
- Audited every other `@SkipOrgCheck()` endpoint in the API; this was the only one combining it with `@OrganizationId()`.

The failure was invisible for 4 days because `FrameworkSelection.tsx` silently swallowed HTTP errors in its SWR fetcher — a 500 looked identical to \"no frameworks available.\"

### Changes

- **Add `@OrganizationIdOptional()`** in `apps/api/src/auth/auth-context.decorator.ts` — returns `string | undefined` instead of throwing. Explicit, safe companion to `@OrganizationId()` for `@SkipOrgCheck()`-decorated endpoints.
- **Harden `@OrganizationId()`** to throw `InternalServerErrorException` (typed, surfaced by Nest's exception filter, logged by monitoring) instead of a plain `Error` (opaque 500). The message points to `@OrganizationIdOptional()` so the next misuse is immediately diagnosable.
- **Swap the decorator** on `findAvailable`. The service already handles `undefined` correctly.
- **Regression tests** in `frameworks.controller.spec.ts` — one asserting the endpoint returns data when `organizationId` is `undefined` (the fresh-signup case), and one asserting it passes the id through when present.
- **Surface API errors** in `FrameworkSelection.tsx` — fetcher now throws on non-OK responses; component renders a visible error + retry button. Prevents the next server-side failure from producing a silent blank screen.

## Test plan

- [ ] Typecheck passes (no new errors introduced — verified locally by stashing changes and confirming same pre-existing errors on `main` before/after)
- [ ] `apps/api` unit tests pass (new `findAvailable` tests follow the exact pattern of the existing `findAll` tests)
- [ ] Sign up a fresh user in incognito → reach \"Which compliance frameworks do you need?\" step → framework options render
- [ ] Simulate a 500 on `/v1/frameworks/available` (e.g., by breaking the env var temporarily) → onboarding UI shows a visible error + retry button, not a blank screen
- [ ] Existing user on `/setup` still sees frameworks (no regression for the with-org path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a 500 that blocked onboarding by making `/v1/frameworks/available` work when the user has no active org. The UI now shows a clear error with a retry instead of a blank screen.

- **Bug Fixes**
  - Added `@OrganizationIdOptional()` for `@SkipOrgCheck()` endpoints; returns `string | undefined`.
  - Updated `@OrganizationId()` to throw `InternalServerErrorException` with guidance to use the optional decorator when appropriate.
  - Switched `findAvailable` to use `@OrganizationIdOptional()`.
  - `FrameworkSelection.tsx`: fetcher now throws on non-OK responses; renders error + retry UI.
  - Regression tests added for `findAvailable` with and without `organizationId`.

<sup>Written for commit 8fee03414bedaced9c2bfb835726ab6b8735c5ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

