### PR TITLE
fix(devices): show stale as distinct state on /people device column

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/EmployeeTasks.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/EmployeeTasks.test.tsx
@@ -163,6 +163,19 @@ describe('EmployeeTasks device compliance badge', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders the stale-explainer tooltip trigger when daysSinceLastCheckIn is null (never reported)', () => {
+    renderWithDevice(
+      makeDevice({
+        complianceStatus: 'stale',
+        daysSinceLastCheckIn: null,
+        lastCheckIn: null,
+      }),
+    );
+    expect(
+      screen.getByRole('button', { name: /What does Stale mean\?/i }),
+    ).toBeInTheDocument();
+  });
+
   it('does not render the stale-explainer tooltip trigger for a compliant device', () => {
     renderWithDevice(makeDevice({ complianceStatus: 'compliant' }));
     expect(

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/EmployeeTasks.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/EmployeeTasks.test.tsx
@@ -156,33 +156,30 @@ describe('EmployeeTasks device compliance badge', () => {
     expect(screen.getByText('Stale')).toBeInTheDocument();
   });
 
-  it('sets stale badge title tooltip based on daysSinceLastCheckIn', () => {
-    const { rerender } = renderWithDevice(
-      makeDevice({ complianceStatus: 'stale', daysSinceLastCheckIn: 9 }),
-    );
-    expect(screen.getByText('Stale (9d)').closest('[title]')?.getAttribute('title')).toBe(
-      'No check-in in 9 days',
-    );
+  it('renders a stale-explainer tooltip trigger for a stale device', () => {
+    renderWithDevice(makeDevice({ complianceStatus: 'stale', daysSinceLastCheckIn: 9 }));
+    expect(
+      screen.getByRole('button', { name: /What does Stale mean\?/i }),
+    ).toBeInTheDocument();
+  });
 
-    rerender(
-      <EmployeeTasks
-        employee={baseEmployee}
-        policies={[]}
-        trainingVideos={[]}
-        host={null as unknown as Host}
-        fleetPolicies={[] as FleetPolicy[]}
-        organization={baseOrganization}
-        memberDevice={makeDevice({
-          complianceStatus: 'stale',
-          daysSinceLastCheckIn: null,
-          lastCheckIn: null,
-        })}
-        hasHipaaFramework={false}
-        hipaaCompletedAt={null}
-      />,
+  it('does not render the stale-explainer tooltip trigger for a compliant device', () => {
+    renderWithDevice(makeDevice({ complianceStatus: 'compliant' }));
+    expect(
+      screen.queryByRole('button', { name: /What does Stale mean\?/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render the stale-explainer tooltip trigger for a non-compliant device', () => {
+    renderWithDevice(
+      makeDevice({
+        complianceStatus: 'non_compliant',
+        isCompliant: false,
+        diskEncryptionEnabled: false,
+      }),
     );
-    expect(screen.getByText('Stale').closest('[title]')?.getAttribute('title')).toBe(
-      'No check-ins recorded',
-    );
+    expect(
+      screen.queryByRole('button', { name: /What does Stale mean\?/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/EmployeeTasks.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/EmployeeTasks.tsx
@@ -4,6 +4,7 @@ import type { TrainingVideo } from '@/lib/data/training-videos';
 import type { EmployeeTrainingVideoCompletion, Member, Organization, Policy, User } from '@db';
 
 import { Card, CardContent, CardHeader, CardTitle } from '@trycompai/ui/card';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@trycompai/ui/tooltip';
 import {
   Badge,
   Section,
@@ -14,6 +15,7 @@ import {
   TabsTrigger,
   Text,
 } from '@trycompai/design-system';
+import { Information } from '@trycompai/design-system/icons';
 import { AlertCircle, Award, CheckCircle2, Download, Info } from 'lucide-react';
 import type { FleetPolicy, Host } from '../../devices/types';
 import type { DeviceWithChecks } from '../../devices/types';
@@ -56,18 +58,30 @@ function staleLabel(daysSinceLastCheckIn: number | null): string {
   return daysSinceLastCheckIn === null ? 'Stale' : `Stale (${daysSinceLastCheckIn}d)`;
 }
 
-function staleTitle(daysSinceLastCheckIn: number | null): string {
-  return daysSinceLastCheckIn === null
-    ? 'No check-ins recorded'
-    : `No check-in in ${daysSinceLastCheckIn} days`;
-}
-
 function DeviceComplianceBadge({ device }: { device: DeviceWithChecks }) {
   if (device.complianceStatus === 'stale') {
     return (
-      <Badge variant="secondary" title={staleTitle(device.daysSinceLastCheckIn)}>
-        {staleLabel(device.daysSinceLastCheckIn)}
-      </Badge>
+      <div className="flex items-center gap-1">
+        <Badge variant="secondary">{staleLabel(device.daysSinceLastCheckIn)}</Badge>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="What does Stale mean?"
+                className="inline-flex items-center text-muted-foreground hover:text-foreground"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <Information size={14} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs text-xs">
+              This device's CompAI agent hasn't reported in over 7 days, so we can't verify its
+              current compliance. Ask the employee to update or reinstall the agent.
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
     );
   }
   if (device.complianceStatus === 'compliant') {

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/EmployeeTasks.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/EmployeeTasks.tsx
@@ -58,6 +58,12 @@ function staleLabel(daysSinceLastCheckIn: number | null): string {
   return daysSinceLastCheckIn === null ? 'Stale' : `Stale (${daysSinceLastCheckIn}d)`;
 }
 
+function staleTooltipCopy(daysSinceLastCheckIn: number | null): string {
+  return daysSinceLastCheckIn === null
+    ? "This device's CompAI agent hasn't reported any check-ins, so we can't verify its current compliance. Ask the employee to install or activate the agent."
+    : "This device's CompAI agent hasn't reported in over 7 days, so we can't verify its current compliance. Ask the employee to update or reinstall the agent.";
+}
+
 function DeviceComplianceBadge({ device }: { device: DeviceWithChecks }) {
   if (device.complianceStatus === 'stale') {
     return (
@@ -76,8 +82,7 @@ function DeviceComplianceBadge({ device }: { device: DeviceWithChecks }) {
               </button>
             </TooltipTrigger>
             <TooltipContent className="max-w-xs text-xs">
-              This device's CompAI agent hasn't reported in over 7 days, so we can't verify its
-              current compliance. Ask the employee to update or reinstall the agent.
+              {staleTooltipCopy(device.daysSinceLastCheckIn)}
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/MemberRow.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/MemberRow.test.tsx
@@ -118,6 +118,34 @@ describe('MemberRow device status', () => {
     expect(container.querySelector('.bg-gray-400')).toBeInTheDocument();
   });
 
+  it('renders an info tooltip trigger next to the Stale label', () => {
+    renderMemberRow('stale');
+    expect(
+      screen.getByRole('button', { name: /What does Stale mean\?/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('does not render the Stale info tooltip for compliant devices', () => {
+    renderMemberRow('compliant');
+    expect(
+      screen.queryByRole('button', { name: /What does Stale mean\?/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render the Stale info tooltip for non-compliant devices', () => {
+    renderMemberRow('non-compliant');
+    expect(
+      screen.queryByRole('button', { name: /What does Stale mean\?/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render the Stale info tooltip for not-installed devices', () => {
+    renderMemberRow('not-installed');
+    expect(
+      screen.queryByRole('button', { name: /What does Stale mean\?/i }),
+    ).not.toBeInTheDocument();
+  });
+
   it('does not show device status for platform admin', () => {
     const adminMember = {
       ...baseMember,

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/MemberRow.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/MemberRow.test.tsx
@@ -60,7 +60,9 @@ const baseMember = {
 
 const noop = vi.fn();
 
-function renderMemberRow(deviceStatus?: 'compliant' | 'non-compliant' | 'not-installed') {
+function renderMemberRow(
+  deviceStatus?: 'compliant' | 'non-compliant' | 'stale' | 'not-installed',
+) {
   return render(
     <table>
       <tbody>
@@ -107,6 +109,13 @@ describe('MemberRow device status', () => {
     renderMemberRow('non-compliant');
     expect(screen.getByText('Non-Compliant')).toBeInTheDocument();
     expect(screen.getByText('Non-Compliant').className).toContain('text-foreground');
+  });
+
+  it('shows "Stale" with gray dot and muted label when deviceStatus is stale', () => {
+    const { container } = renderMemberRow('stale');
+    expect(screen.getByText('Stale')).toBeInTheDocument();
+    expect(screen.getByText('Stale').className).toContain('text-muted-foreground');
+    expect(container.querySelector('.bg-gray-400')).toBeInTheDocument();
   });
 
   it('does not show device status for platform admin', () => {
@@ -175,8 +184,13 @@ describe('MemberRow device status', () => {
     expect(yellowDot).toBeInTheDocument();
     u2();
 
-    const { container: c3 } = renderMemberRow('not-installed');
-    const redDot = c3.querySelector('.bg-red-400');
+    const { container: c3, unmount: u3 } = renderMemberRow('stale');
+    const grayDot = c3.querySelector('.bg-gray-400');
+    expect(grayDot).toBeInTheDocument();
+    u3();
+
+    const { container: c4 } = renderMemberRow('not-installed');
+    const redDot = c4.querySelector('.bg-red-400');
     expect(redDot).toBeInTheDocument();
   });
 

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/MemberRow.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/MemberRow.tsx
@@ -19,6 +19,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@trycompai/ui/dropdown-menu';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@trycompai/ui/tooltip';
 import { parseRolesString } from '@/lib/permissions';
 import type { Role } from '@db';
 import {
@@ -33,7 +34,7 @@ import {
   TableRow,
   Text,
 } from '@trycompai/design-system';
-import { Checkmark, Edit, Laptop, OverflowMenuVertical, TrashCan } from '@trycompai/design-system/icons';
+import { Checkmark, Edit, Information, Laptop, OverflowMenuVertical, TrashCan } from '@trycompai/design-system/icons';
 
 import { toast } from 'sonner';
 import { MultiRoleCombobox } from './MultiRoleCombobox';
@@ -290,6 +291,26 @@ export function MemberRow({
               >
                 {getDeviceStatusLabel(deviceStatus)}
               </span>
+              {deviceStatus === 'stale' && (
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        aria-label="What does Stale mean?"
+                        className="inline-flex items-center text-muted-foreground hover:text-foreground"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <Information size={14} />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-xs text-xs">
+                      This device's CompAI agent hasn't reported in over 7 days, so we can't verify
+                      its current compliance. Ask the employee to update or reinstall the agent.
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              )}
             </div>
           )}
         </TableCell>

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/MemberRow.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/MemberRow.tsx
@@ -52,7 +52,7 @@ interface MemberRowProps {
   isCurrentUserOwner: boolean;
   customRoles?: CustomRoleOption[];
   taskCompletion?: TaskCompletion;
-  deviceStatus?: 'compliant' | 'non-compliant' | 'not-installed';
+  deviceStatus?: 'compliant' | 'non-compliant' | 'stale' | 'not-installed';
   isDeviceStatusLoading?: boolean;
 }
 
@@ -85,6 +85,34 @@ function getRoleLabel(role: string): string {
 function parseRoles(role: Role | Role[] | string): string[] {
   if (Array.isArray(role)) return role as string[];
   return parseRolesString(role);
+}
+
+type DeviceStatus = 'compliant' | 'non-compliant' | 'stale' | 'not-installed';
+
+function getDeviceStatusDotClass(status: DeviceStatus): string {
+  switch (status) {
+    case 'compliant':
+      return 'bg-green-500';
+    case 'non-compliant':
+      return 'bg-yellow-500';
+    case 'stale':
+      return 'bg-gray-400';
+    case 'not-installed':
+      return 'bg-red-400';
+  }
+}
+
+function getDeviceStatusLabel(status: DeviceStatus): string {
+  switch (status) {
+    case 'compliant':
+      return 'Compliant';
+    case 'non-compliant':
+      return 'Non-Compliant';
+    case 'stale':
+      return 'Stale';
+    case 'not-installed':
+      return 'Not Installed';
+  }
 }
 
 export function MemberRow({
@@ -251,26 +279,16 @@ export function MemberRow({
           ) : (
             <div className="flex items-center gap-2">
               <span
-                className={`inline-block h-2 w-2 rounded-full ${
-                  deviceStatus === 'compliant'
-                    ? 'bg-green-500'
-                    : deviceStatus === 'non-compliant'
-                      ? 'bg-yellow-500'
-                      : 'bg-red-400'
-                }`}
+                className={`inline-block h-2 w-2 rounded-full ${getDeviceStatusDotClass(deviceStatus)}`}
               />
               <span
                 className={`text-sm ${
-                  deviceStatus === 'not-installed'
+                  deviceStatus === 'not-installed' || deviceStatus === 'stale'
                     ? 'text-muted-foreground'
                     : 'text-foreground'
                 }`}
               >
-                {deviceStatus === 'compliant'
-                  ? 'Compliant'
-                  : deviceStatus === 'non-compliant'
-                    ? 'Non-Compliant'
-                    : 'Not Installed'}
+                {getDeviceStatusLabel(deviceStatus)}
               </span>
             </div>
           )}

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/MemberRow.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/MemberRow.tsx
@@ -305,7 +305,7 @@ export function MemberRow({
                       </button>
                     </TooltipTrigger>
                     <TooltipContent className="max-w-xs text-xs">
-                      This device's CompAI agent hasn't reported in over 7 days, so we can't verify
+                      This device's CompAI agent hasn't reported in recently, so we can't verify
                       its current compliance. Ask the employee to update or reinstall the agent.
                     </TooltipContent>
                   </Tooltip>

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/compute-device-status-map.test.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/compute-device-status-map.test.ts
@@ -73,7 +73,7 @@ describe('computeDeviceStatusMap', () => {
     expect(map.mem_1).toBe('non-compliant');
   });
 
-  it('counts a stale device as non-compliant in the roll-up', () => {
+  it('returns stale when the only agent device is stale', () => {
     const map = computeDeviceStatusMap({
       agentDevices: [
         makeAgentDevice({
@@ -86,10 +86,10 @@ describe('computeDeviceStatusMap', () => {
       fleetHosts: [],
       complianceMemberIds: ['mem_1'],
     });
-    expect(map.mem_1).toBe('non-compliant');
+    expect(map.mem_1).toBe('stale');
   });
 
-  it('counts stale among mixed devices as non-compliant', () => {
+  it('returns stale when a compliant and a stale device are mixed', () => {
     const map = computeDeviceStatusMap({
       agentDevices: [
         makeAgentDevice({ memberId: 'mem_1', complianceStatus: 'compliant' }),
@@ -102,7 +102,43 @@ describe('computeDeviceStatusMap', () => {
       fleetHosts: [],
       complianceMemberIds: ['mem_1'],
     });
+    expect(map.mem_1).toBe('stale');
+  });
+
+  it('prefers non-compliant over stale when both present', () => {
+    const map = computeDeviceStatusMap({
+      agentDevices: [
+        makeAgentDevice({
+          memberId: 'mem_1',
+          complianceStatus: 'stale',
+          daysSinceLastCheckIn: 10,
+        }),
+        makeAgentDevice({ memberId: 'mem_1', complianceStatus: 'non_compliant' }),
+      ],
+      fleetHosts: [],
+      complianceMemberIds: ['mem_1'],
+    });
     expect(map.mem_1).toBe('non-compliant');
+  });
+
+  it('returns stale when all devices are stale', () => {
+    const map = computeDeviceStatusMap({
+      agentDevices: [
+        makeAgentDevice({
+          memberId: 'mem_1',
+          complianceStatus: 'stale',
+          daysSinceLastCheckIn: 10,
+        }),
+        makeAgentDevice({
+          memberId: 'mem_1',
+          complianceStatus: 'stale',
+          daysSinceLastCheckIn: 20,
+        }),
+      ],
+      fleetHosts: [],
+      complianceMemberIds: ['mem_1'],
+    });
+    expect(map.mem_1).toBe('stale');
   });
 
   it('falls back to Fleet policy status when no agent device is present', () => {
@@ -139,8 +175,8 @@ describe('computeDeviceStatusMap', () => {
       ],
       complianceMemberIds: ['mem_1'],
     });
-    // Agent says stale → non-compliant, even if fleet would say compliant.
-    expect(map.mem_1).toBe('non-compliant');
+    // Agent says stale → member is stale, even if fleet would say compliant.
+    expect(map.mem_1).toBe('stale');
   });
 
   it('ignores devices for members not in the compliance set', () => {

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/compute-device-status-map.test.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/compute-device-status-map.test.ts
@@ -179,6 +179,47 @@ describe('computeDeviceStatusMap', () => {
     expect(map.mem_1).toBe('stale');
   });
 
+  it('keeps a member non-compliant when a failing fleet host precedes a passing one', () => {
+    // Regression test for a fleet-loop last-host-wins bug: a passing host
+    // encountered after a failing one for the same member must not overwrite
+    // non-compliant with compliant.
+    const map = computeDeviceStatusMap({
+      agentDevices: [],
+      fleetHosts: [
+        makeFleetHost({
+          member_id: 'mem_1',
+          policies: [{ id: 1, name: 'Disk Enc', response: 'fail' }],
+        }),
+        makeFleetHost({
+          member_id: 'mem_1',
+          policies: [{ id: 2, name: 'Antivirus', response: 'pass' }],
+        }),
+      ],
+      complianceMemberIds: ['mem_1'],
+    });
+    expect(map.mem_1).toBe('non-compliant');
+  });
+
+  it('keeps a member non-compliant when a passing fleet host precedes a failing one', () => {
+    // Sibling order — the passing host runs first; the later failing host
+    // must still flip the member to non-compliant.
+    const map = computeDeviceStatusMap({
+      agentDevices: [],
+      fleetHosts: [
+        makeFleetHost({
+          member_id: 'mem_1',
+          policies: [{ id: 1, name: 'Antivirus', response: 'pass' }],
+        }),
+        makeFleetHost({
+          member_id: 'mem_1',
+          policies: [{ id: 2, name: 'Disk Enc', response: 'fail' }],
+        }),
+      ],
+      complianceMemberIds: ['mem_1'],
+    });
+    expect(map.mem_1).toBe('non-compliant');
+  });
+
   it('ignores devices for members not in the compliance set', () => {
     const map = computeDeviceStatusMap({
       agentDevices: [

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/compute-device-status-map.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/compute-device-status-map.ts
@@ -60,6 +60,9 @@ export function computeDeviceStatusMap({
   for (const host of fleetHosts) {
     if (!host.member_id || !complianceSet.has(host.member_id)) continue;
     if (agentRollup.has(host.member_id)) continue;
+    // Non-compliant wins across multiple Fleet hosts for the same member —
+    // once we've seen a failing host, a later passing host must not clobber it.
+    if (map[host.member_id] === 'non-compliant') continue;
     const isCompliant = host.policies.every((p) => p.response === 'pass');
     map[host.member_id] = isCompliant ? 'compliant' : 'non-compliant';
   }

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/compute-device-status-map.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/compute-device-status-map.ts
@@ -1,17 +1,22 @@
 import type { DeviceWithChecks, Host } from '../../devices/types';
 
-export type MemberDeviceStatus = 'compliant' | 'non-compliant' | 'not-installed';
+export type MemberDeviceStatus = 'compliant' | 'non-compliant' | 'stale' | 'not-installed';
 
 /**
  * Roll-up per-member device compliance for the People table.
  *
- * Rules (in order):
+ * Rules (in order of precedence):
  * 1. Every member in `complianceMemberIds` starts as `not-installed`.
- * 2. For each agent device with a memberId in the set, ALL of that member's
- *    devices must have `complianceStatus === 'compliant'` to roll up to
- *    `compliant`. `non_compliant` and `stale` both count as non-compliant.
+ * 2. For each agent device with a memberId in the set, the member's roll-up is
+ *    `non-compliant` > `stale` > `compliant`:
+ *      - Any device with `complianceStatus === 'non_compliant'` → member is
+ *        `'non-compliant'`.
+ *      - Else any device with `complianceStatus === 'stale'` → member is
+ *        `'stale'`.
+ *      - Else (all devices compliant) → `'compliant'`.
  * 3. If a member has no agent device but has a Fleet host, we fall back to
- *    Fleet policy status. Agent data always wins when present.
+ *    Fleet policy status (compliant / non-compliant; Fleet has no stale
+ *    concept). Agent data always wins when present.
  */
 export function computeDeviceStatusMap({
   agentDevices,
@@ -28,25 +33,35 @@ export function computeDeviceStatusMap({
     map[id] = 'not-installed';
   }
 
-  const agentComplianceByMember = new Map<string, boolean>();
+  const agentRollup = new Map<string, MemberDeviceStatus>();
   for (const d of agentDevices) {
     if (!d.memberId || !complianceSet.has(d.memberId)) continue;
-    const prev = agentComplianceByMember.get(d.memberId);
-    // Stale devices count as non-compliant for the roll-up.
-    const isCompliant = d.complianceStatus === 'compliant';
-    agentComplianceByMember.set(d.memberId, (prev ?? true) && isCompliant);
+
+    const prev = agentRollup.get(d.memberId);
+    // Once a member has a non-compliant device, nothing can downgrade it.
+    if (prev === 'non-compliant') continue;
+
+    if (d.complianceStatus === 'non_compliant') {
+      agentRollup.set(d.memberId, 'non-compliant');
+      continue;
+    }
+    if (d.complianceStatus === 'stale') {
+      // Stale wins over compliant but loses to non-compliant.
+      if (prev !== 'stale') agentRollup.set(d.memberId, 'stale');
+      continue;
+    }
+    // complianceStatus === 'compliant' (or any other benign value).
+    if (prev === undefined) agentRollup.set(d.memberId, 'compliant');
   }
-  for (const [memberId, allCompliant] of agentComplianceByMember) {
-    map[memberId] = allCompliant ? 'compliant' : 'non-compliant';
+  for (const [memberId, status] of agentRollup) {
+    map[memberId] = status;
   }
 
   for (const host of fleetHosts) {
     if (!host.member_id || !complianceSet.has(host.member_id)) continue;
-    if (agentComplianceByMember.has(host.member_id)) continue;
+    if (agentRollup.has(host.member_id)) continue;
     const isCompliant = host.policies.every((p) => p.response === 'pass');
-    if (map[host.member_id] !== 'non-compliant') {
-      map[host.member_id] = isCompliant ? 'compliant' : 'non-compliant';
-    }
+    map[host.member_id] = isCompliant ? 'compliant' : 'non-compliant';
   }
 
   return map;

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceAgentDevicesList.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceAgentDevicesList.test.tsx
@@ -123,4 +123,41 @@ describe('DeviceAgentDevicesList', () => {
     expect(contents).toContain('Beta');
     expect(contents).toContain('stale');
   });
+
+  it('renders a stale-explainer tooltip trigger next to the Stale badge', () => {
+    render(
+      <DeviceAgentDevicesList
+        devices={[
+          makeDevice({ complianceStatus: 'stale', daysSinceLastCheckIn: 12 }),
+        ]}
+      />,
+    );
+    expect(
+      screen.getByRole('button', { name: /What does Stale mean\?/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('does not render the stale-explainer tooltip trigger for a compliant device', () => {
+    render(<DeviceAgentDevicesList devices={[makeDevice({ complianceStatus: 'compliant' })]} />);
+    expect(
+      screen.queryByRole('button', { name: /What does Stale mean\?/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render the stale-explainer tooltip trigger for a non-compliant device', () => {
+    render(
+      <DeviceAgentDevicesList
+        devices={[
+          makeDevice({
+            complianceStatus: 'non_compliant',
+            isCompliant: false,
+            diskEncryptionEnabled: false,
+          }),
+        ]}
+      />,
+    );
+    expect(
+      screen.queryByRole('button', { name: /What does Stale mean\?/i }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceAgentDevicesList.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceAgentDevicesList.test.tsx
@@ -137,6 +137,23 @@ describe('DeviceAgentDevicesList', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders the stale-explainer tooltip trigger when daysSinceLastCheckIn is null (never reported)', () => {
+    render(
+      <DeviceAgentDevicesList
+        devices={[
+          makeDevice({
+            complianceStatus: 'stale',
+            daysSinceLastCheckIn: null,
+            lastCheckIn: null,
+          }),
+        ]}
+      />,
+    );
+    expect(
+      screen.getByRole('button', { name: /What does Stale mean\?/i }),
+    ).toBeInTheDocument();
+  });
+
   it('does not render the stale-explainer tooltip trigger for a compliant device', () => {
     render(<DeviceAgentDevicesList devices={[makeDevice({ complianceStatus: 'compliant' })]} />);
     expect(

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceAgentDevicesList.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceAgentDevicesList.tsx
@@ -19,7 +19,8 @@ import {
   TableRow,
   Text,
 } from '@trycompai/design-system';
-import { Download, Search } from '@trycompai/design-system/icons';
+import { Download, Information, Search } from '@trycompai/design-system/icons';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@trycompai/ui/tooltip';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { useMemo, useState } from 'react';
@@ -101,16 +102,27 @@ function UserNameCell({ device, orgId }: { device: DeviceWithChecks; orgId: stri
 function CompliantBadge({ device }: { device: DeviceWithChecks }) {
   if (device.complianceStatus === 'stale') {
     return (
-      <Badge
-        variant="secondary"
-        title={
-          device.daysSinceLastCheckIn === null
-            ? 'No check-ins recorded'
-            : `No check-in in ${device.daysSinceLastCheckIn} days`
-        }
-      >
-        {staleLabel(device.daysSinceLastCheckIn)}
-      </Badge>
+      <div className="flex items-center gap-1">
+        <Badge variant="secondary">{staleLabel(device.daysSinceLastCheckIn)}</Badge>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="What does Stale mean?"
+                className="inline-flex items-center text-muted-foreground hover:text-foreground"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <Information size={14} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs text-xs">
+              This device's CompAI agent hasn't reported in over 7 days, so we can't verify its
+              current compliance. Ask the employee to update or reinstall the agent.
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
     );
   }
   if (device.complianceStatus === 'compliant') {

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceAgentDevicesList.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceAgentDevicesList.tsx
@@ -73,6 +73,12 @@ function staleLabel(daysSinceLastCheckIn: number | null): string {
   return daysSinceLastCheckIn === null ? 'Stale' : `Stale (${daysSinceLastCheckIn}d)`;
 }
 
+function staleTooltipCopy(daysSinceLastCheckIn: number | null): string {
+  return daysSinceLastCheckIn === null
+    ? "This device's CompAI agent hasn't reported any check-ins, so we can't verify its current compliance. Ask the employee to install or activate the agent."
+    : "This device's CompAI agent hasn't reported in over 7 days, so we can't verify its current compliance. Ask the employee to update or reinstall the agent.";
+}
+
 function UserNameCell({ device, orgId }: { device: DeviceWithChecks; orgId: string }) {
   const memberId = device.memberId;
 
@@ -117,8 +123,7 @@ function CompliantBadge({ device }: { device: DeviceWithChecks }) {
               </button>
             </TooltipTrigger>
             <TooltipContent className="max-w-xs text-xs">
-              This device's CompAI agent hasn't reported in over 7 days, so we can't verify its
-              current compliance. Ask the employee to update or reinstall the agent.
+              {staleTooltipCopy(device.daysSinceLastCheckIn)}
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceDetails.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceDetails.test.tsx
@@ -85,29 +85,38 @@ describe('DeviceDetails compliance badge', () => {
     expect(screen.getByText('Stale')).toBeInTheDocument();
   });
 
-  it('sets stale badge title tooltip based on daysSinceLastCheckIn', () => {
-    const { rerender } = render(
+  it('renders a stale-explainer tooltip trigger for a stale device', () => {
+    render(
       <DeviceDetails
         device={makeDevice({ complianceStatus: 'stale', daysSinceLastCheckIn: 30 })}
         onClose={vi.fn()}
       />,
     );
-    expect(screen.getByText('Stale (30d)').closest('[title]')?.getAttribute('title')).toBe(
-      'No check-in in 30 days',
-    );
+    expect(
+      screen.getByRole('button', { name: /What does Stale mean\?/i }),
+    ).toBeInTheDocument();
+  });
 
-    rerender(
+  it('does not render the stale-explainer tooltip trigger for a compliant device', () => {
+    render(<DeviceDetails device={makeDevice()} onClose={vi.fn()} />);
+    expect(
+      screen.queryByRole('button', { name: /What does Stale mean\?/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render the stale-explainer tooltip trigger for a non-compliant device', () => {
+    render(
       <DeviceDetails
         device={makeDevice({
-          complianceStatus: 'stale',
-          daysSinceLastCheckIn: null,
-          lastCheckIn: null,
+          complianceStatus: 'non_compliant',
+          isCompliant: false,
+          diskEncryptionEnabled: false,
         })}
         onClose={vi.fn()}
       />,
     );
-    expect(screen.getByText('Stale').closest('[title]')?.getAttribute('title')).toBe(
-      'No check-ins recorded',
-    );
+    expect(
+      screen.queryByRole('button', { name: /What does Stale mean\?/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceDetails.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceDetails.test.tsx
@@ -97,6 +97,22 @@ describe('DeviceDetails compliance badge', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders the stale-explainer tooltip trigger when daysSinceLastCheckIn is null (never reported)', () => {
+    render(
+      <DeviceDetails
+        device={makeDevice({
+          complianceStatus: 'stale',
+          daysSinceLastCheckIn: null,
+          lastCheckIn: null,
+        })}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole('button', { name: /What does Stale mean\?/i }),
+    ).toBeInTheDocument();
+  });
+
   it('does not render the stale-explainer tooltip trigger for a compliant device', () => {
     render(<DeviceDetails device={makeDevice()} onClose={vi.fn()} />);
     expect(

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceDetails.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceDetails.tsx
@@ -43,6 +43,12 @@ function staleLabel(daysSinceLastCheckIn: number | null): string {
   return daysSinceLastCheckIn === null ? 'Stale' : `Stale (${daysSinceLastCheckIn}d)`;
 }
 
+function staleTooltipCopy(daysSinceLastCheckIn: number | null): string {
+  return daysSinceLastCheckIn === null
+    ? "This device's CompAI agent hasn't reported any check-ins, so we can't verify its current compliance. Ask the employee to install or activate the agent."
+    : "This device's CompAI agent hasn't reported in over 7 days, so we can't verify its current compliance. Ask the employee to update or reinstall the agent.";
+}
+
 function DeviceComplianceBadge({ device }: { device: DeviceWithChecks }) {
   if (device.complianceStatus === 'stale') {
     return (
@@ -61,8 +67,7 @@ function DeviceComplianceBadge({ device }: { device: DeviceWithChecks }) {
               </button>
             </TooltipTrigger>
             <TooltipContent className="max-w-xs text-xs">
-              This device's CompAI agent hasn't reported in over 7 days, so we can't verify its
-              current compliance. Ask the employee to update or reinstall the agent.
+              {staleTooltipCopy(device.daysSinceLastCheckIn)}
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceDetails.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceDetails.tsx
@@ -15,7 +15,8 @@ import {
   TableRow,
   Text,
 } from '@trycompai/design-system';
-import { ArrowLeft } from '@trycompai/design-system/icons';
+import { ArrowLeft, Information } from '@trycompai/design-system/icons';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@trycompai/ui/tooltip';
 import type { DeviceWithChecks } from '../types';
 
 const CHECK_FIELDS = [
@@ -42,18 +43,30 @@ function staleLabel(daysSinceLastCheckIn: number | null): string {
   return daysSinceLastCheckIn === null ? 'Stale' : `Stale (${daysSinceLastCheckIn}d)`;
 }
 
-function staleTitle(daysSinceLastCheckIn: number | null): string {
-  return daysSinceLastCheckIn === null
-    ? 'No check-ins recorded'
-    : `No check-in in ${daysSinceLastCheckIn} days`;
-}
-
 function DeviceComplianceBadge({ device }: { device: DeviceWithChecks }) {
   if (device.complianceStatus === 'stale') {
     return (
-      <Badge variant="secondary" title={staleTitle(device.daysSinceLastCheckIn)}>
-        {staleLabel(device.daysSinceLastCheckIn)}
-      </Badge>
+      <div className="flex items-center gap-1">
+        <Badge variant="secondary">{staleLabel(device.daysSinceLastCheckIn)}</Badge>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="What does Stale mean?"
+                className="inline-flex items-center text-muted-foreground hover:text-foreground"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <Information size={14} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs text-xs">
+              This device's CompAI agent hasn't reported in over 7 days, so we can't verify its
+              current compliance. Ask the employee to update or reinstall the agent.
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
     );
   }
   if (device.complianceStatus === 'compliant') {


### PR DESCRIPTION
## Summary

Follow-up to #2626 (already merged). The `/people` table's DEVICE column was collapsing stale devices into a yellow "Non-Compliant" badge, while clicking through to the employee profile shows the correct gray "Stale (Nd)" badge. This closes the visual inconsistency.

## What changed

- `MemberDeviceStatus` gains a fourth state: `'stale'`.
- `computeDeviceStatusMap` roll-up precedence when a member has multiple devices: **`non-compliant` > `stale` > `compliant`**. A hard-failing device still wins (security-first), all-stale devices surface as stale rather than masquerading as non-compliant.
- `MemberRow` renders `'stale'` with a gray dot and a muted "Stale" label — same aesthetic weight as the drill-in's DS secondary badge.

## Tests

- `compute-device-status-map.test.ts` — 10 tests. Includes new cases: `prefers non-compliant over stale when both present`, `returns stale when all agent devices are stale`.
- `MemberRow.test.tsx` — new case asserting stale → gray dot + "Stale" label (plus an extended dot-colors test).

## Test plan

- [ ] Visit `/people`. For a member whose only device is stale (≥7 days since last check-in), the DEVICE column shows a muted gray dot + "Stale", not yellow "Non-Compliant".
- [ ] For a member with one stale + one non-compliant device, DEVICE shows "Non-Compliant" (hard fail wins).
- [ ] For a member with two stale devices, DEVICE shows "Stale".
- [ ] Click into any of the above — the drill-in's "Device" tab badge matches the table.

## Notes

- `MemberRow.test.tsx` surfaces a pre-existing `@trycompai/auth` resolution error in the Vitest environment — unchanged by this PR (confirmed by stashing the diff and re-running against main). The compute-device-status-map tests run clean (10/10).
- Related Linear follow-ups captured under [ENG-215](https://linear.app/compai/issue/ENG-215/prevent-silent-policy-re-acknowledgment-churn-cs-276-follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show “Stale” as a distinct device status in the /people DEVICE column and add a consistent info tooltip explaining it across device views. The roll‑up uses non‑compliant > stale > compliant and preserves non‑compliant across multiple Fleet hosts; tooltip copy now handles never‑reported devices.

- **Bug Fixes**
  - Added `stale` to device roll‑up with precedence: non‑compliant > stale > compliant; agent data still overrides Fleet.
  - Fixed Fleet fallback to avoid last‑host‑wins: once a failing host marks non‑compliant, later passing hosts can’t downgrade.

- **New Features**
  - Render “Stale” with a gray dot and muted label; “Non‑Compliant” still wins when mixed with stale.
  - Added an Information icon next to “Stale” that opens a tooltip explaining the state, with branched copy for never‑reported vs 7+ days. Implemented with `@trycompai/ui/tooltip` across the people table, employee profile, device list, and device details.

<sup>Written for commit 9465e6de2d880bee4d8c20fddf0d295939e11d5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

