### PR TITLE
fix(devices): soften stale tooltip copy to not prescribe a single cause

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/EmployeeTasks.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/EmployeeTasks.tsx
@@ -60,8 +60,8 @@ function staleLabel(daysSinceLastCheckIn: number | null): string {
 
 function staleTooltipCopy(daysSinceLastCheckIn: number | null): string {
   return daysSinceLastCheckIn === null
-    ? "This device's CompAI agent hasn't reported any check-ins, so we can't verify its current compliance. Ask the employee to install or activate the agent."
-    : "This device's CompAI agent hasn't reported in over 7 days, so we can't verify its current compliance. Ask the employee to update or reinstall the agent.";
+    ? "This device was registered but hasn't sent a compliance check yet. If it's not new, the agent may not be running or the device may be offline."
+    : "This device hasn't reported to CompAI in over 7 days, so we can't verify its current compliance. It may be offline, the agent may need to be updated, or the device may no longer be in use. Check with the employee.";
 }
 
 function DeviceComplianceBadge({ device }: { device: DeviceWithChecks }) {

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/MemberRow.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/MemberRow.tsx
@@ -305,8 +305,9 @@ export function MemberRow({
                       </button>
                     </TooltipTrigger>
                     <TooltipContent className="max-w-xs text-xs">
-                      This device's CompAI agent hasn't reported in recently, so we can't verify
-                      its current compliance. Ask the employee to update or reinstall the agent.
+                      We haven't received a recent compliance check from this device. It may be
+                      offline, the agent may need to be updated, or the device may no longer be in
+                      use.
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceAgentDevicesList.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceAgentDevicesList.tsx
@@ -75,8 +75,8 @@ function staleLabel(daysSinceLastCheckIn: number | null): string {
 
 function staleTooltipCopy(daysSinceLastCheckIn: number | null): string {
   return daysSinceLastCheckIn === null
-    ? "This device's CompAI agent hasn't reported any check-ins, so we can't verify its current compliance. Ask the employee to install or activate the agent."
-    : "This device's CompAI agent hasn't reported in over 7 days, so we can't verify its current compliance. Ask the employee to update or reinstall the agent.";
+    ? "This device was registered but hasn't sent a compliance check yet. If it's not new, the agent may not be running or the device may be offline."
+    : "This device hasn't reported to CompAI in over 7 days, so we can't verify its current compliance. It may be offline, the agent may need to be updated, or the device may no longer be in use. Check with the employee.";
 }
 
 function UserNameCell({ device, orgId }: { device: DeviceWithChecks; orgId: string }) {

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceDetails.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceDetails.tsx
@@ -45,8 +45,8 @@ function staleLabel(daysSinceLastCheckIn: number | null): string {
 
 function staleTooltipCopy(daysSinceLastCheckIn: number | null): string {
   return daysSinceLastCheckIn === null
-    ? "This device's CompAI agent hasn't reported any check-ins, so we can't verify its current compliance. Ask the employee to install or activate the agent."
-    : "This device's CompAI agent hasn't reported in over 7 days, so we can't verify its current compliance. Ask the employee to update or reinstall the agent.";
+    ? "This device was registered but hasn't sent a compliance check yet. If it's not new, the agent may not be running or the device may be offline."
+    : "This device hasn't reported to CompAI in over 7 days, so we can't verify its current compliance. It may be offline, the agent may need to be updated, or the device may no longer be in use. Check with the employee.";
 }
 
 function DeviceComplianceBadge({ device }: { device: DeviceWithChecks }) {


### PR DESCRIPTION
## Summary

Follow-up to #2629. The original stale tooltip ("Ask the employee to update or reinstall the agent") diagnosed a specific cause when the underlying signal only tells us that **no successful check-in has been received in 7+ days**. That can mean many things:

- Agent is broken, outdated, or uninstalled
- Device is simply offline (PTO, device powered down, bad network for a week)
- VPN / firewall blocking the check-in endpoint
- Agent is running with a revoked token
- Device was decommissioned but the row wasn't cleaned up
- Brand-new registration that genuinely hasn't run its first check yet

The new copy describes what we know and hints at possible reasons without pretending to diagnose.

## Copy

| Surface | New copy |
|---|---|
| Devices list / drawer / employee device tab — **has history** | "This device hasn't reported to CompAI in over 7 days, so we can't verify its current compliance. It may be offline, the agent may need to be updated, or the device may no longer be in use. Check with the employee." |
| Same surfaces — **never reported** (`daysSinceLastCheckIn === null`) | "This device was registered but hasn't sent a compliance check yet. If it's not new, the agent may not be running or the device may be offline." |
| People table roll-up (no per-device context) | "We haven't received a recent compliance check from this device. It may be offline, the agent may need to be updated, or the device may no longer be in use." |

## Test plan

- [ ] Hover the info icon next to a stale device on `/people` — tooltip renders the roll-up copy.
- [ ] Hover the info icon on a stale device row in the Devices tab — tooltip renders the per-device copy (7-day variant).
- [ ] For a device with `lastCheckIn === null`, the tooltip renders the never-reported variant.
- [ ] Fresh compliant / non-compliant states unchanged (no tooltip).

## Tests

26 existing component tests still pass (no test was asserting on the old copy text; all tests check the trigger button by accessible name). `MemberRow.test.tsx` continues to hit the pre-existing `@trycompai/auth` resolver issue that's unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Softened stale device tooltip copy across Devices and People to avoid prescribing a single cause. Added a “never reported” variant and updated the 7+ days message to list possible reasons (offline, agent needs update, or device not in use).

<sup>Written for commit 9e696c3e9b737dd0fc1feecd0ffb07898f65f52f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

