### PR TITLE
fix(db): increase prisma transaction timeout from 30s to 60s

### DIFF
--- a/apps/api/prisma/client.ts
+++ b/apps/api/prisma/client.ts
@@ -22,7 +22,7 @@ function createPrismaClient(): PrismaClient {
   return new PrismaClient({
     adapter,
     transactionOptions: {
-      timeout: 30000,
+      timeout: 60000,
     },
   });
 }

--- a/apps/api/src/trigger/tasks/onboarding/migrate-policies-for-org.ts
+++ b/apps/api/src/trigger/tasks/onboarding/migrate-policies-for-org.ts
@@ -108,7 +108,7 @@ export const migratePoliciesForOrg = schemaTask({
 
             return { migrated, skipped };
           },
-          { timeout: 30000 },
+          { timeout: 60000 },
         );
 
         totalMigrated += result.migrated;

--- a/apps/app/prisma/client.ts
+++ b/apps/app/prisma/client.ts
@@ -22,7 +22,7 @@ function createPrismaClient(): PrismaClient {
   return new PrismaClient({
     adapter,
     transactionOptions: {
-      timeout: 30000,
+      timeout: 60000,
     },
   });
 }

--- a/apps/framework-editor/prisma/client.ts
+++ b/apps/framework-editor/prisma/client.ts
@@ -22,7 +22,7 @@ function createPrismaClient(): PrismaClient {
   return new PrismaClient({
     adapter,
     transactionOptions: {
-      timeout: 30000,
+      timeout: 60000,
     },
   });
 }

--- a/apps/portal/prisma/client.ts
+++ b/apps/portal/prisma/client.ts
@@ -22,7 +22,7 @@ function createPrismaClient(): PrismaClient {
   return new PrismaClient({
     adapter,
     transactionOptions: {
-      timeout: 30000,
+      timeout: 60000,
     },
   });
 }

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -22,7 +22,7 @@ function createPrismaClient(): PrismaClient {
   return new PrismaClient({
     adapter,
     transactionOptions: {
-      timeout: 30000,
+      timeout: 60000,
     },
   });
 }


### PR DESCRIPTION
## Summary
- Bumps the default Prisma `transactionOptions.timeout` from **30s → 60s** across all five Prisma clients (`packages/db`, `apps/api`, `apps/app`, `apps/portal`, `apps/framework-editor`).
- Also bumps the one inline `$transaction` timeout override in `apps/api/src/trigger/tasks/onboarding/migrate-policies-for-org.ts` to stay consistent with the new default.

## Why
Customers were unable to complete organization creation because the underlying transaction occasionally exceeds 30s and gets aborted. Raising the ceiling to 60s unblocks onboarding immediately.

## Caveat / follow-up
This is a band-aid. A DB transaction that genuinely takes >30s holds locks and a connection for that entire duration and will cause contention / pool pressure at scale. The real fix is to investigate what is happening inside the org-creation transaction and move any non-DB work (external API calls, S3 uploads, email sends, heavy seeding) out of it. Tracking that separately.

## Test plan
- [ ] Verify org creation completes for the affected customers in staging
- [ ] Confirm no regressions in other transactional flows (policy updates, task mutations, comments, ownership transfer)
- [ ] Monitor for any increase in transaction duration or lock-wait alerts after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase Prisma transaction timeout from 30s to 60s across all clients to prevent org creation timeouts and unblock onboarding.

- **Bug Fixes**
  - Set `transactionOptions.timeout` to 60000 in `packages/db`, `apps/api`, `apps/app`, `apps/portal`, `apps/framework-editor`.
  - Updated the inline `$transaction` timeout in `apps/api/src/trigger/tasks/onboarding/migrate-policies-for-org.ts` to match.

<sup>Written for commit 8d1764a67e1c444028a3c853436a667cef13da13. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

