### PR TITLE
fix(evidence-export): address two follow-up review findings from prod deploy PR

### DIFF
--- a/apps/api/src/tasks/evidence-export/evidence-attachment-streamer.ts
+++ b/apps/api/src/tasks/evidence-export/evidence-attachment-streamer.ts
@@ -77,6 +77,11 @@ export function createFilenameTracker(): (rawName: string) => string {
  * - All other failures (network, permissions, throttling, empty body) → rethrow
  *   so the archive aborts and the user sees a real failure instead of silently
  *   receiving an incomplete export.
+ *
+ * Filename collisions are resolved on the *final* ZIP entry name (including
+ * any `_MISSING_…txt` wrapping), not the raw attachment name — otherwise a
+ * success-path file named `_MISSING_foo.txt` could collide with a failure-path
+ * placeholder for a file named `foo` once the wrapping is applied.
  */
 export async function appendAttachmentToArchive(params: {
   archive: Archiver;
@@ -128,8 +133,13 @@ export async function appendAttachmentToArchive(params: {
     logger.warn(
       `Missing S3 object for attachment ${attachment.id} (key=${attachment.url}): ${message}`,
     );
+    // Feed the FULL final name (including `_MISSING_` prefix and `.txt` suffix)
+    // into the same collision tracker that success paths use, so a legitimate
+    // file uploaded as `_MISSING_foo.txt` can't silently collide with a
+    // placeholder for a different missing attachment named `foo`.
+    const placeholderName = uniqueName(`_MISSING_${attachment.name}.txt`);
     archive.append(buildMissingPlaceholder(attachment, message), {
-      name: `${folderPath}/_MISSING_${uniqueName(attachment.name)}.txt`,
+      name: `${folderPath}/${placeholderName}`,
     });
   }
 }

--- a/apps/api/src/tasks/evidence-export/evidence-export.controller.spec.ts
+++ b/apps/api/src/tasks/evidence-export/evidence-export.controller.spec.ts
@@ -59,6 +59,7 @@ function makeFakeResponse() {
     end: jest.fn(),
     headersSent: false,
     writableEnded: false,
+    writableFinished: false,
   });
   return res;
 }
@@ -180,10 +181,43 @@ describe('EvidenceExportController', () => {
 
     expect(archive.abort).not.toHaveBeenCalled();
 
-    // Simulate client closing the connection before the stream finished.
-    req.emit('close');
+    // Simulate a client-side disconnect: res emits 'close' before the response
+    // has fully flushed (writableFinished is still false).
+    res.writableFinished = false;
+    res.emit('close');
 
     expect(archive.abort).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT abort the archive when the response completed normally', async () => {
+    // Regression guard for cubic P1: with req.once('close') this would falsely
+    // abort on Node 16+. Using res.close + writableFinished avoids that.
+    const archive = makeFakeArchive();
+    service.streamTaskEvidenceZip.mockResolvedValue({
+      archive: archive as unknown as import('archiver').Archiver,
+      filename: 'f.zip',
+    });
+    const req = makeFakeRequest();
+    const res = makeFakeResponse();
+
+    await controller.exportTaskEvidenceZip(
+      'org_1',
+      'tsk_1',
+      'false',
+      req as unknown as import('express').Request,
+      res as unknown as import('express').Response,
+    );
+
+    // Successful flow: archiver finishes, writableFinished becomes true before
+    // 'close' fires on the response.
+    res.writableFinished = true;
+    res.emit('close');
+
+    // And even if req 'close' fires too (Node 16+ does this on normal
+    // completion), we ignore it — no listener attached there.
+    req.emit('close');
+
+    expect(archive.abort).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/tasks/evidence-export/evidence-export.controller.ts
+++ b/apps/api/src/tasks/evidence-export/evidence-export.controller.ts
@@ -277,6 +277,12 @@ export class AuditorEvidenceExportController {
  *  1. Archive errors → log and end the response (500 if headers not yet sent).
  *  2. Client disconnect → abort the archive so S3 fetches stop and the
  *     background populate task doesn't keep running for a closed socket.
+ *
+ * We listen on `res.close` only and distinguish normal-completion from
+ * disconnect via `res.writableFinished` (true only after the full response
+ * has been flushed). `req.close` is not used because it fires on normal
+ * request completion in modern Node, which can race with our response flush
+ * and cause false aborts of successful exports.
  */
 function pipeArchiveToResponse(params: {
   archive: Archiver;
@@ -285,19 +291,18 @@ function pipeArchiveToResponse(params: {
   logger: Logger;
   tag: string;
 }): void {
-  const { archive, req, res, logger, tag } = params;
+  const { archive, res, logger, tag } = params;
   let aborted = false;
 
-  const abortIfIncomplete = () => {
+  res.once('close', () => {
     if (aborted) return;
-    if (res.writableEnded) return;
+    // writableFinished becomes true only after the response is fully flushed
+    // and the 'finish' event fires; on a client disconnect this stays false.
+    if (res.writableFinished) return;
     aborted = true;
     logger.warn(`Client disconnected during export (${tag}); aborting archive`);
     archive.abort();
-  };
-
-  req.once('close', abortIfIncomplete);
-  res.once('close', abortIfIncomplete);
+  });
 
   archive.on('error', (err) => {
     logger.error(`Archive stream error (${tag}): ${err.message}`);

--- a/apps/api/src/tasks/evidence-export/evidence-export.service.spec.ts
+++ b/apps/api/src/tasks/evidence-export/evidence-export.service.spec.ts
@@ -358,6 +358,74 @@ describe('EvidenceExportService — streaming ZIPs', () => {
         }),
       );
     });
+
+    it('produces a valid ZIP with automations only (no attachments) — no regression', async () => {
+      // Simulates the common case: task has automation runs but no files
+      // uploaded. Must NOT create an empty 01-attachments/ folder and must
+      // still emit the summary + automation PDFs like before this PR.
+      const appRun = {
+        id: 'icr_1',
+        checkId: 'mfa-check',
+        checkName: 'MFA Enabled',
+        status: 'success',
+        startedAt: new Date('2024-01-15T10:00:00Z'),
+        completedAt: new Date('2024-01-15T10:00:05Z'),
+        durationMs: 5000,
+        totalChecked: 1,
+        passedCount: 1,
+        failedCount: 0,
+        errorMessage: null,
+        logs: null,
+        createdAt: new Date('2024-01-15T10:00:00Z'),
+        connection: { provider: { slug: 'g', name: 'G' } },
+        results: [],
+      };
+      primeTaskQueries({ attachments: [], appRuns: [appRun], customRuns: [] });
+
+      const { archive } = await service.streamTaskEvidenceZip(
+        'org_1',
+        'tsk_123',
+      );
+      const mock = archive as unknown as MockArchive;
+      await mock.finalized;
+
+      const paths = mock.appendCalls.map((c) => c.options.name);
+
+      // Summary PDF present
+      expect(paths).toContain(
+        'acme-corp_soc-2-access-review_evidence/00-summary.pdf',
+      );
+      // No 01-attachments/ folder at all
+      expect(paths.some((p) => p.includes('/01-attachments/'))).toBe(false);
+      // At least one automation PDF was written in a subfolder (per-task uses subfolders)
+      expect(paths.some((p) => /\/app-.+\/evidence\.pdf$/.test(p))).toBe(true);
+
+      // S3 GetObject should NOT have been called — no attachments to fetch.
+      expect(s3Client!.send).not.toHaveBeenCalled();
+
+      // Summary PDF renders with attachmentsCount=0 (line omitted in PDF).
+      expect(generateTaskSummaryPDF).toHaveBeenCalledWith(
+        expect.any(Object),
+        { attachmentsCount: 0 },
+      );
+    });
+
+    it('produces a summary-only ZIP when task has neither automations nor attachments', async () => {
+      primeTaskQueries({ attachments: [], appRuns: [], customRuns: [] });
+
+      const { archive } = await service.streamTaskEvidenceZip(
+        'org_1',
+        'tsk_123',
+      );
+      const mock = archive as unknown as MockArchive;
+      await mock.finalized;
+
+      const paths = mock.appendCalls.map((c) => c.options.name);
+      expect(paths).toEqual([
+        'acme-corp_soc-2-access-review_evidence/00-summary.pdf',
+      ]);
+      expect(s3Client!.send).not.toHaveBeenCalled();
+    });
   });
 
   describe('streamOrganizationEvidenceZip', () => {
@@ -425,6 +493,168 @@ describe('EvidenceExportService — streaming ZIPs', () => {
       expect(paths.some((p) => p.includes('/01-attachments/audit.pdf'))).toBe(
         true,
       );
+    });
+
+    it('works for an org with automations but zero attachments anywhere — no regression', async () => {
+      // Core pre-existing behaviour: org has tasks with automation runs, no
+      // attachments uploaded. Export must succeed with the same structure as
+      // before this PR (manifest + per-task folders with automation PDFs,
+      // no 01-attachments/ folders, totalAttachments: 0).
+      mockDb.organization.findUnique.mockResolvedValue({ name: 'Acme Corp' });
+
+      // findTasksWithEvidence: one task has runs, attachments query returns empty
+      mockDb.task.findMany.mockResolvedValue([{ id: 'tsk_auto' }]);
+      mockDb.attachment.findMany.mockResolvedValueOnce([]); // no tasks with attachments
+
+      // Per-task fetches inside populate loop
+      mockDb.task.findFirst.mockResolvedValue({
+        id: 'tsk_auto',
+        title: 'Automated Task',
+        organization: { name: 'Acme Corp' },
+      });
+      mockDb.integrationCheckRun.findMany.mockResolvedValue([
+        {
+          id: 'icr_1',
+          checkId: 'c1',
+          checkName: 'Check 1',
+          status: 'success',
+          startedAt: new Date('2024-01-01'),
+          completedAt: new Date('2024-01-01'),
+          durationMs: 100,
+          totalChecked: 1,
+          passedCount: 1,
+          failedCount: 0,
+          errorMessage: null,
+          logs: null,
+          createdAt: new Date('2024-01-01'),
+          connection: { provider: { slug: 'g', name: 'G' } },
+          results: [],
+        },
+      ]);
+      mockDb.evidenceAutomationRun.findMany.mockResolvedValue([]);
+      // Per-task attachment fetch inside loop
+      mockDb.attachment.findMany.mockResolvedValue([]);
+
+      const { archive } =
+        await service.streamOrganizationEvidenceZip('org_1');
+      const mock = archive as unknown as MockArchive;
+      await mock.finalized;
+
+      const paths = mock.appendCalls.map((c) => c.options.name);
+
+      // Manifest present, task folder with summary + automation PDF present,
+      // no 01-attachments/ folder anywhere.
+      expect(paths.some((p) => p.endsWith('/manifest.json'))).toBe(true);
+      expect(paths.some((p) => p.endsWith('/00-summary.pdf'))).toBe(true);
+      expect(paths.some((p) => /\/app-.+\.pdf$/.test(p))).toBe(true);
+      expect(paths.some((p) => p.includes('/01-attachments/'))).toBe(false);
+
+      // No S3 fetches triggered (no attachments to stream)
+      expect(s3Client!.send).not.toHaveBeenCalled();
+
+      // Manifest should record zero attachments
+      const manifestCall = mock.appendCalls.find((c) =>
+        c.options.name.endsWith('/manifest.json'),
+      );
+      expect(manifestCall).toBeDefined();
+      const manifestJson = JSON.parse(String(manifestCall!.source));
+      expect(manifestJson.totalAttachments).toBe(0);
+      expect(manifestJson.tasksCount).toBe(1);
+      expect(manifestJson.tasks[0]).toMatchObject({
+        title: 'Automated Task',
+        automations: 1,
+        attachments: 0,
+      });
+    });
+
+    it('mixes attachment-only and automation-only tasks in the same export', async () => {
+      mockDb.organization.findUnique.mockResolvedValue({ name: 'Acme Corp' });
+
+      // findTasksWithEvidence: one task has runs, another has only attachments
+      mockDb.task.findMany.mockResolvedValue([{ id: 'tsk_auto' }]);
+      mockDb.attachment.findMany.mockResolvedValueOnce([
+        { entityId: 'tsk_att' },
+      ]);
+
+      // Per-task dispatch — depends on which task findFirst is called for.
+      mockDb.task.findFirst.mockImplementation((args: { where: { id: string } }) => {
+        if (args.where.id === 'tsk_auto') {
+          return Promise.resolve({
+            id: 'tsk_auto',
+            title: 'Automated',
+            organization: { name: 'Acme Corp' },
+          });
+        }
+        return Promise.resolve({
+          id: 'tsk_att',
+          title: 'Attached',
+          organization: { name: 'Acme Corp' },
+        });
+      });
+      mockDb.integrationCheckRun.findMany.mockImplementation(
+        (args: { where: { taskId: string } }) =>
+          args.where.taskId === 'tsk_auto'
+            ? Promise.resolve([
+                {
+                  id: 'icr_1',
+                  checkId: 'c',
+                  checkName: 'Check',
+                  status: 'success',
+                  startedAt: new Date(),
+                  completedAt: new Date(),
+                  durationMs: 100,
+                  totalChecked: 1,
+                  passedCount: 1,
+                  failedCount: 0,
+                  errorMessage: null,
+                  logs: null,
+                  createdAt: new Date(),
+                  connection: { provider: { slug: 'g', name: 'G' } },
+                  results: [],
+                },
+              ])
+            : Promise.resolve([]),
+      );
+      mockDb.evidenceAutomationRun.findMany.mockResolvedValue([]);
+
+      // Per-task attachment fetches — only tsk_att has any
+      mockDb.attachment.findMany.mockImplementation(
+        (args: { where: { entityId?: string } }) =>
+          args.where.entityId === 'tsk_att'
+            ? Promise.resolve([
+                {
+                  id: 'att_1',
+                  name: 'proof.pdf',
+                  url: 'key',
+                  type: 'document',
+                  createdAt: new Date(),
+                },
+              ])
+            : Promise.resolve([]),
+      );
+
+      (s3Client!.send as jest.Mock).mockResolvedValue({
+        Body: Buffer.from('PDF'),
+      });
+
+      const { archive } =
+        await service.streamOrganizationEvidenceZip('org_1');
+      const mock = archive as unknown as MockArchive;
+      await mock.finalized;
+
+      const paths = mock.appendCalls.map((c) => c.options.name);
+      expect(paths.some((p) => p.includes('/automated-'))).toBe(true);
+      expect(paths.some((p) => p.includes('/attached-'))).toBe(true);
+      expect(
+        paths.some((p) => p.includes('/01-attachments/proof.pdf')),
+      ).toBe(true);
+
+      const manifestCall = mock.appendCalls.find((c) =>
+        c.options.name.endsWith('/manifest.json'),
+      );
+      const manifestJson = JSON.parse(String(manifestCall!.source));
+      expect(manifestJson.totalAttachments).toBe(1);
+      expect(manifestJson.tasksCount).toBe(2);
     });
   });
 });

--- a/apps/api/src/tasks/evidence-export/evidence-export.service.spec.ts
+++ b/apps/api/src/tasks/evidence-export/evidence-export.service.spec.ts
@@ -303,6 +303,69 @@ describe('EvidenceExportService — streaming ZIPs', () => {
       expect(placeholder).toBeUndefined();
     });
 
+    it('prevents placeholder vs success filename collision in final ZIP path', async () => {
+      // Regression guard for cubic P2: if a legitimate file is uploaded with
+      // the name `_MISSING_foo.txt` and succeeds from S3, AND another upload
+      // named `foo` fails (NoSuchKey), the wrapping of the failure into
+      // `_MISSING_foo.txt` must NOT collide with the successful file.
+      const attachments = [
+        {
+          id: 'att_real',
+          name: '_MISSING_foo.txt',
+          url: 'key-real',
+          type: 'document',
+          createdAt: new Date('2024-01-01'),
+        },
+        {
+          id: 'att_miss',
+          name: 'foo',
+          url: 'key-miss',
+          type: 'document',
+          createdAt: new Date('2024-01-02'),
+        },
+      ];
+
+      (s3Client!.send as jest.Mock).mockImplementation(
+        (cmd: { input: { Key: string } }) => {
+          if (cmd.input.Key === 'key-real') {
+            return Promise.resolve({ Body: Buffer.from('REAL') });
+          }
+          return Promise.reject(
+            Object.assign(new Error('NoSuchKey'), {
+              name: 'NoSuchKey',
+              $metadata: { httpStatusCode: 404 },
+            }),
+          );
+        },
+      );
+      primeTaskQueries({ attachments });
+
+      const { archive } = await service.streamTaskEvidenceZip(
+        'org_1',
+        'tsk_123',
+      );
+      const mock = archive as unknown as MockArchive;
+      await mock.finalized;
+
+      const attachmentPaths = mock.appendCalls
+        .map((c) => c.options.name)
+        .filter((p) => p.includes('/01-attachments/'));
+
+      // Two entries, each with a distinct final path inside the ZIP.
+      expect(attachmentPaths).toHaveLength(2);
+      const uniquePaths = new Set(attachmentPaths);
+      expect(uniquePaths.size).toBe(2);
+
+      // The real file keeps its name; the placeholder gets a numeric suffix
+      // because the tracker now dedupes on the final ZIP entry name.
+      expect(attachmentPaths).toContain(
+        'acme-corp_soc-2-access-review_evidence/01-attachments/_MISSING_foo.txt',
+      );
+      expect(attachmentPaths).toContain(
+        'acme-corp_soc-2-access-review_evidence/01-attachments/_MISSING_foo (1).txt',
+      );
+    });
+
     it('disambiguates duplicate filenames within attachments folder', async () => {
       const attachments = [
         {


### PR DESCRIPTION
## Summary
Fixes two issues cubic flagged on the production deploy PR #2640, plus adds regression tests for automation-only and mixed-org scenarios that weren't covered explicitly in #2639.

## Fixes

### P1 — Client-disconnect detection could falsely abort successful exports
`evidence-export.controller.ts` listened on `req.once('close')`. In Node 16+ `req.close` fires on **both** client disconnect AND normal request completion, which could falsely abort a successful export in a timing window. The guard was `res.writableEnded` which becomes true as soon as `.end()` is *called*, not when data is actually flushed — leaving a small window where an abnormal close could be incorrectly treated as normal.

Fix: listen only on `res.close` and distinguish completion via `res.writableFinished` (true only after all data is flushed and the `'finish'` event fires).

### P2 — Placeholder vs success filename collision
The collision tracker was being fed the raw attachment name, and the `_MISSING_<name>.txt` wrapping was applied *after* tracking. A legitimate upload literally named `_MISSING_foo.txt` plus a missing upload named `foo` could both end up at the same final ZIP entry path.

Fix: pass the full final name (including any `_MISSING_` wrapping and `.txt` suffix) through the tracker so collisions are resolved on what actually ends up in the ZIP.

## Also included
Regression tests from a separate follow-up covering:
- Per-task export with automations only (no attachments) → verifies no `01-attachments/` folder is created and no S3 calls are made
- Per-task export with neither automations nor attachments → verifies ZIP contains only the summary PDF
- Org-wide export with automations only (no attachments anywhere) → verifies the classic pre-#2639 structure is preserved
- Org-wide export mixing an attachment-only task with an automation-only task → verifies both appear correctly

## Test plan
- [x] 38 tests pass: `cd apps/api && npx jest src/tasks/evidence-export`
- [x] Typecheck clean in `evidence-export/` files
- [ ] Manual: export for a task with attachments and automations — verify no behavior regression
- [ ] Manual: hit the per-task export endpoint, close the browser tab mid-download, check API logs for `Client disconnected during export (…); aborting archive`
- [ ] Manual: hit per-task export on a completing response — verify no `aborting archive` log appears

## Linear
Follow-up on CS-279

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false export aborts on normal completion and prevents `_MISSING_` placeholder filename collisions in evidence ZIPs. Adds regression tests for automation-only, summary-only, and mixed-org exports. Linear: CS-279.

- **Bug Fixes**
  - Client disconnect handling: listen on `res.close` only and gate by `res.writableFinished` to avoid aborting completed downloads; remove `req.close` listener.
  - Filename collisions: dedupe on the final ZIP entry name (including `_MISSING_` prefix and `.txt`), so real files like `_MISSING_foo.txt` don’t collide with placeholders for missing `foo`.

<sup>Written for commit 8c655b37bff3533b003d619223ce5069c1e703d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

