### PR TITLE
fix(integration-platform): fail Dependabot check on open high/critical alerts

### DIFF
--- a/packages/integration-platform/src/manifests/github/checks/__tests__/dependabot.test.ts
+++ b/packages/integration-platform/src/manifests/github/checks/__tests__/dependabot.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it } from 'bun:test';
+import type { CheckContext, CheckResult, CheckVariableValues } from '../../../../types';
+import type { GitHubDependabotAlert, GitHubRepo } from '../../types';
+import { dependabotCheck } from '../dependabot';
+import {
+  countAtOrAboveSeverity,
+  highestPresentSeverity,
+  resolveSeverityThreshold,
+  thresholdLabel,
+} from '../dependabot-alert-severity';
+
+type AlertSeverity = 'critical' | 'high' | 'medium' | 'low';
+
+interface RepoFixture {
+  full_name: string;
+  name: string;
+  html_url: string;
+  dependabotStatus: 'enabled' | 'paused' | 'disabled' | 'unknown';
+  openAlertSeverities: AlertSeverity[];
+  fixedCount?: number;
+  dismissedCount?: number;
+  alertsFetchFails?: boolean;
+}
+
+interface RunResult {
+  passed: Array<{ resourceId: string; title: string; description: string }>;
+  failed: Array<{
+    resourceId: string;
+    title: string;
+    description: string;
+    severity: CheckResult['severity'];
+  }>;
+}
+
+const makeRepo = (fixture: RepoFixture): GitHubRepo =>
+  ({
+    id: 1,
+    name: fixture.name,
+    full_name: fixture.full_name,
+    private: false,
+    html_url: fixture.html_url,
+    default_branch: 'main',
+    owner: { login: fixture.full_name.split('/')[0]!, type: 'Organization' },
+  }) as GitHubRepo;
+
+const makeAlert = (severity: AlertSeverity): GitHubDependabotAlert =>
+  ({
+    number: Math.floor(Math.random() * 10000),
+    state: 'open',
+    security_vulnerability: { severity },
+  }) as unknown as GitHubDependabotAlert;
+
+async function runCheck(
+  fixtures: RepoFixture[],
+  variables: CheckVariableValues,
+): Promise<RunResult> {
+  const passed: RunResult['passed'] = [];
+  const failed: RunResult['failed'] = [];
+
+  const byFullName = new Map(fixtures.map((f) => [f.full_name, f]));
+
+  const ctx: CheckContext = {
+    accessToken: 'tok',
+    credentials: {},
+    variables,
+    connectionId: 'conn_1',
+    organizationId: 'org_1',
+    metadata: {},
+    log: () => {},
+    warn: () => {},
+    pass: (result) => {
+      passed.push({
+        resourceId: result.resourceId ?? '',
+        title: result.title,
+        description: result.description,
+      });
+    },
+    fail: (result) => {
+      failed.push({
+        resourceId: result.resourceId ?? '',
+        title: result.title,
+        description: result.description,
+        severity: result.severity,
+      });
+    },
+    fetch: (async <T,>(path: string): Promise<T> => {
+      // /repos/<owner>/<repo>
+      const repoMatch = path.match(/^\/repos\/([^/]+\/[^/]+)$/);
+      if (repoMatch) {
+        const fixture = byFullName.get(repoMatch[1]!);
+        if (!fixture) throw new Error(`404 ${path}`);
+        return makeRepo(fixture) as unknown as T;
+      }
+      // /repos/<owner>/<repo>/automated-security-fixes
+      const statusMatch = path.match(/^\/repos\/([^/]+\/[^/]+)\/automated-security-fixes$/);
+      if (statusMatch) {
+        const fixture = byFullName.get(statusMatch[1]!);
+        if (!fixture) throw new Error(`404 ${path}`);
+        if (fixture.dependabotStatus === 'unknown') throw new Error('403 Forbidden');
+        if (fixture.dependabotStatus === 'disabled') throw new Error('404 Not Found');
+        return {
+          enabled: true,
+          paused: fixture.dependabotStatus === 'paused',
+        } as unknown as T;
+      }
+      throw new Error(`Unexpected fetch: ${path}`);
+    }) as CheckContext['fetch'],
+    fetchAllPages: (async () => []) as CheckContext['fetchAllPages'],
+    fetchWithLinkHeader: (async <T,>(
+      path: string,
+      options?: { params?: Record<string, string> },
+    ): Promise<T[]> => {
+      const alertsMatch = path.match(/^\/repos\/([^/]+\/[^/]+)\/dependabot\/alerts$/);
+      if (!alertsMatch) throw new Error(`Unexpected fetchWithLinkHeader: ${path}`);
+      const fixture = byFullName.get(alertsMatch[1]!);
+      if (!fixture) throw new Error(`404 ${path}`);
+      if (fixture.alertsFetchFails) throw new Error('403 Forbidden');
+      const state = options?.params?.state;
+      if (state === 'open') {
+        return fixture.openAlertSeverities.map(makeAlert) as unknown as T[];
+      }
+      if (state === 'fixed') {
+        return (Array(fixture.fixedCount ?? 0).fill(makeAlert('low')) as unknown) as T[];
+      }
+      if (state === 'dismissed') {
+        return (Array(fixture.dismissedCount ?? 0).fill(makeAlert('low')) as unknown) as T[];
+      }
+      return [] as unknown as T[];
+    }) as CheckContext['fetchWithLinkHeader'],
+    fetchWithCursor: (async () => []) as CheckContext['fetchWithCursor'],
+    graphql: (async () => ({})) as CheckContext['graphql'],
+    getState: (async () => null) as CheckContext['getState'],
+    setState: (async () => {}) as CheckContext['setState'],
+  } as CheckContext;
+
+  await dependabotCheck.run(ctx);
+  return { passed, failed };
+}
+
+const repo = (fullName: string, overrides: Partial<RepoFixture> = {}): RepoFixture => ({
+  full_name: fullName,
+  name: fullName.split('/')[1]!,
+  html_url: `https://github.com/${fullName}`,
+  dependabotStatus: 'enabled',
+  openAlertSeverities: [],
+  ...overrides,
+});
+
+describe('dependabotCheck severity gating', () => {
+  it('passes when Dependabot is enabled and there are zero open alerts', async () => {
+    const result = await runCheck([repo('acme/api')], {
+      target_repos: ['acme/api'],
+    });
+    expect(result.passed.map((p) => p.title)).toEqual(['Dependabot enabled on api']);
+    expect(result.failed).toEqual([]);
+  });
+
+  it('fails when Dependabot is enabled but open high alerts exist (default threshold)', async () => {
+    // This is the exact bug reported: 8 high alerts should fail, not pass.
+    const result = await runCheck(
+      [
+        repo('acme/api', {
+          openAlertSeverities: Array<AlertSeverity>(8).fill('high'),
+        }),
+      ],
+      { target_repos: ['acme/api'] },
+    );
+    expect(result.passed).toEqual([]);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0]!.title).toBe('8 unresolved Dependabot alerts on api');
+    expect(result.failed[0]!.severity).toBe('high');
+    expect(result.failed[0]!.description).toContain('8 open high severity or above alerts');
+  });
+
+  it('fails with critical severity when critical alerts are present', async () => {
+    const result = await runCheck(
+      [
+        repo('acme/api', {
+          openAlertSeverities: ['critical', 'critical', 'high'],
+        }),
+      ],
+      { target_repos: ['acme/api'] },
+    );
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0]!.severity).toBe('critical');
+    expect(result.failed[0]!.title).toBe('3 unresolved Dependabot alerts on api');
+  });
+
+  it('passes when only medium alerts exist and default threshold is high', async () => {
+    const result = await runCheck(
+      [
+        repo('acme/api', {
+          openAlertSeverities: ['medium', 'medium', 'low'],
+        }),
+      ],
+      { target_repos: ['acme/api'] },
+    );
+    expect(result.passed).toHaveLength(1);
+    expect(result.failed).toEqual([]);
+  });
+
+  it('passes when threshold is critical and only high alerts exist', async () => {
+    const result = await runCheck(
+      [repo('acme/api', { openAlertSeverities: ['high', 'high'] })],
+      { target_repos: ['acme/api'], alert_severity_threshold: 'critical' },
+    );
+    expect(result.passed).toHaveLength(1);
+    expect(result.failed).toEqual([]);
+  });
+
+  it('fails when threshold is low and any alert exists', async () => {
+    const result = await runCheck(
+      [repo('acme/api', { openAlertSeverities: ['low'] })],
+      { target_repos: ['acme/api'], alert_severity_threshold: 'low' },
+    );
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0]!.title).toBe('1 unresolved Dependabot alert on api');
+    expect(result.failed[0]!.description).toContain('1 open any severity alert is still unresolved');
+  });
+
+  it('fails when Dependabot is paused but high alerts exist', async () => {
+    const result = await runCheck(
+      [
+        repo('acme/api', {
+          dependabotStatus: 'paused',
+          openAlertSeverities: ['high', 'high'],
+        }),
+      ],
+      { target_repos: ['acme/api'] },
+    );
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0]!.title).toBe('2 unresolved Dependabot alerts on api (paused)');
+    expect(result.failed[0]!.description).toContain('Paused Dependabot');
+  });
+
+  it('passes (paused) when no threshold alerts exist', async () => {
+    const result = await runCheck(
+      [repo('acme/api', { dependabotStatus: 'paused', openAlertSeverities: [] })],
+      { target_repos: ['acme/api'] },
+    );
+    expect(result.passed).toHaveLength(1);
+    expect(result.passed[0]!.title).toBe('Dependabot enabled on api (paused)');
+  });
+
+  it('fails with generic "not enabled" message when Dependabot is disabled, ignoring threshold', async () => {
+    const result = await runCheck(
+      [
+        repo('acme/api', {
+          dependabotStatus: 'disabled',
+          openAlertSeverities: ['critical'],
+        }),
+      ],
+      { target_repos: ['acme/api'] },
+    );
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0]!.title).toBe('Dependabot not enabled on api');
+  });
+
+  it('passes when alert fetch fails (null alertCounts) and Dependabot is enabled', async () => {
+    // No alert signal -> do not regress to a false-fail.
+    const result = await runCheck(
+      [repo('acme/api', { alertsFetchFails: true })],
+      { target_repos: ['acme/api'] },
+    );
+    expect(result.passed).toHaveLength(1);
+    expect(result.failed).toEqual([]);
+  });
+
+  it('handles unknown threshold by falling back to "high"', async () => {
+    const result = await runCheck(
+      [repo('acme/api', { openAlertSeverities: ['high'] })],
+      { target_repos: ['acme/api'], alert_severity_threshold: 'bogus' },
+    );
+    expect(result.failed).toHaveLength(1);
+  });
+});
+
+describe('dependabot severity helpers', () => {
+  it('countAtOrAboveSeverity sums the right buckets per threshold', () => {
+    const counts = { critical: 2, high: 3, medium: 5, low: 7 };
+    expect(countAtOrAboveSeverity(counts, 'critical')).toBe(2);
+    expect(countAtOrAboveSeverity(counts, 'high')).toBe(5);
+    expect(countAtOrAboveSeverity(counts, 'medium')).toBe(10);
+    expect(countAtOrAboveSeverity(counts, 'low')).toBe(17);
+  });
+
+  it('highestPresentSeverity returns the highest bucket with a non-zero count', () => {
+    expect(highestPresentSeverity({ critical: 1, high: 5, medium: 0, low: 0 })).toBe('critical');
+    expect(highestPresentSeverity({ critical: 0, high: 5, medium: 0, low: 0 })).toBe('high');
+    expect(highestPresentSeverity({ critical: 0, high: 0, medium: 2, low: 1 })).toBe('medium');
+    expect(highestPresentSeverity({ critical: 0, high: 0, medium: 0, low: 0 })).toBe('low');
+  });
+
+  it('resolveSeverityThreshold normalizes invalid input to "high"', () => {
+    expect(resolveSeverityThreshold(undefined)).toBe('high');
+    expect(resolveSeverityThreshold('')).toBe('high');
+    expect(resolveSeverityThreshold('BOGUS')).toBe('high');
+    expect(resolveSeverityThreshold('critical')).toBe('critical');
+    expect(resolveSeverityThreshold('low')).toBe('low');
+  });
+
+  it('thresholdLabel humanizes each level', () => {
+    expect(thresholdLabel('critical')).toBe('critical severity or above');
+    expect(thresholdLabel('high')).toBe('high severity or above');
+    expect(thresholdLabel('medium')).toBe('medium severity or above');
+    expect(thresholdLabel('low')).toBe('any severity');
+  });
+});

--- a/packages/integration-platform/src/manifests/github/checks/dependabot-alert-severity.ts
+++ b/packages/integration-platform/src/manifests/github/checks/dependabot-alert-severity.ts
@@ -1,0 +1,72 @@
+/**
+ * Severity helpers for the Dependabot check.
+ * Kept in a separate module so the main check file stays focused and the
+ * helpers can be unit-tested independently of the NestJS/GitHub fetch layer.
+ */
+
+import type { FindingSeverity } from '../../../types';
+
+export type AlertSeverity = 'critical' | 'high' | 'medium' | 'low';
+
+export interface AlertCounts {
+  open: number;
+  dismissed: number;
+  fixed: number;
+  total: number;
+  bySeverity: Record<AlertSeverity, number>;
+}
+
+export const VALID_ALERT_SEVERITIES: ReadonlySet<AlertSeverity> = new Set([
+  'critical',
+  'high',
+  'medium',
+  'low',
+]);
+
+export const DEFAULT_ALERT_SEVERITY_THRESHOLD: AlertSeverity = 'high';
+
+/**
+ * Normalize an arbitrary string into a valid AlertSeverity, falling back to
+ * the default threshold when the value is missing or unknown.
+ */
+export const resolveSeverityThreshold = (raw: string | undefined): AlertSeverity =>
+  raw && VALID_ALERT_SEVERITIES.has(raw as AlertSeverity)
+    ? (raw as AlertSeverity)
+    : DEFAULT_ALERT_SEVERITY_THRESHOLD;
+
+/**
+ * Count open alerts at or above the configured severity threshold.
+ * e.g. threshold='high' counts critical + high.
+ */
+export const countAtOrAboveSeverity = (
+  bySeverity: Record<AlertSeverity, number>,
+  threshold: AlertSeverity,
+): number => {
+  switch (threshold) {
+    case 'critical':
+      return bySeverity.critical;
+    case 'high':
+      return bySeverity.critical + bySeverity.high;
+    case 'medium':
+      return bySeverity.critical + bySeverity.high + bySeverity.medium;
+    case 'low':
+    default:
+      return bySeverity.critical + bySeverity.high + bySeverity.medium + bySeverity.low;
+  }
+};
+
+/**
+ * Highest actual severity present in the counts, used to set the severity of
+ * the emitted ctx.fail finding.
+ */
+export const highestPresentSeverity = (
+  bySeverity: Record<AlertSeverity, number>,
+): FindingSeverity => {
+  if (bySeverity.critical > 0) return 'critical';
+  if (bySeverity.high > 0) return 'high';
+  if (bySeverity.medium > 0) return 'medium';
+  return 'low';
+};
+
+export const thresholdLabel = (threshold: AlertSeverity): string =>
+  threshold === 'low' ? 'any severity' : `${threshold} severity or above`;

--- a/packages/integration-platform/src/manifests/github/checks/dependabot.ts
+++ b/packages/integration-platform/src/manifests/github/checks/dependabot.ts
@@ -7,20 +7,18 @@
 import { TASK_TEMPLATES } from '../../../task-mappings';
 import type { IntegrationCheck } from '../../../types';
 import type { GitHubDependabotAlert, GitHubOrg, GitHubRepo } from '../types';
-import { parseRepoBranch, targetReposVariable } from '../variables';
-
-interface AlertCounts {
-  open: number;
-  dismissed: number;
-  fixed: number;
-  total: number;
-  bySeverity: {
-    critical: number;
-    high: number;
-    medium: number;
-    low: number;
-  };
-}
+import {
+  alertSeverityThresholdVariable,
+  parseRepoBranch,
+  targetReposVariable,
+} from '../variables';
+import {
+  countAtOrAboveSeverity,
+  highestPresentSeverity,
+  resolveSeverityThreshold,
+  thresholdLabel,
+  type AlertCounts,
+} from './dependabot-alert-severity';
 
 export const dependabotCheck: IntegrationCheck = {
   id: 'dependabot_enabled',
@@ -30,12 +28,16 @@ export const dependabotCheck: IntegrationCheck = {
   taskMapping: TASK_TEMPLATES.secureCode,
   defaultSeverity: 'medium',
 
-  variables: [targetReposVariable],
+  variables: [targetReposVariable, alertSeverityThresholdVariable],
 
   run: async (ctx) => {
     const targetReposRaw = ctx.variables.target_repos as string[] | undefined;
     // Extract just the repo names (values may be in "owner/repo:branch" format)
     const targetRepos = (targetReposRaw || []).map((v) => parseRepoBranch(v).repo);
+
+    const severityThreshold = resolveSeverityThreshold(
+      ctx.variables.alert_severity_threshold as string | undefined,
+    );
 
     let repos: GitHubRepo[];
 
@@ -225,7 +227,37 @@ export const dependabotCheck: IntegrationCheck = {
         ? `\n\nAlert Summary: ${formatAlertSummary(alertCounts)}`
         : '';
 
-      if (dependabotStatus === 'enabled') {
+      // Gate pass/fail on open alerts at/above the configured threshold. If we
+      // couldn't fetch alerts (alertCounts == null), fall back to the original
+      // "Dependabot on = pass" path — we have no alert signal to act on.
+      const alertsAtOrAboveThreshold = alertCounts
+        ? countAtOrAboveSeverity(alertCounts.bySeverity, severityThreshold)
+        : 0;
+      const isDependabotActive =
+        dependabotStatus === 'enabled' || dependabotStatus === 'paused';
+
+      if (alertCounts && alertsAtOrAboveThreshold > 0 && isDependabotActive) {
+        const isSingular = alertsAtOrAboveThreshold === 1;
+        const noun = isSingular ? 'alert' : 'alerts';
+        const verb = isSingular ? 'is' : 'are';
+        const pausedNote =
+          dependabotStatus === 'paused'
+            ? ' Paused Dependabot will not open fix PRs until it resumes.'
+            : '';
+        const titleSuffix = dependabotStatus === 'paused' ? ' (paused)' : '';
+
+        ctx.fail({
+          title: `${alertsAtOrAboveThreshold} unresolved Dependabot ${noun} on ${repo.name}${titleSuffix}`,
+          description: `Dependabot is ${dependabotStatus} but ${alertsAtOrAboveThreshold} open ${thresholdLabel(severityThreshold)} ${noun} ${verb} still unresolved.${pausedNote}${alertSummary}`,
+          resourceType: 'repository',
+          resourceId: repo.full_name,
+          severity: highestPresentSeverity(alertCounts.bySeverity),
+          remediation: `1. Review open alerts at ${repo.html_url}/security/dependabot\n2. Merge the auto-generated fix PRs, or dismiss alerts with a documented justification\n3. Re-run this check once the alert count drops to zero`,
+          evidence: {
+            [repo.full_name]: repoEvidence,
+          },
+        });
+      } else if (dependabotStatus === 'enabled') {
         ctx.pass({
           title: `Dependabot enabled on ${repo.name}`,
           description: `Dependabot security updates are enabled and will automatically create pull requests to fix vulnerable dependencies.${alertSummary}`,

--- a/packages/integration-platform/src/manifests/github/variables.ts
+++ b/packages/integration-platform/src/manifests/github/variables.ts
@@ -151,3 +151,23 @@ export const recentPullRequestDaysVariable: CheckVariable = {
   helpText:
     'How many days back to look when determining whether pull requests are "recent". Confirm the right value with your security/compliance owner.',
 };
+
+/**
+ * Minimum severity of open Dependabot alerts that should cause the check to fail.
+ * Alerts below the threshold do not affect the pass/fail verdict.
+ */
+export const alertSeverityThresholdVariable: CheckVariable = {
+  id: 'alert_severity_threshold',
+  label: 'Fail on open alerts at severity',
+  type: 'select',
+  required: false,
+  default: 'high',
+  helpText:
+    'The check fails when the repository has open Dependabot alerts at or above this severity. Alerts below this level are informational only.',
+  options: [
+    { value: 'critical', label: 'Critical only' },
+    { value: 'high', label: 'High or above (recommended)' },
+    { value: 'medium', label: 'Medium or above' },
+    { value: 'low', label: 'Low (fail on any open alert)' },
+  ],
+};


### PR DESCRIPTION
## Summary

Fixes a bug where the GitHub **Dependabot Security Updates Enabled** automation (evidence for the Secure Code task) would return **Passed** even when the repo had open high- or critical-severity Dependabot alerts. Reported with a screenshot showing 8 open high alerts + 21 medium yet a green checkmark.

- Adds an **\`alert_severity_threshold\`** variable (default \`high\`) — CX can now configure per connection whether only critical alerts trigger a fail, or all alerts.
- When alerts at/above the threshold exist for an \`enabled\` or \`paused\` repo, the check now calls \`ctx.fail()\` with a clear title, severity mapped to the highest actual alert severity present, and a remediation link to the repo's \`/security/dependabot\` page.
- Preserves the previous fallback when the alert-fetch endpoint returns 403/400 (permission denied / feature off): without an alert signal, the check falls back to the prior "Dependabot enabled = pass" behaviour rather than emitting a false fail.
- Pulls the severity math (\`countAtOrAboveSeverity\`, \`highestPresentSeverity\`, threshold parsing) out of \`dependabot.ts\` into a small \`dependabot-alert-severity.ts\` module — keeps the main check single-responsibility and lets the helpers be unit-tested without the NestJS/GitHub fetch surface.

## Test plan

- [x] 15 new tests in \`packages/integration-platform/src/manifests/github/checks/__tests__/dependabot.test.ts\` (all passing, including the exact bug case of "8 open high alerts on enabled Dependabot → must fail")
- [x] Full package test suite green: 98/98 passing
- [x] \`tsc --noEmit\` passes for \`@trycompai/integration-platform\` (and via turbo for downstream consumers of the package). Unrelated pre-existing typecheck failures on main in \`apps/api\` spec files are not caused by this change — diff touches only \`packages/integration-platform\`.
- [ ] Before merge: re-run the Dependabot automation in staging against a repo that has open high alerts and confirm the UI now renders a red "failed" result with the expected remediation text.

## Behaviour change (customer-visible)

Automations that were passing with the default settings will now **fail** if the connected repos have open high/critical Dependabot alerts. This is intentional — it was the bug. CX should expect incoming questions from customers who see a previously-passing check flip red. The remediation text in the fail message walks them through merging the auto-generated Dependabot fix PRs or dismissing alerts with justification.

Customers who want the old "pass on enabled" behaviour can set the new variable to \`critical\` (fails on critical only) or switch to a lower threshold if they want stricter gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the GitHub Dependabot check to fail when a repo has open alerts at/above a configurable severity threshold. This may flip some green checks to red; set `alert_severity_threshold` to `critical` to keep the old behavior.

- **Bug Fixes**
  - For `enabled` or `paused` repos, fail if open alerts meet the threshold; severity reflects the highest alert, and the remediation links to `/security/dependabot`.
  - Preserves fallback when alert data can’t be fetched (e.g. 403/400): no alert signal = pass if enabled; still fail when Dependabot is disabled.

- **New Features**
  - Adds `alert_severity_threshold` (default `high`) to gate on `critical`, `high`, `medium`, or `low`.

<sup>Written for commit b4492d1fa229295d51a2f355632f19a098677f81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

