### PR TITLE
fix(app): show evidence block for failed automation runs

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/TaskIntegrationChecks.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/TaskIntegrationChecks.tsx
@@ -1046,6 +1046,18 @@ function CheckRunItem({
                         )}
                       </div>
                     </div>
+                    {finding.evidence && Object.keys(finding.evidence).length > 0 && (
+                      <details className="text-xs">
+                        <summary className="text-muted-foreground cursor-pointer">
+                          View Evidence
+                        </summary>
+                        <EvidenceJsonView
+                          evidence={finding.evidence}
+                          organizationName={organizationName}
+                          automationName={run.checkName}
+                        />
+                      </details>
+                    )}
                   </div>
                 ))}
                 {findings.length > 3 && (


### PR DESCRIPTION
## Summary

Follow-up to #2643. The automation-run detail card in **Compliance → Task → Integration Checks** rendered a **View Evidence** expandable JSON tree for every *passing* result but never for a *failing* one — even though the backend saves the same \`evidence\` payload in both cases and the API returns it identically.

After the Dependabot severity gating in #2643, fails surface exactly the context users need to understand them (the \`open_by_severity\` breakdown, \`checked_at\`, the \`alerts\` totals). Hiding that JSON for fails defeats the point of showing the evidence at all.

This PR mirrors the passing block's \`<details> > <EvidenceJsonView>\` pattern onto the findings map so both states render identically. 12-line diff, one file.

**Trace of the pre-existing inconsistency:**
- Check emits \`evidence\` identically for pass/fail (\`packages/integration-platform/src/manifests/github/checks/dependabot.ts\`)
- Backend save path writes \`evidence: JSON.parse(JSON.stringify(finding.evidence || {}))\` for both (\`apps/api/src/trigger/integration-platform/run-connection-checks.ts:191-214\`)
- DB schema has single \`evidence Json?\` column shared by pass/fail (\`IntegrationCheckResult\`)
- API endpoint returns \`evidence: r.evidence\` with no pass/fail filtering (\`task-integrations.controller.ts:614\`)
- Frontend hook types \`evidence?: Record<string, unknown>\` on all results (\`useIntegrationChecks.ts:54\`)
- Frontend component only renders it in the passing map (\`TaskIntegrationChecks.tsx:1077-1088\`) — **this was the only gap, now closed**

## Test plan

- [x] \`tsc --noEmit\` clean for this file's module graph (unrelated pre-existing failures in \`auth-client.ts\` and \`ai-elements/tool.tsx\` already present on \`main\`)
- [x] Diff is additive only; no existing behaviour changed for passing results, logs, remediation, or badges
- [ ] Before merge: run a Dependabot automation against a repo with open high alerts and visually confirm the red failing card now shows the same "▶ View Evidence" expandable block that passing cards show

## Why not also write a unit test?

\`TaskIntegrationChecks.tsx\` is a 1432-line component with no existing test file of its own. Adding one purely for this 12-line conditional would be out-of-scope scaffolding; the sibling component tests (\`SingleTask.test.tsx\`, etc.) don't reach into this code path. Happy to add one if you'd prefer — flag it in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the "View Evidence" JSON block for failing automation runs in Compliance → Task → Integration Checks, not only for passing results. This fixes the UI inconsistency and lets users see the same evidence (e.g., open_by_severity, checked_at) to understand failures.

<sup>Written for commit 975b4c9089c2ab603dea65f769e2daa53fc2c516. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

