### PR TITLE
fix(onboarding): normalize hyphenated formTypes from backfilled framework manifests

### DIFF
--- a/apps/app/src/actions/organization/lib/form-type-normalize.test.ts
+++ b/apps/app/src/actions/organization/lib/form-type-normalize.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeFormType } from './form-type-normalize';
+
+describe('normalizeFormType', () => {
+  it('converts backfilled hyphenated DB values to underscored Prisma enum keys', () => {
+    expect(normalizeFormType('infrastructure-inventory')).toBe('infrastructure_inventory');
+    expect(normalizeFormType('access-request')).toBe('access_request');
+    expect(normalizeFormType('penetration-test')).toBe('penetration_test');
+    expect(normalizeFormType('board-meeting')).toBe('board_meeting');
+    expect(normalizeFormType('tabletop-exercise')).toBe('tabletop_exercise');
+    expect(normalizeFormType('network-diagram')).toBe('network_diagram');
+  });
+
+  it('passes through already-underscored values unchanged (newer manifests)', () => {
+    expect(normalizeFormType('infrastructure_inventory')).toBe('infrastructure_inventory');
+    expect(normalizeFormType('meeting')).toBe('meeting');
+  });
+
+  it('is idempotent', () => {
+    const once = normalizeFormType('employee-performance-evaluation');
+    const twice = normalizeFormType(once);
+    expect(twice).toBe('employee_performance_evaluation');
+    expect(twice).toBe(once);
+  });
+
+  it('replaces every hyphen, not just the first', () => {
+    expect(normalizeFormType('a-b-c-d')).toBe('a_b_c_d');
+  });
+});

--- a/apps/app/src/actions/organization/lib/form-type-normalize.ts
+++ b/apps/app/src/actions/organization/lib/form-type-normalize.ts
@@ -1,0 +1,29 @@
+/**
+ * EvidenceFormType has `@map` directives that expose hyphenated labels at the
+ * DB level (e.g. `"infrastructure-inventory"`) while the Prisma client uses
+ * underscored names (e.g. `"infrastructure_inventory"`).
+ *
+ * The one-shot backfill data migration
+ * (20260423121434_backfill_framework_versions) serialized doc types via
+ * `to_jsonb(ct."documentTypes"::text[])`, which renders the DB @map'd form.
+ * So every backfilled v1.0.0 manifest stored hyphens. Newer manifests built
+ * through the TS manifest builder store underscores (what Prisma client
+ * returns).
+ *
+ * Any code that passes `formType` from a manifest into the Prisma client
+ * must normalize first, otherwise Prisma throws
+ * `PrismaClientValidationError: Invalid value for argument `formType`` on
+ * the hyphen form. This hit onboarding (`initializeOrganization` →
+ * `controlDocumentType.createMany`) whenever a selected framework was pinned
+ * to a backfilled v1.0.0 manifest.
+ *
+ * Every `@map` in the schema just swaps `_` → `-`, so hyphens-to-underscores
+ * covers all existing values and any future ones CX adds — no hardcoded list
+ * to keep in sync.
+ *
+ * Mirrors apps/api/src/frameworks/framework-versioning/form-type-normalize.ts.
+ * Duplicated because apps/app can't cross-import from apps/api.
+ */
+export function normalizeFormType(value: string): string {
+  return value.replace(/-/g, '_');
+}

--- a/apps/app/src/actions/organization/lib/load-framework-sources.ts
+++ b/apps/app/src/actions/organization/lib/load-framework-sources.ts
@@ -5,6 +5,7 @@ import type {
   Departments,
   TaskAutomationStatus,
 } from '@db/server';
+import { normalizeFormType } from './form-type-normalize';
 
 /**
  * Shape of FrameworkVersion.manifest. Kept in sync with the authoritative
@@ -158,7 +159,12 @@ export async function loadFrameworkSources({
           id: c.id,
           name: c.name,
           description: c.description,
-          documentTypes: (c.documentTypes ?? []) as EvidenceFormType[],
+          // Backfilled v1.0.0 manifests stored hyphenated DB @map values; newer
+          // manifests store underscored Prisma-client names. Normalize here so
+          // downstream Prisma writes (controlDocumentType.createMany) receive
+          // valid enum keys regardless of which manifest generation they came
+          // from.
+          documentTypes: (c.documentTypes ?? []).map(normalizeFormType) as EvidenceFormType[],
         });
       }
       const rel = getOrCreateRelation(c.id);


### PR DESCRIPTION
## Summary

- Onboarding (`create-organization-minimal` → `initializeOrganization` → `loadFrameworkSources`) failed with `PrismaClientValidationError: Invalid value for argument 'formType'` whenever the selected framework was pinned to a v1.0.0 manifest produced by the backfill migration.
- Backfilled manifests serialized `documentTypes` as the DB `@map`'d (hyphenated) form (e.g. `"infrastructure-inventory"`); Prisma Client expects the underscored enum keys (`"infrastructure_inventory"`). The existing fix for the API side (05f44eb6f) missed the Next.js onboarding path.
- Fix normalizes at the manifest-ingestion boundary in `load-framework-sources.ts`. Live-template reads are already safe (Prisma Client handles `@map` on reads), so only the manifest JSON path needed the fix.

## Root cause

The migration `20260423121434_backfill_framework_versions` serialized doc types via `to_jsonb(ct."documentTypes"::text[])`, which renders the `@map`'d form. Every backfilled v1.0.0 manifest stored hyphens; newer manifests built via the TS manifest builder store underscores. The app was passing the raw manifest value through to `controlDocumentType.createMany` without normalizing.

## Changes

- New: `apps/app/src/actions/organization/lib/form-type-normalize.ts` — mirrors `apps/api/src/frameworks/framework-versioning/form-type-normalize.ts` (app can't cross-import from api).
- New: `apps/app/src/actions/organization/lib/form-type-normalize.test.ts` — unit tests for the normalizer.
- Modified: `apps/app/src/actions/organization/lib/load-framework-sources.ts` — applies `normalizeFormType` where manifest `documentTypes` are ingested.

## Test plan

- [x] Unit tests for `normalizeFormType` pass (`cd apps/app && npx vitest run src/actions/organization/lib/form-type-normalize.test.ts`).
- [x] Typecheck clean on changed files.
- [ ] Manually verify onboarding completes for an org where the selected framework is pinned to a v1.0.0 backfilled manifest.
- [ ] Verify `ControlDocumentType` rows are created with the correct (underscored) enum values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes onboarding failures by normalizing hyphenated `formType` values from backfilled framework manifests to underscored enum keys expected by Prisma. Prevents `PrismaClientValidationError` during org initialization when using v1.0.0 backfilled manifests.

- **Bug Fixes**
  - Normalize manifest `documentTypes` on ingestion in `load-framework-sources` using a new `normalizeFormType`.
  - Add `form-type-normalize.ts` with unit tests; mirrors the API-side helper since `apps/app` cannot cross-import.
  - Ensures `controlDocumentType.createMany` receives valid enum keys from both backfilled and new manifests.

<sup>Written for commit cb86975a58fb26d1562ac57328c4600e1e2b5b75. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

