### PR TITLE
fix(db): ship flattened dist/schema.prisma for external consumers

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -44,7 +44,7 @@
     },
     "scripts": {
         "backfill:framework-versions": "bun src/scripts/backfill-framework-versions.ts",
-        "build": "rm -rf dist && node scripts/generate-prisma-client-js.js && tsc",
+        "build": "rm -rf dist && node scripts/generate-prisma-client-js.js && tsc && node scripts/build-dist-schema.js",
         "check-types": "tsc --noEmit",
         "db:generate": "node scripts/generate-prisma-client-js.js",
         "db:migrate": "prisma migrate dev",

--- a/packages/db/scripts/build-dist-schema.js
+++ b/packages/db/scripts/build-dist-schema.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+/**
+ * Builds dist/schema.prisma from prisma/schema/*.prisma so consumers that
+ * pull from the published @trycompai/db package (e.g. comp-private apps,
+ * which run `cp .../@trycompai/db/dist/schema.prisma prisma/schema.prisma`)
+ * receive a single, ready-to-use schema.
+ *
+ * Native multi-file Prisma v7 schemas live in `prisma/schema/`. Inside the
+ * monorepo, consumers can read those files directly. Outside the monorepo
+ * they cannot, so we ship a flattened copy in dist/.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+const schemaDir = path.join(root, 'prisma/schema');
+const distDir = path.join(root, 'dist');
+const outFile = path.join(distDir, 'schema.prisma');
+
+if (!fs.existsSync(distDir)) fs.mkdirSync(distDir, { recursive: true });
+
+// schema.prisma (generator + datasource) must come first; everything else
+// after, in deterministic order.
+const all = fs.readdirSync(schemaDir).filter((f) => f.endsWith('.prisma'));
+const ordered = [
+  'schema.prisma',
+  ...all.filter((f) => f !== 'schema.prisma').sort(),
+];
+
+const parts = ordered.map((file) => {
+  const body = fs.readFileSync(path.join(schemaDir, file), 'utf8').trimEnd();
+  if (file === 'schema.prisma') return body;
+  return `// ===== ${file} =====\n${body}`;
+});
+
+fs.writeFileSync(outFile, parts.join('\n\n') + '\n');
+console.log(`[build-dist-schema] wrote ${outFile} (${ordered.length} files)`);


### PR DESCRIPTION
## Summary

`@trycompai/db@2.0.1` shipped without `dist/schema.prisma`, breaking every `db:getschema` script across comp-private apps (`enterprise-api`, `cx-dashboard`, `framework-editor`, `trust`). All four `cp .../@trycompai/db/dist/schema.prisma prisma/schema.prisma` calls now fail because the file isn't in the tarball.

The regression was introduced by the v7 multi-file refactor (c58045f, April 2) which removed the legacy `combine-schemas.js` step. That worked inside the monorepo (apps read `prisma/schema/` directly), but external consumers were never re-tested because we hadn't published since the refactor. 2.0.1 was the first publish post-refactor — and it broke comp-private's CI.

## Fix

`packages/db/scripts/build-dist-schema.js`: deterministically concatenates `prisma/schema/*.prisma` (`schema.prisma` first for the generator + datasource block, models alphabetically after) into `dist/schema.prisma`. Matches the v2.0.0 published shape exactly, so consumers don't change.

Wired into `packages/db`'s `build` script after `tsc` so the file lands in the published tarball.

## Verification

- Ran `bun run build` locally → tarball will now include `dist/schema.prisma` (47 model files concatenated, ~one block per source file).
- `bunx prisma validate --schema=dist/schema.prisma` ✅ valid.
- Diff-checked against the v2.0.0 file in npm: same generator block, same datasource, same `// ===== <file>.prisma =====` separators, same model bodies.

## Test plan

- [ ] Merge → `release` PR auto-cuts → `@trycompai/db@2.0.2` publishes
- [ ] Bump `@trycompai/db` in comp-private apps → `bun run db:getschema` succeeds → CI green
- [ ] Unblocks comp-private#251 (SALE-49 evidence automation scheduler)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore a single-file Prisma schema for `@trycompai/db` by building `dist/schema.prisma` from the v7 multi-file sources. This fixes broken `db:getschema` scripts for external consumers and unblocks comp-private CI (SALE-49).

- **Bug Fixes**
  - Added `scripts/build-dist-schema.js` to concatenate `prisma/schema/*.prisma` into `dist/schema.prisma` (base schema first, others sorted) matching the v2.0.0 format.
  - Hooked into `build` so the file is published; `prisma validate` passes and comp-private `db:getschema` runs succeed.

<sup>Written for commit 602aad721f4109f1638971003dd7bf72f2fdbd98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

