### PR TITLE
fix(gws): coerce target_org_units to array in check-user-filter

### DIFF
--- a/packages/integration-platform/src/manifests/google-workspace/__tests__/check-user-filter.test.ts
+++ b/packages/integration-platform/src/manifests/google-workspace/__tests__/check-user-filter.test.ts
@@ -36,6 +36,21 @@ describe('parseGoogleWorkspaceCheckUserFilter', () => {
     expect(config.userFilterMode).toBe('exclude');
     expect(config.includeSuspended).toBe(false);
   });
+
+  it('coerces a string target_org_units into an array', () => {
+    const config = parseGoogleWorkspaceCheckUserFilter({
+      target_org_units: '/Staff' as unknown as string[],
+      include_suspended: 'false',
+    });
+    expect(config.targetOrgUnits).toEqual(['/Staff']);
+  });
+
+  it('returns undefined for missing target_org_units', () => {
+    const config = parseGoogleWorkspaceCheckUserFilter({
+      include_suspended: 'false',
+    });
+    expect(config.targetOrgUnits).toBeUndefined();
+  });
 });
 
 describe('shouldIncludeGoogleWorkspaceUserForCheck', () => {

--- a/packages/integration-platform/src/manifests/google-workspace/check-user-filter.ts
+++ b/packages/integration-platform/src/manifests/google-workspace/check-user-filter.ts
@@ -21,7 +21,11 @@ export function parseGoogleWorkspaceCheckUserFilter(
   variables: CheckVariableValues,
 ): GoogleWorkspaceCheckUserFilterConfig {
   return {
-    targetOrgUnits: variables.target_org_units as string[] | undefined,
+    targetOrgUnits: Array.isArray(variables.target_org_units)
+      ? variables.target_org_units
+      : typeof variables.target_org_units === 'string'
+        ? [variables.target_org_units]
+        : undefined,
     excludedTerms: parseSyncFilterTerms(
       variables.sync_excluded_emails ?? variables.excluded_emails,
     ),


### PR DESCRIPTION
## Problem

Snoonu customer's GWS **2-Step Verification Enabled** check crashes with:
```
userFilterConfig.targetOrgUnits.join is not a function
```

The `target_org_units` variable is defined as `multi-select`, but when a customer saves a single value, it can be stored as a plain string rather than an array. The code in `parseGoogleWorkspaceCheckUserFilter` cast it directly as `string[]` without validation, so `.join()` and `.some()` called on it crash.

## Fix

Coerce `target_org_units` to an array in `parseGoogleWorkspaceCheckUserFilter`:
- If it's already an array, use it as-is
- If it's a string, wrap in `[value]`
- If missing/falsy, return `undefined`

## Tests

Added 2 test cases:
- `coerces a string target_org_units into an array`
- `returns undefined for missing target_org_units`

All 6 tests pass.

## Affected customers

- **Snoonu** (`#demo-snoonu`) - reported GWS not working
- Potentially any customer who selected a single org unit in GWS settings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coerces `target_org_units` to an array in `parseGoogleWorkspaceCheckUserFilter` to prevent crashes when a single org unit is saved as a string. This normalizes input and fixes the Google Workspace 2-Step Verification check, with tests added for single-value and missing cases.

<sup>Written for commit 65e60ccb227bbc26edc50ad9c89cde09dad48249. Summary will update on new commits. <a href="https://cubic.dev/pr/trycompai/comp/pull/2680?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

