### PR TITLE
fix(gws): coerce target_org_units to array in check-user-filter

### DIFF
--- a/packages/integration-platform/src/manifests/google-workspace/__tests__/check-user-filter.test.ts
+++ b/packages/integration-platform/src/manifests/google-workspace/__tests__/check-user-filter.test.ts
@@ -36,6 +36,21 @@ describe('parseGoogleWorkspaceCheckUserFilter', () => {
     expect(config.userFilterMode).toBe('exclude');
     expect(config.includeSuspended).toBe(false);
   });
+
+  it('coerces a string target_org_units into an array', () => {
+    const config = parseGoogleWorkspaceCheckUserFilter({
+      target_org_units: '/Staff' as unknown as string[],
+      include_suspended: 'false',
+    });
+    expect(config.targetOrgUnits).toEqual(['/Staff']);
+  });
+
+  it('returns undefined for missing target_org_units', () => {
+    const config = parseGoogleWorkspaceCheckUserFilter({
+      include_suspended: 'false',
+    });
+    expect(config.targetOrgUnits).toBeUndefined();
+  });
 });
 
 describe('shouldIncludeGoogleWorkspaceUserForCheck', () => {

--- a/packages/integration-platform/src/manifests/google-workspace/check-user-filter.ts
+++ b/packages/integration-platform/src/manifests/google-workspace/check-user-filter.ts
@@ -21,7 +21,11 @@ export function parseGoogleWorkspaceCheckUserFilter(
   variables: CheckVariableValues,
 ): GoogleWorkspaceCheckUserFilterConfig {
   return {
-    targetOrgUnits: variables.target_org_units as string[] | undefined,
+    targetOrgUnits: Array.isArray(variables.target_org_units)
+      ? variables.target_org_units
+      : typeof variables.target_org_units === 'string'
+        ? [variables.target_org_units]
+        : undefined,
     excludedTerms: parseSyncFilterTerms(
       variables.sync_excluded_emails ?? variables.excluded_emails,
     ),


### PR DESCRIPTION
## Summary

Cherry-pick of `65e60cc` from `main` onto `release` so we can ship this fix without bringing along the rest of main's in-flight changes.

Fixes the Google Workspace check-user-filter crash where `target_org_units` (multi-select) is stored as a string when only a single value is saved. The code assumed it was always an array, causing `.join()` and `.some()` to throw `'join is not a function'`.

Hit in production by Snoonu's GWS 2FA check.

## Changes

- `parseGoogleWorkspaceCheckUserFilter`: coerce string values into a single-element array; return `undefined` when missing.
- Added 2 tests: string coercion + missing value.

## Why cherry-pick

`main` has unrelated changes not yet ready for prod. This is a self-contained hotfix — only touches `packages/integration-platform/src/manifests/google-workspace/`.

## Test plan

- [ ] CI green on this PR
- [ ] After release deploy, verify Snoonu's GWS 2FA check no longer throws

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hotfix for Google Workspace user filter: coerce `target_org_units` to an array when a single value is stored as a string. Prevents "join is not a function" crashes in the GWS 2FA check.

- **Bug Fixes**
  - Updated parseGoogleWorkspaceCheckUserFilter to return an array for `target_org_units` (string -> [string], missing -> undefined).
  - Added tests for string coercion and missing value.

<sup>Written for commit f5e6754af8805307d79f046fef22a6e871fabd27. Summary will update on new commits. <a href="https://cubic.dev/pr/trycompai/comp/pull/2681?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

