### PR TITLE
fix(sync): validate employee.role before persisting (limbo-role guard)

### DIFF
--- a/apps/api/src/integration-platform/services/generic-employee-sync.service.spec.ts
+++ b/apps/api/src/integration-platform/services/generic-employee-sync.service.spec.ts
@@ -152,4 +152,93 @@ describe('GenericEmployeeSyncService role validation', () => {
       }),
     );
   });
+
+  describe('limbo role self-heal on re-sync', () => {
+    it('heals an existing member whose role is entirely invalid', async () => {
+      mockUserFindUnique.mockResolvedValue({
+        id: 'user_1',
+        email: 'mc@example.com',
+      });
+      mockMemberFindFirst.mockResolvedValue({
+        id: 'mem_1',
+        role: 'Senior Front End Engineer',
+        deactivated: false,
+      });
+
+      await service.processEmployees({
+        organizationId: 'org_1',
+        employees: [baseEmployee({ email: 'mc@example.com', role: 'employee' })],
+        options: { defaultRole: 'employee' },
+      });
+
+      expect(mockMemberUpdate).toHaveBeenCalledWith({
+        where: { id: 'mem_1' },
+        data: { role: 'employee' },
+      });
+    });
+
+    it('heals an existing member whose role mixes valid + invalid tokens', async () => {
+      mockUserFindUnique.mockResolvedValue({
+        id: 'user_1',
+        email: 'mc@example.com',
+      });
+      mockMemberFindFirst.mockResolvedValue({
+        id: 'mem_1',
+        role: 'admin,Senior Front End Engineer',
+        deactivated: false,
+      });
+
+      await service.processEmployees({
+        organizationId: 'org_1',
+        employees: [baseEmployee({ email: 'mc@example.com' })],
+      });
+
+      expect(mockMemberUpdate).toHaveBeenCalledWith({
+        where: { id: 'mem_1' },
+        data: { role: 'admin' },
+      });
+    });
+
+    it('does not touch an existing member whose role is already valid', async () => {
+      mockUserFindUnique.mockResolvedValue({
+        id: 'user_1',
+        email: 'mc@example.com',
+      });
+      mockMemberFindFirst.mockResolvedValue({
+        id: 'mem_1',
+        role: 'admin',
+        deactivated: false,
+      });
+
+      await service.processEmployees({
+        organizationId: 'org_1',
+        employees: [baseEmployee({ email: 'mc@example.com' })],
+      });
+
+      expect(mockMemberUpdate).not.toHaveBeenCalled();
+    });
+
+    it('heals AND reactivates a deactivated member with a limbo role', async () => {
+      mockUserFindUnique.mockResolvedValue({
+        id: 'user_1',
+        email: 'mc@example.com',
+      });
+      mockMemberFindFirst.mockResolvedValue({
+        id: 'mem_1',
+        role: 'Senior Front End Engineer',
+        deactivated: true,
+      });
+
+      await service.processEmployees({
+        organizationId: 'org_1',
+        employees: [baseEmployee({ email: 'mc@example.com' })],
+        options: { allowReactivation: true, defaultRole: 'employee' },
+      });
+
+      expect(mockMemberUpdate).toHaveBeenCalledWith({
+        where: { id: 'mem_1' },
+        data: { deactivated: false, isActive: true, role: 'employee' },
+      });
+    });
+  });
 });

--- a/apps/api/src/integration-platform/services/generic-employee-sync.service.spec.ts
+++ b/apps/api/src/integration-platform/services/generic-employee-sync.service.spec.ts
@@ -1,0 +1,155 @@
+import type { SyncEmployee } from '@trycompai/integration-platform';
+
+const mockUserFindUnique = jest.fn();
+const mockUserCreate = jest.fn();
+const mockMemberFindFirst = jest.fn();
+const mockMemberCreate = jest.fn();
+const mockMemberFindMany = jest.fn();
+const mockMemberUpdate = jest.fn();
+const mockOrgRoleFindMany = jest.fn();
+
+jest.mock('@trycompai/auth', () => ({
+  BUILT_IN_ROLE_PERMISSIONS: {
+    owner: {},
+    admin: {},
+    auditor: {},
+    employee: {},
+    contractor: {},
+  },
+}));
+
+jest.mock('@db', () => ({
+  db: {
+    user: {
+      findUnique: (...args: unknown[]) => mockUserFindUnique(...args),
+      create: (...args: unknown[]) => mockUserCreate(...args),
+    },
+    member: {
+      findFirst: (...args: unknown[]) => mockMemberFindFirst(...args),
+      create: (...args: unknown[]) => mockMemberCreate(...args),
+      findMany: (...args: unknown[]) => mockMemberFindMany(...args),
+      update: (...args: unknown[]) => mockMemberUpdate(...args),
+    },
+    organizationRole: {
+      findMany: (...args: unknown[]) => mockOrgRoleFindMany(...args),
+    },
+  },
+}));
+
+import { GenericEmployeeSyncService } from './generic-employee-sync.service';
+
+describe('GenericEmployeeSyncService role validation', () => {
+  let service: GenericEmployeeSyncService;
+
+  const baseEmployee = (
+    overrides: Partial<SyncEmployee> = {},
+  ): SyncEmployee => ({
+    email: 'new-hire@example.com',
+    name: 'New Hire',
+    status: 'active',
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new GenericEmployeeSyncService();
+
+    // Default: user does not exist (will be created), no existing member,
+    // no other org members (skip phase 2).
+    mockUserFindUnique.mockResolvedValue(null);
+    mockUserCreate.mockResolvedValue({
+      id: 'user_1',
+      email: 'new-hire@example.com',
+    });
+    mockMemberFindFirst.mockResolvedValue(null);
+    mockMemberCreate.mockResolvedValue({ id: 'mem_1' });
+    mockMemberFindMany.mockResolvedValue([]);
+    mockOrgRoleFindMany.mockResolvedValue([]);
+  });
+
+  it('persists a built-in role from the provider as-is', async () => {
+    await service.processEmployees({
+      organizationId: 'org_1',
+      employees: [baseEmployee({ role: 'admin' })],
+    });
+
+    expect(mockMemberCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ role: 'admin' }),
+      }),
+    );
+  });
+
+  it('persists a known custom role from the provider as-is', async () => {
+    mockOrgRoleFindMany.mockResolvedValue([
+      { name: 'security-engineer' },
+    ]);
+
+    await service.processEmployees({
+      organizationId: 'org_1',
+      employees: [baseEmployee({ role: 'security-engineer' })],
+    });
+
+    expect(mockMemberCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ role: 'security-engineer' }),
+      }),
+    );
+  });
+
+  it('falls back to defaultRole when provider sends an unknown role (e.g. Microsoft jobTitle)', async () => {
+    await service.processEmployees({
+      organizationId: 'org_1',
+      employees: [baseEmployee({ role: 'Senior Front End Engineer' })],
+      options: { defaultRole: 'employee' },
+    });
+
+    expect(mockMemberCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ role: 'employee' }),
+      }),
+    );
+  });
+
+  it('falls back to defaultRole when provider sends an empty role', async () => {
+    await service.processEmployees({
+      organizationId: 'org_1',
+      employees: [baseEmployee({ role: '' })],
+      options: { defaultRole: 'contractor' },
+    });
+
+    expect(mockMemberCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ role: 'contractor' }),
+      }),
+    );
+  });
+
+  it('looks up custom roles scoped to the org being synced', async () => {
+    await service.processEmployees({
+      organizationId: 'org_42',
+      employees: [baseEmployee({ role: 'employee' })],
+    });
+
+    expect(mockOrgRoleFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { organizationId: 'org_42' },
+        select: { name: true },
+      }),
+    );
+  });
+
+  it('keeps only the valid tokens when role is comma-separated', async () => {
+    await service.processEmployees({
+      organizationId: 'org_1',
+      employees: [baseEmployee({ role: 'admin,Senior Front End Engineer' })],
+      options: { defaultRole: 'employee' },
+    });
+
+    expect(mockMemberCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ role: 'admin' }),
+      }),
+    );
+  });
+});

--- a/apps/api/src/integration-platform/services/generic-employee-sync.service.ts
+++ b/apps/api/src/integration-platform/services/generic-employee-sync.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { db } from '@db';
 import type { SyncEmployee } from '@trycompai/integration-platform';
+import { BUILT_IN_ROLE_PERMISSIONS } from '@trycompai/auth';
 
 // ============================================================================
 // Types
@@ -75,6 +76,28 @@ export class GenericEmployeeSyncService {
     const allowReactivation = options.allowReactivation ?? false;
     const protectedRoles = options.protectedRoles ?? DEFAULT_PROTECTED_ROLES;
     const providerName = options.providerName ?? 'provider';
+
+    // Build the set of role identifiers we'll accept on this sync. Anything
+    // outside this set is dropped (e.g. a Microsoft DSL that mis-maps
+    // jobTitle into role would otherwise plant "Senior Front End Engineer"
+    // strings into member.role with no matching organization_role row).
+    const customRoles: { name: string }[] = await db.organizationRole.findMany({
+      where: { organizationId },
+      select: { name: true },
+    });
+    const validRoleNames = new Set<string>([
+      ...Object.keys(BUILT_IN_ROLE_PERMISSIONS),
+      ...customRoles.map((r) => r.name),
+    ]);
+
+    const sanitizeRole = (raw: string | undefined | null): string => {
+      if (!raw) return defaultRole;
+      const tokens = raw
+        .split(',')
+        .map((t) => t.trim())
+        .filter((t) => t.length > 0 && validRoleNames.has(t));
+      return tokens.length > 0 ? tokens.join(',') : defaultRole;
+    };
 
     const results: SyncResult = {
       success: true,
@@ -174,11 +197,17 @@ export class GenericEmployeeSyncService {
         }
 
         // Create new member
+        const sanitizedRole = sanitizeRole(employee.role);
+        if (employee.role && sanitizedRole !== employee.role) {
+          this.logger.warn(
+            `[GenericSync] Provider "${providerName}" sent unrecognized role "${employee.role}" for ${normalizedEmail}; falling back to "${sanitizedRole}"`,
+          );
+        }
         await db.member.create({
           data: {
             organizationId,
             userId: existingUser.id,
-            role: employee.role || defaultRole,
+            role: sanitizedRole,
             isActive: true,
           },
         });

--- a/apps/api/src/integration-platform/services/generic-employee-sync.service.ts
+++ b/apps/api/src/integration-platform/services/generic-employee-sync.service.ts
@@ -172,11 +172,27 @@ export class GenericEmployeeSyncService {
         });
 
         if (existingMember) {
+          // Self-heal limbo roles: if the persisted member.role contains
+          // tokens that don't map to any valid role today (e.g. an Entra
+          // jobTitle planted by a misconfigured DSL pre-fix), drop them.
+          // We only ever shrink the role string here — never overwrite a
+          // valid assignment with whatever the provider sent.
+          const healedRole = sanitizeRole(existingMember.role);
+          const needsHeal = healedRole !== existingMember.role;
+          if (needsHeal) {
+            this.logger.warn(
+              `[GenericSync] Healing limbo role for ${normalizedEmail}: "${existingMember.role}" → "${healedRole}"`,
+            );
+          }
+
           if (existingMember.deactivated && allowReactivation) {
-            // Reactivate the member
             await db.member.update({
               where: { id: existingMember.id },
-              data: { deactivated: false, isActive: true },
+              data: {
+                deactivated: false,
+                isActive: true,
+                ...(needsHeal ? { role: healedRole } : {}),
+              },
             });
             results.reactivated++;
             results.details.push({
@@ -184,6 +200,12 @@ export class GenericEmployeeSyncService {
               status: 'reactivated',
             });
           } else {
+            if (needsHeal) {
+              await db.member.update({
+                where: { id: existingMember.id },
+                data: { role: healedRole },
+              });
+            }
             results.skipped++;
             results.details.push({
               email: normalizedEmail,


### PR DESCRIPTION
## Summary

The generic employee sync (`apps/api/src/integration-platform/services/generic-employee-sync.service.ts`) used to write `employee.role` straight into `member.role` with **no validation**. A misconfigured DSL — most notably the Microsoft sync, which appears to map Entra Graph's `jobTitle` into `role` — could plant strings like `"Senior Front End Engineer"` in `member.role` with no matching `organization_role` row. The result was a "limbo role": the People list rendered it as a Badge (because `getRoleLabel` falls back to title-case for unknown roles), but the Roles page correctly showed it didn't exist, and every RBAC check against the user silently denied because the value matched neither a built-in role nor any custom role.

This PR does two things:

### 1. Guard new writes (commit 1)
Sanitize `employee.role` before inserting a new member:
- Loads the org's built-in roles (`BUILT_IN_ROLE_PERMISSIONS`) plus its `organization_role.name` rows once per sync.
- For each new member, splits `employee.role` on commas and keeps only tokens that match the valid set.
- If every token is invalid — or the field is empty — falls back to `defaultRole` (`'employee'` for the dynamic-sync path).
- Logs a `warn` when fall-back occurs, so a misconfigured DSL is loud in sync logs.

### 2. Self-heal existing members on re-sync (commit 2)
When the sync re-encounters an existing member, sanitize their persisted `member.role` too:
- Drop unknown tokens, fall back to `defaultRole` if every token is invalid.
- **Conservative — only ever shrinks the role string.** Never overwrites a manually-assigned valid role with whatever the provider sent (so an `admin` won't get downgraded if the DSL still mis-maps `jobTitle`).
- Both the "already a member" path and the reactivation path heal.

**Net effect: customers stuck with limbo roles get cleaned up automatically on their next sync run — no DB scrub required.** The DSL still needs a fix on their side (so it stops trying to plant `jobTitle` into `role` in the first place), but even without that, the data won't stay polluted: the heal will keep falling back to `defaultRole` each cycle and the warn logs will surface the misconfiguration.

## Tests

10 new tests in `generic-employee-sync.service.spec.ts`, watched RED, then GREEN:

**Insert path (commit 1):**
- Built-in role passthrough
- Known custom role passthrough
- Unknown role (e.g. `"Senior Front End Engineer"`) falls back to `defaultRole`
- Empty/missing role falls back to `defaultRole`
- `organization_role` lookup is scoped to the synced org
- Comma-separated input keeps only the valid tokens (e.g. `"admin,Senior Front End Engineer"` → `"admin"`)

**Heal path (commit 2):**
- Heals an existing member whose role is entirely invalid
- Heals an existing member whose role mixes valid + invalid tokens
- Does not touch an existing member whose role is already valid
- Heals AND reactivates a deactivated member with a limbo role

## Out of scope

The DSL itself (the Microsoft `DynamicIntegration.syncDefinition` JSON in the affected org's DB) still needs to be edited to stop mapping `jobTitle` into `role`. That's a one-row JSON edit on the DB side. Without it, every sync will keep emitting fall-back warns; with it, sync logs go quiet.

## Test plan
- [ ] Unit tests pass: `cd apps/api && npx jest src/integration-platform/services/generic-employee-sync`
- [ ] After deploy: trigger a sync against the affected Microsoft integration. Confirm:
  - Existing members' `member.role` values get healed back to `'employee'` (or the valid subset).
  - The API logs a `[GenericSync] Healing limbo role for <email>: "<old>" → "<new>"` warning per healed row.
- [ ] Confirm a member with a manually-assigned valid role (e.g. `admin`) is left alone, even if the provider sends a `jobTitle` for them.
- [ ] Confirm a custom role created in the org and referenced by DSL still passes through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)