### PR TITLE
chore(pentest): genericize target URL placeholder

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/CreateRunPanel.tsx
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/CreateRunPanel.tsx
@@ -107,7 +107,7 @@ export function CreateRunPanel({
                 id="pt-target-url"
                 value={targetUrl}
                 onChange={(e) => setTargetUrl(e.target.value)}
-                placeholder="app.staging.trycomp.ai"
+                placeholder="your.staging.app"
                 autoFocus
                 required
                 className="flex-1 bg-transparent font-mono text-xs outline-none"


### PR DESCRIPTION
## Summary
- Change the Target URL placeholder in the pentest "New Scan" panel from `app.staging.trycomp.ai` to `your.staging.app`.
- The previous placeholder hinted at a Comp AI internal hostname; the new one is generic.

## Test plan
- [ ] Open the pentest "New Scan" panel — the Target URL input shows `your.staging.app` as placeholder text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Target URL placeholder in the pentest “New Scan” panel from `app.staging.trycomp.ai` to `your.staging.app` to remove the internal reference and make it generic.

<sup>Written for commit 967a44f72096a505d2089b7fc013058483d17601. Summary will update on new commits. <a href="https://cubic.dev/pr/trycompai/comp/pull/2697?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

