### PR TITLE
fix(pentest): loading shell + mobile-friendly split-view

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/[reportId]/loading.tsx
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/[reportId]/loading.tsx
@@ -1,0 +1,9 @@
+import {
+  DetailMainSkeleton,
+  LoadingShell,
+} from '../_components/LoadingShell';
+
+/** Detail-route loading state. Mobile shows ONLY the detail-shape main pane. */
+export default function Loading() {
+  return <LoadingShell variant="detail" mainPane={<DetailMainSkeleton />} />;
+}

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/CompletedDetail.tsx
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/CompletedDetail.tsx
@@ -43,7 +43,7 @@ export function CompletedDetail({
 
   return (
     <div className="min-h-0 overflow-y-auto">
-      <div className="mx-auto max-w-5xl px-8 py-8 space-y-6">
+      <div className="mx-auto max-w-5xl space-y-6 px-4 py-6 md:px-8 md:py-8">
         <header className="space-y-3 pb-3">
           <div className="flex items-center gap-3">
             <StatusPill status="completed" findingCount={issues.length} />

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/EmptyState.tsx
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/EmptyState.tsx
@@ -46,7 +46,7 @@ export function EmptyState({
     ? "You've used your trial run. Paid plans are coming soon — contact support if you need access today."
     : 'Automated black-box pen testing. Start a scan to see findings here.';
   return (
-    <div className="mx-auto flex h-full max-w-3xl flex-col items-start justify-center gap-6 px-8 py-12">
+    <div className="mx-auto flex h-full max-w-3xl flex-col items-start justify-center gap-6 px-4 py-10 md:px-8 md:py-12">
       <div>
         <div className="mb-3 inline-flex items-center gap-2">
           <h1 className="text-[26px] font-medium tracking-[-0.02em]">

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/FailedDetail.tsx
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/FailedDetail.tsx
@@ -16,7 +16,7 @@ export function FailedDetail({ run, onRetry }: FailedDetailProps) {
 
   return (
     <div className="min-h-0 overflow-y-auto">
-      <div className="mx-auto max-w-5xl px-8 py-8 space-y-6">
+      <div className="mx-auto max-w-5xl space-y-6 px-4 py-6 md:px-8 md:py-8">
         <header className="space-y-3">
           <div className="flex items-center gap-3">
             <StatusPill status={run.status} />

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/FindingDetail.tsx
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/FindingDetail.tsx
@@ -34,7 +34,7 @@ export function FindingDetail({ issue, onBack }: FindingDetailProps) {
 
   return (
     <div className="min-h-0 overflow-y-auto">
-      <div className="mx-auto max-w-5xl px-8 py-8 space-y-6">
+      <div className="mx-auto max-w-5xl space-y-6 px-4 py-6 md:px-8 md:py-8">
         <div>
           <Button variant="ghost" size="sm" onClick={onBack}>
             <ArrowLeft className="h-3.5 w-3.5" />

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/LoadingShell.tsx
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/LoadingShell.tsx
@@ -62,6 +62,18 @@ export function LoadingShell({ variant, mainPane }: LoadingShellProps) {
           showMainMobile ? 'flex' : 'hidden md:flex',
         ].join(' ')}
       >
+        {/* Mobile-only back-bar skeleton on non-list routes. Matches the
+            "← Scans" bar that SplitView renders on detail/create URLs
+            below md — without this placeholder, resolving the page
+            shifts the main content down ~33px when the real bar mounts. */}
+        {variant !== 'list' && (
+          <div
+            className="md:hidden flex items-center border-b border-border bg-background px-3 py-2"
+            aria-hidden
+          >
+            <div className="h-4 w-16 rounded bg-muted animate-pulse" />
+          </div>
+        )}
         {mainPane}
       </main>
     </div>

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/LoadingShell.tsx
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/LoadingShell.tsx
@@ -1,0 +1,196 @@
+/**
+ * Shared loading skeleton for pentest routes. Mirrors the SplitView shell
+ * one-to-one (full-bleed, 340px sidebar + main pane on desktop) so a hard
+ * refresh transitions into the live page without a CLS jump.
+ *
+ * On mobile (<md) only ONE pane is rendered, picked by `variant` to match
+ * the route the user is hard-refreshing on:
+ *   - 'list'   — only the sidebar shape
+ *   - 'detail' — only the main pane shape
+ *   - 'create' — only the main pane shape
+ *
+ * Desktop always shows both. Pure JSX, no hooks — safe to consume from
+ * server-component `loading.tsx` files.
+ */
+type Variant = 'list' | 'detail' | 'create';
+
+interface LoadingShellProps {
+  variant: Variant;
+  /** Right-pane skeleton — typed/lined to roughly match the resolving page. */
+  mainPane: React.ReactNode;
+}
+
+export function LoadingShell({ variant, mainPane }: LoadingShellProps) {
+  const showSidebarMobile = variant === 'list';
+  const showMainMobile = !showSidebarMobile;
+
+  return (
+    <div className="flex h-[calc(100vh-4rem)] min-h-0 -m-4 md:-m-6">
+      <aside
+        className={[
+          'flex h-full min-h-0 w-full md:w-[340px] md:shrink-0 flex-col border-r border-border bg-background',
+          showSidebarMobile ? 'flex' : 'hidden md:flex',
+        ].join(' ')}
+        aria-hidden
+      >
+        <div className="flex items-center justify-between border-b border-border px-4 py-3">
+          <div className="flex items-center gap-2">
+            <div className="h-4 w-12 rounded bg-muted animate-pulse" />
+            <div className="h-4 w-6 rounded bg-muted animate-pulse" />
+          </div>
+          <div className="h-6 w-14 rounded border border-border bg-muted/50 animate-pulse" />
+        </div>
+        <ul className="flex-1 min-h-0 divide-y divide-border overflow-hidden">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <li key={i} className="flex flex-col gap-1.5 px-4 py-3">
+              <div className="flex items-center gap-2">
+                <div className="h-4 w-20 rounded-full bg-muted animate-pulse" />
+                <div className="h-3 w-14 rounded bg-muted animate-pulse" />
+              </div>
+              <div className="h-4 w-3/4 rounded bg-muted animate-pulse" />
+              <div className="h-3 w-1/3 rounded bg-muted animate-pulse" />
+            </li>
+          ))}
+        </ul>
+        <div className="border-t border-border px-4 py-3">
+          <div className="h-3 w-2/3 rounded bg-muted animate-pulse" />
+        </div>
+      </aside>
+      <main
+        className={[
+          'min-w-0 flex-1 flex-col',
+          showMainMobile ? 'flex' : 'hidden md:flex',
+        ].join(' ')}
+      >
+        {mainPane}
+      </main>
+    </div>
+  );
+}
+
+/** Overview-shape main-pane skeleton (header + hero card + 4-stat band). */
+export function OverviewMainSkeleton() {
+  return (
+    <div className="min-h-0 flex-1 overflow-hidden">
+      <div className="mx-auto max-w-5xl space-y-6 px-4 py-6 md:px-8 md:py-8">
+        <div className="flex items-end justify-between gap-3 pb-3">
+          <div className="space-y-2">
+            <div className="h-7 w-40 rounded bg-muted animate-pulse" />
+            <div className="h-3 w-72 rounded bg-muted animate-pulse" />
+          </div>
+          <div className="h-9 w-28 rounded border border-border bg-muted/50 animate-pulse" />
+        </div>
+        <div className="rounded border border-border p-6 space-y-3">
+          <div className="h-4 w-32 rounded bg-muted animate-pulse" />
+          <div className="h-9 w-1/2 rounded bg-muted animate-pulse" />
+          <div className="h-3 w-2/3 rounded bg-muted animate-pulse" />
+        </div>
+        <div className="grid grid-cols-2 gap-6 border-b-2 border-border pb-6 md:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className={
+                i > 0
+                  ? 'space-y-3 md:border-l md:border-border md:pl-6'
+                  : 'space-y-3'
+              }
+            >
+              <div className="h-3 w-20 rounded bg-muted animate-pulse" />
+              <div className="h-10 w-16 rounded bg-muted animate-pulse" />
+              <div className="h-3 w-24 rounded bg-muted animate-pulse" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Detail-shape main-pane skeleton (header + sev tally + agent grid + table). */
+export function DetailMainSkeleton() {
+  return (
+    <div className="min-h-0 flex-1 overflow-hidden">
+      <div className="mx-auto max-w-5xl space-y-6 px-4 py-6 md:px-8 md:py-8">
+        <div className="space-y-3">
+          <div className="flex items-center gap-3">
+            <div className="h-5 w-20 rounded-full bg-muted animate-pulse" />
+            <div className="h-3 w-32 rounded bg-muted animate-pulse" />
+          </div>
+          <div className="h-7 w-2/3 rounded bg-muted animate-pulse" />
+          <div className="flex flex-wrap gap-x-6 gap-y-1">
+            <div className="h-3 w-40 rounded bg-muted animate-pulse" />
+            <div className="h-3 w-44 rounded bg-muted animate-pulse" />
+          </div>
+        </div>
+        <div className="space-y-2">
+          <div className="h-3 w-24 rounded bg-muted animate-pulse" />
+          <div className="grid grid-cols-11 gap-1.5">
+            {Array.from({ length: 22 }).map((_, i) => (
+              <div
+                key={i}
+                className="aspect-square rounded bg-muted animate-pulse"
+              />
+            ))}
+          </div>
+          <div className="h-3 w-32 rounded bg-muted animate-pulse" />
+        </div>
+        <div className="space-y-2">
+          <div className="h-3 w-28 rounded bg-muted animate-pulse" />
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div
+                key={i}
+                className="h-12 rounded border border-border bg-muted/40 animate-pulse"
+              />
+            ))}
+          </div>
+        </div>
+        <div className="space-y-2">
+          <div className="h-3 w-24 rounded bg-muted animate-pulse" />
+          <div className="space-y-1 rounded border border-border p-2">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div
+                key={i}
+                className="h-8 rounded bg-muted animate-pulse"
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Create-form-shape main-pane skeleton. */
+export function CreateMainSkeleton() {
+  return (
+    <div className="min-h-0 flex-1 overflow-hidden">
+      <div className="mx-auto w-full max-w-[680px] px-4 py-8 md:px-6 md:py-10">
+        <div className="rounded-[var(--radius)] border border-border bg-card p-6 md:p-8 space-y-5">
+          <div className="space-y-2">
+            <div className="h-3 w-20 rounded bg-muted animate-pulse" />
+            <div className="h-6 w-2/3 rounded bg-muted animate-pulse" />
+            <div className="h-3 w-full rounded bg-muted animate-pulse" />
+          </div>
+          {Array.from({ length: 2 }).map((_, i) => (
+            <div key={i} className="space-y-1.5">
+              <div className="h-3 w-24 rounded bg-muted animate-pulse" />
+              <div className="h-9 rounded border border-border bg-muted/40 animate-pulse" />
+              <div className="h-3 w-3/4 rounded bg-muted animate-pulse" />
+            </div>
+          ))}
+          <div className="rounded border border-border bg-muted/40 p-3.5 space-y-2">
+            <div className="h-3 w-24 rounded bg-muted animate-pulse" />
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="h-3 w-full rounded bg-muted animate-pulse" />
+            ))}
+          </div>
+          <div className="flex justify-end gap-2">
+            <div className="h-9 w-20 rounded border border-border bg-muted/40 animate-pulse" />
+            <div className="h-9 w-28 rounded bg-muted animate-pulse" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/OverviewPane.tsx
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/OverviewPane.tsx
@@ -74,7 +74,7 @@ function OnboardingState({
   canCreate: boolean;
 }) {
   return (
-    <div className="flex h-full items-center justify-center px-8 py-12">
+    <div className="flex h-full items-center justify-center px-4 py-10 md:px-8 md:py-12">
       <div className="w-full max-w-[560px]">
         <div className="font-mono text-[11px] uppercase tracking-[0.1em] text-muted-foreground">
           Penetration tests · Overview
@@ -142,7 +142,7 @@ function PostureOverview({
 
   return (
     <div className="min-h-0 overflow-y-auto">
-      <div className="mx-auto max-w-5xl px-8 py-8 space-y-6">
+      <div className="mx-auto max-w-5xl space-y-6 px-4 py-6 md:px-8 md:py-8">
         <header className="flex flex-wrap items-end justify-between gap-3 pb-3">
           <div>
             <h1 className="text-[28px] font-medium tracking-[-0.02em]">

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/OverviewPane.tsx
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/OverviewPane.tsx
@@ -250,16 +250,21 @@ function PostureOverview({
   onDownloadMarkdown,
   onDownloadPdf,
 }: PostureOverviewProps) {
-  // Coverage and stale-target stats use ONLY completed runs — a target
-  // that's only ever had failed/cancelled scans isn't truly "covered,"
-  // and a target whose latest scan failed shouldn't reset the staleness
-  // clock. The full `runs` list is only used for the recent activity
-  // sidebar elsewhere.
+  // Coverage / avg-duration / stale stats are completed-only on purpose:
+  // a target whose only scans are running or failed isn't actually
+  // "covered," a running scan has no real duration yet, and a failed
+  // scan shouldn't reset the staleness clock.
+  //
+  // "Recent scans" is the exception — that's an activity feed, not a
+  // success metric, so it uses the full `runs` list. Otherwise a user
+  // with completed history but a fresh running scan would see the
+  // running one in the sidebar but NOT here, which contradicts the
+  // sidebar and hides the live scan from the overview.
   const targets = uniqueTargets(completed);
   const lastScan = mostRecent(completed);
   const avgDuration = avgDurationMs(completed);
   const scansLast30d = countWithin(completed, 30 * 24 * 60 * 60 * 1000);
-  const recentScans = sortByUpdatedDesc(completed).slice(0, 6);
+  const recentScans = sortByUpdatedDesc(runs).slice(0, 6);
   const staleTargets = computeStaleTargets(completed, targets);
 
   return (

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/OverviewPane.tsx
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/OverviewPane.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Button } from '@trycompai/design-system';
-import { Add } from '@trycompai/design-system/icons';
+import { Add, ArrowRight } from '@trycompai/design-system/icons';
+import { useRouter } from 'next/navigation';
 import type { PentestRun } from '@/lib/security/penetration-tests-client';
 import {
   LatestAssessment,
@@ -17,6 +18,8 @@ import {
   sortByUpdatedDesc,
   uniqueTargets,
 } from './overview-internals';
+import { StatusPill } from './StatusPill';
+import { isRunInProgress } from './severity';
 
 interface OverviewPaneProps {
   orgId: string;
@@ -29,10 +32,13 @@ interface OverviewPaneProps {
 }
 
 /**
- * Right pane shown when no scan is selected. Two real states:
+ * Right pane shown when no scan is selected. Three real states:
  *
- *   - 0 completed scans → onboarding card with primary CTA
- *   - 1+ completed scans → posture overview: real counts, recent scans,
+ *   - 0 completed, 0 in-progress → onboarding card with primary CTA
+ *   - 0 completed, 1+ in-progress → in-progress card surfacing the running
+ *     scan(s); avoids the "No scans yet" lie when the sidebar already
+ *     shows a running scan.
+ *   - 1+ completed → posture overview: real counts, recent scans,
  *     stale-coverage list. NO cross-scan severity aggregation, NO trend
  *     chart, NO "open findings" queue — those need per-run issue counts
  *     in the list endpoint (backend aggregation), which we don't have
@@ -50,6 +56,22 @@ export function OverviewPane({
   const completed = runs.filter((r) => r.status === 'completed');
 
   if (completed.length === 0) {
+    // If there are no completed runs but a scan is currently running, surface
+    // it instead of the "No scans yet" onboarding — that headline contradicts
+    // the sidebar (which already shows the running scan) and was the source
+    // of a customer report: "I left, came back, it says no scans yet instead
+    // of just showing the latest one which had already started."
+    const inProgress = runs.filter((r) => isRunInProgress(r.status));
+    if (inProgress.length > 0) {
+      return (
+        <InProgressState
+          orgId={orgId}
+          runs={inProgress}
+          onCreateClick={onCreateClick}
+          canCreate={canCreate}
+        />
+      );
+    }
     return <OnboardingState onCreateClick={onCreateClick} canCreate={canCreate} />;
   }
 
@@ -64,6 +86,106 @@ export function OverviewPane({
       onDownloadPdf={onDownloadPdf}
     />
   );
+}
+
+interface InProgressStateProps {
+  orgId: string;
+  runs: PentestRun[];
+  onCreateClick: () => void;
+  canCreate: boolean;
+}
+
+/**
+ * Shown on `/pentests` when the org has only in-progress scans (no
+ * completed history yet). Lists the running scans with a click-to-view
+ * card so the user lands on something that matches the sidebar instead
+ * of the onboarding empty state.
+ */
+function InProgressState({
+  orgId,
+  runs,
+  onCreateClick,
+  canCreate,
+}: InProgressStateProps) {
+  const router = useRouter();
+  const sorted = [...runs].sort(
+    (a, b) =>
+      new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+  );
+  const headline =
+    sorted.length === 1 ? 'Scan in progress' : `${sorted.length} scans in progress`;
+
+  return (
+    <div className="flex h-full items-center justify-center px-4 py-10 md:px-8 md:py-12">
+      <div className="w-full max-w-[640px]">
+        <div className="font-mono text-[11px] uppercase tracking-[0.1em] text-muted-foreground">
+          Penetration tests · Overview
+        </div>
+        <h1 className="mt-3 text-[24px] font-medium tracking-[-0.01em]">
+          {headline}
+        </h1>
+        <p className="mt-2 max-w-[480px] text-sm text-muted-foreground">
+          Findings stream in as agents discover them. You don't need to keep
+          this page open — open the run any time to see live progress.
+        </p>
+
+        <ul className="mt-6 space-y-2">
+          {sorted.slice(0, 3).map((run) => (
+            <li key={run.id}>
+              <button
+                type="button"
+                onClick={() =>
+                  router.push(
+                    `/${orgId}/security/penetration-tests/${encodeURIComponent(run.id)}`,
+                  )
+                }
+                className="flex w-full items-center justify-between gap-4 rounded-[var(--radius)] border border-border bg-card p-4 text-left transition hover:border-foreground/20 hover:bg-muted/40"
+              >
+                <div className="min-w-0 flex-1 space-y-1.5">
+                  <div className="flex items-center gap-2">
+                    <StatusPill status={run.status} />
+                    <span className="font-mono text-[11px] text-muted-foreground">
+                      {toShortRunId(run.id)}
+                    </span>
+                  </div>
+                  <div className="truncate font-mono text-sm">
+                    {targetHost(run.targetUrl)}
+                  </div>
+                </div>
+                <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+              </button>
+            </li>
+          ))}
+        </ul>
+
+        {sorted.length > 3 ? (
+          <p className="mt-3 text-[11px] text-muted-foreground">
+            +{sorted.length - 3} more in the sidebar.
+          </p>
+        ) : null}
+
+        <div className="mt-6">
+          <Button variant="outline" onClick={onCreateClick} disabled={!canCreate}>
+            <Add className="h-3.5 w-3.5" />
+            New scan
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function toShortRunId(fullId: string): string {
+  const tail = fullId.replace(/[^0-9]/g, '').slice(-4);
+  return tail ? `PT-${tail}` : fullId;
+}
+
+function targetHost(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
 }
 
 function OnboardingState({

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/RunList.tsx
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/RunList.tsx
@@ -36,7 +36,7 @@ export function RunList({
       : 'No pentest runs remaining.'
     : 'Start a new scan';
   return (
-    <aside className="flex h-full min-h-0 w-[340px] shrink-0 flex-col border-r border-border bg-background">
+    <aside className="flex h-full min-h-0 w-full md:w-[340px] md:shrink-0 flex-col border-r border-border bg-background">
       {/* Header — matches "Scans  6   Filter  Sort" from the design */}
       <div className="flex items-center justify-between border-b border-border px-4 py-3">
         <button

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/RunningDetail.tsx
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/RunningDetail.tsx
@@ -51,7 +51,7 @@ export function RunningDetail({
 
   return (
     <div className="min-h-0 overflow-y-auto">
-      <div className="mx-auto max-w-5xl px-8 py-8 space-y-6">
+      <div className="mx-auto max-w-5xl space-y-6 px-4 py-6 md:px-8 md:py-8">
         <header className="space-y-3">
           <div className="flex items-center gap-3">
             <StatusPill status={run.status} />

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/SplitView.tsx
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/SplitView.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { api } from '@/lib/api-client';
+import { cn } from '@trycompai/design-system/cn';
+import { ArrowLeft } from '@trycompai/design-system/icons';
 import type {
   PentestCreateRequest,
   PentestIssue,
@@ -128,6 +130,14 @@ export function SplitView({
 
   const goToCreate = () =>
     router.push(`/${orgId}/security/penetration-tests/new`);
+  const goToList = () =>
+    router.push(`/${orgId}/security/penetration-tests`);
+
+  // Mobile shows ONE pane at a time, picked from the URL. List on
+  // `/pentests`, main pane on `/pentests/:id` and `/pentests/new`. Below
+  // `md` we hide whichever isn't active so an IDE-style split doesn't
+  // collapse into ~200px columns. On desktop both are always shown.
+  const showListOnMobile = selectedRunId === null && !isCreateMode;
 
   // Empty state only shown when there are no runs AND no selection AND not
   // in create mode. Once there is at least one run we always render the
@@ -152,7 +162,11 @@ export function SplitView({
     <div className="pt-tokens flex h-[calc(100vh-4rem)] min-h-0 -m-4 md:-m-6">
       <div
         aria-hidden={isCreateMode}
-        className={isCreateMode ? 'pointer-events-none opacity-45' : ''}
+        className={cn(
+          'w-full md:w-auto md:shrink-0',
+          showListOnMobile ? 'block' : 'hidden md:block',
+          isCreateMode ? 'pointer-events-none opacity-45' : '',
+        )}
       >
         <RunList
           orgId={orgId}
@@ -163,7 +177,28 @@ export function SplitView({
           trialUsed={trialUsed}
         />
       </div>
-      <main className="flex-1 min-w-0 flex flex-col">
+      <main
+        className={cn(
+          'min-w-0 flex-1 flex-col',
+          showListOnMobile ? 'hidden md:flex' : 'flex',
+        )}
+      >
+        {/* Mobile-only back bar. The sidebar is hidden on phones once a
+            run is selected (or in create mode), so we surface a
+            persistent path back to the list. md+ never sees this — the
+            sidebar itself is the navigation. */}
+        {!showListOnMobile && (
+          <div className="md:hidden flex items-center border-b border-border bg-background px-3 py-2">
+            <button
+              type="button"
+              onClick={goToList}
+              className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-foreground"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Scans
+            </button>
+          </div>
+        )}
         {isCreateMode ? (
           <CreateRunPanel
             orgId={orgId}

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/loading.tsx
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/loading.tsx
@@ -1,78 +1,15 @@
+import {
+  LoadingShell,
+  OverviewMainSkeleton,
+} from './_components/LoadingShell';
+
 /**
- * Loading state for the pentests route. Mirrors the `SplitView` shell —
- * full-bleed (negative margins escape the app-shell's `p-4 md:p-6`), a
- * 340px sidebar, and a main pane — so a hard refresh on any pentest URL
- * (overview, detail, or create) doesn't briefly render the inherited
- * padded `[orgId]/loading.tsx` and visibly snap into the IDE-style
- * layout. The default `<PageLayout loading />` placeholder is a
- * centered card; pentest is edge-to-edge, so they don't overlap and the
- * jump shows up as a large CLS event on slower networks.
+ * List-route loading state. Mobile shows ONLY the sidebar skeleton (this
+ * URL resolves into a full-width list); desktop shows the full split
+ * shell. The `[reportId]/loading.tsx` and `new/loading.tsx` siblings
+ * override this for nested routes so each variant's mobile skeleton
+ * matches its resolving page.
  */
 export default function Loading() {
-  return (
-    <div className="flex h-[calc(100vh-4rem)] min-h-0 -m-4 md:-m-6">
-      <aside className="flex h-full min-h-0 w-[340px] shrink-0 flex-col border-r border-border bg-background">
-        <div className="flex items-center justify-between border-b border-border px-4 py-3">
-          <div className="flex items-center gap-2">
-            <div className="h-4 w-12 rounded bg-muted animate-pulse" />
-            <div className="h-4 w-6 rounded bg-muted animate-pulse" />
-          </div>
-          <div className="h-6 w-14 rounded border border-border bg-muted/50 animate-pulse" />
-        </div>
-        <ul className="flex-1 min-h-0 divide-y divide-border overflow-hidden">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <li
-              key={i}
-              className="flex flex-col gap-1.5 px-4 py-3"
-              aria-hidden
-            >
-              <div className="flex items-center gap-2">
-                <div className="h-4 w-20 rounded-full bg-muted animate-pulse" />
-                <div className="h-3 w-14 rounded bg-muted animate-pulse" />
-              </div>
-              <div className="h-4 w-3/4 rounded bg-muted animate-pulse" />
-              <div className="h-3 w-1/3 rounded bg-muted animate-pulse" />
-            </li>
-          ))}
-        </ul>
-        <div className="border-t border-border px-4 py-3">
-          <div className="h-3 w-2/3 rounded bg-muted animate-pulse" />
-        </div>
-      </aside>
-      <main className="flex flex-1 min-w-0 flex-col">
-        <div className="min-h-0 flex-1 overflow-hidden">
-          <div className="mx-auto max-w-5xl space-y-6 px-8 py-8">
-            <div className="flex items-end justify-between gap-3 pb-3">
-              <div className="space-y-2">
-                <div className="h-7 w-40 rounded bg-muted animate-pulse" />
-                <div className="h-3 w-72 rounded bg-muted animate-pulse" />
-              </div>
-              <div className="h-9 w-28 rounded border border-border bg-muted/50 animate-pulse" />
-            </div>
-            <div className="rounded border border-border p-6 space-y-3">
-              <div className="h-4 w-32 rounded bg-muted animate-pulse" />
-              <div className="h-9 w-1/2 rounded bg-muted animate-pulse" />
-              <div className="h-3 w-2/3 rounded bg-muted animate-pulse" />
-            </div>
-            <div className="grid grid-cols-2 gap-6 border-b-2 border-border pb-6 md:grid-cols-4">
-              {Array.from({ length: 4 }).map((_, i) => (
-                <div
-                  key={i}
-                  className={
-                    i > 0
-                      ? 'space-y-3 md:border-l md:border-border md:pl-6'
-                      : 'space-y-3'
-                  }
-                >
-                  <div className="h-3 w-20 rounded bg-muted animate-pulse" />
-                  <div className="h-10 w-16 rounded bg-muted animate-pulse" />
-                  <div className="h-3 w-24 rounded bg-muted animate-pulse" />
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
-      </main>
-    </div>
-  );
+  return <LoadingShell variant="list" mainPane={<OverviewMainSkeleton />} />;
 }

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/loading.tsx
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/loading.tsx
@@ -1,0 +1,78 @@
+/**
+ * Loading state for the pentests route. Mirrors the `SplitView` shell —
+ * full-bleed (negative margins escape the app-shell's `p-4 md:p-6`), a
+ * 340px sidebar, and a main pane — so a hard refresh on any pentest URL
+ * (overview, detail, or create) doesn't briefly render the inherited
+ * padded `[orgId]/loading.tsx` and visibly snap into the IDE-style
+ * layout. The default `<PageLayout loading />` placeholder is a
+ * centered card; pentest is edge-to-edge, so they don't overlap and the
+ * jump shows up as a large CLS event on slower networks.
+ */
+export default function Loading() {
+  return (
+    <div className="flex h-[calc(100vh-4rem)] min-h-0 -m-4 md:-m-6">
+      <aside className="flex h-full min-h-0 w-[340px] shrink-0 flex-col border-r border-border bg-background">
+        <div className="flex items-center justify-between border-b border-border px-4 py-3">
+          <div className="flex items-center gap-2">
+            <div className="h-4 w-12 rounded bg-muted animate-pulse" />
+            <div className="h-4 w-6 rounded bg-muted animate-pulse" />
+          </div>
+          <div className="h-6 w-14 rounded border border-border bg-muted/50 animate-pulse" />
+        </div>
+        <ul className="flex-1 min-h-0 divide-y divide-border overflow-hidden">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <li
+              key={i}
+              className="flex flex-col gap-1.5 px-4 py-3"
+              aria-hidden
+            >
+              <div className="flex items-center gap-2">
+                <div className="h-4 w-20 rounded-full bg-muted animate-pulse" />
+                <div className="h-3 w-14 rounded bg-muted animate-pulse" />
+              </div>
+              <div className="h-4 w-3/4 rounded bg-muted animate-pulse" />
+              <div className="h-3 w-1/3 rounded bg-muted animate-pulse" />
+            </li>
+          ))}
+        </ul>
+        <div className="border-t border-border px-4 py-3">
+          <div className="h-3 w-2/3 rounded bg-muted animate-pulse" />
+        </div>
+      </aside>
+      <main className="flex flex-1 min-w-0 flex-col">
+        <div className="min-h-0 flex-1 overflow-hidden">
+          <div className="mx-auto max-w-5xl space-y-6 px-8 py-8">
+            <div className="flex items-end justify-between gap-3 pb-3">
+              <div className="space-y-2">
+                <div className="h-7 w-40 rounded bg-muted animate-pulse" />
+                <div className="h-3 w-72 rounded bg-muted animate-pulse" />
+              </div>
+              <div className="h-9 w-28 rounded border border-border bg-muted/50 animate-pulse" />
+            </div>
+            <div className="rounded border border-border p-6 space-y-3">
+              <div className="h-4 w-32 rounded bg-muted animate-pulse" />
+              <div className="h-9 w-1/2 rounded bg-muted animate-pulse" />
+              <div className="h-3 w-2/3 rounded bg-muted animate-pulse" />
+            </div>
+            <div className="grid grid-cols-2 gap-6 border-b-2 border-border pb-6 md:grid-cols-4">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <div
+                  key={i}
+                  className={
+                    i > 0
+                      ? 'space-y-3 md:border-l md:border-border md:pl-6'
+                      : 'space-y-3'
+                  }
+                >
+                  <div className="h-3 w-20 rounded bg-muted animate-pulse" />
+                  <div className="h-10 w-16 rounded bg-muted animate-pulse" />
+                  <div className="h-3 w-24 rounded bg-muted animate-pulse" />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/new/loading.tsx
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/new/loading.tsx
@@ -1,0 +1,9 @@
+import {
+  CreateMainSkeleton,
+  LoadingShell,
+} from '../_components/LoadingShell';
+
+/** Create-route loading state. Mobile shows ONLY the create-form skeleton. */
+export default function Loading() {
+  return <LoadingShell variant="create" mainPane={<CreateMainSkeleton />} />;
+}


### PR DESCRIPTION
## Summary

Three related pentest UX fixes bundled into one PR:

1. **Loading-shell layout shift** — pentest had no `loading.tsx`, so a hard refresh fell through to the parent `[orgId]/loading.tsx` (`<PageLayout loading />`, a centered padded card). The actual `SplitView` is full-bleed with negative margins and a 340px sidebar. The geometric mismatch produced a visible CLS jump.

2. **Mobile is broken** — the IDE-style 340px sidebar + main pane was rendering both panes side-by-side at phone widths, squeezing the running-scan detail down to ~100px and wrapping text letter-by-letter.

3. **Overview lies when only running scans exist** — customer report: *"I left the page, went back to the penetration test tab and it says no scans yet instead of just showing the latest one which had already started."* `OverviewPane` filtered to `completed` runs and showed "No scans yet" when there were 0 completed — even when the sidebar simultaneously displayed a running scan. The two contradicted each other.

## What changed

### Mobile-friendly split-view
Standard master-detail responsive routing — on mobile, show ONE pane picked from the URL:

| URL | Mobile | Desktop |
|---|---|---|
| `/pentests` | List only (full-width) | List + Overview |
| `/pentests/:id` | Detail only (back-bar at top → list) | List + Detail |
| `/pentests/new` | Create form only (back-bar at top → list) | List + Create |

- `RunList` is `w-full md:w-[340px]` — full viewport on phones, fixed 340px column on tablet+.
- Mobile-only "← Scans" bar at the top of the main pane on detail/create routes (the sidebar is the desktop equivalent).
- Detail / overview / failed / finding / empty-state padding drops from `px-8 py-8` to `px-4 py-6 md:px-8 md:py-8` so content doesn't crowd phone edges.

### Per-route loading skeletons
Replaced the single shared loading skeleton with `LoadingShell` plus three `loading.tsx` files:
- `pentests/loading.tsx` → list shape (mobile: list skeleton; desktop: full split)
- `pentests/[reportId]/loading.tsx` → detail shape (mobile: detail skeleton; desktop: full split)
- `pentests/new/loading.tsx` → create shape (mobile: create skeleton; desktop: full split)

Each variant's mobile skeleton matches the resolving page so a hard refresh on any pentest URL transitions in without a CLS jump regardless of viewport.

### Overview "in-progress" state
`OverviewPane` now has three cases instead of two:
- 0 completed AND 0 in-progress → onboarding card (existing)
- 0 completed AND 1+ in-progress → **NEW**: card surfacing the running scan(s) with click-to-view CTA
- 1+ completed → posture overview (existing)

No auto-redirect — the user might intentionally hit `/pentests` to see the list of scans, and forcing them into the live detail would be an annoying loop. They get a clear, predictable card to click into instead.

## Test plan

- [ ] On phone width, hard-refresh `/pentests` — full-width list skeleton, then list resolves with no jump.
- [ ] On phone width, hard-refresh `/pentests/:id` — full-width detail skeleton, then detail resolves with no jump. Tap "← Scans" at top, returns to list.
- [ ] On phone width, hard-refresh `/pentests/new` — full-width create-form skeleton, then form resolves with no jump.
- [ ] On phone, navigate list → detail → list. Sidebar is hidden on detail, visible on list.
- [ ] On desktop, all three URLs render the full split shell — no regression.
- [ ] On desktop, hard-refresh resolves without CLS (original CEO bug).
- [ ] **Customer flow:** Start a scan, leave the tab, come back to `/pentests` → main pane shows "Scan in progress" with the running scan's card, NOT "No scans yet".
- [ ] After the scan completes, refreshing `/pentests` shows the posture overview as before.
- [ ] Dark mode renders pulse skeletons correctly on both viewports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)