### PR TITLE
feat(sentry): unmask replay text and media

### DIFF
--- a/apps/app/src/instrumentation-client.ts
+++ b/apps/app/src/instrumentation-client.ts
@@ -24,7 +24,16 @@ Sentry.init({
     process.env.NEXT_PUBLIC_SENTRY_DSN ??
     'https://331f1c3d4b08e9352dd1a2621e1ae845@o4509214247813120.ingest.us.sentry.io/4511304630927360',
 
-  integrations: [Sentry.replayIntegration()],
+  integrations: [
+    // Add `data-sentry-mask` (or `.sentry-mask`) to any element rendering
+    // customer-confidential data; `data-sentry-block` to drop whole sections.
+    Sentry.replayIntegration({
+      maskAllText: false,
+      blockAllMedia: false,
+      mask: ['.sentry-mask', '[data-sentry-mask]'],
+      block: ['[data-sentry-block]'],
+    }),
+  ],
 
   tracesSampleRate: process.env.NODE_ENV === 'development' ? 1.0 : 0.1,
 

--- a/apps/portal/src/instrumentation-client.ts
+++ b/apps/portal/src/instrumentation-client.ts
@@ -9,7 +9,16 @@ Sentry.init({
     process.env.NEXT_PUBLIC_SENTRY_DSN ??
     'https://331f1c3d4b08e9352dd1a2621e1ae845@o4509214247813120.ingest.us.sentry.io/4511304630927360',
 
-  integrations: [Sentry.replayIntegration()],
+  integrations: [
+    // Add `data-sentry-mask` (or `.sentry-mask`) to any element rendering
+    // customer-confidential data; `data-sentry-block` to drop whole sections.
+    Sentry.replayIntegration({
+      maskAllText: false,
+      blockAllMedia: false,
+      mask: ['.sentry-mask', '[data-sentry-mask]'],
+      block: ['[data-sentry-block]'],
+    }),
+  ],
 
   tracesSampleRate: process.env.NODE_ENV === 'development' ? 1.0 : 0.1,
 


### PR DESCRIPTION
## Summary

Sentry session replay defaults to `maskAllText: true` + `blockAllMedia: true`, which produces unreadable replays — every text node renders as `***` and the layout is covered by diagonal-stripe block overlays. Disabling both for `app` and `portal` so replays are useful for debugging.

Added selector hooks for opt-in masking of customer-sensitive elements:

- `.sentry-mask` / `[data-sentry-mask]` — mask the element's text
- `[data-sentry-block]` — drop the whole element from the recording

`<input type="password">` is masked automatically by the SDK regardless of these settings.

## Why

Default replay output was unusable — see https://github.com/trycompai/comp/pull/2705 follow-up discussion. Trade-off: customer-visible content (org names, framework text, risk descriptions, policy markdown, vendor lists) will now appear in replays. Sensitive areas should opt back in via the selectors above as we identify them.

## Test plan

- [ ] Vercel preview build succeeds for `app` and `portal`
- [ ] Trigger an error on the preview and inspect the resulting replay in Sentry — text should be readable instead of asterisks
- [ ] Verify `<input type="password">` (e.g. on auth pages) is still masked
- [ ] Smoke check: add `data-sentry-mask` to a single test element, confirm only that element shows asterisks while surrounding text is visible

## Follow-ups (not in this PR)

- Audit policy markdown editor, risk descriptions, vendor list, secrets settings, API key display — apply `data-sentry-mask` / `data-sentry-block` where appropriate
- Document the masking convention in CLAUDE.md or a frontend pattern doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Sentry session replays readable by default in `app` and `portal` by turning off mask-all-text and block-all-media. Sensitive areas can opt back into masking or blocking; password inputs remain masked by the SDK.

- **New Features**
  - Default replay config set to `maskAllText: false` and `blockAllMedia: false`.
  - Opt-in selectors: `.sentry-mask` / `[data-sentry-mask]` to mask text; `[data-sentry-block]` to exclude elements from recordings.

<sup>Written for commit 457fcf9f62cfbab11c70420dffab86fb2b2cc75a. Summary will update on new commits. <a href="https://cubic.dev/pr/trycompai/comp/pull/2709?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

