### PR TITLE
fix(background-checks): remove employee PII from sessionStorage

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/EmployeeBackgroundCheck.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/EmployeeBackgroundCheck.tsx
@@ -191,8 +191,8 @@ export function EmployeeBackgroundCheck({
       }
 
       form.reset({
-        employeeName: pendingRequest.employeeName,
-        employeeEmail: pendingRequest.employeeEmail,
+        employeeName: form.getValues('employeeName') || employee.user.name || '',
+        employeeEmail: form.getValues('employeeEmail') || '',
         requesterNotes: pendingRequest.requesterNotes ?? '',
       });
       setBillingSetupComplete(true);

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/backgroundCheckForm.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/backgroundCheckForm.ts
@@ -8,9 +8,10 @@ export const backgroundCheckSchema = z.object({
 
 export type BackgroundCheckFormValues = z.infer<typeof backgroundCheckSchema>;
 
-const pendingBackgroundCheckSchema = backgroundCheckSchema.extend({
+const pendingBackgroundCheckSchema = z.object({
   memberId: z.string(),
   organizationId: z.string(),
+  requesterNotes: z.string().optional(),
 });
 
 export type PendingBackgroundCheckRequest = z.infer<typeof pendingBackgroundCheckSchema>;
@@ -65,8 +66,6 @@ export function writePendingBackgroundCheckRequest({
   const pendingRequest: PendingBackgroundCheckRequest = {
     organizationId,
     memberId,
-    employeeName: values.employeeName,
-    employeeEmail: values.employeeEmail,
     requesterNotes: values.requesterNotes,
   };
   window.sessionStorage.setItem(


### PR DESCRIPTION
Stop storing employeeName and employeeEmail in sessionStorage during the Stripe billing redirect flow. Only requesterNotes (non-PII) is persisted. After redirect, employeeName re-derives from the employee prop and the email field resets to its default.

Resolves code-scanning alert #133 (clear text storage of sensitive information).

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #XXXX (GitHub issue number)
- Fixes COMP-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://trycomp.ai/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/trycompai/comp/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove employee PII from sessionStorage in the background check Stripe redirect flow. Only `requesterNotes` is persisted; after return, the form derives the name from the employee prop and clears the email, resolving code-scanning alert #133.

- **Bug Fixes**
  - Stop writing `employeeName` and `employeeEmail` to sessionStorage; persist only `requesterNotes`.
  - On return, reset form: `employeeName` from `employee.user.name` (or existing form value), `employeeEmail` empty.
  - Narrow `PendingBackgroundCheckRequest` to `organizationId`, `memberId`, and optional `requesterNotes`.

<sup>Written for commit ea082b34733e9002fe65a54b8ee44338cc859979. Summary will update on new commits. <a href="https://cubic.dev/pr/trycompai/comp/pull/2715?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

