### PR TITLE
fix(integrations): source OAuth initiator userId from auth context

### DIFF
--- a/apps/api/src/integration-platform/controllers/oauth.controller.spec.ts
+++ b/apps/api/src/integration-platform/controllers/oauth.controller.spec.ts
@@ -176,9 +176,8 @@ describe('OAuthController', () => {
       mockedGetManifest.mockReturnValue(undefined as never);
 
       await expect(
-        controller.startOAuth('org_1', {
+        controller.startOAuth('org_1', 'user_1', {
           providerSlug: 'nonexistent',
-          userId: 'user_1',
         }),
       ).rejects.toThrow(HttpException);
     });
@@ -189,9 +188,8 @@ describe('OAuthController', () => {
       } as never);
 
       await expect(
-        controller.startOAuth('org_1', {
+        controller.startOAuth('org_1', 'user_1', {
           providerSlug: 'datadog',
-          userId: 'user_1',
         }),
       ).rejects.toThrow(HttpException);
     });
@@ -219,9 +217,8 @@ describe('OAuthController', () => {
       });
 
       await expect(
-        controller.startOAuth('org_1', {
+        controller.startOAuth('org_1', 'user_1', {
           providerSlug: 'github',
-          userId: 'user_1',
         }),
       ).rejects.toThrow(HttpException);
     });
@@ -254,9 +251,8 @@ describe('OAuthController', () => {
         state: 'random_state_token',
       });
 
-      const result = await controller.startOAuth('org_1', {
+      const result = await controller.startOAuth('org_1', 'user_1', {
         providerSlug: 'github',
-        userId: 'user_1',
       });
 
       expect(result.authorizationUrl).toContain(
@@ -303,9 +299,8 @@ describe('OAuthController', () => {
         state: 'state_abc',
       });
 
-      const result = await controller.startOAuth('org_1', {
+      const result = await controller.startOAuth('org_1', 'user_1', {
         providerSlug: 'linear',
-        userId: 'user_1',
       });
 
       expect(result.authorizationUrl).toContain('code_challenge=');

--- a/apps/api/src/integration-platform/controllers/oauth.controller.spec.ts
+++ b/apps/api/src/integration-platform/controllers/oauth.controller.spec.ts
@@ -4,6 +4,7 @@ import type { Request } from 'express';
 import { OAuthController } from './oauth.controller';
 import { HybridAuthGuard } from '../../auth/hybrid-auth.guard';
 import { PermissionGuard } from '../../auth/permission.guard';
+import { SessionOnlyGuard } from '../../auth/session-only.guard';
 import { OAuthStateRepository } from '../repositories/oauth-state.repository';
 import { ProviderRepository } from '../repositories/provider.repository';
 import { ConnectionRepository } from '../repositories/connection.repository';
@@ -34,6 +35,10 @@ jest.mock('../../auth/hybrid-auth.guard', () => ({
 
 jest.mock('../../auth/permission.guard', () => ({
   PermissionGuard: class PermissionGuard {},
+}));
+
+jest.mock('../../auth/session-only.guard', () => ({
+  SessionOnlyGuard: class SessionOnlyGuard {},
 }));
 
 jest.mock('@trycompai/auth', () => ({
@@ -133,6 +138,8 @@ describe('OAuthController', () => {
       ],
     })
       .overrideGuard(HybridAuthGuard)
+      .useValue(mockGuard)
+      .overrideGuard(SessionOnlyGuard)
       .useValue(mockGuard)
       .overrideGuard(PermissionGuard)
       .useValue(mockGuard)

--- a/apps/api/src/integration-platform/controllers/oauth.controller.ts
+++ b/apps/api/src/integration-platform/controllers/oauth.controller.ts
@@ -18,7 +18,7 @@ import { auth } from '../../auth/auth.server';
 import { HybridAuthGuard } from '../../auth/hybrid-auth.guard';
 import { PermissionGuard } from '../../auth/permission.guard';
 import { RequirePermission } from '../../auth/require-permission.decorator';
-import { OrganizationId } from '../../auth/auth-context.decorator';
+import { OrganizationId, UserId } from '../../auth/auth-context.decorator';
 import { OAuthStateRepository } from '../repositories/oauth-state.repository';
 import { ProviderRepository } from '../repositories/provider.repository';
 import { ConnectionRepository } from '../repositories/connection.repository';
@@ -30,7 +30,6 @@ import { getManifest, type OAuthConfig } from '@trycompai/integration-platform';
 
 interface StartOAuthDto {
   providerSlug: string;
-  userId: string;
   redirectUrl?: string;
 }
 
@@ -90,9 +89,10 @@ export class OAuthController {
   @RequirePermission('integration', 'create')
   async startOAuth(
     @OrganizationId() organizationId: string,
+    @UserId() userId: string,
     @Body() body: StartOAuthDto,
   ): Promise<{ authorizationUrl: string }> {
-    const { providerSlug, userId, redirectUrl } = body;
+    const { providerSlug, redirectUrl } = body;
 
     // Get manifest and OAuth config
     const manifest = getManifest(providerSlug);

--- a/apps/api/src/integration-platform/controllers/oauth.controller.ts
+++ b/apps/api/src/integration-platform/controllers/oauth.controller.ts
@@ -17,6 +17,7 @@ import { randomBytes, createHash } from 'crypto';
 import { auth } from '../../auth/auth.server';
 import { HybridAuthGuard } from '../../auth/hybrid-auth.guard';
 import { PermissionGuard } from '../../auth/permission.guard';
+import { SessionOnlyGuard } from '../../auth/session-only.guard';
 import { RequirePermission } from '../../auth/require-permission.decorator';
 import { OrganizationId, UserId } from '../../auth/auth-context.decorator';
 import { OAuthStateRepository } from '../repositories/oauth-state.repository';
@@ -85,7 +86,11 @@ export class OAuthController {
    */
   @Post('start')
   @ApiOperation({ summary: 'Start an OAuth authorization flow' })
-  @UseGuards(HybridAuthGuard, PermissionGuard)
+  // SessionOnlyGuard rejects API-key and service-token callers with a 403
+  // before @UserId() is evaluated. The OAuth callback also requires a real
+  // session (see checkSessionMatchesState), so non-session auth could never
+  // complete the flow anyway.
+  @UseGuards(HybridAuthGuard, SessionOnlyGuard, PermissionGuard)
   @RequirePermission('integration', 'create')
   async startOAuth(
     @OrganizationId() organizationId: string,

--- a/apps/app/src/hooks/use-integration-platform.ts
+++ b/apps/app/src/hooks/use-integration-platform.ts
@@ -216,7 +216,6 @@ export function useIntegrationMutations() {
       const response = await api.post<OAuthStartResponse>('/v1/integrations/oauth/start', {
         providerSlug,
         organizationId: orgId,
-        userId: '', // Will be filled by API from auth context
         redirectUrl,
       });
 


### PR DESCRIPTION
## Summary

- **Production regression fix.** Every OAuth integration flow (GitHub, GCP, AWS, Rippling, Linear, Slack, etc.) is currently broken in prod, redirecting with `error=session_mismatch&error_description=OAuth flow can only be completed by the user who initiated it.`
- The frontend hook posts `userId: ''` with a comment claiming the API will fill it in from the auth context, but `oauth.controller.ts` reads `userId` straight from the request body — so every `IntegrationOAuthState` row is written with an empty string.
- This was harmless until #2712 (yesterday) added a defense-in-depth session check that compares `session.user.id` to `oauthState.userId`. Empty string never matches a real user ID → every flow fails.
- Resolve `userId` via the `@UserId()` decorator, drop the field from `StartOAuthDto`, and stop sending it from the client. The defense-in-depth check from #2712 is preserved and now actually works as intended.

## Why the spec didn't catch it

The new callback tests in #2712 mock `oauthState` directly with `userId: 'user_1'` rather than exercising `startOAuth → callback` end-to-end, so the empty-userId write path was never exposed.

## Scope

Strictly in scope. Verified:
- `IntegrationOAuthState.userId` is read in only two places (the new check at `oauth.controller.ts:475` and a warning log at `:289`) — both will continue working with the real userId.
- The repository (`oauth-state.repository.ts`) only queries by `state` (the random token), never by `userId`.
- No usages in `comp-private`, `apps/portal`, or `apps/framework-editor`.
- Only one caller of `/v1/integrations/oauth/start`: the frontend hook, which is updated here.

## Deploy-order safety

- **API ships first**: old frontends keep working — extra `userId: ''` in the body is ignored, decorator wins.
- **Frontend ships first**: the old API would crash on missing body field — but in practice this monorepo deploys API + app together.
- No data migration needed: in-flight OAuth states with empty userId expire after 10 minutes via `deleteExpired()`.

## Test plan

- [x] `npx jest src/integration-platform/controllers/oauth.controller.spec.ts` — 19/19 passing
- [x] `npx turbo run typecheck --filter=@trycompai/api` — no new errors introduced (177 pre-existing in unrelated files, identical count before/after)
- [x] `npx turbo run typecheck --filter=@trycompai/app` — no new errors introduced
- [ ] Manual smoke test in staging: connect GitHub via OAuth as the same user who initiated the flow → expect success
- [ ] Manual smoke test: confirm session check still rejects when initiating in one browser and completing in another (the security goal of #2712)

🤖 Generated with [Claude Code](https://claude.com/claude-code)