### PR TITLE
fix(frameworks): repair sync drift for controls and tasks

### DIFF
--- a/apps/api/src/frameworks/framework-versioning/framework-sync-apply.spec.ts
+++ b/apps/api/src/frameworks/framework-versioning/framework-sync-apply.spec.ts
@@ -339,6 +339,58 @@ describe('applySync', () => {
     }));
   });
 
+  it('creates missing control row before reconciling RequirementMap drift when v1 and v2 both claim it', async () => {
+    const tx = mockTx();
+    tx.control.create.mockResolvedValue({
+      id: 'ctl_created',
+      controlTemplateId: 'ct_1',
+      organizationId: 'org_1',
+      name: 'C',
+      description: 'D',
+      archivedAt: null,
+    });
+    tx.control.findMany.mockResolvedValue([]);
+    tx.requirementMap.findMany.mockResolvedValue([]);
+
+    const sameControl = { id: 'ct_1', name: 'C', description: 'D', requirementIds: ['rq_1'], policyIds: [], taskIds: [] };
+    await applySync(tx, {
+      instance: baseInstance as any,
+      currentVersion: {
+        id: 'fvr_v1',
+        frameworkId: 'frk_soc2',
+        manifest: manifest({
+          requirements: [{ id: 'rq_1', identifier: 'CC1', name: 'X', description: null }],
+          controls: [sameControl],
+        }),
+      } as any,
+      targetVersion: {
+        id: 'fvr_v2',
+        frameworkId: 'frk_soc2',
+        manifest: manifest({
+          requirements: [{ id: 'rq_1', identifier: 'CC1', name: 'X', description: null }],
+          controls: [sameControl],
+        }),
+      } as any,
+      memberId: 'mem_1',
+    });
+
+    expect(tx.control.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        organizationId: 'org_1',
+        controlTemplateId: 'ct_1',
+        name: 'C',
+        description: 'D',
+      }),
+    }));
+    expect(tx.requirementMap.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        controlId: 'ctl_created',
+        requirementId: 'rq_1',
+        frameworkInstanceId: 'frm_1',
+      }),
+    }));
+  });
+
   it('unarchives an existing archived RequirementMap row instead of creating a duplicate', async () => {
     const tx = mockTx();
     tx.control.findMany.mockResolvedValue([
@@ -412,6 +464,54 @@ describe('applySync', () => {
     const calls = tx.$executeRaw.mock.calls.map((c: unknown[]) => String(c[0]?.[0] ?? ''));
     const cpInsertCalled = calls.some((s: string) => s.includes('INSERT INTO "_ControlToPolicy"'));
     expect(cpInsertCalled).toBe(true);
+  });
+
+  it('creates missing task row before reconciling _ControlToTask drift when v1 and v2 both claim it', async () => {
+    const tx = mockTx();
+    tx.control.findMany.mockResolvedValue([
+      { id: 'ctl_1', controlTemplateId: 'ct_1', organizationId: 'org_1', name: 'C', description: 'D', archivedAt: null },
+    ]);
+    tx.task.findMany.mockResolvedValue([]);
+    tx.task.create.mockResolvedValue({
+      id: 'tsk_created',
+      taskTemplateId: 'tt_1',
+      organizationId: 'org_1',
+      title: 'T',
+      description: 'D',
+      frequency: null,
+      department: null,
+      archivedAt: null,
+    });
+    tx.$queryRaw.mockResolvedValue([]);
+
+    const sameControl = { id: 'ct_1', name: 'C', description: 'D', requirementIds: [], policyIds: [], taskIds: ['tt_1'] };
+    const sameTask = { id: 'tt_1', name: 'T', description: 'D', frequency: null, department: null };
+    await applySync(tx, {
+      instance: baseInstance as any,
+      currentVersion: {
+        id: 'fvr_v1',
+        frameworkId: 'frk_soc2',
+        manifest: manifest({ controls: [sameControl], tasks: [sameTask] }),
+      } as any,
+      targetVersion: {
+        id: 'fvr_v2',
+        frameworkId: 'frk_soc2',
+        manifest: manifest({ controls: [sameControl], tasks: [sameTask] }),
+      } as any,
+      memberId: 'mem_1',
+    });
+
+    expect(tx.task.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        organizationId: 'org_1',
+        taskTemplateId: 'tt_1',
+        title: 'T',
+        description: 'D',
+      }),
+    }));
+    const calls = tx.$executeRaw.mock.calls.map((c: unknown[]) => String(c[0]?.[0] ?? ''));
+    const ctInsertCalled = calls.some((s: string) => s.includes('INSERT INTO "_ControlToTask"'));
+    expect(ctInsertCalled).toBe(true);
   });
 
   it('creates missing ControlDocumentType row when v1 and v2 both claim it but customer has no row (drift)', async () => {

--- a/apps/api/src/frameworks/framework-versioning/framework-sync-apply.ts
+++ b/apps/api/src/frameworks/framework-versioning/framework-sync-apply.ts
@@ -67,17 +67,17 @@ export async function applySync(
   };
 
   // --- Controls ---
-  for (const added of diff.controls.added) {
-    if (ctlByTemplate.has(added.id)) continue;
+  for (const targetControl of to.controls) {
+    if (ctlByTemplate.has(targetControl.id)) continue;
     const created = await tx.control.create({
       data: {
         organizationId: ctx.instance.organizationId,
-        controlTemplateId: added.id,
-        name: added.name,
-        description: added.description,
+        controlTemplateId: targetControl.id,
+        name: targetControl.name,
+        description: targetControl.description,
       },
     });
-    ctlByTemplate.set(added.id, created);
+    ctlByTemplate.set(targetControl.id, created);
     undo.controls.created.push(created.id);
     summary.controlsAdded += 1;
   }
@@ -103,19 +103,19 @@ export async function applySync(
   }
 
   // --- Tasks ---
-  for (const added of diff.tasks.added) {
-    if (taskByTemplate.has(added.id)) continue;
+  for (const targetTask of to.tasks) {
+    if (taskByTemplate.has(targetTask.id)) continue;
     const created = await tx.task.create({
       data: {
         organizationId: ctx.instance.organizationId,
-        taskTemplateId: added.id,
-        title: added.name,
-        description: added.description,
-        frequency: added.frequency as Frequency | null,
-        department: added.department as Departments | null,
+        taskTemplateId: targetTask.id,
+        title: targetTask.name,
+        description: targetTask.description,
+        frequency: targetTask.frequency as Frequency | null,
+        department: targetTask.department as Departments | null,
       },
     });
-    taskByTemplate.set(added.id, created);
+    taskByTemplate.set(targetTask.id, created);
     undo.tasks.created.push(created.id);
     summary.tasksAdded += 1;
   }


### PR DESCRIPTION
## Summary
- ensure framework sync creates missing org control rows from the target manifest before reconciling requirement maps
- ensure framework sync creates missing org task rows from the target manifest before reconciling control-task links
- add regression coverage for older-account drift where v1/v2 manifests claim rows that the customer DB is missing

## Tests
- cd apps/api && bunx jest src/frameworks/framework-versioning/framework-sync-apply.spec.ts --passWithNoTests
- cd apps/api && bunx jest src/frameworks/framework-versioning --passWithNoTests

Fixes CS-334