### PR TITLE
fix(cloud-tests): scope to aws/gcp/azure and remove hardcoded copy

### DIFF
--- a/apps/api/src/cloud-security/cloud-security-query.service.ts
+++ b/apps/api/src/cloud-security/cloud-security-query.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { db } from '@db';
 import { getManifest } from '@trycompai/integration-platform';
 
-const CLOUD_PROVIDER_CATEGORY = 'Cloud';
+const CLOUD_PROVIDER_SLUGS = ['aws', 'gcp', 'azure'] as const;
 
 /** Scan window for filtering legacy results to latest scan only */
 const SCAN_WINDOW_MS = 10 * 60 * 1000; // 10 minutes
@@ -88,7 +88,7 @@ export class CloudSecurityQueryService {
       where: {
         organizationId,
         status: 'active',
-        provider: { category: CLOUD_PROVIDER_CATEGORY },
+        provider: { slug: { in: [...CLOUD_PROVIDER_SLUGS] } },
       },
       include: { provider: true },
     });
@@ -98,10 +98,9 @@ export class CloudSecurityQueryService {
       where: { organizationId },
     });
 
-    const activeLegacy = legacyIntegrations.filter((i) => {
-      const manifest = getManifest(i.integrationId);
-      return manifest?.category === CLOUD_PROVIDER_CATEGORY;
-    });
+    const activeLegacy = legacyIntegrations.filter((i) =>
+      (CLOUD_PROVIDER_SLUGS as readonly string[]).includes(i.integrationId),
+    );
 
     // Map new connections
     const newProviders: CloudProvider[] = newConnections.map((conn) => {
@@ -207,7 +206,7 @@ export class CloudSecurityQueryService {
       where: {
         organizationId,
         status: 'active',
-        provider: { category: CLOUD_PROVIDER_CATEGORY },
+        provider: { slug: { in: [...CLOUD_PROVIDER_SLUGS] } },
       },
       include: { provider: true },
     });
@@ -303,10 +302,9 @@ export class CloudSecurityQueryService {
       where: { organizationId },
     });
 
-    const activeLegacy = legacyIntegrations.filter((i) => {
-      const manifest = getManifest(i.integrationId);
-      return manifest?.category === CLOUD_PROVIDER_CATEGORY;
-    });
+    const activeLegacy = legacyIntegrations.filter((i) =>
+      (CLOUD_PROVIDER_SLUGS as readonly string[]).includes(i.integrationId),
+    );
 
     const legacyIds = activeLegacy.map((i) => i.id);
     if (legacyIds.length === 0) return [];

--- a/apps/app/src/app/(app)/[orgId]/integrations/components/PlatformIntegrations.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/components/PlatformIntegrations.tsx
@@ -659,12 +659,6 @@ export function PlatformIntegrations({ className, taskTemplates }: PlatformInteg
                           {provider.description}
                         </CardDescription>
 
-                        {provider.category === 'Cloud' && (
-                          <p className="text-xs text-muted-foreground italic">
-                            This integration is used exclusively for Cloud Security Tests.
-                          </p>
-                        )}
-
                         {/* Mapped tasks */}
                         {provider.mappedTasks && provider.mappedTasks.length > 0 && (
                           <div className="flex flex-wrap gap-1.5">

--- a/apps/app/src/components/integrations/ConnectIntegrationDialog.tsx
+++ b/apps/app/src/components/integrations/ConnectIntegrationDialog.tsx
@@ -555,11 +555,6 @@ export function ConnectIntegrationDialog({
                 <p className="whitespace-pre-wrap text-xs break-words">{provider.setupInstructions}</p>
               </div>
             )}
-            {provider?.category === 'Cloud' && !provider?.setupScript && (
-              <div className="text-xs text-muted-foreground bg-muted/50 p-3 rounded-md">
-                This integration will only be used for Cloud Security Tests. Your credentials are encrypted and used exclusively to run read-only security scans.
-              </div>
-            )}
             {allFields
               .filter((field) => {
                 if (!provider?.setupScript) return true;


### PR DESCRIPTION
## Summary
- Cloud Tests page previously included any integration with manifest `category: 'Cloud'`, which leaked Vercel into the providers list and findings. Filter by an explicit slug allowlist (`aws`, `gcp`, `azure`) in the API service so only real cloud providers are returned.
- Remove two hardcoded copy blocks ("This integration is used exclusively for Cloud Security Tests" / "...will only be used for Cloud Security Tests...") that were gated on the same broken category check and incorrectly appeared on Vercel as well.

## Files changed
- `apps/api/src/cloud-security/cloud-security-query.service.ts` — replace `category: 'Cloud'` filter with `slug IN ('aws','gcp','azure')` for both new-platform connections and legacy integrations, in both providers and findings queries.
- `apps/app/src/app/(app)/[orgId]/integrations/components/PlatformIntegrations.tsx` — remove the italic "exclusively for Cloud Security Tests" line on integration cards.
- `apps/app/src/components/integrations/ConnectIntegrationDialog.tsx` — remove the same notice from the connect dialog.

## Test plan
- [ ] Cloud Tests page shows only AWS, GCP, Azure provider tiles.
- [ ] Cloud Tests findings list shows only findings from those three providers (no Vercel).
- [ ] Vercel still appears on the main Integrations page (under Cloud category) and connects normally.
- [ ] Integration cards no longer display the "exclusively for Cloud Security Tests" subtitle.
- [ ] Connect dialog for AWS/GCP/Azure no longer shows the "credentials are encrypted..." notice.
- [ ] Existing AWS/GCP/Azure connections continue to surface providers and findings as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)