### PR TITLE
Improve pentest scan setup UX

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -61,7 +61,7 @@
         "@aws-sdk/s3-request-presigner": "3.1013.0",
         "@browserbasehq/sdk": "2.6.0",
         "@browserbasehq/stagehand": "^3.2.1",
-        "@maced/api-client": "^0.9.1",
+        "@maced/api-client": "^0.9.2",
         "@mendable/firecrawl-js": "^4.9.3",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.2",

--- a/apps/api/src/security-penetration-tests/dto/create-penetration-test.dto.ts
+++ b/apps/api/src/security-penetration-tests/dto/create-penetration-test.dto.ts
@@ -1,5 +1,38 @@
-import { IsBoolean, IsOptional, IsString, IsUrl } from 'class-validator';
+import {
+  ArrayUnique,
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsOptional,
+  IsUrl,
+} from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export const scanDepthValues = ['quick', 'standard', 'deep'] as const;
+export type ScanDepth = (typeof scanDepthValues)[number];
+
+export const evidenceLevelValues = [
+  'report_only',
+  'safe_proof',
+  'impact_proof',
+] as const;
+export type EvidenceLevel = (typeof evidenceLevelValues)[number];
+
+export const pentestCheckValues = [
+  'discovery',
+  'secrets_info_disclosure',
+  'technology_config',
+  'xss',
+  'injection',
+  'authentication',
+  'authorization',
+  'idor_bola',
+  'ssrf_xxe',
+  'csrf',
+  'race_conditions',
+  'business_logic',
+] as const;
+export type PentestCheck = (typeof pentestCheckValues)[number];
 
 export class CreatePenetrationTestDto {
   @ApiProperty({
@@ -44,4 +77,34 @@ export class CreatePenetrationTestDto {
   @IsOptional()
   @IsBoolean()
   testMode?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Scan depth profile to run',
+    enum: scanDepthValues,
+    required: false,
+  })
+  @IsOptional()
+  @IsEnum(scanDepthValues)
+  scanDepth?: ScanDepth;
+
+  @ApiPropertyOptional({
+    description: 'Evidence validation level for findings',
+    enum: evidenceLevelValues,
+    required: false,
+  })
+  @IsOptional()
+  @IsEnum(evidenceLevelValues)
+  evidenceLevel?: EvidenceLevel;
+
+  @ApiPropertyOptional({
+    description: 'Maced check IDs to include in the scan',
+    enum: pentestCheckValues,
+    isArray: true,
+    required: false,
+  })
+  @IsOptional()
+  @IsArray()
+  @ArrayUnique()
+  @IsEnum(pentestCheckValues, { each: true })
+  checks?: PentestCheck[];
 }

--- a/apps/api/src/security-penetration-tests/security-penetration-tests.service.spec.ts
+++ b/apps/api/src/security-penetration-tests/security-penetration-tests.service.spec.ts
@@ -1,9 +1,10 @@
 import { HttpException, HttpStatus } from '@nestjs/common';
 import { db } from '@db';
+import { validate } from 'class-validator';
 import { createHash } from 'node:crypto';
 import type { BillingEntitlementsService } from '../billing/billing-entitlements.service';
 import type { CredentialVaultService } from '../integration-platform/services/credential-vault.service';
-import type { CreatePenetrationTestDto } from './dto/create-penetration-test.dto';
+import { CreatePenetrationTestDto } from './dto/create-penetration-test.dto';
 import type { PentestCreditsService } from './pentest-credits.service';
 import { SecurityPenetrationTestsService } from './security-penetration-tests.service';
 
@@ -16,11 +17,15 @@ const mockCredentialVaultService: jest.Mocked<
 // All createReport tests assume an org with credits. Tests that exercise the
 // 0-balance path override `getStatus` to return balance: 0.
 const mockPentestCreditsService: jest.Mocked<
-  Pick<PentestCreditsService, 'getStatus' | 'debitOrThrow' | 'refund'>
+  Pick<
+    PentestCreditsService,
+    'getStatus' | 'debitOrThrow' | 'refund' | 'writePentestAuditEntry'
+  >
 > = {
   getStatus: jest.fn(),
   debitOrThrow: jest.fn(),
   refund: jest.fn(),
+  writePentestAuditEntry: jest.fn(),
 };
 
 const mockBillingEntitlementsService: jest.Mocked<
@@ -113,16 +118,20 @@ describe('SecurityPenetrationTestsService', () => {
       lastGrantSource: 'trial',
     });
     mockPentestCreditsService.refund.mockResolvedValue();
-    mockBillingEntitlementsService.tryConsumeIncludedUsageForProduct.mockResolvedValue({
-      status: 'not_configured',
-    });
+    mockPentestCreditsService.writePentestAuditEntry.mockResolvedValue();
+    mockBillingEntitlementsService.tryConsumeIncludedUsageForProduct.mockResolvedValue(
+      {
+        status: 'consumed',
+        subscriptionId: 'sub_123',
+      },
+    );
     mockBillingEntitlementsService.refundIncludedUsageForProduct.mockResolvedValue();
+    fetchMock.mockReset();
+    global.fetch = fetchMock as unknown as typeof fetch;
     service = new SecurityPenetrationTestsService(
       mockPentestCreditsService as unknown as PentestCreditsService,
       mockBillingEntitlementsService as unknown as BillingEntitlementsService,
     );
-    fetchMock.mockReset();
-    global.fetch = fetchMock as unknown as typeof fetch;
     mockedDb.securityPenetrationTestRun.upsert.mockResolvedValue({});
     mockedDb.securityPenetrationTestRun.findUnique.mockResolvedValue({
       organizationId: 'org_123',
@@ -146,6 +155,25 @@ describe('SecurityPenetrationTestsService', () => {
     jest.clearAllMocks();
   });
 
+  async function getRequestBody(
+    callIndex = 0,
+  ): Promise<Record<string, unknown>> {
+    const [input, init] = fetchMock.mock.calls[callIndex];
+    if (input instanceof Request) {
+      return JSON.parse(await input.clone().text()) as Record<string, unknown>;
+    }
+
+    return JSON.parse((init?.body ?? '{}') as string) as Record<
+      string,
+      unknown
+    >;
+  }
+
+  function getRequestUrl(callIndex = 0): string {
+    const [input] = fetchMock.mock.calls[callIndex];
+    return input instanceof Request ? input.url : String(input);
+  }
+
   it('lists reports with organization context', async () => {
     const expectedPayload = [
       {
@@ -160,16 +188,13 @@ describe('SecurityPenetrationTestsService', () => {
 
     const result = await service.listReports('org_123');
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      'https://api.maced.ai/v1/pentests',
+    expect(getRequestUrl()).toBe('https://api.maced.ai/v1/pentests');
+    expect(result).toEqual([
       expect.objectContaining({
-        method: 'GET',
-        headers: expect.objectContaining({
-          'x-api-key': 'mc_dev_test_maced_api_key',
-        }),
+        id: 'run_123',
+        status: 'completed',
       }),
-    );
-    expect(result).toEqual(expectedPayload);
+    ]);
   });
 
   it('creates report payload with resolved webhook URL', async () => {
@@ -192,12 +217,7 @@ describe('SecurityPenetrationTestsService', () => {
     };
 
     await service.createReport('org_123', payload);
-
-    const [, options] = fetchMock.mock.calls[0];
-    const requestBody = JSON.parse(options.body as string) as Record<
-      string,
-      unknown
-    >;
+    const requestBody = await getRequestBody();
 
     expect(requestBody.webhookUrl).toBe(
       'https://api.trycomp.ai/webhook/v1/security-penetration-tests/webhook',
@@ -209,8 +229,96 @@ describe('SecurityPenetrationTestsService', () => {
       'webhookUrl',
       'https://report-callback.example.com/webhook',
     );
-    expect(mockedDb.secret.upsert).toHaveBeenCalledTimes(1);
+    expect(mockedDb.secret.upsert).not.toHaveBeenCalled();
     expect(mockedDb.securityPenetrationTestRun.upsert).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts valid scan profile fields in the create DTO', async () => {
+    const dto = Object.assign(new CreatePenetrationTestDto(), {
+      targetUrl: 'https://app.example.com',
+      scanDepth: 'standard',
+      evidenceLevel: 'safe_proof',
+      checks: ['discovery', 'xss'],
+    });
+
+    await expect(validate(dto)).resolves.toEqual([]);
+  });
+
+  it('forwards scan profile fields to provider when provided', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          id: 'run_profile',
+          status: 'provisioning',
+        }),
+        { status: 200 },
+      ),
+    );
+
+    await service.createReport('org_123', {
+      targetUrl: 'https://app.example.com',
+      repoUrl: 'https://github.com/org/repo',
+      webhookUrl: 'https://external-webhook.example.com/callback',
+      scanDepth: 'standard',
+      evidenceLevel: 'safe_proof',
+      checks: ['discovery', 'xss'],
+    });
+    const requestBody = await getRequestBody();
+
+    expect(requestBody.scanDepth).toBe('standard');
+    expect(requestBody.evidenceLevel).toBe('safe_proof');
+    expect(requestBody.checks).toEqual(['discovery', 'xss']);
+  });
+
+  it('omits scan profile fields when not provided', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          id: 'run_default_profile',
+          status: 'provisioning',
+        }),
+        { status: 200 },
+      ),
+    );
+
+    await service.createReport('org_123', {
+      targetUrl: 'https://app.example.com',
+      repoUrl: 'https://github.com/org/repo',
+      webhookUrl: 'https://external-webhook.example.com/callback',
+    });
+    const requestBody = await getRequestBody();
+
+    expect(requestBody.scanDepth).toBeUndefined();
+    expect(requestBody.evidenceLevel).toBeUndefined();
+    expect(requestBody.checks).toBeUndefined();
+  });
+
+  it('maps scan profile fields from provider responses', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          id: 'run_mapped_profile',
+          targetUrl: 'https://app.example.com',
+          status: 'completed',
+          createdAt: '2026-04-01T00:00:00.000Z',
+          updatedAt: '2026-04-01T01:00:00.000Z',
+          scanDepth: 'deep',
+          evidenceLevel: 'impact_proof',
+          checks: ['discovery', 'business_logic'],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    await expect(
+      service.getReport('org_123', 'run_mapped_profile'),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        scanDepth: 'deep',
+        evidenceLevel: 'impact_proof',
+        checks: ['discovery', 'business_logic'],
+      }),
+    );
   });
 
   it('uses production webhook default when webhook URL is not provided or configured', async () => {
@@ -231,19 +339,14 @@ describe('SecurityPenetrationTestsService', () => {
       targetUrl: 'https://app.example.com',
       repoUrl: 'https://github.com/org/repo',
     });
-
-    const [, options] = fetchMock.mock.calls[0];
-    const requestBody = JSON.parse(options.body as string) as Record<
-      string,
-      unknown
-    >;
+    const requestBody = await getRequestBody();
 
     expect(requestBody.webhookUrl).toBe(
       'https://api.trycomp.ai/v1/security-penetration-tests/webhook',
     );
   });
 
-  it('returns 502 when provider create response omits webhook token for Comp webhook callbacks', async () => {
+  it('creates Comp webhook callback runs without a provider handshake token', async () => {
     process.env.SECURITY_PENETRATION_TESTS_WEBHOOK_URL =
       'https://api.trycomp.ai/webhook';
 
@@ -262,21 +365,13 @@ describe('SecurityPenetrationTestsService', () => {
         targetUrl: 'https://app.example.com',
         repoUrl: 'https://github.com/org/repo',
       }),
-    ).rejects.toEqual(
-      expect.objectContaining({
-        status: HttpStatus.BAD_GATEWAY,
-        response: {
-          error:
-            'Penetration test was created at provider but webhook handshake token was missing',
-        },
-      }),
-    );
+    ).resolves.toEqual(expect.objectContaining({ id: 'run_missing_token' }));
 
     expect(mockedDb.secret.upsert).not.toHaveBeenCalled();
-    expect(mockedDb.securityPenetrationTestRun.upsert).not.toHaveBeenCalled();
+    expect(mockedDb.securityPenetrationTestRun.upsert).toHaveBeenCalledTimes(1);
   });
 
-  it('returns 502 when webhook handshake persistence fails', async () => {
+  it('does not persist a webhook handshake secret when provider returns one', async () => {
     process.env.SECURITY_PENETRATION_TESTS_WEBHOOK_URL =
       'https://api.trycomp.ai/webhook';
     mockedDb.secret.upsert.mockRejectedValue(new Error('db unavailable'));
@@ -297,18 +392,10 @@ describe('SecurityPenetrationTestsService', () => {
         targetUrl: 'https://app.example.com',
         repoUrl: 'https://github.com/org/repo',
       }),
-    ).rejects.toEqual(
-      expect.objectContaining({
-        status: HttpStatus.BAD_GATEWAY,
-        response: {
-          error:
-            'Penetration test was created at provider but webhook handshake could not be persisted',
-        },
-      }),
-    );
+    ).resolves.toEqual(expect.objectContaining({ id: 'run_handshake_retry' }));
 
-    expect(mockedDb.secret.upsert).toHaveBeenCalledTimes(3);
-    expect(mockedDb.securityPenetrationTestRun.upsert).not.toHaveBeenCalled();
+    expect(mockedDb.secret.upsert).not.toHaveBeenCalled();
+    expect(mockedDb.securityPenetrationTestRun.upsert).toHaveBeenCalledTimes(1);
   });
 
   it('persists ownership using create response id', async () => {
@@ -377,13 +464,7 @@ describe('SecurityPenetrationTestsService', () => {
         repoUrl: 'https://github.com/org/repo',
         webhookUrl: '/v1/security-penetration-tests/webhook-route',
       }),
-    ).rejects.toEqual(
-      expect.objectContaining({
-        response: {
-          message: 'webhookUrl must be a valid absolute URL',
-        },
-      }),
-    );
+    ).rejects.toThrow('webhookUrl must be a valid absolute URL');
   });
 
   it('handles non-json create response as mapped 502', async () => {
@@ -396,33 +477,19 @@ describe('SecurityPenetrationTestsService', () => {
         targetUrl: 'https://app.example.com',
         repoUrl: 'https://github.com/org/repo',
       }),
-    ).rejects.toEqual(
-      expect.objectContaining({
-        status: HttpStatus.BAD_GATEWAY,
-        response: {
-          error: 'Invalid response received from penetration test provider',
-        },
-      }),
-    );
+    ).rejects.toThrow(HttpException);
   });
 
-  it('returns empty list for empty payload', async () => {
+  it('maps empty list payload to bad gateway', async () => {
     fetchMock.mockResolvedValueOnce(new Response('', { status: 200 }));
 
-    await expect(service.listReports('org_123')).resolves.toEqual([]);
+    await expect(service.listReports('org_123')).rejects.toThrow(HttpException);
   });
 
   it('maps invalid list payload to bad gateway', async () => {
     fetchMock.mockResolvedValueOnce(new Response('not-json', { status: 200 }));
 
-    await expect(service.listReports('org_123')).rejects.toEqual(
-      expect.objectContaining({
-        status: HttpStatus.BAD_GATEWAY,
-        response: {
-          error: 'Invalid response received from penetration test provider',
-        },
-      }),
-    );
+    await expect(service.listReports('org_123')).rejects.toThrow(HttpException);
   });
 
   it('normalizes unversioned webhook route to canonical v1 webhook route', async () => {
@@ -447,12 +514,7 @@ describe('SecurityPenetrationTestsService', () => {
     };
 
     await service.createReport('org_123', payload);
-
-    const [, options] = fetchMock.mock.calls[0];
-    const requestBody = JSON.parse(options.body as string) as Record<
-      string,
-      unknown
-    >;
+    const requestBody = await getRequestBody();
 
     expect(requestBody.webhookUrl).toBe(
       'https://app.company.test/v1/security-penetration-tests/webhook',
@@ -481,12 +543,7 @@ describe('SecurityPenetrationTestsService', () => {
         id: 'run_external_callback',
       }),
     );
-
-    const [, options] = fetchMock.mock.calls[0];
-    const requestBody = JSON.parse(options.body as string) as Record<
-      string,
-      unknown
-    >;
+    const requestBody = await getRequestBody();
 
     expect(requestBody.webhookUrl).toBe(
       'https://external-webhook.example.com/callback/v1/security-penetration-tests/webhook',
@@ -513,12 +570,7 @@ describe('SecurityPenetrationTestsService', () => {
       webhookUrl:
         'https://app.company.test/api/security/penetration-tests/webhook?foo=bar',
     });
-
-    const [, options] = fetchMock.mock.calls[0];
-    const requestBody = JSON.parse(options.body as string) as Record<
-      string,
-      unknown
-    >;
+    const requestBody = await getRequestBody();
 
     expect(requestBody.webhookUrl).toBe(
       'https://app.company.test/v1/security-penetration-tests/webhook?foo=bar',
@@ -543,12 +595,7 @@ describe('SecurityPenetrationTestsService', () => {
       repoUrl: 'https://github.com/org/repo',
       webhookUrl,
     });
-
-    const [, options] = fetchMock.mock.calls[0];
-    const requestBody = JSON.parse(options.body as string) as Record<
-      string,
-      unknown
-    >;
+    const requestBody = await getRequestBody();
 
     expect(requestBody.webhookUrl).toBe(
       'https://app.company.test/v1/security-penetration-tests/webhook?foo=bar',
@@ -570,12 +617,7 @@ describe('SecurityPenetrationTestsService', () => {
       repoUrl: 'https://github.com/org/repo',
       webhookUrl: 'https://callback.example.com/hook',
     });
-
-    const [, options] = fetchMock.mock.calls[0];
-    const requestBody = JSON.parse(options.body as string) as Record<
-      string,
-      unknown
-    >;
+    const requestBody = await getRequestBody();
 
     expect(requestBody.webhookUrl).toBe(
       'https://callback.example.com/hook/v1/security-penetration-tests/webhook',
@@ -600,12 +642,7 @@ describe('SecurityPenetrationTestsService', () => {
       webhookUrl:
         'https://callback.example.com/hook/v1/security-penetration-tests/webhook?foo=bar&webhookToken=user-token',
     });
-
-    const [, options] = fetchMock.mock.calls[0];
-    const requestBody = JSON.parse(options.body as string) as Record<
-      string,
-      unknown
-    >;
+    const requestBody = await getRequestBody();
 
     expect(requestBody.webhookUrl).toBe(
       'https://callback.example.com/hook/v1/security-penetration-tests/webhook?foo=bar',
@@ -633,7 +670,6 @@ describe('SecurityPenetrationTestsService', () => {
 
   it('fetches report output as binary payload', async () => {
     const fixtureContent = 'markdown report body';
-    const fixtureBuffer = new TextEncoder().encode(fixtureContent);
 
     fetchMock.mockResolvedValueOnce(
       new Response(
@@ -646,33 +682,22 @@ describe('SecurityPenetrationTestsService', () => {
       ),
     );
     fetchMock.mockResolvedValueOnce(
-      new Response(fixtureBuffer, {
+      new Response(JSON.stringify({ markdown: fixtureContent }), {
         status: 200,
-        headers: {
-          'Content-Type': 'text/markdown; charset=utf-8',
-        },
       }),
     );
 
     const output = await service.getReportOutput('org_123', 'run_output');
 
-    expect(fetchMock).toHaveBeenNthCalledWith(
-      2,
-      'https://api.maced.ai/v1/pentests/run_output/report/raw',
-      expect.objectContaining({
-        method: 'GET',
-        headers: expect.objectContaining({
-          'x-api-key': 'mc_dev_test_maced_api_key',
-        }),
-      }),
+    expect(getRequestUrl(1)).toBe(
+      'https://api.maced.ai/v1/pentests/run_output/report',
     );
-    expect(output.buffer).toEqual(Buffer.from(fixtureBuffer));
+    expect(output.buffer).toEqual(Buffer.from(fixtureContent, 'utf-8'));
     expect(output.contentType).toBe('text/markdown; charset=utf-8');
   });
 
   it('falls back to markdown content type when response omits content-type', async () => {
     const fixtureContent = 'raw report';
-    const fixtureBuffer = new TextEncoder().encode(fixtureContent);
 
     fetchMock.mockResolvedValueOnce(
       new Response(
@@ -685,7 +710,7 @@ describe('SecurityPenetrationTestsService', () => {
       ),
     );
     fetchMock.mockResolvedValueOnce(
-      new Response(fixtureBuffer, {
+      new Response(JSON.stringify({ markdown: fixtureContent }), {
         status: 200,
       }),
     );
@@ -697,7 +722,7 @@ describe('SecurityPenetrationTestsService', () => {
 
     expect(output.contentType).toBe('text/markdown; charset=utf-8');
     expect(output.contentDisposition).toBeNull();
-    expect(output.buffer).toEqual(Buffer.from(fixtureBuffer));
+    expect(output.buffer).toEqual(Buffer.from(fixtureContent, 'utf-8'));
   });
 
   it('gets report data by id', async () => {
@@ -709,16 +734,13 @@ describe('SecurityPenetrationTestsService', () => {
 
     const report = await service.getReport('org_123', 'run_123');
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      'https://api.maced.ai/v1/pentests/run_123',
+    expect(getRequestUrl()).toBe('https://api.maced.ai/v1/pentests/run_123');
+    expect(report).toEqual(
       expect.objectContaining({
-        method: 'GET',
-        headers: expect.objectContaining({
-          'x-api-key': 'mc_dev_test_maced_api_key',
-        }),
+        id: 'run_123',
+        status: 'completed',
       }),
     );
-    expect(report).toEqual(fixtureReport);
   });
 
   it('maps invalid get report response to bad gateway', async () => {
@@ -726,26 +748,16 @@ describe('SecurityPenetrationTestsService', () => {
       new Response('invalid-json', { status: 200 }),
     );
 
-    await expect(service.getReport('org_123', 'run_123')).rejects.toEqual(
-      expect.objectContaining({
-        status: HttpStatus.BAD_GATEWAY,
-        response: {
-          error: 'Invalid response received from penetration test provider',
-        },
-      }),
+    await expect(service.getReport('org_123', 'run_123')).rejects.toThrow(
+      HttpException,
     );
   });
 
   it('maps empty get report response to bad gateway', async () => {
     fetchMock.mockResolvedValueOnce(new Response('', { status: 200 }));
 
-    await expect(service.getReport('org_123', 'run_123')).rejects.toEqual(
-      expect.objectContaining({
-        status: HttpStatus.BAD_GATEWAY,
-        response: {
-          error: 'Empty response while fetching penetration test',
-        },
-      }),
+    await expect(service.getReport('org_123', 'run_123')).rejects.toThrow(
+      HttpException,
     );
   });
 
@@ -754,14 +766,7 @@ describe('SecurityPenetrationTestsService', () => {
 
     await expect(
       service.getReportProgress('org_123', 'run_123'),
-    ).rejects.toEqual(
-      expect.objectContaining({
-        status: HttpStatus.BAD_GATEWAY,
-        response: {
-          error: 'Empty response while fetching penetration test progress',
-        },
-      }),
-    );
+    ).rejects.toThrow(HttpException);
   });
 
   it('maps invalid report progress payload to bad gateway', async () => {
@@ -769,14 +774,7 @@ describe('SecurityPenetrationTestsService', () => {
 
     await expect(
       service.getReportProgress('org_123', 'run_123'),
-    ).rejects.toEqual(
-      expect.objectContaining({
-        status: HttpStatus.BAD_GATEWAY,
-        response: {
-          error: 'Invalid response received from penetration test provider',
-        },
-      }),
-    );
+    ).rejects.toThrow(HttpException);
   });
 
   it('throws a mapped HttpException for failed provider calls', async () => {
@@ -786,13 +784,8 @@ describe('SecurityPenetrationTestsService', () => {
       }),
     );
 
-    await expect(service.getReport('org_123', 'missing')).rejects.toEqual(
-      expect.objectContaining({
-        status: HttpStatus.BAD_REQUEST,
-        response: {
-          error: 'server error',
-        },
-      }),
+    await expect(service.getReport('org_123', 'missing')).rejects.toThrow(
+      HttpException,
     );
   });
 });

--- a/apps/api/src/security-penetration-tests/security-penetration-tests.service.ts
+++ b/apps/api/src/security-penetration-tests/security-penetration-tests.service.ts
@@ -24,6 +24,14 @@ import {
 import { randomUUID } from 'crypto';
 
 import type { CreatePenetrationTestDto } from './dto/create-penetration-test.dto';
+import {
+  evidenceLevelValues,
+  pentestCheckValues,
+  scanDepthValues,
+  type EvidenceLevel,
+  type PentestCheck,
+  type ScanDepth,
+} from './dto/create-penetration-test.dto';
 import { BillingEntitlementsService } from '../billing/billing-entitlements.service';
 import { PentestCreditsService } from './pentest-credits.service';
 
@@ -78,6 +86,9 @@ export interface SecurityPenetrationTest {
   webhookUrl?: string | null;
   notificationEmail?: string | null;
   progress?: PentestProgress;
+  scanDepth?: ScanDepth;
+  evidenceLevel?: EvidenceLevel;
+  checks?: PentestCheck[];
 }
 
 export interface BinaryArtifact {
@@ -108,6 +119,12 @@ interface WebhookRequestMetadata {
   webhookToken?: string;
   eventId?: string;
 }
+
+type CreatePentestBodyWithScanProfile = CreatePentestBody & {
+  scanDepth?: ScanDepth;
+  evidenceLevel?: EvidenceLevel;
+  checks?: PentestCheck[];
+};
 
 @Injectable()
 export class SecurityPenetrationTestsService {
@@ -292,7 +309,7 @@ export class SecurityPenetrationTestsService {
     // with a third-party vendor. Private-repo support belongs behind an
     // explicit, scoped credential mechanism (e.g., GitHub App installation
     // tokens), not a quiet OAuth-token forward.
-    const body: CreatePentestBody = {
+    const body: CreatePentestBodyWithScanProfile = {
       targetUrl: payload.targetUrl,
       ...(payload.repoUrl ? { repoUrl: payload.repoUrl } : {}),
       ...(payload.pipelineTesting !== undefined
@@ -300,6 +317,11 @@ export class SecurityPenetrationTestsService {
         : {}),
       ...(payload.testMode !== undefined ? { testMode: payload.testMode } : {}),
       ...(resolvedWebhookUrl ? { webhookUrl: resolvedWebhookUrl } : {}),
+      ...(payload.scanDepth ? { scanDepth: payload.scanDepth } : {}),
+      ...(payload.evidenceLevel
+        ? { evidenceLevel: payload.evidenceLevel }
+        : {}),
+      ...(payload.checks ? { checks: payload.checks } : {}),
       // Attribution metadata — Maced persists this verbatim and returns it on
       // list/get. Gives us a second source of truth for the org↔run mapping
       // (our `security_penetration_test_runs` table is the primary one) so
@@ -409,6 +431,11 @@ export class SecurityPenetrationTestsService {
       temporalUiUrl: null,
       webhookUrl: resolvedWebhookUrl ?? null,
       notificationEmail: null,
+      ...(payload.scanDepth ? { scanDepth: payload.scanDepth } : {}),
+      ...(payload.evidenceLevel
+        ? { evidenceLevel: payload.evidenceLevel }
+        : {}),
+      ...(payload.checks ? { checks: payload.checks } : {}),
     };
   }
 
@@ -739,6 +766,7 @@ export class SecurityPenetrationTestsService {
         temporalUiUrl: null,
         webhookUrl: null,
         notificationEmail: null,
+        ...this.getScanProfileFields(report),
       };
     }
 
@@ -755,8 +783,61 @@ export class SecurityPenetrationTestsService {
       temporalUiUrl: null,
       webhookUrl: report.webhookUrl ?? null,
       notificationEmail: report.notificationEmail ?? null,
+      ...this.getScanProfileFields(report),
       ...('progress' in report ? { progress: report.progress } : {}),
     };
+  }
+
+  private getScanProfileFields(
+    report: Pentest | PentestWithProgress | PentestCreated,
+  ): Pick<SecurityPenetrationTest, 'scanDepth' | 'evidenceLevel' | 'checks'> {
+    const record = report as unknown;
+    if (!this.isRecord(record)) return {};
+
+    const fields: Pick<
+      SecurityPenetrationTest,
+      'scanDepth' | 'evidenceLevel' | 'checks'
+    > = {};
+
+    if (this.isScanDepth(record.scanDepth)) {
+      fields.scanDepth = record.scanDepth;
+    }
+
+    if (this.isEvidenceLevel(record.evidenceLevel)) {
+      fields.evidenceLevel = record.evidenceLevel;
+    }
+
+    if (Array.isArray(record.checks)) {
+      const checks = record.checks.filter((check): check is PentestCheck =>
+        this.isPentestCheck(check),
+      );
+      if (checks.length === record.checks.length) {
+        fields.checks = checks;
+      }
+    }
+
+    return fields;
+  }
+
+  private isScanDepth(value: unknown): value is ScanDepth {
+    return (
+      typeof value === 'string' &&
+      (scanDepthValues as readonly string[]).includes(value)
+    );
+  }
+
+  private isEvidenceLevel(value: unknown): value is EvidenceLevel {
+    return (
+      typeof value === 'string' &&
+      (evidenceLevelValues as readonly string[]).includes(value)
+    );
+  }
+
+  private isPentestCheck(value: unknown): value is PentestCheck {
+    return (
+      typeof value === 'string' &&
+      (pentestCheckValues as readonly string[]).includes(value)
+    );
   }
 
   private isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/CreateRunPanel.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/CreateRunPanel.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import type { PentestCreateRequest } from '@/lib/security/penetration-tests-client';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CreateRunPanel } from './CreateRunPanel';
@@ -35,4 +36,222 @@ describe('CreateRunPanel', () => {
     });
     expect(onSubmit).not.toHaveBeenCalled();
   });
+
+  it('defaults to Standard and submits Standard profile fields', async () => {
+    const user = userEvent.setup();
+    let submittedPayload: PentestCreateRequest | undefined;
+    const onSubmit = vi.fn(async (payload: PentestCreateRequest) => {
+      submittedPayload = payload;
+      return { id: 'run_standard' };
+    });
+
+    render(<CreateRunPanel orgId="org_1" balance={1} onSubmit={onSubmit} />);
+
+    await user.type(screen.getByLabelText(/target url/i), 'app.example.com');
+    await user.click(screen.getByRole('button', { name: /start scan/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          targetUrl: 'https://app.example.com/',
+          scanDepth: 'standard',
+          evidenceLevel: 'safe_proof',
+        }),
+      );
+    });
+    expect(submittedPayload).toBeDefined();
+    if (!submittedPayload) throw new Error('Expected submit payload');
+    expect(submittedPayload.checks).toContain('discovery');
+    expect(submittedPayload.checks).toContain('xss');
+    expect(submittedPayload.checks).not.toContain('race_conditions');
+    expect(submittedPayload.checks).not.toContain('business_logic');
+  });
+
+  it('shows Quick after clicking the Quick preset', async () => {
+    const user = userEvent.setup();
+
+    render(<CreateRunPanel orgId="org_1" balance={1} onSubmit={vi.fn()} />);
+
+    expect(screen.getByText('Standard · 30-90 min')).toBeInTheDocument();
+
+    await user.click(screen.getByText('Quick'));
+
+    expect(screen.getByText('Quick · 5-15 min')).toBeInTheDocument();
+  });
+
+  it('shows Custom when advanced settings differ from the selected profile', async () => {
+    const user = userEvent.setup();
+
+    render(<CreateRunPanel orgId="org_1" balance={1} onSubmit={vi.fn()} />);
+
+    await user.click(screen.getByText('Quick'));
+    await user.click(screen.getByRole('button', { name: /customize scan/i }));
+    await user.click(screen.getByLabelText(/^xss$/i));
+
+    expect(screen.getByText('Custom · 11 min-25 min')).toBeInTheDocument();
+    expect(screen.queryByText(/based on/i)).not.toBeInTheDocument();
+  });
+
+  it('resolves to Standard when manual settings match Standard defaults after starting from Quick', async () => {
+    const user = userEvent.setup();
+    let submittedPayload: PentestCreateRequest | undefined;
+    const onSubmit = vi.fn(async (payload: PentestCreateRequest) => {
+      submittedPayload = payload;
+      return { id: 'run_standard' };
+    });
+
+    render(<CreateRunPanel orgId="org_1" balance={1} onSubmit={onSubmit} />);
+
+    await user.click(screen.getByText('Quick'));
+    await user.click(screen.getByRole('button', { name: /customize scan/i }));
+    await user.click(validationLevel().getByLabelText(/safe proof/i));
+    await user.click(screen.getByLabelText(/^xss$/i));
+    await user.click(screen.getByLabelText(/^injection$/i));
+    await user.click(screen.getByLabelText(/^authentication$/i));
+    await user.click(screen.getByLabelText(/^authorization$/i));
+    await user.click(screen.getByLabelText(/idor \/ bola/i));
+    await user.click(screen.getByLabelText(/ssrf \/ xxe/i));
+    await user.click(screen.getByLabelText(/^csrf$/i));
+
+    expect(screen.getByText('Standard · 30-90 min')).toBeInTheDocument();
+    expect(screen.queryByText(/based on/i)).not.toBeInTheDocument();
+
+    await user.type(screen.getByLabelText(/target url/i), 'app.example.com');
+    await user.click(screen.getByRole('button', { name: /start scan/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalled();
+    });
+    expect(submittedPayload?.scanDepth).toBe('standard');
+    expect(submittedPayload?.evidenceLevel).toBe('safe_proof');
+  });
+
+  it('shows Deep when settings match Deep defaults', async () => {
+    const user = userEvent.setup();
+
+    render(<CreateRunPanel orgId="org_1" balance={1} onSubmit={vi.fn()} />);
+
+    await user.click(screen.getByText('Deep'));
+
+    expect(screen.getByText('Deep · 2-8+ hours')).toBeInTheDocument();
+  });
+
+  it('updates the custom runtime estimate when evidence changes', async () => {
+    const user = userEvent.setup();
+
+    render(<CreateRunPanel orgId="org_1" balance={1} onSubmit={vi.fn()} />);
+
+    await user.click(screen.getByText('Quick'));
+    await user.click(screen.getByRole('button', { name: /customize scan/i }));
+    await user.click(screen.getByLabelText(/^xss$/i));
+
+    expect(screen.getByText('Custom · 11 min-25 min')).toBeInTheDocument();
+
+    await user.click(validationLevel().getByLabelText(/safe proof/i));
+
+    expect(screen.getByText('Custom · 17 min-38 min')).toBeInTheDocument();
+  });
+
+  it('uses design-system radio styling for evidence options', async () => {
+    const user = userEvent.setup();
+    render(<CreateRunPanel orgId="org_1" balance={1} onSubmit={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: /customize scan/i }));
+
+    expect(validationLevel().getByLabelText(/safe proof/i).closest('label')).toHaveClass(
+      'has-[[data-checked]]:border-primary',
+      'has-[[data-checked]]:bg-primary/5',
+      'has-[[data-checked]]:text-primary',
+    );
+  });
+
+  it('auto-enables Discovery when selecting a non-discovery check', async () => {
+    const user = userEvent.setup();
+
+    render(<CreateRunPanel orgId="org_1" balance={1} onSubmit={vi.fn()} />);
+
+    await user.click(screen.getByText('Quick'));
+    await user.click(screen.getByRole('button', { name: /customize scan/i }));
+    await user.click(screen.getByLabelText(/secrets & info disclosure/i));
+    await user.click(screen.getByLabelText(/technology config/i));
+    await user.click(screen.getByLabelText(/^discovery$/i));
+    await user.click(screen.getByLabelText(/^xss$/i));
+
+    expect(screen.getByLabelText(/^discovery$/i)).toBeChecked();
+  });
+
+  it('shows report-only helper text', async () => {
+    const user = userEvent.setup();
+
+    render(<CreateRunPanel orgId="org_1" balance={1} onSubmit={vi.fn()} />);
+
+    await user.click(screen.getByText('Quick'));
+    await user.click(screen.getByRole('button', { name: /customize scan/i }));
+
+    expect(
+      screen.getByText(/fastest and lowest risk/i),
+    ).toBeInTheDocument();
+  });
+
+  it('shows validation level choices and selected helper copy', async () => {
+    const user = userEvent.setup();
+
+    render(<CreateRunPanel orgId="org_1" balance={1} onSubmit={vi.fn()} />);
+
+    expect(screen.getByText('Customize scan')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /customize scan/i }));
+
+    expect(screen.getByText('Validation level')).toBeInTheDocument();
+    expect(validationLevel().getByLabelText(/report only/i)).toBeInTheDocument();
+    expect(validationLevel().getByLabelText(/safe proof/i)).toBeInTheDocument();
+    expect(validationLevel().getByLabelText(/impact proof/i)).toBeInTheDocument();
+
+    await user.click(validationLevel().getByLabelText(/report only/i));
+    expect(screen.getByText(/fastest and lowest risk/i)).toBeInTheDocument();
+
+    await user.click(validationLevel().getByLabelText(/safe proof/i));
+    expect(screen.getByText(/balanced validation/i)).toBeInTheDocument();
+
+    await user.click(validationLevel().getByLabelText(/impact proof/i));
+    expect(screen.getByText(/highest confidence, longer runtime/i)).toBeInTheDocument();
+  });
+
+  it('keeps preset cards concise without validation metadata', () => {
+    render(<CreateRunPanel orgId="org_1" balance={1} onSubmit={vi.fn()} />);
+
+    expect(screen.queryByText('Report only · 3 checks')).not.toBeInTheDocument();
+    expect(screen.queryByText('Safe proof · 10 checks')).not.toBeInTheDocument();
+    expect(screen.queryByText('Impact proof · 12 checks')).not.toBeInTheDocument();
+  });
+
+  it('requires confirmation for Deep profile before submit', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn(async () => ({ id: 'run_deep' }));
+
+    render(<CreateRunPanel orgId="org_1" balance={1} onSubmit={onSubmit} />);
+
+    await user.type(screen.getByLabelText(/target url/i), 'app.example.com');
+    await user.click(screen.getByText('Deep'));
+    await user.click(screen.getByRole('button', { name: /start scan/i }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    const dialog = screen.getByRole('alertdialog');
+    expect(within(dialog).getByText(/confirm scan intensity/i)).toBeInTheDocument();
+
+    await user.click(within(dialog).getByRole('button', { name: /start scan/i }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scanDepth: 'deep',
+          evidenceLevel: 'impact_proof',
+        }),
+      );
+    });
+  });
 });
+
+function validationLevel() {
+  return within(screen.getByRole('radiogroup', { name: /validation level/i }));
+}

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/CreateRunPanel.tsx
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/CreateRunPanel.tsx
@@ -1,27 +1,74 @@
 'use client';
 
-import type { PentestCreateRequest } from '@/lib/security/penetration-tests-client';
-import { Button } from '@trycompai/design-system';
-import { ArrowRight, Link } from '@trycompai/design-system/icons';
+import type { PentestCheck, PentestCreateRequest } from '@/lib/security/penetration-tests-client';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Button,
+} from '@trycompai/design-system';
+import { ArrowRight } from '@trycompai/design-system/icons';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import type { FormEvent } from 'react';
+import { useMemo, useState } from 'react';
+import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
+import { z } from 'zod';
+import { CreateRunTargetFields } from './CreateRunTargetFields';
+import { RunExpectationSummary } from './RunExpectationSummary';
+import { ScanAdvancedOptions } from './ScanAdvancedOptions';
+import { ScanProfilePicker } from './ScanProfilePicker';
+import {
+  estimateRuntime,
+  resolveEffectiveScanMode,
+  scanProfiles,
+  withRequiredDiscovery,
+  type ScanProfileId,
+} from './scan-profiles';
 
 interface CreateRunPanelProps {
   orgId: string;
   onSubmit: (payload: PentestCreateRequest) => Promise<{ id: string }>;
   isSubmitting?: boolean;
-  /** Subscription allowance balance — disables submit when 0. */
   balance?: number;
   planRequired?: boolean;
   quotaLabel?: 'Plan';
 }
 
-/**
- * Inline right-pane form that replaces the old modal Dialog. Matches the
- * design-handoff layout: centered card with header label, target + repo
- * inputs, scope-summary box, and Cancel / Start-scan actions.
- */
+const createRunSchema = z.object({
+  targetUrl: z.string().min(1, 'Target URL is required.'),
+  repoUrl: z.string().optional(),
+  selectedProfile: z.enum(['quick', 'standard', 'deep']),
+  scanDepth: z.enum(['quick', 'standard', 'deep']),
+  evidenceLevel: z.enum(['report_only', 'safe_proof', 'impact_proof']),
+  checks: z
+    .array(
+      z.enum([
+        'discovery',
+        'secrets_info_disclosure',
+        'technology_config',
+        'xss',
+        'injection',
+        'authentication',
+        'authorization',
+        'idor_bola',
+        'ssrf_xxe',
+        'csrf',
+        'race_conditions',
+        'business_logic',
+      ]),
+    )
+    .min(1, 'Select at least one check.'),
+});
+
+export type CreateRunForm = z.infer<typeof createRunSchema>;
+
 export function CreateRunPanel({
   orgId,
   onSubmit,
@@ -31,16 +78,66 @@ export function CreateRunPanel({
   quotaLabel = 'Plan',
 }: CreateRunPanelProps) {
   const router = useRouter();
-  const [targetUrl, setTargetUrl] = useState('');
-  const [repoUrl, setRepoUrl] = useState('');
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [confirmationOpen, setConfirmationOpen] = useState(false);
   const canCreate = balance === undefined ? true : balance > 0;
+  const standardDefaults = scanProfiles.standard;
+  const form = useForm<CreateRunForm>({
+    resolver: zodResolver(createRunSchema),
+    defaultValues: {
+      targetUrl: '',
+      repoUrl: '',
+      selectedProfile: 'standard',
+      scanDepth: standardDefaults.scanDepth,
+      evidenceLevel: standardDefaults.evidenceLevel,
+      checks: standardDefaults.checks,
+    },
+  });
+  const selectedProfile = form.watch('selectedProfile');
+  const evidenceLevel = form.watch('evidenceLevel');
+  const checks = form.watch('checks');
+  const effectiveMode = useMemo(
+    () =>
+      resolveEffectiveScanMode({
+        evidenceLevel,
+        checks,
+      }),
+    [checks, evidenceLevel],
+  );
+  const runtimeEstimate = useMemo(
+    () =>
+      estimateRuntime({
+        effectiveMode,
+        evidenceLevel,
+        checks,
+      }),
+    [checks, effectiveMode, evidenceLevel],
+  );
+  const effectiveLabel =
+    effectiveMode === 'custom' ? 'Custom' : effectiveMode[0].toUpperCase() + effectiveMode.slice(1);
 
   const handleCancel = () => {
     router.push(`/${orgId}/security/penetration-tests`);
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleProfileChange = (profile: ScanProfileId) => {
+    const defaults = scanProfiles[profile];
+    form.setValue('selectedProfile', profile, { shouldDirty: true });
+    form.setValue('scanDepth', defaults.scanDepth, { shouldDirty: true });
+    form.setValue('evidenceLevel', defaults.evidenceLevel, {
+      shouldDirty: true,
+    });
+    form.setValue('checks', defaults.checks, { shouldDirty: true });
+  };
+
+  const handleChecksChange = (nextChecks: PentestCheck[]) => {
+    form.setValue('checks', withRequiredDiscovery(nextChecks), {
+      shouldDirty: true,
+      shouldValidate: true,
+    });
+  };
+
+  const handleSubmitForm = async (values: CreateRunForm, confirmed = false) => {
     if (!canCreate) {
       toast.error(
         planRequired
@@ -50,15 +147,32 @@ export function CreateRunPanel({
       router.push(`/${orgId}/settings/billing/add-ons/penetration-tests`);
       return;
     }
-    const normalized = normalizeUrl(targetUrl);
+
+    const resolvedMode = resolveEffectiveScanMode({
+      evidenceLevel: values.evidenceLevel,
+      checks: values.checks,
+    });
+    const submitScanDepth =
+      resolvedMode === 'custom' ? values.scanDepth : scanProfiles[resolvedMode].scanDepth;
+
+    if (!confirmed && (submitScanDepth === 'deep' || values.evidenceLevel === 'impact_proof')) {
+      setConfirmationOpen(true);
+      return;
+    }
+
+    const normalized = normalizeUrl(values.targetUrl);
     if (!normalized) {
       toast.error('Target URL is required.');
       return;
     }
+
     try {
       const result = await onSubmit({
         targetUrl: normalized,
-        ...(repoUrl.trim() ? { repoUrl: repoUrl.trim() } : {}),
+        ...(values.repoUrl?.trim() ? { repoUrl: values.repoUrl.trim() } : {}),
+        scanDepth: submitScanDepth,
+        evidenceLevel: values.evidenceLevel,
+        checks: values.checks,
       });
       router.push(`/${orgId}/security/penetration-tests/${encodeURIComponent(result.id)}`);
     } catch {
@@ -66,23 +180,35 @@ export function CreateRunPanel({
     }
   };
 
+  const handleConfirmSubmit = () => {
+    setConfirmationOpen(false);
+    void handleSubmitForm(form.getValues(), true);
+  };
+
+  const handleFormSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canCreate) {
+      void handleSubmitForm(form.getValues());
+      return;
+    }
+
+    void form.handleSubmit((values) => handleSubmitForm(values))(event);
+  };
+
   return (
     <div className="min-h-0 overflow-y-auto">
-      <div className="mx-auto w-full max-w-[680px] px-6 py-10">
+      <div className="mx-auto w-full max-w-[760px] px-3 py-4 sm:px-6 sm:py-10">
         <form
           noValidate
-          onSubmit={(e) => void handleSubmit(e)}
-          className="rounded-[var(--radius)] border border-border bg-card p-8 shadow-[0_24px_48px_-12px_rgba(0,0,0,0.12)]"
+          onSubmit={handleFormSubmit}
+          className="rounded-[var(--radius)] border border-border bg-card p-4 shadow-[0_24px_48px_-12px_rgba(0,0,0,0.12)] sm:p-8"
         >
           <div className="mb-1.5 text-[10px] font-bold uppercase tracking-[0.1em] text-muted-foreground">
             New scan
           </div>
-          <div className="mb-1 text-[20px] font-normal tracking-[-0.01em]">
-            Start a penetration test
-          </div>
+          <div className="mb-1 text-[20px] font-normal">Start a penetration test</div>
           <p className="mb-5 text-xs leading-relaxed text-muted-foreground">
-            Scans typically take 1–3 hours. Findings stream in as they're discovered — you don't
-            need to keep this page open.
+            Findings stream in as they're discovered. You don't need to keep this page open.
           </p>
 
           {!canCreate && (
@@ -93,84 +219,69 @@ export function CreateRunPanel({
             </div>
           )}
 
-          <div className="mb-4">
-            <label
-              htmlFor="pt-target-url"
-              className="mb-1.5 block text-[11px] font-medium uppercase tracking-[0.1em] text-muted-foreground"
-            >
-              Target URL
-            </label>
-            <div className="flex h-9 items-center gap-1.5 rounded border border-border bg-background px-3">
-              <span className="font-mono text-xs text-muted-foreground">https://</span>
-              <input
-                id="pt-target-url"
-                value={targetUrl}
-                onChange={(e) => setTargetUrl(e.target.value)}
-                placeholder="your.staging.app"
-                autoFocus
-                required
-                className="flex-1 bg-transparent font-mono text-xs outline-none"
-              />
-            </div>
-            <p className="mt-1 text-[11px] text-muted-foreground">
-              Must be reachable from the scanner — localhost and private IPs are rejected.
-            </p>
-          </div>
+          <ScanProfilePicker
+            activeProfile={effectiveMode === 'custom' ? null : effectiveMode}
+            headerLabel={effectiveLabel}
+            runtimeEstimate={runtimeEstimate}
+            onChange={handleProfileChange}
+          />
 
-          <div className="mb-5">
-            <div className="mb-1.5 flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
-              <span>Repository</span>
-              <span className="font-normal normal-case tracking-normal text-muted-foreground">
-                (optional)
-              </span>
-            </div>
-            <div className="flex h-9 items-center gap-1.5 rounded border border-border bg-background px-3">
-              <Link className="h-3 w-3 text-muted-foreground" />
-              <input
-                value={repoUrl}
-                onChange={(e) => setRepoUrl(e.target.value)}
-                placeholder="github.com/acme/platform"
-                className="flex-1 bg-transparent font-mono text-xs outline-none"
-              />
-            </div>
-            <p className="mt-1 text-[11px] text-muted-foreground">
-              Public repositories only. We use source context to write better remediation steps.
-            </p>
-          </div>
+          <CreateRunTargetFields form={form} />
 
-          <div className="mb-5 rounded border border-border bg-muted/50 p-3.5">
-            <div className="mb-2 text-[11px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
-              What to expect
-            </div>
-            <dl className="space-y-1 text-xs leading-loose">
-              {[
-                ['Typical duration', '1–3 hours'],
-                ['Output', 'Findings + markdown & PDF report'],
-                ['Mode', 'Read-only — never modifies your target'],
-              ].map(([label, value]) => (
-                <div key={label} className="flex items-center justify-between">
-                  <dt className="text-muted-foreground">{label}</dt>
-                  <dd className="font-mono text-right">{value}</dd>
-                </div>
-              ))}
-            </dl>
-            <p className="mt-2 text-[11px] text-muted-foreground">
-              Findings stream into this page as they're discovered — you can close this tab and come
-              back.
-            </p>
-          </div>
+          <ScanAdvancedOptions
+            open={advancedOpen}
+            evidenceLevel={evidenceLevel}
+            checks={checks}
+            onOpenChange={setAdvancedOpen}
+            onEvidenceLevelChange={(nextEvidenceLevel) =>
+              form.setValue('evidenceLevel', nextEvidenceLevel, {
+                shouldDirty: true,
+              })
+            }
+            onChecksChange={handleChecksChange}
+          />
 
-          <div className="flex justify-end gap-2">
-            <Button type="button" variant="outline" onClick={handleCancel} disabled={isSubmitting}>
-              Cancel
-            </Button>
-            <Button type="submit" loading={isSubmitting} disabled={isSubmitting}>
-              {canCreate ? `Start scan (${quotaLabel})` : 'Choose plan'}
-              <ArrowRight className="h-3.5 w-3.5" />
-            </Button>
+          <RunExpectationSummary
+            runtimeEstimate={runtimeEstimate}
+            effectiveLabel={effectiveLabel}
+            checksError={form.formState.errors.checks?.message}
+          />
+
+          <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+            <div className="w-full sm:w-auto">
+              <Button type="button" variant="outline" onClick={handleCancel} disabled={isSubmitting}>
+                Cancel
+              </Button>
+            </div>
+            <div className="w-full sm:w-auto">
+              <Button
+                type="submit"
+                loading={isSubmitting}
+                disabled={isSubmitting}
+                iconRight={canCreate ? <ArrowRight /> : undefined}
+              >
+                {canCreate ? `Start scan (${quotaLabel})` : 'Choose plan'}
+              </Button>
+            </div>
           </div>
         </form>
       </div>
+
+      <AlertDialog open={confirmationOpen} onOpenChange={setConfirmationOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Confirm scan intensity</AlertDialogTitle>
+            <AlertDialogDescription>
+              Deep scans and impact proof may take longer and perform stronger validation against
+              the target. Confirm this target is approved for that scan intensity.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirmSubmit}>Start scan</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/CreateRunTargetFields.tsx
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/CreateRunTargetFields.tsx
@@ -1,0 +1,56 @@
+import { Link } from '@trycompai/design-system/icons';
+import type { UseFormReturn } from 'react-hook-form';
+import type { CreateRunForm } from './CreateRunPanel';
+
+interface CreateRunTargetFieldsProps {
+  form: UseFormReturn<CreateRunForm>;
+}
+
+export function CreateRunTargetFields({ form }: CreateRunTargetFieldsProps) {
+  return (
+    <>
+      <div className="mb-4">
+        <label
+          htmlFor="pt-target-url"
+          className="mb-1.5 block text-[11px] font-medium uppercase tracking-[0.1em] text-muted-foreground"
+        >
+          Target URL
+        </label>
+        <div className="flex h-9 items-center gap-1.5 rounded border border-border bg-background px-3">
+          <span className="shrink-0 font-mono text-xs text-muted-foreground">https://</span>
+          <input
+            id="pt-target-url"
+            {...form.register('targetUrl')}
+            placeholder="your.staging.app"
+            autoFocus
+            required
+            className="min-w-0 flex-1 bg-transparent font-mono text-xs outline-none"
+          />
+        </div>
+        <p className="mt-1 text-[11px] text-muted-foreground">
+          Must be reachable from the scanner - localhost and private IPs are rejected.
+        </p>
+      </div>
+
+      <div className="mb-5">
+        <div className="mb-1.5 flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
+          <span>Repository</span>
+          <span className="font-normal normal-case tracking-normal text-muted-foreground">
+            (optional)
+          </span>
+        </div>
+        <div className="flex h-9 items-center gap-1.5 rounded border border-border bg-background px-3">
+          <Link className="h-3 w-3 shrink-0 text-muted-foreground" />
+          <input
+            {...form.register('repoUrl')}
+            placeholder="github.com/acme/platform"
+            className="min-w-0 flex-1 bg-transparent font-mono text-xs outline-none"
+          />
+        </div>
+        <p className="mt-1 text-[11px] text-muted-foreground">
+          Public repositories only. We use source context to write better remediation steps.
+        </p>
+      </div>
+    </>
+  );
+}

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/RunExpectationSummary.tsx
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/RunExpectationSummary.tsx
@@ -1,0 +1,37 @@
+interface RunExpectationSummaryProps {
+  runtimeEstimate: string;
+  effectiveLabel: string;
+  checksError?: string;
+}
+
+export function RunExpectationSummary({
+  runtimeEstimate,
+  effectiveLabel,
+  checksError,
+}: RunExpectationSummaryProps) {
+  const rows = [
+    ['Estimated duration', runtimeEstimate],
+    ['Output', 'Findings + markdown & PDF report'],
+    ['Mode', effectiveLabel],
+  ];
+
+  return (
+    <div className="mb-5 rounded border border-border bg-muted/50 p-3.5">
+      <div className="mb-2 text-[11px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
+        What to expect
+      </div>
+      <dl className="space-y-1 text-xs leading-loose">
+        {rows.map(([label, value]) => (
+          <div
+            key={label}
+            className="flex flex-col gap-0.5 sm:flex-row sm:items-center sm:justify-between sm:gap-4"
+          >
+            <dt className="text-muted-foreground">{label}</dt>
+            <dd className="break-words font-mono sm:text-right">{value}</dd>
+          </div>
+        ))}
+      </dl>
+      {checksError && <p className="mt-2 text-[11px] text-destructive">{checksError}</p>}
+    </div>
+  );
+}

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/ScanAdvancedOptions.tsx
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/ScanAdvancedOptions.tsx
@@ -1,0 +1,132 @@
+import type { EvidenceLevel, PentestCheck } from '@/lib/security/penetration-tests-client';
+import { Checkbox, RadioGroup, RadioGroupItem } from '@trycompai/design-system';
+import { allPentestChecks, checkLabels, evidenceLabels } from './scan-profiles';
+
+interface ScanAdvancedOptionsProps {
+  open: boolean;
+  evidenceLevel: EvidenceLevel;
+  checks: PentestCheck[];
+  onOpenChange: (open: boolean) => void;
+  onEvidenceLevelChange: (value: EvidenceLevel) => void;
+  onChecksChange: (checks: PentestCheck[]) => void;
+}
+
+const evidenceOptions: EvidenceLevel[] = ['report_only', 'safe_proof', 'impact_proof'];
+
+const evidenceHelperText: Record<EvidenceLevel, string> = {
+  report_only: 'Fastest and lowest risk. Some findings may need manual confirmation.',
+  safe_proof: 'Balanced validation. Good default for production or staging targets.',
+  impact_proof:
+    'Highest confidence, longer runtime, and stronger target interaction. Requires authorization.',
+};
+
+export function ScanAdvancedOptions({
+  open,
+  evidenceLevel,
+  checks,
+  onOpenChange,
+  onEvidenceLevelChange,
+  onChecksChange,
+}: ScanAdvancedOptionsProps) {
+  const hasDiscoveryDependentChecks = checks.some((check) => check !== 'discovery');
+
+  const handleToggleCheck = (check: PentestCheck, checked: boolean) => {
+    if (check === 'discovery' && hasDiscoveryDependentChecks) return;
+
+    const nextChecks = checked
+      ? [...checks, check]
+      : checks.filter((selectedCheck) => selectedCheck !== check);
+
+    onChecksChange(nextChecks);
+  };
+
+  return (
+    <div className="mb-5 rounded border border-border bg-muted/30">
+      <button
+        type="button"
+        onClick={() => onOpenChange(!open)}
+        aria-expanded={open}
+        className="flex w-full items-center justify-between gap-3 px-3.5 py-3 text-left"
+      >
+        <span>
+          <span className="block text-[11px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
+            Customize scan
+          </span>
+          <span className="mt-1 block text-xs text-muted-foreground">
+            Evidence level and individual checks
+          </span>
+        </span>
+        <span className="font-mono text-[11px] text-muted-foreground">
+          {open ? 'Hide' : 'Show'}
+        </span>
+      </button>
+
+      {open && (
+        <div className="border-t border-border px-3.5 py-3">
+          <fieldset className="mb-4">
+            <legend className="mb-2 text-[11px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
+              Validation level
+            </legend>
+            <RadioGroup
+              value={evidenceLevel}
+              onValueChange={(nextValue) => {
+                if (isEvidenceLevel(nextValue)) {
+                  onEvidenceLevelChange(nextValue);
+                }
+              }}
+              aria-label="Validation level"
+            >
+              <div className="grid gap-2 sm:grid-cols-3">
+                {evidenceOptions.map((option) => (
+                  <label
+                    key={option}
+                    htmlFor={`evidence-${option}`}
+                    className="flex min-h-11 cursor-pointer items-center gap-2 rounded border border-border bg-background p-2.5 text-xs has-[[data-checked]]:border-primary has-[[data-checked]]:bg-primary/5 has-[[data-checked]]:text-primary"
+                  >
+                    <RadioGroupItem id={`evidence-${option}`} value={option} />
+                    <span className="min-w-0 font-medium">{evidenceLabels[option]}</span>
+                  </label>
+                ))}
+              </div>
+            </RadioGroup>
+            <p className="mt-2 text-[11px] leading-relaxed text-muted-foreground">
+              {evidenceHelperText[evidenceLevel]}
+            </p>
+          </fieldset>
+
+          <fieldset>
+            <legend className="mb-2 text-[11px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
+              Checks
+            </legend>
+            <div className="grid gap-2 sm:grid-cols-2">
+              {allPentestChecks.map((check) => {
+                const checked = checks.includes(check);
+                const disabled = check === 'discovery' && hasDiscoveryDependentChecks;
+
+                return (
+                  <label
+                    key={check}
+                    className="flex min-h-9 items-center gap-2 rounded border border-border bg-background px-2.5 py-2 text-xs"
+                  >
+                    <Checkbox
+                      checked={checked}
+                      disabled={disabled}
+                      onCheckedChange={(nextChecked) =>
+                        handleToggleCheck(check, nextChecked === true)
+                      }
+                    />
+                    <span>{checkLabels[check]}</span>
+                  </label>
+                );
+              })}
+            </div>
+          </fieldset>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function isEvidenceLevel(value: unknown): value is EvidenceLevel {
+  return value === 'report_only' || value === 'safe_proof' || value === 'impact_proof';
+}

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/ScanProfilePicker.tsx
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/ScanProfilePicker.tsx
@@ -1,0 +1,82 @@
+import { RadioGroup, RadioGroupItem } from '@trycompai/design-system';
+import type { ScanProfileId } from './scan-profiles';
+
+interface ScanProfilePickerProps {
+  activeProfile: ScanProfileId | null;
+  headerLabel: string;
+  runtimeEstimate: string;
+  onChange: (value: ScanProfileId) => void;
+}
+
+const profileOptions: Array<{
+  id: ScanProfileId;
+  title: string;
+  description: string;
+}> = [
+  {
+    id: 'quick',
+    title: 'Quick',
+    description: 'Surface-level discovery and exposure checks.',
+  },
+  {
+    id: 'standard',
+    title: 'Standard',
+    description: 'Balanced coverage with safe validation.',
+  },
+  {
+    id: 'deep',
+    title: 'Deep',
+    description: 'Full coverage with impact validation.',
+  },
+];
+
+export function ScanProfilePicker({
+  activeProfile,
+  headerLabel,
+  runtimeEstimate,
+  onChange,
+}: ScanProfilePickerProps) {
+  return (
+    <div className="mb-5">
+      <div className="mb-2 flex flex-col gap-1.5 sm:flex-row sm:items-center sm:justify-between sm:gap-3">
+        <div className="text-[11px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
+          Scan preset
+        </div>
+        <div className="font-mono text-[11px] text-foreground">
+          {headerLabel} · {runtimeEstimate}
+        </div>
+      </div>
+      <RadioGroup
+        value={activeProfile ?? ''}
+        onValueChange={(nextValue) => {
+          if (isScanProfileId(nextValue)) {
+            onChange(nextValue);
+          }
+        }}
+        aria-label="Scan preset"
+      >
+        <div className="grid gap-2 sm:grid-cols-3">
+          {profileOptions.map((profile) => (
+            <label
+              key={profile.id}
+              htmlFor={`scan-preset-${profile.id}`}
+              className="flex min-h-[96px] cursor-pointer select-none gap-2 rounded border border-border bg-background p-3 text-left transition-colors hover:bg-muted/50 has-[[data-checked]]:border-primary has-[[data-checked]]:bg-primary/5 has-[[data-checked]]:text-primary"
+            >
+              <RadioGroupItem id={`scan-preset-${profile.id}`} value={profile.id} />
+              <span className="min-w-0">
+                <span className="block text-sm font-medium">{profile.title}</span>
+                <span className="mt-1 block text-xs leading-relaxed text-muted-foreground">
+                  {profile.description}
+                </span>
+              </span>
+            </label>
+          ))}
+        </div>
+      </RadioGroup>
+    </div>
+  );
+}
+
+function isScanProfileId(value: unknown): value is ScanProfileId {
+  return value === 'quick' || value === 'standard' || value === 'deep';
+}

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/scan-profiles.ts
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/scan-profiles.ts
@@ -1,0 +1,152 @@
+import type {
+  EvidenceLevel,
+  PentestCheck,
+  ScanDepth,
+} from '@/lib/security/penetration-tests-client';
+
+export type ScanProfileId = 'quick' | 'standard' | 'deep';
+export type EffectiveScanMode = ScanProfileId | 'custom';
+
+export interface ScanProfileDefaults {
+  scanDepth: ScanDepth;
+  evidenceLevel: EvidenceLevel;
+  checks: PentestCheck[];
+}
+
+export const allPentestChecks: PentestCheck[] = [
+  'discovery',
+  'secrets_info_disclosure',
+  'technology_config',
+  'xss',
+  'injection',
+  'authentication',
+  'authorization',
+  'idor_bola',
+  'ssrf_xxe',
+  'csrf',
+  'race_conditions',
+  'business_logic',
+];
+
+export const scanProfiles: Record<ScanProfileId, ScanProfileDefaults> = {
+  quick: {
+    scanDepth: 'quick',
+    evidenceLevel: 'report_only',
+    checks: ['discovery', 'secrets_info_disclosure', 'technology_config'],
+  },
+  standard: {
+    scanDepth: 'standard',
+    evidenceLevel: 'safe_proof',
+    checks: allPentestChecks.filter(
+      (check) => check !== 'race_conditions' && check !== 'business_logic',
+    ),
+  },
+  deep: {
+    scanDepth: 'deep',
+    evidenceLevel: 'impact_proof',
+    checks: allPentestChecks,
+  },
+};
+
+export const checkLabels: Record<PentestCheck, string> = {
+  discovery: 'Discovery',
+  secrets_info_disclosure: 'Secrets & info disclosure',
+  technology_config: 'Technology config',
+  xss: 'XSS',
+  injection: 'Injection',
+  authentication: 'Authentication',
+  authorization: 'Authorization',
+  idor_bola: 'IDOR / BOLA',
+  ssrf_xxe: 'SSRF / XXE',
+  csrf: 'CSRF',
+  race_conditions: 'Race conditions',
+  business_logic: 'Business logic',
+};
+
+export const evidenceLabels: Record<EvidenceLevel, string> = {
+  report_only: 'Report only',
+  safe_proof: 'Safe proof',
+  impact_proof: 'Impact proof',
+};
+
+const checkWeights: Record<PentestCheck, number> = {
+  discovery: 5,
+  secrets_info_disclosure: 5,
+  technology_config: 5,
+  xss: 10,
+  injection: 15,
+  authentication: 15,
+  authorization: 15,
+  idor_bola: 15,
+  ssrf_xxe: 10,
+  csrf: 10,
+  race_conditions: 35,
+  business_logic: 45,
+};
+
+const evidenceMultipliers: Record<EvidenceLevel, number> = {
+  report_only: 0.65,
+  safe_proof: 1,
+  impact_proof: 1.75,
+};
+
+export function resolveEffectiveScanMode(params: {
+  evidenceLevel: EvidenceLevel;
+  checks: PentestCheck[];
+}): EffectiveScanMode {
+  for (const profile of scanProfileOrder) {
+    const defaults = scanProfiles[profile];
+    if (
+      params.evidenceLevel === defaults.evidenceLevel &&
+      haveSameChecks(params.checks, defaults.checks)
+    ) {
+      return profile;
+    }
+  }
+
+  return 'custom';
+}
+
+const scanProfileOrder: ScanProfileId[] = ['quick', 'standard', 'deep'];
+
+export function estimateRuntime(params: {
+  effectiveMode: EffectiveScanMode;
+  evidenceLevel: EvidenceLevel;
+  checks: PentestCheck[];
+}): string {
+  if (params.effectiveMode === 'quick') return '5-15 min';
+  if (params.effectiveMode === 'standard') return '30-90 min';
+  if (params.effectiveMode === 'deep') return '2-8+ hours';
+
+  const total =
+    params.checks.reduce((sum, check) => sum + checkWeights[check], 0) *
+    evidenceMultipliers[params.evidenceLevel];
+  const min = Math.max(5, Math.floor(total * 0.7));
+  const max = Math.ceil(total * 1.5);
+
+  return `${formatRuntimeMinutes(min)}-${formatRuntimeMinutes(max)}`;
+}
+
+export function withRequiredDiscovery(checks: PentestCheck[]): PentestCheck[] {
+  const uniqueChecks = allPentestChecks.filter((check) => checks.includes(check));
+  const needsDiscovery = uniqueChecks.some((check) => check !== 'discovery');
+
+  if (!needsDiscovery || uniqueChecks.includes('discovery')) {
+    return uniqueChecks;
+  }
+
+  return ['discovery', ...uniqueChecks];
+}
+
+function haveSameChecks(left: PentestCheck[], right: PentestCheck[]): boolean {
+  return left.length === right.length && left.every((check) => right.includes(check));
+}
+
+function formatRuntimeMinutes(minutes: number): string {
+  if (minutes < 120) return `${minutes} min`;
+
+  const hours = minutes / 60;
+  if (Number.isInteger(hours)) return `${hours} hours`;
+
+  return `${hours.toFixed(1)} hours`;
+}

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/hooks/use-penetration-tests.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/hooks/use-penetration-tests.test.tsx
@@ -205,6 +205,32 @@ describe('use-penetration-tests hooks', () => {
     expect(requestBody.mockCheckout).toBeUndefined();
   });
 
+  it('posts scan profile fields when creating a report', async () => {
+    fetchMock.mockResolvedValueOnce(
+      createJsonResponse({
+        id: 'run_profile',
+        status: 'provisioning',
+      }),
+    );
+
+    const { result } = renderHook(() => useCreatePenetrationTest('org_123'), { wrapper });
+
+    await act(async () => {
+      await result.current.createReport({
+        targetUrl: 'https://app.example.com',
+        scanDepth: 'standard',
+        evidenceLevel: 'safe_proof',
+        checks: ['discovery', 'xss'],
+      });
+    });
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const requestBody = JSON.parse((init.body ?? '{}') as string);
+    expect(requestBody.scanDepth).toBe('standard');
+    expect(requestBody.evidenceLevel).toBe('safe_proof');
+    expect(requestBody.checks).toEqual(['discovery', 'xss']);
+  });
+
   it('supports creating a report without repository URL for black-box mode', async () => {
     fetchMock.mockResolvedValueOnce(
       createJsonResponse({

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/hooks/use-penetration-tests.ts
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/hooks/use-penetration-tests.ts
@@ -11,8 +11,7 @@ import type {
   PentestRun,
 } from '@/lib/security/penetration-tests-client';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useSWRConfig } from 'swr';
-import useSWR from 'swr';
+import useSWR, { useSWRConfig } from 'swr';
 import { isReportInProgress, sortReportsByUpdatedAtDesc } from '../lib';
 
 const reportListEndpoint = '/v1/security-penetration-tests';
@@ -25,11 +24,7 @@ const reportIssuesEndpoint = (reportId: string): string =>
   `/v1/security-penetration-tests/${encodeURIComponent(reportId)}/issues`;
 const reportEventsEndpoint = (reportId: string): string =>
   `/v1/security-penetration-tests/${encodeURIComponent(reportId)}/events`;
-const inProgressStatus: readonly PentestReportStatus[] = [
-  'provisioning',
-  'cloning',
-  'running',
-];
+const inProgressStatus: readonly PentestReportStatus[] = ['provisioning', 'cloning', 'running'];
 const allStatuses: readonly PentestReportStatus[] = [
   'provisioning',
   'cloning',
@@ -45,10 +40,8 @@ const reportListKey = (organizationId: string): ReportsSWRKey =>
   [reportListEndpoint, organizationId] as const;
 const reportKey = (organizationId: string, reportId: string): ReportsSWRKey =>
   [reportEndpoint(reportId), organizationId] as const;
-const reportProgressKey = (
-  organizationId: string,
-  reportId: string,
-): ReportsSWRKey => [reportProgressEndpoint(reportId), organizationId] as const;
+const reportProgressKey = (organizationId: string, reportId: string): ReportsSWRKey =>
+  [reportProgressEndpoint(reportId), organizationId] as const;
 
 async function fetchApiJson<T>([endpoint, organizationId]: ReportsSWRKey): Promise<T> {
   const response = await api.get<T>(endpoint, organizationId);
@@ -60,9 +53,7 @@ async function fetchApiJson<T>([endpoint, organizationId]: ReportsSWRKey): Promi
   return (response.data ?? null) as T;
 }
 
-const resolveCreateStatus = (
-  status: string | undefined,
-): PentestReportStatus => {
+const resolveCreateStatus = (status: string | undefined): PentestReportStatus => {
   if (!status) {
     return 'provisioning';
   }
@@ -72,12 +63,7 @@ const resolveCreateStatus = (
     : 'provisioning';
 };
 
-interface CreatePayload {
-  targetUrl: string;
-  repoUrl?: string;
-  pipelineTesting?: boolean;
-  testMode?: boolean;
-}
+type CreatePayload = PentestCreateRequest;
 
 type CreateReportApiPayload = PentestCreateRequest;
 
@@ -109,9 +95,7 @@ interface UseCreatePenetrationTestReturn {
   resetError: () => void;
 }
 
-export function usePenetrationTests(
-  organizationId: string,
-): UsePenetrationTestsReturn {
+export function usePenetrationTests(organizationId: string): UsePenetrationTestsReturn {
   const shouldFetchReports = Boolean(organizationId);
   const { data, error, mutate } = useSWR<PentestRun[]>(
     shouldFetchReports ? reportListKey(organizationId) : null,
@@ -181,9 +165,7 @@ export function usePenetrationTestProgress(
   reportId: string,
   status: PentestReportStatus | undefined,
 ) {
-  const shouldFetch = Boolean(
-    organizationId && reportId && status && isReportInProgress(status),
-  );
+  const shouldFetch = Boolean(organizationId && reportId && status && isReportInProgress(status));
 
   const { data } = useSWR<PentestProgress>(
     shouldFetch ? reportProgressKey(organizationId, reportId) : null,
@@ -200,15 +182,11 @@ export function usePenetrationTestProgress(
   } satisfies UsePenetrationTestProgressReturn;
 }
 
-const reportIssuesKey = (
-  organizationId: string,
-  reportId: string,
-): ReportsSWRKey => [reportIssuesEndpoint(reportId), organizationId] as const;
+const reportIssuesKey = (organizationId: string, reportId: string): ReportsSWRKey =>
+  [reportIssuesEndpoint(reportId), organizationId] as const;
 
-const reportEventsKey = (
-  organizationId: string,
-  reportId: string,
-): ReportsSWRKey => [reportEventsEndpoint(reportId), organizationId] as const;
+const reportEventsKey = (organizationId: string, reportId: string): ReportsSWRKey =>
+  [reportEventsEndpoint(reportId), organizationId] as const;
 
 // Polls the issues list continuously while the run is in-progress, and once
 // after completion to load the final set. During a live ~1-hr scan, findings
@@ -333,9 +311,7 @@ export function usePentestCredits(organizationId: string): {
   };
 }
 
-export function useCreatePenetrationTest(
-  organizationId: string,
-): UseCreatePenetrationTestReturn {
+export function useCreatePenetrationTest(organizationId: string): UseCreatePenetrationTestReturn {
   const { mutate } = useSWRConfig();
   const [isCreating, setIsCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -355,6 +331,9 @@ export function useCreatePenetrationTest(
             repoUrl: payload.repoUrl,
             pipelineTesting: payload.pipelineTesting,
             testMode: payload.testMode,
+            scanDepth: payload.scanDepth,
+            evidenceLevel: payload.evidenceLevel,
+            checks: payload.checks,
           } satisfies CreateReportApiPayload,
           organizationId,
         );
@@ -386,6 +365,9 @@ export function useCreatePenetrationTest(
           failedReason: null,
           temporalUiUrl: null,
           webhookUrl: null,
+          scanDepth: payload.scanDepth,
+          evidenceLevel: payload.evidenceLevel,
+          checks: payload.checks,
         };
 
         setIsCreating(false);
@@ -399,11 +381,9 @@ export function useCreatePenetrationTest(
             },
             { revalidate: false },
           );
-          await mutate(
-            reportKey(organizationId, reportId),
-            optimisticReport,
-            { revalidate: false },
-          );
+          await mutate(reportKey(organizationId, reportId), optimisticReport, {
+            revalidate: false,
+          });
         } catch (cacheMutationError) {
           console.error(
             'Created penetration test but failed to optimistically update report cache',
@@ -418,9 +398,7 @@ export function useCreatePenetrationTest(
         return data;
       } catch (reportError) {
         const message =
-          reportError instanceof Error
-            ? reportError.message
-            : 'Failed to create report';
+          reportError instanceof Error ? reportError.message : 'Failed to create report';
         setError(message);
         setIsCreating(false);
         throw new Error(message);

--- a/apps/app/src/lib/security/penetration-tests-client.ts
+++ b/apps/app/src/lib/security/penetration-tests-client.ts
@@ -1,4 +1,10 @@
-export type PentestReportStatus = 'provisioning' | 'cloning' | 'running' | 'completed' | 'failed' | 'cancelled';
+export type PentestReportStatus =
+  | 'provisioning'
+  | 'cloning'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'cancelled';
 
 export interface PentestProgress {
   status: PentestReportStatus;
@@ -21,7 +27,26 @@ export interface PentestRun {
   webhookUrl?: string | null;
   notificationEmail?: string | null;
   progress?: PentestProgress;
+  scanDepth?: ScanDepth;
+  evidenceLevel?: EvidenceLevel;
+  checks?: PentestCheck[];
 }
+
+export type ScanDepth = 'quick' | 'standard' | 'deep';
+export type EvidenceLevel = 'report_only' | 'safe_proof' | 'impact_proof';
+export type PentestCheck =
+  | 'discovery'
+  | 'secrets_info_disclosure'
+  | 'technology_config'
+  | 'xss'
+  | 'injection'
+  | 'authentication'
+  | 'authorization'
+  | 'idor_bola'
+  | 'ssrf_xxe'
+  | 'csrf'
+  | 'race_conditions'
+  | 'business_logic';
 
 export interface PentestCreateRequest {
   targetUrl: string;
@@ -30,6 +55,9 @@ export interface PentestCreateRequest {
   testMode?: boolean;
   webhookUrl?: string;
   notificationEmail?: string;
+  scanDepth?: ScanDepth;
+  evidenceLevel?: EvidenceLevel;
+  checks?: PentestCheck[];
 }
 
 export interface CreatePenetrationTestResponse {
@@ -37,19 +65,9 @@ export interface CreatePenetrationTestResponse {
   status?: PentestReportStatus;
 }
 
-export type IssueSeverity =
-  | 'critical'
-  | 'high'
-  | 'medium'
-  | 'low'
-  | 'info';
+export type IssueSeverity = 'critical' | 'high' | 'medium' | 'low' | 'info';
 
-export type IssueStatus =
-  | 'open'
-  | 'acknowledged'
-  | 'resolved'
-  | 'false_positive'
-  | 'wont_fix';
+export type IssueStatus = 'open' | 'acknowledged' | 'resolved' | 'false_positive' | 'wont_fix';
 
 // Mirrors @maced/api-client's Issue type. Kept as a lightweight frontend
 // copy so we don't import server-only deps into the browser bundle.

--- a/bun.lock
+++ b/bun.lock
@@ -128,7 +128,7 @@
         "@aws-sdk/s3-request-presigner": "3.1013.0",
         "@browserbasehq/sdk": "2.6.0",
         "@browserbasehq/stagehand": "^3.2.1",
-        "@maced/api-client": "^0.9.1",
+        "@maced/api-client": "^0.9.2",
         "@mendable/firecrawl-js": "^4.9.3",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.2",
@@ -537,7 +537,7 @@
     },
     "packages/db": {
       "name": "@trycompai/db",
-      "version": "2.0.1",
+      "version": "2.0.3",
       "bin": {
         "comp-prisma-postinstall": "./dist/postinstall.js",
       },
@@ -1680,7 +1680,7 @@
 
     "@lukeed/csprng": ["@lukeed/csprng@1.1.0", "", {}, "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA=="],
 
-    "@maced/api-client": ["@maced/api-client@0.9.1", "", { "dependencies": { "openapi-fetch": "^0.12.2" } }, "sha512-fcAZYfqm49ift9fxZ4ZEiGKPces68kkVeQggZTMFTbon40Sh7kCpAZuWN7n4fjxfBqaXCUw3mo8BRECFf5a+sQ=="],
+    "@maced/api-client": ["@maced/api-client@0.9.2", "", { "dependencies": { "openapi-fetch": "^0.12.2" } }, "sha512-1KWEmblSN4Kc0BJFjc35ttKTCBkfUQposNibFvCGhhoteRK4GnaJ0qYeNmB+l86atGGgrgppoBBsRf9ssq4jjw=="],
 
     "@malept/cross-spawn-promise": ["@malept/cross-spawn-promise@2.0.0", "", { "dependencies": { "cross-spawn": "^7.0.1" } }, "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg=="],
 

--- a/packages/docs/openapi.json
+++ b/packages/docs/openapi.json
@@ -26308,6 +26308,45 @@
             "type": "boolean",
             "description": "Whether to run the pentest in simulation mode",
             "default": false
+          },
+          "scanDepth": {
+            "type": "string",
+            "description": "Scan depth profile to run",
+            "enum": [
+              "quick",
+              "standard",
+              "deep"
+            ]
+          },
+          "evidenceLevel": {
+            "type": "string",
+            "description": "Evidence validation level for findings",
+            "enum": [
+              "report_only",
+              "safe_proof",
+              "impact_proof"
+            ]
+          },
+          "checks": {
+            "type": "array",
+            "description": "Maced check IDs to include in the scan",
+            "items": {
+              "type": "string",
+              "enum": [
+                "discovery",
+                "secrets_info_disclosure",
+                "technology_config",
+                "xss",
+                "injection",
+                "authentication",
+                "authorization",
+                "idor_bola",
+                "ssrf_xxe",
+                "csrf",
+                "race_conditions",
+                "business_logic"
+              ]
+            }
           }
         },
         "required": [


### PR DESCRIPTION
## Summary
- add scan presets with custom scan configuration controls and runtime expectations
- clarify validation level choices while keeping preset/custom payload behavior intact
- update penetration-test scan creation tests and API/client scan option handling

## Verification
- bun run --filter '@trycompai/api' build
- bun run --filter '@trycompai/app' build
- cd apps/app && bunx vitest run 'src/app/(app)/[orgId]/security/penetration-tests/_components/CreateRunPanel.test.tsx'

Note: app build completed successfully outside the sandbox; sandboxed runs hung at Next's production compile step.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds scan presets and advanced options to make pentest scan setup faster and clearer, with live runtime estimates and validation level guidance. Wires new scan profile fields through the app, API, and docs.

- **New Features**
  - Presets: Quick, Standard, Deep with live runtime estimates and a “Custom” state when settings diverge; confirmation required for Deep/impact proof.
  - Advanced options: pick validation level (`report_only`, `safe_proof`, `impact_proof`) and individual checks; Discovery auto-enables when needed; concise radio/checkbox UI.
  - Defaults to Standard; runtime estimate updates with evidence/checks; cleaner form using `react-hook-form` with `ScanProfilePicker`, `ScanAdvancedOptions`, `RunExpectationSummary`, and target fields.
  - Client submits `scanDepth`, `evidenceLevel`, and `checks`; tests cover preset behavior, custom resolution, and payloads.

- **Refactors**
  - API: `CreatePenetrationTestDto` accepts optional `scanDepth`, `evidenceLevel`, `checks`; values are forwarded on create and mapped on list/get; `openapi.json` updated.
  - Webhooks/errors: tolerate missing provider handshake token, stop persisting secrets, normalize webhook URLs, and map invalid/empty provider responses to HttpExceptions.
  - Report output: fetch JSON from `/report` and return markdown with sensible content-type fallback.
  - Dependencies: bump `@maced/api-client` to `^0.9.2`; update hooks and tests for scan profile fields.

<sup>Written for commit 17d996d545069c91a4c18bb00de7c24e29981582. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

