### PR TITLE
Fix pentest scan setup review issues

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/CreateRunPanel.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/CreateRunPanel.test.tsx
@@ -152,6 +152,26 @@ describe('CreateRunPanel', () => {
     expect(screen.getByText('Custom · 17 min-38 min')).toBeInTheDocument();
   });
 
+  it('does not show an inverted runtime range when no checks are selected', async () => {
+    const user = userEvent.setup();
+
+    render(<CreateRunPanel orgId="org_1" balance={1} onSubmit={vi.fn()} />);
+
+    await user.click(screen.getByText('Quick'));
+    await user.click(screen.getByRole('button', { name: /customize scan/i }));
+    await user.click(screen.getByLabelText(/secrets & info disclosure/i));
+    await user.click(screen.getByLabelText(/technology config/i));
+    await user.click(screen.getByLabelText(/^discovery$/i));
+
+    expect(screen.getByText('Custom · 5 min-5 min')).toBeInTheDocument();
+  });
+
+  it('labels the optional repository field for assistive technology', () => {
+    render(<CreateRunPanel orgId="org_1" balance={1} onSubmit={vi.fn()} />);
+
+    expect(screen.getByLabelText(/repository/i)).toBeInTheDocument();
+  });
+
   it('uses design-system radio styling for evidence options', async () => {
     const user = userEvent.setup();
     render(<CreateRunPanel orgId="org_1" balance={1} onSubmit={vi.fn()} />);

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/CreateRunTargetFields.tsx
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/CreateRunTargetFields.tsx
@@ -33,15 +33,19 @@ export function CreateRunTargetFields({ form }: CreateRunTargetFieldsProps) {
       </div>
 
       <div className="mb-5">
-        <div className="mb-1.5 flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-[0.1em] text-muted-foreground">
+        <label
+          htmlFor="pt-repo-url"
+          className="mb-1.5 flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-[0.1em] text-muted-foreground"
+        >
           <span>Repository</span>
           <span className="font-normal normal-case tracking-normal text-muted-foreground">
             (optional)
           </span>
-        </div>
+        </label>
         <div className="flex h-9 items-center gap-1.5 rounded border border-border bg-background px-3">
           <Link className="h-3 w-3 shrink-0 text-muted-foreground" />
           <input
+            id="pt-repo-url"
             {...form.register('repoUrl')}
             placeholder="github.com/acme/platform"
             className="min-w-0 flex-1 bg-transparent font-mono text-xs outline-none"

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/scan-profiles.ts
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/scan-profiles.ts
@@ -122,7 +122,7 @@ export function estimateRuntime(params: {
     params.checks.reduce((sum, check) => sum + checkWeights[check], 0) *
     evidenceMultipliers[params.evidenceLevel];
   const min = Math.max(5, Math.floor(total * 0.7));
-  const max = Math.ceil(total * 1.5);
+  const max = Math.max(min, Math.ceil(total * 1.5));
 
   return `${formatRuntimeMinutes(min)}-${formatRuntimeMinutes(max)}`;
 }


### PR DESCRIPTION
## Summary
- associate the optional repository field text with its input for screen readers
- clamp custom runtime max to the already-clamped minimum to avoid inverted ranges
- add focused regression coverage for both issues

## Verification
- cd apps/app && bunx vitest run 'src/app/(app)/[orgId]/security/penetration-tests/_components/CreateRunPanel.test.tsx'

Context: these were the two PR 2741 review findings identified by cubic, and both are valid.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two issues in the pentest scan setup: adds an accessible label for the optional Repository field and clamps the custom runtime range to prevent inverted values. Adds focused regression tests.

- **Bug Fixes**
  - Associate the "Repository (optional)" label with its input via `htmlFor`/`id` for screen readers.
  - Clamp max runtime to at least the min in custom profiles, so empty selections show "5 min-5 min" instead of an inverted range.

<sup>Written for commit 6f11e0355a07eb242b66281cbe00f42bb573b760. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

