### PR TITLE
Move integration settings into detail page

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/IntegrationEvidenceTasks.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/IntegrationEvidenceTasks.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import type { IntegrationProvider } from '@/hooks/use-integration-platform';
+import { Button } from '@trycompai/design-system';
+import { ArrowRight } from '@trycompai/design-system/icons';
+import Link from 'next/link';
+import { useMemo } from 'react';
+
+export interface IntegrationTaskTemplate {
+  id: string;
+  taskId: string;
+  name: string;
+  description: string;
+}
+
+interface IntegrationEvidenceTasksProps {
+  provider: IntegrationProvider;
+  taskTemplates: IntegrationTaskTemplate[];
+  orgId: string;
+}
+
+interface MappedTask {
+  id: string;
+  name: string;
+}
+
+export function IntegrationEvidenceTasks({
+  provider,
+  taskTemplates,
+  orgId,
+}: IntegrationEvidenceTasksProps) {
+  const mappedTasks = getMappedTasks(provider);
+  const taskByTemplateId = useMemo(
+    () => new Map(taskTemplates.map((task) => [task.id, task])),
+    [taskTemplates],
+  );
+
+  if (mappedTasks.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="rounded-lg border bg-background">
+      <div className="border-b px-4 py-3">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h2 className="text-sm font-semibold">Evidence tasks</h2>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Tasks this integration can help automate or verify.
+            </p>
+          </div>
+          <span className="shrink-0 rounded-full bg-muted px-2 py-1 text-xs text-muted-foreground">
+            {mappedTasks.length}
+          </span>
+        </div>
+      </div>
+
+      <div className="divide-y">
+        {mappedTasks.map((mappedTask) => {
+          const task = taskByTemplateId.get(mappedTask.id);
+
+          return (
+            <div key={mappedTask.id} className="flex items-center justify-between gap-4 px-4 py-3">
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium">{task?.name ?? mappedTask.name}</p>
+                <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
+                  {task?.description ||
+                    'This task is mapped to the integration template, but is not available in this organization yet.'}
+                </p>
+              </div>
+
+              {task ? (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  render={<Link href={`/${orgId}/tasks/${task.taskId}`} />}
+                  iconRight={<ArrowRight size={14} />}
+                >
+                  Open
+                </Button>
+              ) : (
+                <span className="shrink-0 text-xs text-muted-foreground">Not added</span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function getMappedTasks(provider: IntegrationProvider): MappedTask[] {
+  const mappedTasks = (provider as IntegrationProvider & { mappedTasks?: MappedTask[] })
+    .mappedTasks;
+
+  return Array.isArray(mappedTasks) ? mappedTasks : [];
+}

--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/ProviderDetailView.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/ProviderDetailView.tsx
@@ -8,31 +8,25 @@ import {
   type ConnectionListItem,
   type IntegrationProvider,
 } from '@/hooks/use-integration-platform';
-import {
-  CLOUD_RECONNECT_CUTOFF_LABEL,
-  requiresCloudReconnect,
-} from '@/lib/cloud-reconnect-policy';
 import { api } from '@/lib/api-client';
-import {
-  Breadcrumb,
-  Button,
-  Stack,
-} from '@trycompai/design-system';
-import { Add, Security } from '@trycompai/design-system/icons';
-import { GcpProjectPicker } from './GcpProjectPicker';
+import { CLOUD_RECONNECT_CUTOFF_LABEL, requiresCloudReconnect } from '@/lib/cloud-reconnect-policy';
+import { Breadcrumb, Button, Stack } from '@trycompai/design-system';
 import Link from 'next/link';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { AccountSettingsSheet } from './AccountSettingsSheet';
 import { getConnectionDisplayLabel } from './connection-display';
-import { IntegrationProviderHero } from './IntegrationProviderHero';
 import { EmptyStateOnboarding } from './EmptyStateOnboarding';
+import { GcpProjectPicker } from './GcpProjectPicker';
+import { IntegrationEvidenceTasks, type IntegrationTaskTemplate } from './IntegrationEvidenceTasks';
+import { IntegrationProviderHero } from './IntegrationProviderHero';
 import { ServicesGrid } from './services-grid';
 
 interface ProviderDetailViewProps {
   provider: IntegrationProvider;
   initialConnections: ConnectionListItem[];
+  taskTemplates: IntegrationTaskTemplate[];
   /** Server passes true when URL was ?success=true&provider=gcp (OAuth return) */
   gcpOAuthJustConnected?: boolean;
 }
@@ -40,10 +34,12 @@ interface ProviderDetailViewProps {
 export function ProviderDetailView({
   provider,
   initialConnections,
+  taskTemplates,
   gcpOAuthJustConnected = false,
 }: ProviderDetailViewProps) {
   const { orgId } = useParams<{ orgId: string }>();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { connections: allConnections, refresh: refreshConnections } = useIntegrationConnections();
   const { startOAuth } = useIntegrationMutations();
   const [showAddAccount, setShowAddAccount] = useState(false);
@@ -70,12 +66,20 @@ export function ProviderDetailView({
     return activeConnections[0] ?? null;
   }, [selectedConnectionId, activeConnections]);
 
-  const services =
-    (
-      provider as IntegrationProvider & {
-        services?: Array<{ id: string; name: string; description: string; implemented?: boolean }>;
-      }
-    ).services ?? [];
+  const services = useMemo(
+    () =>
+      (
+        provider as IntegrationProvider & {
+          services?: Array<{
+            id: string;
+            name: string;
+            description: string;
+            implemented?: boolean;
+          }>;
+        }
+      ).services ?? [],
+    [provider],
+  );
   const isCloudProvider = provider.category === 'Cloud';
   const selectedConnectionRequiresReconnect = useMemo(() => {
     if (!isCloudProvider || !selectedConnection) return false;
@@ -83,8 +87,7 @@ export function ProviderDetailView({
     return requiresCloudReconnect({
       providerId: provider.id,
       createdAt: selectedConnection.createdAt,
-      reconnectedAt:
-        typeof metadata.reconnectedAt === 'string' ? metadata.reconnectedAt : null,
+      reconnectedAt: typeof metadata.reconnectedAt === 'string' ? metadata.reconnectedAt : null,
       status: selectedConnection.status,
     });
   }, [isCloudProvider, provider.id, selectedConnection]);
@@ -106,6 +109,7 @@ export function ProviderDetailView({
   >([]);
   const [gcpSelectedProjectIds, setGcpSelectedProjectIds] = useState<string[]>([]);
   const oauthBootstrapHandledRef = useRef(false);
+  const settingsQueryHandledRef = useRef(false);
 
   const handleToggleService = useCallback(
     async (serviceId: string, enabled: boolean): Promise<boolean> => {
@@ -141,13 +145,7 @@ export function ProviderDetailView({
 
     // For GCP: only detect orgs/projects — service detection waits for project selection
     // (The detect-gcp-org effect already fires on connection)
-  }, [
-    gcpOAuthJustConnected,
-    provider.id,
-    selectedConnection?.id,
-    orgId,
-    router,
-  ]);
+  }, [gcpOAuthJustConnected, provider.id, selectedConnection?.id, orgId, router]);
 
   // Auto-detect GCP organization after OAuth connect
   const gcpDetectedRef = useRef<Set<string>>(new Set());
@@ -169,9 +167,7 @@ export function ProviderDetailView({
           projects: Array<{ id: string; name: string }>;
         }>;
         selectedProjectIds?: string[];
-      }>(
-        `/v1/cloud-security/detect-gcp-org/${selectedConnection.id}`,
-      )
+      }>(`/v1/cloud-security/detect-gcp-org/${selectedConnection.id}`)
       .then((res) => {
         const orgs = res.data?.organizations ?? [];
         if (orgs.length > 0) setGcpOrgs(orgs);
@@ -202,9 +198,7 @@ export function ProviderDetailView({
 
     const connectionForRun = selectedConnection;
     api
-      .post<{ services: string[] }>(
-        `/v1/cloud-security/detect-services/${connectionForRun.id}`,
-      )
+      .post<{ services: string[] }>(`/v1/cloud-security/detect-services/${connectionForRun.id}`)
       .then((res) => {
         if (res.error) return;
         detectedConnections.current.add(connectionForRun.id);
@@ -216,11 +210,11 @@ export function ProviderDetailView({
         return refreshServices();
       })
       .catch(() => {});
-  }, [isCloudProvider, isConnected, selectedConnection?.id, refreshServices, provider.id]);
+  }, [isCloudProvider, isConnected, selectedConnection, refreshServices, provider.id]);
 
   const handleConnect = useCallback(async () => {
     if (provider.authType === 'oauth2') {
-      const redirectUrl = `${window.location.origin}/${orgId}/integrations/${provider.id}?success=true`;
+      const redirectUrl = `${window.location.origin}/${orgId}/integrations/${provider.id}?success=true&settings=true`;
       const result = await startOAuth(provider.id, redirectUrl);
       if (result?.authorizationUrl) {
         window.location.href = result.authorizationUrl;
@@ -233,6 +227,21 @@ export function ProviderDetailView({
       setShowAddAccount(true);
     }
   }, [provider, orgId, startOAuth]);
+
+  useEffect(() => {
+    if (!selectedConnection?.id || settingsQueryHandledRef.current) return;
+
+    const shouldOpenSettings =
+      searchParams.get('settings') === 'true' ||
+      searchParams.get('configure') === 'true' ||
+      searchParams.get('success') === 'true';
+
+    if (!shouldOpenSettings) return;
+
+    settingsQueryHandledRef.current = true;
+    setSettingsOpen(true);
+    router.replace(`/${orgId}/integrations/${provider.id}`, { scroll: false });
+  }, [orgId, provider.id, router, searchParams, selectedConnection?.id]);
 
   return (
     <>
@@ -258,12 +267,15 @@ export function ProviderDetailView({
           onAddAccount={() => void handleConnect()}
         />
 
+        <IntegrationEvidenceTasks provider={provider} taskTemplates={taskTemplates} orgId={orgId} />
+
         {selectedConnectionRequiresReconnect && (
           <div className="rounded-lg border border-warning/30 bg-warning/10 px-4 py-3 flex items-center justify-between gap-3">
             <div>
               <p className="text-sm font-medium">Reconnect this account</p>
               <p className="text-xs text-muted-foreground mt-0.5">
-                This connection was created before {CLOUD_RECONNECT_CUTOFF_LABEL}. Reconnect it to keep scans and remediation fully reliable.
+                This connection was created before {CLOUD_RECONNECT_CUTOFF_LABEL}. Reconnect it to
+                keep scans and remediation fully reliable.
               </p>
             </div>
             <Button size="sm" variant="outline" onClick={() => setReconnectDialogOpen(true)}>
@@ -295,7 +307,9 @@ export function ProviderDetailView({
               className="flex items-center justify-between rounded-xl border bg-background shadow-sm px-5 py-4 hover:bg-muted/30 transition-colors group"
             >
               <div>
-                <p className="text-sm font-semibold group-hover:text-primary transition-colors">View Findings & Auto-Fix</p>
+                <p className="text-sm font-semibold group-hover:text-primary transition-colors">
+                  View Findings & Auto-Fix
+                </p>
                 <p className="text-xs text-muted-foreground mt-0.5">
                   Security findings, auto-remediation, and batch fixes are now in Cloud Tests.
                 </p>
@@ -327,10 +341,11 @@ export function ProviderDetailView({
                     }
                   }
                   void api
-                    .post(
-                      `/v1/cloud-security/select-gcp-projects/${selectedConnection.id}`,
-                      { projectIds: next, projectNames, gcpOrganizationId: gcpOrgId },
-                    )
+                    .post(`/v1/cloud-security/select-gcp-projects/${selectedConnection.id}`, {
+                      projectIds: next,
+                      projectNames,
+                      gcpOrganizationId: gcpOrgId,
+                    })
                     .then(async (res) => {
                       if (res.error) {
                         setGcpSelectedProjectIds(prev);
@@ -361,19 +376,29 @@ export function ProviderDetailView({
                 {provider.id === 'gcp' && gcpSelectedProjectIds.length === 0 ? (
                   <div className="flex items-start gap-3 rounded-lg border bg-muted/30 px-4 py-3.5">
                     <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted mt-0.5">
-                      <svg className="h-4 w-4 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 12.75V12A2.25 2.25 0 014.5 9.75h15A2.25 2.25 0 0121.75 12v.75m-8.69-6.44l-2.12-2.12a1.5 1.5 0 00-1.061-.44H4.5A2.25 2.25 0 002.25 6v12a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9a2.25 2.25 0 00-2.25-2.25h-5.379a1.5 1.5 0 01-1.06-.44z" />
+                      <svg
+                        className="h-4 w-4 text-muted-foreground"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        strokeWidth={1.5}
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M2.25 12.75V12A2.25 2.25 0 014.5 9.75h15A2.25 2.25 0 0121.75 12v.75m-8.69-6.44l-2.12-2.12a1.5 1.5 0 00-1.061-.44H4.5A2.25 2.25 0 002.25 6v12a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9a2.25 2.25 0 00-2.25-2.25h-5.379a1.5 1.5 0 01-1.06-.44z"
+                        />
                       </svg>
                     </div>
                     <div>
                       <p className="text-sm font-medium">Select projects first</p>
                       <p className="text-xs text-muted-foreground mt-0.5">
-                        Choose GCP projects above to detect which services are active. Service toggles will appear here once projects are selected.
+                        Choose GCP projects above to detect which services are active. Service
+                        toggles will appear here once projects are selected.
                       </p>
                     </div>
                   </div>
-                ) : provider.id === 'gcp' &&
-                  servicesMeta.detectionReady === false ? (
+                ) : provider.id === 'gcp' && servicesMeta.detectionReady === false ? (
                   <div className="rounded-lg border bg-muted/20 px-4 py-3">
                     <p className="text-sm font-medium text-foreground">
                       Detecting active GCP services…
@@ -439,4 +464,3 @@ export function ProviderDetailView({
     </>
   );
 }
-

--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/account-settings-oauth.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/account-settings-oauth.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { normalizeVariableValue } from '@/components/integrations/ConnectionVariablesForm';
 import type { IntegrationProvider } from '@/hooks/use-integration-platform';
 import {
   useIntegrationConnection,
@@ -37,15 +38,9 @@ export function AccountSettingsOAuthBody({
   onUpdated,
   onOpenChange,
 }: AccountSettingsOAuthProps) {
-  const { connection, isLoading } = useIntegrationConnection(
-    open ? connectionId : null,
-  );
-  const {
-    getConnectionVariables,
-    saveConnectionVariables,
-    getVariableOptions,
-    deleteConnection,
-  } = useIntegrationMutations();
+  const { connection, isLoading } = useIntegrationConnection(open ? connectionId : null);
+  const { getConnectionVariables, saveConnectionVariables, getVariableOptions, deleteConnection } =
+    useIntegrationMutations();
 
   const [variables, setVariables] = useState<OAuthVariableRow[]>([]);
   const [variableValues, setVariableValues] = useState<
@@ -68,7 +63,7 @@ export function AccountSettingsOAuthBody({
         const next: Record<string, string | number | boolean | string[]> = {};
         for (const v of result.data.variables) {
           if (v.currentValue !== undefined) {
-            next[v.id] = v.currentValue as string | number | boolean | string[];
+            next[v.id] = normalizeVariableValue(v, v.currentValue);
           }
         }
         setVariableValues(next);
@@ -151,11 +146,7 @@ export function AccountSettingsOAuthBody({
   return (
     <div className="space-y-5 py-5">
       <div className="rounded-md border bg-muted/20 px-3 py-2.5 space-y-1">
-        <AccountSettingsInfoRow
-          label="Integration"
-          value={provider.name}
-          valueTruncate
-        />
+        <AccountSettingsInfoRow label="Integration" value={provider.name} valueTruncate />
         <AccountSettingsInfoRow
           label="Status"
           badge={
@@ -204,9 +195,7 @@ export function AccountSettingsOAuthBody({
             <AlertTriangle className="h-3.5 w-3.5 text-destructive shrink-0" />
             <div className="min-w-0">
               <p className="text-xs font-medium">Disconnect</p>
-              <p className="text-[10px] text-muted-foreground">
-                Remove this account and all data
-              </p>
+              <p className="text-[10px] text-muted-foreground">Remove this account and all data</p>
             </div>
           </div>
           <Button

--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/oauth-connection-variables-form.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/oauth-connection-variables-form.tsx
@@ -1,36 +1,21 @@
 'use client';
 
-import { Button, Label } from '@trycompai/design-system';
-import { Input } from '@trycompai/ui/input';
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@trycompai/ui/select';
-import { Loader2 } from 'lucide-react';
+  ConnectionVariablesFields,
+  validateTargetRepos,
+  type ConnectionVariable,
+} from '@/components/integrations/ConnectionVariablesForm';
+import { Button } from '@trycompai/design-system';
 import type { Dispatch, SetStateAction } from 'react';
 
-export type OAuthVariableRow = {
-  id: string;
-  label: string;
-  type: string;
-  required: boolean;
-  helpText?: string;
-  placeholder?: string;
-  description?: string;
+export type OAuthVariableRow = ConnectionVariable & {
   currentValue?: string | number | boolean | string[];
-  hasDynamicOptions?: boolean;
-  options?: { value: string; label: string }[];
 };
 
 type Props = {
   variables: OAuthVariableRow[];
   variableValues: Record<string, string | number | boolean | string[]>;
-  setVariableValues: Dispatch<
-    SetStateAction<Record<string, string | number | boolean | string[]>>
-  >;
+  setVariableValues: Dispatch<SetStateAction<Record<string, string | number | boolean | string[]>>>;
   dynamicOptions: Record<string, { value: string; label: string }[]>;
   loadingOptions: Record<string, boolean>;
   fetchOptions: (variableId: string) => void;
@@ -48,6 +33,8 @@ export function OAuthConnectionVariablesForm({
   onSave,
   savingVariables,
 }: Props) {
+  const isTargetReposValid = validateTargetRepos(variableValues);
+
   if (variables.length === 0) {
     return (
       <p className="text-xs text-muted-foreground">
@@ -61,93 +48,18 @@ export function OAuthConnectionVariablesForm({
       <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">
         Configuration
       </p>
-      {variables.map((variable) => {
-        const options = dynamicOptions[variable.id] ?? variable.options ?? [];
-        return (
-          <div key={variable.id} className="space-y-2">
-            <Label htmlFor={variable.id}>
-              {variable.label}
-              {variable.required ? <span className="text-destructive ml-1">*</span> : null}
-            </Label>
-            {variable.description ? (
-              <p className="text-xs text-muted-foreground">{variable.description}</p>
-            ) : null}
-            {variable.helpText ? (
-              <p className="text-xs text-muted-foreground">{variable.helpText}</p>
-            ) : null}
-
-            {variable.type === 'boolean' ? (
-              <Select
-                value={String(variableValues[variable.id] ?? 'false')}
-                onValueChange={(val) =>
-                  setVariableValues((prev) => ({
-                    ...prev,
-                    [variable.id]: val === 'true',
-                  }))
-                }
-              >
-                <SelectTrigger id={variable.id}>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="true">Yes</SelectItem>
-                  <SelectItem value="false">No</SelectItem>
-                </SelectContent>
-              </Select>
-            ) : variable.type === 'select' ? (
-              <Select
-                value={String(variableValues[variable.id] ?? '')}
-                onValueChange={(val) =>
-                  setVariableValues((prev) => ({ ...prev, [variable.id]: val }))
-                }
-                onOpenChange={(openSel) => {
-                  if (openSel && variable.hasDynamicOptions && options.length === 0) {
-                    void fetchOptions(variable.id);
-                  }
-                }}
-              >
-                <SelectTrigger id={variable.id}>
-                  <SelectValue placeholder={`Select ${variable.label.toLowerCase()}`} />
-                </SelectTrigger>
-                <SelectContent>
-                  {loadingOptions[variable.id] ? (
-                    <div className="py-2 px-3 text-sm text-muted-foreground flex items-center gap-2">
-                      <Loader2 className="h-3 w-3 animate-spin" />
-                      Loading…
-                    </div>
-                  ) : options.length === 0 ? (
-                    <div className="py-2 px-3 text-sm text-muted-foreground">No options</div>
-                  ) : (
-                    options.map((opt) => (
-                      <SelectItem key={opt.value} value={opt.value}>
-                        {opt.label}
-                      </SelectItem>
-                    ))
-                  )}
-                </SelectContent>
-              </Select>
-            ) : (
-              <Input
-                id={variable.id}
-                type={variable.type === 'number' ? 'number' : 'text'}
-                value={String(variableValues[variable.id] ?? '')}
-                onChange={(e) =>
-                  setVariableValues((prev) => ({
-                    ...prev,
-                    [variable.id]:
-                      variable.type === 'number' ? Number(e.target.value) : e.target.value,
-                  }))
-                }
-                placeholder={variable.placeholder}
-              />
-            )}
-          </div>
-        );
-      })}
+      <ConnectionVariablesFields
+        variables={variables}
+        variableValues={variableValues}
+        setVariableValues={setVariableValues}
+        dynamicOptions={dynamicOptions}
+        loadingOptions={loadingOptions}
+        fetchOptions={fetchOptions}
+      />
       <Button
         onClick={() => void onSave()}
         loading={savingVariables}
-        disabled={savingVariables}
+        disabled={savingVariables || !isTargetReposValid}
         size="sm"
       >
         Save configuration

--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/page.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/page.tsx
@@ -1,9 +1,20 @@
 import { serverApi } from '@/lib/api-server';
-import type { IntegrationProviderResponse } from '@trycompai/integration-platform';
-import type { ConnectionListItemResponse } from '@trycompai/integration-platform';
 import { PageLayout } from '@trycompai/design-system';
+import type {
+  ConnectionListItemResponse,
+  IntegrationProviderResponse,
+} from '@trycompai/integration-platform';
 import { redirect } from 'next/navigation';
 import { ProviderDetailView } from './components/ProviderDetailView';
+
+interface TaskApiResponse {
+  data: Array<{
+    id: string;
+    title: string;
+    description: string;
+    taskTemplateId: string | null;
+  }>;
+}
 
 interface PageProps {
   params: Promise<{ orgId: string; slug: string }>;
@@ -15,16 +26,12 @@ export default async function ProviderDetailPage({ params, searchParams }: PageP
   const sp = await searchParams;
   const success = typeof sp.success === 'string' ? sp.success : '';
   const providerParam = typeof sp.provider === 'string' ? sp.provider : '';
-  const gcpOAuthJustConnected =
-    slug === 'gcp' && success === 'true' && providerParam === 'gcp';
+  const gcpOAuthJustConnected = slug === 'gcp' && success === 'true' && providerParam === 'gcp';
 
-  const [providerResult, connectionsResult] = await Promise.all([
-    serverApi.get<IntegrationProviderResponse>(
-      `/v1/integrations/connections/providers/${slug}`,
-    ),
-    serverApi.get<ConnectionListItemResponse[]>(
-      '/v1/integrations/connections',
-    ),
+  const [providerResult, connectionsResult, tasksResult] = await Promise.all([
+    serverApi.get<IntegrationProviderResponse>(`/v1/integrations/connections/providers/${slug}`),
+    serverApi.get<ConnectionListItemResponse[]>('/v1/integrations/connections'),
+    serverApi.get<TaskApiResponse>('/v1/tasks'),
   ]);
 
   if (!providerResult.data || providerResult.error) {
@@ -32,15 +39,23 @@ export default async function ProviderDetailPage({ params, searchParams }: PageP
   }
 
   const provider = providerResult.data;
-  const connections = (connectionsResult.data ?? []).filter(
-    (c) => c.providerSlug === slug,
-  );
+  const connections = (connectionsResult.data ?? []).filter((c) => c.providerSlug === slug);
+  const taskTemplates = (tasksResult.data?.data ?? [])
+    .filter((task) => task.taskTemplateId)
+    .map((task) => ({
+      id: task.taskTemplateId as string,
+      taskId: task.id,
+      name: task.title,
+      description: task.description,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
 
   return (
     <PageLayout>
       <ProviderDetailView
         provider={provider}
         initialConnections={connections}
+        taskTemplates={taskTemplates}
         gcpOAuthJustConnected={gcpOAuthJustConnected}
       />
     </PageLayout>

--- a/apps/app/src/app/(app)/[orgId]/integrations/components/PlatformIntegrations.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/components/PlatformIntegrations.tsx
@@ -1,9 +1,5 @@
 'use client';
 
-import { ConnectIntegrationDialog } from '@/components/integrations/ConnectIntegrationDialog';
-import { ManageIntegrationDialog } from '@/components/integrations/ManageIntegrationDialog';
-import { usePermissions } from '@/hooks/use-permissions';
-import { useVendors } from '@/hooks/use-vendors';
 import {
   ConnectionListItem,
   IntegrationProvider,
@@ -11,6 +7,8 @@ import {
   useIntegrationMutations,
   useIntegrationProviders,
 } from '@/hooks/use-integration-platform';
+import { usePermissions } from '@/hooks/use-permissions';
+import { useVendors } from '@/hooks/use-vendors';
 import { Badge } from '@trycompai/ui/badge';
 import { Button } from '@trycompai/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@trycompai/ui/card';
@@ -39,23 +37,11 @@ import Link from 'next/link';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
-import {
-  CATEGORIES,
-  INTEGRATIONS,
-  type Integration,
-  type IntegrationCategory,
-} from '../data/integrations';
+import { CATEGORIES, type Integration, type IntegrationCategory } from '../data/integrations';
 import { SearchInput } from './SearchInput';
 import { TaskCard, TaskCardSkeleton } from './TaskCard';
 
 const LOGO_TOKEN = 'pk_AZatYxV5QDSfWpRDaBxzRQ';
-
-// Providers that support employee sync via People > All
-const EMPLOYEE_SYNC_PROVIDERS = new Set([
-  'google-workspace',
-  'rippling',
-  'jumpcloud',
-]);
 
 // Check if a provider needs variable configuration based on manifest's required variables
 const providerNeedsConfiguration = (
@@ -132,11 +118,7 @@ export function PlatformIntegrations({ className, taskTemplates }: PlatformInteg
   const router = useRouter();
   const searchParams = useSearchParams();
   const { providers, isLoading: loadingProviders } = useIntegrationProviders(true);
-  const {
-    connections,
-    isLoading: loadingConnections,
-    refresh: refreshConnections,
-  } = useIntegrationConnections();
+  const { connections, isLoading: loadingConnections } = useIntegrationConnections();
   const { hasPermission } = usePermissions();
   const canCreate = hasPermission('integration', 'create');
   const { startOAuth } = useIntegrationMutations();
@@ -146,17 +128,6 @@ export function PlatformIntegrations({ className, taskTemplates }: PlatformInteg
   const [selectedCategory, setSelectedCategory] = useState<IntegrationCategory | 'All'>('All');
   const [connectingProvider, setConnectingProvider] = useState<string | null>(null);
   const hasHandledOAuthRef = useRef(false);
-
-  // Management dialog state
-  const [manageDialogOpen, setManageDialogOpen] = useState(false);
-  const [selectedConnection, setSelectedConnection] = useState<ConnectionListItem | null>(null);
-  const [selectedProvider, setSelectedProvider] = useState<IntegrationProvider | null>(null);
-
-  // Connect dialog state (for non-OAuth)
-  const [connectDialogOpen, setConnectDialogOpen] = useState(false);
-  const [connectingProviderInfo, setConnectingProviderInfo] = useState<IntegrationProvider | null>(
-    null,
-  );
 
   // Custom integration dialog state
   const [selectedCustomIntegration, setSelectedCustomIntegration] = useState<Integration | null>(
@@ -189,37 +160,8 @@ export function PlatformIntegrations({ className, taskTemplates }: PlatformInteg
     router.push(`/${orgId}/integrations/${provider.id}`);
   };
 
-  const handleConnectDialogSuccess = () => {
-    // Prompt user to import employees for providers that support sync
-    if (connectingProviderInfo && EMPLOYEE_SYNC_PROVIDERS.has(connectingProviderInfo.id)) {
-      toast.info(`Import your ${connectingProviderInfo.name} users`, {
-        description:
-          'Go to People to import and sync your team members.',
-        duration: 15000,
-        action: {
-          label: 'Go to People',
-          onClick: () => router.push(`/${orgId}/people/all`),
-        },
-      });
-    }
-    refreshConnections();
-    setConnectDialogOpen(false);
-    setConnectingProviderInfo(null);
-  };
-
-  const handleOpenManageDialog = (
-    connection: ConnectionListItem,
-    provider: IntegrationProvider,
-  ) => {
-    setSelectedConnection(connection);
-    setSelectedProvider(provider);
-    setManageDialogOpen(true);
-  };
-
-  const handleCloseManageDialog = () => {
-    setManageDialogOpen(false);
-    setSelectedConnection(null);
-    setSelectedProvider(null);
+  const handleOpenProviderSettings = (provider: IntegrationProvider) => {
+    router.push(`/${orgId}/integrations/${provider.id}?settings=true`);
   };
 
   // Map connections by provider slug
@@ -249,12 +191,9 @@ export function PlatformIntegrations({ className, taskTemplates }: PlatformInteg
 
   // Merge/sort integrations, then prioritize entries matching vendors in the org's vendor list.
   const unifiedIntegrations = useMemo<UnifiedIntegration[]>(() => {
-    const platformSortTier = (
-      item: UnifiedIntegration & { type: 'platform' },
-    ): 0 | 1 | 2 => {
+    const platformSortTier = (item: UnifiedIntegration & { type: 'platform' }): 0 | 1 | 2 => {
       const { provider, connection } = item;
-      const isComingSoon =
-        provider.authType === 'oauth2' && provider.oauthConfigured === false;
+      const isComingSoon = provider.authType === 'oauth2' && provider.oauthConfigured === false;
       if (isComingSoon) return 2;
 
       const hasEstablishedConnection =
@@ -367,60 +306,33 @@ export function PlatformIntegrations({ className, taskTemplates }: PlatformInteg
     return filtered;
   }, [unifiedIntegrations, searchQuery, selectedCategory]);
 
-  // Handle OAuth callback - auto-open config dialog for newly connected provider
+  // Handle legacy OAuth callbacks that still land on the integrations grid.
   useEffect(() => {
-    // Only handle once
     if (hasHandledOAuthRef.current) return;
 
     const success = searchParams.get('success');
     const providerSlug = searchParams.get('provider');
 
-    // Check if this is an OAuth callback
     if (success !== 'true' || !providerSlug) return;
 
-    // Wait for data to load
-    if (!connections || !providers || loadingConnections || loadingProviders) {
+    if (!providers || loadingProviders) {
       return;
     }
 
-    // Mark as handled
     hasHandledOAuthRef.current = true;
-
-    const connection = connections.find((c) => c.providerSlug === providerSlug);
     const provider = providers.find((p) => p.id === providerSlug);
 
-    if (connection && provider) {
+    if (provider) {
       toast.success(`${provider.name} connected successfully!`);
-
-      // Prompt user to import employees for providers that support sync
-      if (EMPLOYEE_SYNC_PROVIDERS.has(providerSlug)) {
-        toast.info(`Import your ${provider.name} users`, {
-          description:
-            'Go to People to import and sync your team members.',
-          duration: 15000,
-          action: {
-            label: 'Go to People',
-            onClick: () => router.push(`/${orgId}/people/all`),
-          },
-        });
-      }
-
-      // Set state first
-      setSelectedConnection(connection);
-      setSelectedProvider(provider);
-
-      // Open dialog after a tick to ensure state is updated
-      setTimeout(() => {
-        setManageDialogOpen(true);
-      }, 150);
+      router.replace(`/${orgId}/integrations/${providerSlug}?settings=true`);
+      return;
     }
 
-    // Clean up URL parameters
     const url = new URL(window.location.href);
     url.searchParams.delete('success');
     url.searchParams.delete('provider');
     window.history.replaceState({}, '', url.toString());
-  }, [searchParams, connections, providers, loadingConnections, loadingProviders]);
+  }, [searchParams, providers, loadingProviders, router, orgId]);
 
   // Create a map from templateId to taskId for quick lookup
   const templateToTaskMap = useMemo(
@@ -448,16 +360,25 @@ export function PlatformIntegrations({ className, taskTemplates }: PlatformInteg
         }),
       })
         .then((res) => res.json())
-        .then((data: { tasks: Array<{ taskTemplateId: string; taskName: string; reason: string; prompt: string }> }) => {
-          const aiTasks = Array.isArray(data.tasks) ? data.tasks : [];
-          const tasksWithIds = aiTasks
-            .map((task) => ({
-              ...task,
-              taskId: templateToTaskMap.get(task.taskTemplateId) || '',
-            }))
-            .filter((task) => task.taskId);
-          setRelevantTasks(tasksWithIds);
-        })
+        .then(
+          (data: {
+            tasks: Array<{
+              taskTemplateId: string;
+              taskName: string;
+              reason: string;
+              prompt: string;
+            }>;
+          }) => {
+            const aiTasks = Array.isArray(data.tasks) ? data.tasks : [];
+            const tasksWithIds = aiTasks
+              .map((task) => ({
+                ...task,
+                taskId: templateToTaskMap.get(task.taskTemplateId) || '',
+              }))
+              .filter((task) => task.taskId);
+            setRelevantTasks(tasksWithIds);
+          },
+        )
         .catch((error) => {
           console.error('Error fetching relevant tasks:', error);
           setRelevantTasks([]);
@@ -564,15 +485,12 @@ export function PlatformIntegrations({ className, taskTemplates }: PlatformInteg
                     connection?.variables as Record<string, unknown> | null,
                   );
 
-                const isComingSoon = provider.authType === 'oauth2' && provider.oauthConfigured === false;
+                const isComingSoon =
+                  provider.authType === 'oauth2' && provider.oauthConfigured === false;
 
                 /** Primary CTA is Connect / Set up — card still opens details on click; hide redundant “View details” row */
                 const showConnectOrSetup =
-                  canCreate &&
-                  !needsConfiguration &&
-                  !isConnected &&
-                  !hasError &&
-                  !isComingSoon;
+                  canCreate && !needsConfiguration && !isConnected && !hasError && !isComingSoon;
 
                 return (
                   <div
@@ -589,7 +507,11 @@ export function PlatformIntegrations({ className, taskTemplates }: PlatformInteg
                         ? undefined
                         : `Open ${provider.name} — connection details, services, and settings`
                     }
-                    onClick={isComingSoon ? undefined : () => router.push(`/${orgId}/integrations/${provider.id}`)}
+                    onClick={
+                      isComingSoon
+                        ? undefined
+                        : () => router.push(`/${orgId}/integrations/${provider.id}`)
+                    }
                     onKeyDown={
                       isComingSoon
                         ? undefined
@@ -601,203 +523,224 @@ export function PlatformIntegrations({ className, taskTemplates }: PlatformInteg
                           }
                     }
                   >
-                  <Card
-                    className={`relative overflow-hidden transition-all flex flex-col h-full ${isComingSoon ? 'opacity-75' : 'cursor-pointer'} ${
-                      needsConfiguration
-                        ? 'border-warning/30 bg-warning/5'
-                        : isConnected
-                          ? 'border-primary/30 bg-primary/5'
-                          : 'hover:border-primary/20 hover:shadow-sm'
-                    } ${!isComingSoon ? 'group-hover:border-primary/30 group-hover:shadow-md' : ''}`}
-                  >
-                    <CardHeader className="pb-3">
-                      <div className="flex items-start justify-between">
-                        <div className="flex items-center gap-3">
-                          <div className="w-12 h-12 rounded-xl bg-background border border-border flex items-center justify-center overflow-hidden">
-                            <Image
-                              src={provider.logoUrl}
-                              alt={`${provider.name} logo`}
-                              width={32}
-                              height={32}
-                              className="object-contain"
-                            />
-                          </div>
-                          <div>
-                            <CardTitle className="text-base font-semibold flex items-center gap-2">
-                              {provider.name}
-                              {isConnected && !needsConfiguration && (
-                                <CheckCircle2 className="h-4 w-4 text-primary" />
-                              )}
-                              {needsConfiguration && (
-                                <AlertTriangle className="h-4 w-4 text-warning" />
-                              )}
-                              {hasError && <AlertCircle className="h-4 w-4 text-destructive" />}
-                            </CardTitle>
-                            <div className="flex items-center gap-2 mt-0.5">
-                              <p className="text-xs text-muted-foreground">{provider.category}</p>
-                              <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
-                                Platform
-                              </Badge>
+                    <Card
+                      className={`relative overflow-hidden transition-all flex flex-col h-full ${isComingSoon ? 'opacity-75' : 'cursor-pointer'} ${
+                        needsConfiguration
+                          ? 'border-warning/30 bg-warning/5'
+                          : isConnected
+                            ? 'border-primary/30 bg-primary/5'
+                            : 'hover:border-primary/20 hover:shadow-sm'
+                      } ${!isComingSoon ? 'group-hover:border-primary/30 group-hover:shadow-md' : ''}`}
+                    >
+                      <CardHeader className="pb-3">
+                        <div className="flex items-start justify-between">
+                          <div className="flex items-center gap-3">
+                            <div className="w-12 h-12 rounded-xl bg-background border border-border flex items-center justify-center overflow-hidden">
+                              <Image
+                                src={provider.logoUrl}
+                                alt={`${provider.name} logo`}
+                                width={32}
+                                height={32}
+                                className="object-contain"
+                              />
+                            </div>
+                            <div>
+                              <CardTitle className="text-base font-semibold flex items-center gap-2">
+                                {provider.name}
+                                {isConnected && !needsConfiguration && (
+                                  <CheckCircle2 className="h-4 w-4 text-primary" />
+                                )}
+                                {needsConfiguration && (
+                                  <AlertTriangle className="h-4 w-4 text-warning" />
+                                )}
+                                {hasError && <AlertCircle className="h-4 w-4 text-destructive" />}
+                              </CardTitle>
+                              <div className="flex items-center gap-2 mt-0.5">
+                                <p className="text-xs text-muted-foreground">{provider.category}</p>
+                                <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
+                                  Platform
+                                </Badge>
+                              </div>
                             </div>
                           </div>
+                          {isConnected && (
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="h-8 w-8 p-0"
+                              onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                handleOpenProviderSettings(provider);
+                              }}
+                            >
+                              <Settings2 className="h-4 w-4" />
+                            </Button>
+                          )}
                         </div>
-                        {isConnected && (
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-8 w-8 p-0"
-                            onClick={(e) => { e.preventDefault(); e.stopPropagation(); handleOpenManageDialog(connection, provider); }}
-                          >
-                            <Settings2 className="h-4 w-4" />
-                          </Button>
-                        )}
-                      </div>
-                    </CardHeader>
-                    <CardContent className="flex flex-col h-full">
-                      <div className="flex-1 space-y-4">
-                        <CardDescription className="text-sm leading-relaxed line-clamp-2">
-                          {provider.description}
-                        </CardDescription>
+                      </CardHeader>
+                      <CardContent className="flex flex-col h-full">
+                        <div className="flex-1 space-y-4">
+                          <CardDescription className="text-sm leading-relaxed line-clamp-2">
+                            {provider.description}
+                          </CardDescription>
 
-                        {/* Mapped tasks */}
-                        {provider.mappedTasks && provider.mappedTasks.length > 0 && (
-                          <div className="flex flex-wrap gap-1.5">
-                            {provider.mappedTasks.slice(0, 3).map((task) => {
-                              const taskId = templateToTaskMap.get(task.id);
-                              return taskId ? (
-                                <Link
-                                  key={task.id}
-                                  href={`/${orgId}/tasks/${taskId}`}
-                                  onClick={(e) => e.stopPropagation()}
-                                >
+                          {/* Mapped tasks */}
+                          {provider.mappedTasks && provider.mappedTasks.length > 0 && (
+                            <div className="flex flex-wrap gap-1.5">
+                              {provider.mappedTasks.slice(0, 3).map((task) => {
+                                const taskId = templateToTaskMap.get(task.id);
+                                return taskId ? (
+                                  <Link
+                                    key={task.id}
+                                    href={`/${orgId}/tasks/${taskId}`}
+                                    onClick={(e) => e.stopPropagation()}
+                                  >
+                                    <Badge
+                                      variant="secondary"
+                                      className="text-[10px] px-1.5 py-0.5 font-normal cursor-pointer hover:bg-secondary/80 transition-colors"
+                                    >
+                                      {task.name}
+                                    </Badge>
+                                  </Link>
+                                ) : (
                                   <Badge
+                                    key={task.id}
                                     variant="secondary"
-                                    className="text-[10px] px-1.5 py-0.5 font-normal cursor-pointer hover:bg-secondary/80 transition-colors"
+                                    className="text-[10px] px-1.5 py-0.5 font-normal"
                                   >
                                     {task.name}
                                   </Badge>
-                                </Link>
-                              ) : (
-                                <Badge
-                                  key={task.id}
-                                  variant="secondary"
-                                  className="text-[10px] px-1.5 py-0.5 font-normal"
-                                >
-                                  {task.name}
-                                </Badge>
-                              );
-                            })}
-                            {provider.mappedTasks.length > 3 && (
-                              <TooltipProvider>
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <Badge
-                                    variant="outline"
-                                    className="text-[10px] px-1.5 py-0.5 font-normal cursor-default"
-                                  >
-                                    +{provider.mappedTasks.length - 3} more
-                                  </Badge>
-                                </TooltipTrigger>
-                                <TooltipContent side="bottom" className="max-w-xs">
-                                  <div className="flex flex-wrap gap-1">
-                                    {provider.mappedTasks.slice(3).map((t) => {
-                                      const tid = templateToTaskMap.get(t.id);
-                                      return tid ? (
-                                        <Link
-                                          key={t.id}
-                                          href={`/${orgId}/tasks/${tid}`}
-                                          className="text-xs text-primary hover:underline"
-                                          onClick={(e) => e.stopPropagation()}
-                                        >
-                                          {t.name}
-                                        </Link>
-                                      ) : (
-                                        <span key={t.id} className="text-xs">{t.name}</span>
-                                      );
-                                    })}
-                                  </div>
-                                </TooltipContent>
-                              </Tooltip>
-                              </TooltipProvider>
-                            )}
+                                );
+                              })}
+                              {provider.mappedTasks.length > 3 && (
+                                <TooltipProvider>
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <Badge
+                                        variant="outline"
+                                        className="text-[10px] px-1.5 py-0.5 font-normal cursor-default"
+                                      >
+                                        +{provider.mappedTasks.length - 3} more
+                                      </Badge>
+                                    </TooltipTrigger>
+                                    <TooltipContent side="bottom" className="max-w-xs">
+                                      <div className="flex flex-wrap gap-1">
+                                        {provider.mappedTasks.slice(3).map((t) => {
+                                          const tid = templateToTaskMap.get(t.id);
+                                          return tid ? (
+                                            <Link
+                                              key={t.id}
+                                              href={`/${orgId}/tasks/${tid}`}
+                                              className="text-xs text-primary hover:underline"
+                                              onClick={(e) => e.stopPropagation()}
+                                            >
+                                              {t.name}
+                                            </Link>
+                                          ) : (
+                                            <span key={t.id} className="text-xs">
+                                              {t.name}
+                                            </span>
+                                          );
+                                        })}
+                                      </div>
+                                    </TooltipContent>
+                                  </Tooltip>
+                                </TooltipProvider>
+                              )}
+                            </div>
+                          )}
+                        </div>
+
+                        {!isComingSoon && !showConnectOrSetup && (
+                          <div className="mt-4 flex items-center justify-end gap-1.5 border-t border-border/50 pt-3 text-xs font-medium text-primary">
+                            <span>View details</span>
+                            <ArrowRight
+                              className="h-3.5 w-3.5 shrink-0 transition-transform group-hover:translate-x-0.5"
+                              aria-hidden
+                            />
                           </div>
                         )}
-                      </div>
 
-                      {!isComingSoon && !showConnectOrSetup && (
-                        <div className="mt-4 flex items-center justify-end gap-1.5 border-t border-border/50 pt-3 text-xs font-medium text-primary">
-                          <span>View details</span>
-                          <ArrowRight
-                            className="h-3.5 w-3.5 shrink-0 transition-transform group-hover:translate-x-0.5"
-                            aria-hidden
-                          />
+                        <div className="mt-auto pt-4">
+                          {needsConfiguration ? (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              className="w-full"
+                              onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                handleOpenProviderSettings(provider);
+                              }}
+                            >
+                              Configure Variables
+                            </Button>
+                          ) : isConnected ? null : hasError ? (
+                            <div className="space-y-2 pt-2 border-t border-border/50">
+                              <p className="text-xs text-destructive line-clamp-1">
+                                {connection?.errorMessage || 'Connection error'}
+                              </p>
+                              {canCreate && (
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  className="w-full"
+                                  onClick={(e) => {
+                                    e.preventDefault();
+                                    e.stopPropagation();
+                                    handleConnect(provider);
+                                  }}
+                                  disabled={isConnecting}
+                                >
+                                  {isConnecting ? (
+                                    <>
+                                      <Loader2 className="h-3 w-3 mr-2 animate-spin" />
+                                      Reconnecting...
+                                    </>
+                                  ) : (
+                                    'Reconnect'
+                                  )}
+                                </Button>
+                              )}
+                            </div>
+                          ) : provider.authType === 'oauth2' &&
+                            provider.oauthConfigured === false ? (
+                            <Button size="sm" variant="outline" className="w-full" disabled>
+                              Coming Soon
+                            </Button>
+                          ) : canCreate ? (
+                            <Button
+                              size="sm"
+                              className="w-full"
+                              onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                handleConnect(provider);
+                              }}
+                              disabled={isConnecting}
+                            >
+                              {isConnecting ? (
+                                <>
+                                  <Loader2 className="h-3 w-3 mr-2 animate-spin" />
+                                  Connecting...
+                                </>
+                              ) : provider.authType === 'oauth2' ? (
+                                'Connect'
+                              ) : (
+                                'Set up'
+                              )}
+                            </Button>
+                          ) : null}
                         </div>
+                      </CardContent>
+                      {!isComingSoon && (
+                        <div
+                          className="pointer-events-none absolute inset-0 rounded-xl bg-primary/5 opacity-0 transition-opacity group-hover:opacity-100"
+                          aria-hidden
+                        />
                       )}
-
-                      <div className="mt-auto pt-4">
-                        {needsConfiguration ? (
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            className="w-full"
-                            onClick={(e) => { e.preventDefault(); e.stopPropagation(); handleOpenManageDialog(connection, provider); }}
-                          >
-                            Configure Variables
-                          </Button>
-                        ) : isConnected ? null : hasError ? (
-                          <div className="space-y-2 pt-2 border-t border-border/50">
-                            <p className="text-xs text-destructive line-clamp-1">
-                              {connection?.errorMessage || 'Connection error'}
-                            </p>
-                            {canCreate && (
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                className="w-full"
-                                onClick={(e) => { e.preventDefault(); e.stopPropagation(); handleConnect(provider); }}
-                                disabled={isConnecting}
-                              >
-                                {isConnecting ? (
-                                  <>
-                                    <Loader2 className="h-3 w-3 mr-2 animate-spin" />
-                                    Reconnecting...
-                                  </>
-                                ) : (
-                                  'Reconnect'
-                                )}
-                              </Button>
-                            )}
-                          </div>
-                        ) : provider.authType === 'oauth2' && provider.oauthConfigured === false ? (
-                          <Button size="sm" variant="outline" className="w-full" disabled>
-                            Coming Soon
-                          </Button>
-                        ) : canCreate ? (
-                          <Button
-                            size="sm"
-                            className="w-full"
-                            onClick={(e) => { e.preventDefault(); e.stopPropagation(); handleConnect(provider); }}
-                            disabled={isConnecting}
-                          >
-                            {isConnecting ? (
-                              <>
-                                <Loader2 className="h-3 w-3 mr-2 animate-spin" />
-                                Connecting...
-                              </>
-                            ) : (
-                              provider.authType === 'oauth2' ? 'Connect' : 'Set up'
-                            )}
-                          </Button>
-                        ) : null}
-                      </div>
-                    </CardContent>
-                    {!isComingSoon && (
-                      <div
-                        className="pointer-events-none absolute inset-0 rounded-xl bg-primary/5 opacity-0 transition-opacity group-hover:opacity-100"
-                        aria-hidden
-                      />
-                    )}
-                  </Card>
+                    </Card>
                   </div>
                 );
               }
@@ -933,43 +876,6 @@ export function PlatformIntegrations({ className, taskTemplates }: PlatformInteg
           </div>
         )}
       </div>
-
-      {/* Manage Connection Dialog - Use ConnectIntegrationDialog for multi-connection providers */}
-      {selectedConnection &&
-        selectedProvider &&
-        (selectedProvider.supportsMultipleConnections ? (
-          <ConnectIntegrationDialog
-            open={manageDialogOpen}
-            onOpenChange={(open) => {
-              if (!open) {
-                handleCloseManageDialog();
-                refreshConnections();
-              } else {
-                setManageDialogOpen(open);
-              }
-            }}
-            integrationId={selectedProvider.id}
-            integrationName={selectedProvider.name}
-            integrationLogoUrl={selectedProvider.logoUrl}
-            onConnected={refreshConnections}
-          />
-        ) : (
-          <ManageIntegrationDialog
-            open={manageDialogOpen}
-            onOpenChange={(open) => {
-              if (!open) handleCloseManageDialog();
-              else setManageDialogOpen(open);
-            }}
-            connectionId={selectedConnection.id}
-            integrationId={selectedProvider.id}
-            integrationName={selectedProvider.name}
-            integrationLogoUrl={selectedProvider.logoUrl}
-            onDeleted={refreshConnections}
-            onSaved={refreshConnections}
-          />
-        ))}
-
-      {/* Connect dialog removed — non-OAuth providers navigate to detail page */}
 
       {/* Custom Integration Detail Modal */}
       {selectedCustomIntegration && (

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/TaskIntegrationChecks.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/TaskIntegrationChecks.tsx
@@ -4,11 +4,9 @@ import { ConnectIntegrationDialog } from '@/components/integrations/ConnectInteg
 import { ManageIntegrationDialog } from '@/components/integrations/ManageIntegrationDialog';
 import { SchedulePicker } from '@/components/schedule-picker';
 import { downloadAutomationPDF } from '@/lib/evidence-download';
-import type { TaskFrequency } from '@db';
-import type { TaskIntegrationCheck, StoredCheckRun } from '../hooks/useIntegrationChecks';
-import { useIntegrationChecks } from '../hooks/useIntegrationChecks';
 import { cn } from '@/lib/utils';
 import { useActiveOrganization } from '@/utils/auth-client';
+import type { TaskFrequency } from '@db';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -43,8 +41,10 @@ import {
 import Image from 'next/image';
 import Link from 'next/link';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
 import { toast } from 'sonner';
+import type { StoredCheckRun, TaskIntegrationCheck } from '../hooks/useIntegrationChecks';
+import { useIntegrationChecks } from '../hooks/useIntegrationChecks';
 import { EvidenceJsonView } from './EvidenceJsonView';
 
 interface TaskIntegrationChecksProps {
@@ -59,6 +59,8 @@ interface TaskIntegrationChecksProps {
   lastRunAt?: Date | string | null;
   onScheduleChange?: (value: TaskFrequency) => void | Promise<void>;
 }
+
+const INTEGRATIONS_PER_PAGE = 10;
 
 export function TaskIntegrationChecks({
   taskId,
@@ -173,8 +175,7 @@ export function TaskIntegrationChecks({
 
   const handleConfirmDisconnect = useCallback(async () => {
     if (!disconnectTarget) return;
-    const { connectionId, checkId, checkName, integrationName } =
-      disconnectTarget;
+    const { connectionId, checkId, checkName, integrationName } = disconnectTarget;
     const monitorName = integrationName || checkName;
     setTogglingCheck(checkId);
     setDisconnectError(null);
@@ -184,9 +185,7 @@ export function TaskIntegrationChecks({
       setDisconnectTarget(null);
     } catch (err) {
       console.error('Failed to disconnect check:', err);
-      setDisconnectError(
-        err instanceof Error ? err.message : 'Failed to disconnect check',
-      );
+      setDisconnectError(err instanceof Error ? err.message : 'Failed to disconnect check');
     } finally {
       setTogglingCheck(null);
     }
@@ -201,9 +200,7 @@ export function TaskIntegrationChecks({
         toast.success(`Reconnected "${checkName}" to this task.`);
       } catch (err) {
         console.error('Failed to reconnect check:', err);
-        setError(
-          err instanceof Error ? err.message : 'Failed to reconnect check',
-        );
+        setError(err instanceof Error ? err.message : 'Failed to reconnect check');
       } finally {
         setTogglingCheck(null);
       }
@@ -238,12 +235,8 @@ export function TaskIntegrationChecks({
   //   1. connectedChecks        — active + not disabled for this task
   //   2. disabledForTaskChecks  — connected but manually disconnected from this task
   //   3. disconnectedChecks     — no connection at all (suggestions)
-  const connectedChecks = checks.filter(
-    (c) => c.isConnected && !c.isDisabledForTask,
-  );
-  const disabledForTaskChecks = checks.filter(
-    (c) => c.isConnected && c.isDisabledForTask,
-  );
+  const connectedChecks = checks.filter((c) => c.isConnected && !c.isDisabledForTask);
+  const disabledForTaskChecks = checks.filter((c) => c.isConnected && c.isDisabledForTask);
   const disconnectedChecks = checks.filter((c) => !c.isConnected);
 
   // If there are no checks at all for this task, don't render anything
@@ -286,9 +279,7 @@ export function TaskIntegrationChecks({
     };
     const last = lastRunAt ? new Date(lastRunAt) : null;
     const periodDays = PERIOD_DAYS[scheduleFrequency ?? 'daily'];
-    const earliestDueFromLast = last
-      ? addDays(last, periodDays)
-      : now;
+    const earliestDueFromLast = last ? addDays(last, periodDays) : now;
     // Snap to next 6 AM UTC at or after the earliest-due date
     let nextRun = setMinutes(setHours(earliestDueFromLast, 6), 0);
     if (isBefore(nextRun, now)) {
@@ -298,10 +289,8 @@ export function TaskIntegrationChecks({
   };
 
   const nextRun = connectedChecks.length > 0 ? getNextScheduledRun() : null;
-  const hasConfiguredChecks =
-    connectedChecks.length > 0 || disabledForTaskChecks.length > 0;
-  const showSchedulePicker =
-    hasConfiguredChecks && !!scheduleFrequency && !!onScheduleChange;
+  const hasConfiguredChecks = connectedChecks.length > 0 || disabledForTaskChecks.length > 0;
+  const showSchedulePicker = hasConfiguredChecks && !!scheduleFrequency && !!onScheduleChange;
 
   return (
     <div className="rounded-lg border border-border bg-card overflow-hidden">
@@ -349,8 +338,7 @@ export function TaskIntegrationChecks({
 
       {/* Card Content */}
       <div className="p-5">
-        {connectedChecks.length === 0 &&
-        disabledForTaskChecks.length === 0 ? (
+        {connectedChecks.length === 0 && disabledForTaskChecks.length === 0 ? (
           <IntegrationEmptyState
             disconnectedChecks={disconnectedChecks}
             hasNoMappedChecks={disconnectedChecks.length === 0}
@@ -514,9 +502,7 @@ export function TaskIntegrationChecks({
                             {monitorName}
                           </p>
                           {check.checkName !== monitorName && (
-                            <span className="text-xs text-muted-foreground">
-                              {check.checkName}
-                            </span>
+                            <span className="text-xs text-muted-foreground">{check.checkName}</span>
                           )}
                         </div>
                         {needsConfig ? (
@@ -597,7 +583,7 @@ export function TaskIntegrationChecks({
                                       automationName: check.checkName,
                                     });
                                     toast.success('Evidence PDF downloaded');
-                                  } catch (err) {
+                                  } catch {
                                     toast.error('Failed to download evidence');
                                   }
                                 }}
@@ -726,11 +712,7 @@ export function TaskIntegrationChecks({
                           className="h-8 px-3"
                           disabled={isToggling}
                           onClick={() =>
-                            handleReconnect(
-                              check.connectionId!,
-                              check.checkId,
-                              monitorName,
-                            )
+                            handleReconnect(check.connectionId!, check.checkId, monitorName)
                           }
                         >
                           {isToggling ? (
@@ -809,21 +791,16 @@ export function TaskIntegrationChecks({
             <AlertDialogDescription>
               {disconnectTarget ? (
                 <>
-                  <strong>
-                    {disconnectTarget.integrationName ||
-                      disconnectTarget.checkName}
-                  </strong>
+                  <strong>{disconnectTarget.integrationName || disconnectTarget.checkName}</strong>
                   {disconnectTarget.checkName !==
-                    (disconnectTarget.integrationName ||
-                      disconnectTarget.checkName) && (
+                    (disconnectTarget.integrationName || disconnectTarget.checkName) && (
                     <>
                       {' '}
                       (<strong>{disconnectTarget.checkName}</strong> check)
                     </>
                   )}{' '}
-                  will no longer run for this task. The integration itself
-                  stays connected and will continue running for other tasks. You
-                  can reconnect it to this task at any time.
+                  will no longer run for this task. The integration itself stays connected and will
+                  continue running for other tasks. You can reconnect it to this task at any time.
                 </>
               ) : null}
             </AlertDialogDescription>
@@ -835,9 +812,7 @@ export function TaskIntegrationChecks({
             </div>
           )}
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={togglingCheck !== null}>
-              Cancel
-            </AlertDialogCancel>
+            <AlertDialogCancel disabled={togglingCheck !== null}>Cancel</AlertDialogCancel>
             <AlertDialogAction
               onClick={(e) => {
                 // Radix's AlertDialogAction auto-closes the dialog on click.
@@ -896,25 +871,6 @@ function GroupedCheckRuns({
   organizationName: string;
 }) {
   const [showAll, setShowAll] = useState(false);
-
-  // Group runs by date
-  const groupedRuns = useMemo(() => {
-    const groups: Record<string, StoredCheckRun[]> = {};
-
-    runs.forEach((run) => {
-      const date = new Date(run.createdAt).toLocaleDateString('en-US', {
-        month: 'short',
-        day: 'numeric',
-        year: 'numeric',
-      });
-      if (!groups[date]) {
-        groups[date] = [];
-      }
-      groups[date].push(run);
-    });
-
-    return groups;
-  }, [runs]);
 
   // Get the runs to display (limited or all)
   const displayRuns = showAll ? runs : runs.slice(0, maxRuns);
@@ -1259,10 +1215,46 @@ function IntegrationEmptyState({
     };
   }, []);
 
+  const [page, setPage] = useState(1);
+  const [searchQuery, setSearchQuery] = useState('');
+
   // Get unique integrations from disconnected checks
-  const uniqueIntegrations = Array.from(
-    new Map(disconnectedChecks.map((c) => [c.integrationId, c])).values(),
+  const uniqueIntegrations = useMemo(
+    () => Array.from(new Map(disconnectedChecks.map((c) => [c.integrationId, c])).values()),
+    [disconnectedChecks],
   );
+
+  const filteredIntegrations = useMemo(() => {
+    if (!searchQuery.trim()) return uniqueIntegrations;
+    const query = searchQuery.trim().toLowerCase();
+    return uniqueIntegrations.filter((integration) =>
+      integration.integrationName.toLowerCase().includes(query),
+    );
+  }, [uniqueIntegrations, searchQuery]);
+
+  const pageCount = Math.max(1, Math.ceil(filteredIntegrations.length / INTEGRATIONS_PER_PAGE));
+  const currentPage = Math.min(page, pageCount);
+
+  const paginatedIntegrations = filteredIntegrations.slice(
+    (currentPage - 1) * INTEGRATIONS_PER_PAGE,
+    currentPage * INTEGRATIONS_PER_PAGE,
+  );
+
+  useEffect(() => {
+    setPage(1);
+  }, [searchQuery]);
+
+  const handleSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(event.target.value);
+  };
+
+  const handlePreviousPage = () => {
+    setPage((current) => Math.max(1, current - 1));
+  };
+
+  const handleNextPage = () => {
+    setPage((current) => Math.min(pageCount, current + 1));
+  };
 
   const handleConnectClick = (integration: TaskIntegrationCheck) => {
     setSelectedIntegration(integration);
@@ -1369,8 +1361,32 @@ function IntegrationEmptyState({
 
           {/* Options */}
           <div className="border-t border-primary/10 divide-y divide-primary/10">
+            {uniqueIntegrations.length > INTEGRATIONS_PER_PAGE && (
+              <div className="px-6 py-3 bg-background/60">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                  <input
+                    value={searchQuery}
+                    onChange={handleSearchChange}
+                    aria-label="Search integrations"
+                    placeholder="Search integrations"
+                    className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm text-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-primary sm:max-w-xs"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    {filteredIntegrations.length} of {uniqueIntegrations.length}
+                  </p>
+                </div>
+              </div>
+            )}
+
             {/* Pre-built integrations */}
-            {uniqueIntegrations.map((integration) => {
+            {paginatedIntegrations.length === 0 && (
+              <div className="px-6 py-6 text-center">
+                <p className="text-sm font-medium text-foreground">No integrations found</p>
+                <p className="mt-1 text-xs text-muted-foreground">Try a different search term.</p>
+              </div>
+            )}
+
+            {paginatedIntegrations.map((integration) => {
               const checksForIntegration = disconnectedChecks.filter(
                 (c) => c.integrationId === integration.integrationId,
               );
@@ -1437,6 +1453,32 @@ function IntegrationEmptyState({
                 </button>
               );
             })}
+
+            {pageCount > 1 && (
+              <div className="flex items-center justify-between gap-3 px-6 py-3 bg-background/60">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 px-3"
+                  disabled={currentPage === 1}
+                  onClick={handlePreviousPage}
+                >
+                  Previous
+                </Button>
+                <span className="text-xs text-muted-foreground">
+                  Page {currentPage} of {pageCount}
+                </span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 px-3"
+                  disabled={currentPage === pageCount}
+                  onClick={handleNextPage}
+                >
+                  Next
+                </Button>
+              </div>
+            )}
 
             {/* Custom automation option */}
             <Link

--- a/apps/app/src/components/integrations/ConnectionVariableMultiSelect.tsx
+++ b/apps/app/src/components/integrations/ConnectionVariableMultiSelect.tsx
@@ -133,6 +133,7 @@ export function ConnectionVariableMultiSelect({
               </div>
               <button
                 type="button"
+                aria-label={`Remove ${config.repo}`}
                 onClick={() => handleRemoveRepo(config.repo)}
                 className="shrink-0 rounded p-1 hover:bg-destructive/10 text-muted-foreground hover:text-destructive"
               >

--- a/apps/app/src/components/integrations/ConnectionVariableMultiSelect.tsx
+++ b/apps/app/src/components/integrations/ConnectionVariableMultiSelect.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { Input, Spinner } from '@trycompai/design-system';
+import { Close } from '@trycompai/design-system/icons';
+import MultipleSelector from '@trycompai/ui/multiple-selector';
+import { useEffect, useRef } from 'react';
+import type { ConnectionVariable, VariableValue } from './ConnectionVariablesForm';
+
+interface ConnectionVariableMultiSelectProps {
+  variable: ConnectionVariable;
+  options: { value: string; label: string }[];
+  isLoadingOptions: boolean;
+  value: VariableValue | undefined;
+  onChange: (value: string[]) => void;
+  onLoadOptions: () => void;
+}
+
+export function ConnectionVariableMultiSelect({
+  variable,
+  options,
+  isLoadingOptions,
+  value,
+  onChange,
+  onLoadOptions,
+}: ConnectionVariableMultiSelectProps) {
+  const selectedValues = Array.isArray(value) ? value : [];
+  const normalizedSelectedValues = selectedValues
+    .map((item) => String(item).trim())
+    .filter((item) => item.length > 0);
+  const hasLoadedRef = useRef(false);
+  const isGitHubRepos = variable.id === 'target_repos';
+  const parsedConfigs = isGitHubRepos ? normalizedSelectedValues.map(parseRepoBranch) : [];
+
+  useEffect(() => {
+    if (
+      variable.hasDynamicOptions &&
+      options.length === 0 &&
+      !hasLoadedRef.current &&
+      !isLoadingOptions
+    ) {
+      hasLoadedRef.current = true;
+      onLoadOptions();
+    }
+  }, [variable.hasDynamicOptions, options.length, isLoadingOptions, onLoadOptions]);
+
+  const handleRepoSelectionChange = (selectedRepos: string[]) => {
+    if (!isGitHubRepos) {
+      onChange(selectedRepos);
+      return;
+    }
+
+    const newValues = selectedRepos
+      .map((repo) => repo.trim())
+      .filter(Boolean)
+      .map((repo) => {
+        const existing = parsedConfigs.find((config) => config.repo === repo);
+        return formatRepoBranch({ repo, branch: existing?.branch || '' });
+      });
+    onChange(newValues);
+  };
+
+  const handleBranchChange = ({ repo, branch }: { repo: string; branch: string }) => {
+    const newValues = normalizedSelectedValues.map((value) => {
+      const parsed = parseRepoBranch(value);
+      if (parsed.repo === repo) {
+        return formatRepoBranch({ repo, branch });
+      }
+      return value;
+    });
+    onChange(newValues);
+  };
+
+  const handleRemoveRepo = (repo: string) => {
+    const newValues = normalizedSelectedValues.filter(
+      (value) => parseRepoBranch(value).repo !== repo,
+    );
+    onChange(newValues);
+  };
+
+  const reposForSelector = isGitHubRepos
+    ? parsedConfigs.map((config) => config.repo)
+    : normalizedSelectedValues;
+  const isCreatable = isGitHubRepos || options.length === 0;
+
+  return (
+    <div className="space-y-3">
+      <MultipleSelector
+        value={reposForSelector.map((value) => ({
+          value,
+          label: options.find((option) => option.value === value)?.label || value,
+        }))}
+        onChange={(selected) => handleRepoSelectionChange(selected.map((item) => item.value))}
+        defaultOptions={options.map((option) => ({ value: option.value, label: option.label }))}
+        options={options.map((option) => ({ value: option.value, label: option.label }))}
+        placeholder={variable.placeholder || `Select ${variable.label.toLowerCase()}...`}
+        creatable={isCreatable}
+        emptyIndicator={
+          isLoadingOptions ? (
+            <div className="flex items-center gap-2 py-2 px-3 text-sm text-muted-foreground">
+              <Spinner />
+              Loading options...
+            </div>
+          ) : isCreatable ? (
+            <p className="text-center text-sm text-muted-foreground">
+              Type a value and press Enter
+            </p>
+          ) : (
+            <p className="text-center text-sm text-muted-foreground">No options available</p>
+          )
+        }
+      />
+
+      {isGitHubRepos && parsedConfigs.length > 0 && (
+        <div className="space-y-2 rounded-md border border-border bg-muted/30 p-3">
+          <p className="text-xs font-medium text-muted-foreground">
+            Optional: specify branches for each repository (comma-separated). Leave blank to use the
+            default branch (main).
+          </p>
+          {parsedConfigs.map((config) => (
+            <div key={config.repo} className="flex items-center gap-2">
+              <span className="shrink-0 rounded bg-secondary px-2 py-1 font-mono text-xs">
+                {config.repo}
+              </span>
+              <span className="text-muted-foreground">:</span>
+              <div className="min-w-0 flex-1">
+                <Input
+                  value={config.branch}
+                  onChange={(event) =>
+                    handleBranchChange({ repo: config.repo, branch: event.target.value })
+                  }
+                  placeholder="main, develop"
+                />
+              </div>
+              <button
+                type="button"
+                onClick={() => handleRemoveRepo(config.repo)}
+                className="shrink-0 rounded p-1 hover:bg-destructive/10 text-muted-foreground hover:text-destructive"
+              >
+                <Close size={16} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const parseRepoBranch = (value: unknown): { repo: string; branch: string } => {
+  const stringValue = String(value ?? '');
+  const cleanValue = stringValue.endsWith(':') ? stringValue.slice(0, -1) : stringValue;
+  const colonIndex = cleanValue.lastIndexOf(':');
+
+  if (colonIndex > 0 && colonIndex < cleanValue.length - 1) {
+    return {
+      repo: cleanValue.substring(0, colonIndex),
+      branch: cleanValue.substring(colonIndex + 1),
+    };
+  }
+
+  return { repo: cleanValue, branch: '' };
+};
+
+const formatRepoBranch = ({ repo, branch }: { repo: string; branch: string }): string => {
+  const trimmedBranch = branch.trim();
+  if (!trimmedBranch) {
+    return repo;
+  }
+
+  return `${repo}:${trimmedBranch}`;
+};

--- a/apps/app/src/components/integrations/ConnectionVariablesForm.tsx
+++ b/apps/app/src/components/integrations/ConnectionVariablesForm.tsx
@@ -1,0 +1,252 @@
+'use client';
+
+import {
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Spinner,
+} from '@trycompai/design-system';
+import type { Dispatch, SetStateAction } from 'react';
+import { ConnectionVariableMultiSelect } from './ConnectionVariableMultiSelect';
+
+export interface ConnectionVariable {
+  id: string;
+  label: string;
+  description?: string;
+  helpText?: string;
+  placeholder?: string;
+  type: 'string' | 'number' | 'boolean' | 'select' | 'multi-select';
+  required: boolean;
+  default?: string | number | boolean | string[];
+  options?: { value: string; label: string }[];
+  hasDynamicOptions?: boolean;
+}
+
+export type VariableValue = string | number | boolean | string[];
+
+interface ConnectionVariablesFieldsProps {
+  variables: ConnectionVariable[];
+  variableValues: Record<string, VariableValue>;
+  setVariableValues: Dispatch<SetStateAction<Record<string, VariableValue>>>;
+  dynamicOptions: Record<string, { value: string; label: string }[]>;
+  loadingOptions: Record<string, boolean>;
+  fetchOptions: (variableId: string) => void;
+}
+
+export const normalizeVariableValue = (
+  variable: ConnectionVariable,
+  value: unknown,
+): VariableValue => {
+  if (variable.type === 'multi-select') {
+    return normalizeMultiSelectValue(value);
+  }
+
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+
+  return variable.default ?? '';
+};
+
+export const validateTargetRepos = (values: Record<string, VariableValue>): boolean => {
+  const targetReposValue = values.target_repos;
+  if (!Array.isArray(targetReposValue) || targetReposValue.length === 0) {
+    return true;
+  }
+
+  for (const value of targetReposValue) {
+    const stringValue = String(value ?? '').trim();
+    if (!stringValue) {
+      return false;
+    }
+
+    const colonIndex = stringValue.lastIndexOf(':');
+    if (colonIndex === 0) {
+      return false;
+    }
+
+    if (colonIndex > 0) {
+      const repo = stringValue.substring(0, colonIndex).trim();
+      if (!repo) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+};
+
+export function ConnectionVariablesFields({
+  variables,
+  variableValues,
+  setVariableValues,
+  dynamicOptions,
+  loadingOptions,
+  fetchOptions,
+}: ConnectionVariablesFieldsProps) {
+  const syncModeVariable = variables.find((variable) => variable.id === 'sync_user_filter_mode');
+  const hasSyncModeVariable = Boolean(syncModeVariable);
+  const rawSyncMode = variableValues.sync_user_filter_mode ?? syncModeVariable?.default ?? 'all';
+  const effectiveSyncMode = String(rawSyncMode).toLowerCase();
+  const hasSyncScopedFields =
+    hasSyncModeVariable &&
+    variables.some(
+      (variable) =>
+        variable.id === 'sync_excluded_emails' || variable.id === 'sync_included_emails',
+    );
+
+  const shouldShowVariable = (variable: ConnectionVariable): boolean => {
+    if (variable.id === 'sync_excluded_emails' && hasSyncModeVariable) {
+      return effectiveSyncMode === 'exclude';
+    }
+
+    if (variable.id === 'sync_included_emails' && hasSyncModeVariable) {
+      return effectiveSyncMode === 'include';
+    }
+
+    return true;
+  };
+
+  return (
+    <>
+      {hasSyncScopedFields && effectiveSyncMode === 'all' && (
+        <p className="text-xs text-muted-foreground">
+          Employee sync is set to all users. Include and exclude fields are hidden because they are
+          not used in this mode.
+        </p>
+      )}
+
+      {variables.filter(shouldShowVariable).map((variable) => {
+        const options = dynamicOptions[variable.id] || variable.options || [];
+        const isLoadingOptions = loadingOptions[variable.id];
+
+        return (
+          <div key={variable.id} className="space-y-2">
+            <Label htmlFor={variable.id}>
+              {variable.label}
+              {variable.required && <span className="text-destructive ml-1">*</span>}
+            </Label>
+            {variable.description && (
+              <p className="text-xs text-muted-foreground">{variable.description}</p>
+            )}
+            {variable.helpText && (
+              <p className="text-xs text-muted-foreground">{variable.helpText}</p>
+            )}
+            {variable.placeholder && !variable.description && !variable.helpText && (
+              <p className="text-xs text-muted-foreground">Example: {variable.placeholder}</p>
+            )}
+
+            {variable.type === 'multi-select' ? (
+              <ConnectionVariableMultiSelect
+                variable={variable}
+                options={options}
+                isLoadingOptions={isLoadingOptions}
+                value={variableValues[variable.id]}
+                onChange={(value) =>
+                  setVariableValues((prev) => ({
+                    ...prev,
+                    [variable.id]: value,
+                  }))
+                }
+                onLoadOptions={() => fetchOptions(variable.id)}
+              />
+            ) : variable.type === 'select' ? (
+              <Select
+                value={String(variableValues[variable.id] || '')}
+                onValueChange={(value) => {
+                  if (value === null) return;
+                  setVariableValues((prev) => ({ ...prev, [variable.id]: value }));
+                }}
+                onOpenChange={(isOpen) => {
+                  if (isOpen && variable.hasDynamicOptions && !options.length) {
+                    fetchOptions(variable.id);
+                  }
+                }}
+              >
+                <SelectTrigger id={variable.id}>
+                  <SelectValue placeholder={`Select ${variable.label.toLowerCase()}`} />
+                </SelectTrigger>
+                <SelectContent>
+                  {isLoadingOptions ? (
+                    <div className="py-2 px-3 text-sm text-muted-foreground flex items-center gap-2">
+                      <Spinner />
+                      Loading options...
+                    </div>
+                  ) : options.length === 0 ? (
+                    <div className="py-2 px-3 text-sm text-muted-foreground">
+                      No options available
+                    </div>
+                  ) : (
+                    options.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))
+                  )}
+                </SelectContent>
+              </Select>
+            ) : variable.type === 'boolean' ? (
+              <Select
+                value={String(variableValues[variable.id] ?? variable.default ?? 'false')}
+                onValueChange={(value) => {
+                  if (value === null) return;
+                  setVariableValues((prev) => ({
+                    ...prev,
+                    [variable.id]: value === 'true',
+                  }));
+                }}
+              >
+                <SelectTrigger id={variable.id}>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="true">Yes</SelectItem>
+                  <SelectItem value="false">No</SelectItem>
+                </SelectContent>
+              </Select>
+            ) : (
+              <Input
+                id={variable.id}
+                type={variable.type === 'number' ? 'number' : 'text'}
+                value={String(variableValues[variable.id] || '')}
+                onChange={(event) =>
+                  setVariableValues((prev) => ({
+                    ...prev,
+                    [variable.id]:
+                      variable.type === 'number' ? Number(event.target.value) : event.target.value,
+                  }))
+                }
+                placeholder={variable.placeholder || `Enter ${variable.label.toLowerCase()}`}
+              />
+            )}
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
+const normalizeMultiSelectValue = (value: unknown): string[] => {
+  if (Array.isArray(value)) {
+    return Array.from(
+      new Set(value.map((item) => String(item).trim()).filter((item) => item.length > 0)),
+    );
+  }
+
+  if (typeof value === 'string') {
+    return Array.from(
+      new Set(
+        value
+          .split(/[\n,;]+/)
+          .map((item) => item.trim())
+          .filter((item) => item.length > 0),
+      ),
+    );
+  }
+
+  return [];
+};

--- a/apps/app/src/components/integrations/ConnectionVariablesForm.tsx
+++ b/apps/app/src/components/integrations/ConnectionVariablesForm.tsx
@@ -156,7 +156,7 @@ export function ConnectionVariablesFields({
               />
             ) : variable.type === 'select' ? (
               <Select
-                value={String(variableValues[variable.id] || '')}
+                value={String(variableValues[variable.id] ?? '')}
                 onValueChange={(value) => {
                   if (value === null) return;
                   setVariableValues((prev) => ({ ...prev, [variable.id]: value }));
@@ -212,12 +212,14 @@ export function ConnectionVariablesFields({
               <Input
                 id={variable.id}
                 type={variable.type === 'number' ? 'number' : 'text'}
-                value={String(variableValues[variable.id] || '')}
+                value={String(variableValues[variable.id] ?? '')}
                 onChange={(event) =>
                   setVariableValues((prev) => ({
                     ...prev,
                     [variable.id]:
-                      variable.type === 'number' ? Number(event.target.value) : event.target.value,
+                      variable.type === 'number' && event.target.value !== ''
+                        ? Number(event.target.value)
+                        : event.target.value,
                   }))
                 }
                 placeholder={variable.placeholder || `Enter ${variable.label.toLowerCase()}`}

--- a/apps/app/src/components/integrations/ManageIntegrationDialog.tsx
+++ b/apps/app/src/components/integrations/ManageIntegrationDialog.tsx
@@ -1,6 +1,12 @@
 'use client';
 
 import {
+  ConnectionVariablesFields,
+  normalizeVariableValue,
+  validateTargetRepos,
+  type ConnectionVariable,
+} from '@/components/integrations/ConnectionVariablesForm';
+import {
   useIntegrationConnections,
   useIntegrationMutations,
 } from '@/hooks/use-integration-platform';
@@ -17,28 +23,21 @@ import {
 import { Input } from '@trycompai/ui/input';
 import { Label } from '@trycompai/ui/label';
 import MultipleSelector from '@trycompai/ui/multiple-selector';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@trycompai/ui/select';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@trycompai/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@trycompai/ui/tabs';
-import { Key, Loader2, Settings, Trash2, X } from 'lucide-react';
+import { Key, Loader2, Settings, Trash2 } from 'lucide-react';
 import Image from 'next/image';
 import { useParams } from 'next/navigation';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
 
-interface CheckVariable {
-  id: string;
-  label: string;
-  description?: string;
-  helpText?: string;
-  placeholder?: string;
-  type: 'string' | 'number' | 'boolean' | 'select' | 'multi-select';
-  required: boolean;
-  default?: string | number | boolean | string[];
-  options?: { value: string; label: string }[];
-  hasDynamicOptions?: boolean;
-}
-
-interface VariableWithValue extends CheckVariable {
+interface VariableWithValue extends ConnectionVariable {
   currentValue?: string | number | boolean | string[];
 }
 
@@ -93,58 +92,10 @@ interface ManageIntegrationDialogProps {
   onSaved?: () => void;
 }
 
-const validateTargetRepos = (
-  values: Record<string, string | number | boolean | string[]>,
-): boolean => {
-  const targetReposValue = values.target_repos;
-  if (!Array.isArray(targetReposValue) || targetReposValue.length === 0) {
-    return true;
-  }
-  for (const value of targetReposValue) {
-    const stringValue = String(value ?? '').trim();
-    if (!stringValue) {
-      return false;
-    }
-    const colonIndex = stringValue.lastIndexOf(':');
-    if (colonIndex === 0) {
-      return false;
-    }
-    if (colonIndex > 0) {
-      const repo = stringValue.substring(0, colonIndex).trim();
-      if (!repo) {
-        return false;
-      }
-    }
-  }
-  return true;
-};
-
-const normalizeMultiSelectValue = (value: unknown): string[] => {
-  if (Array.isArray(value)) {
-    return Array.from(
-      new Set(value.map((item) => String(item).trim()).filter((item) => item.length > 0)),
-    );
-  }
-
-  if (typeof value === 'string') {
-    return Array.from(
-      new Set(
-        value
-          .split(/[\n,;]+/)
-          .map((item) => item.trim())
-          .filter((item) => item.length > 0),
-      ),
-    );
-  }
-
-  return [];
-};
-
 export function ManageIntegrationDialog({
   open,
   onOpenChange,
   connectionId,
-  integrationId,
   integrationName,
   integrationLogoUrl,
   configureOnly = false,
@@ -164,7 +115,7 @@ export function ManageIntegrationDialog({
   const { refresh: refreshConnections } = useIntegrationConnections();
 
   // Variables state
-  const [variables, setVariables] = useState<CheckVariable[]>([]);
+  const [variables, setVariables] = useState<ConnectionVariable[]>([]);
   const [variableValues, setVariableValues] = useState<
     Record<string, string | number | boolean | string[]>
   >({});
@@ -223,11 +174,7 @@ export function ManageIntegrationDialog({
         const values: Record<string, string | number | boolean | string[]> = {};
         for (const v of vars) {
           if (v.currentValue !== undefined) {
-            if (v.type === 'multi-select') {
-              values[v.id] = normalizeMultiSelectValue(v.currentValue);
-            } else {
-              values[v.id] = v.currentValue;
-            }
+            values[v.id] = normalizeVariableValue(v, v.currentValue);
           }
         }
         setVariableValues(values);
@@ -488,7 +435,7 @@ function ConfigurationContent({
   activeTab,
   setActiveTab,
 }: {
-  variables: CheckVariable[];
+  variables: ConnectionVariable[];
   variableValues: Record<string, string | number | boolean | string[]>;
   setVariableValues: React.Dispatch<
     React.SetStateAction<Record<string, string | number | boolean | string[]>>
@@ -514,142 +461,17 @@ function ConfigurationContent({
     );
   }
 
-  const syncModeVariable = variables.find((variable) => variable.id === 'sync_user_filter_mode');
-  const hasSyncModeVariable = Boolean(syncModeVariable);
-  const rawSyncMode = variableValues.sync_user_filter_mode ?? syncModeVariable?.default ?? 'all';
-  const effectiveSyncMode = String(rawSyncMode).toLowerCase();
-  const hasSyncScopedFields =
-    hasSyncModeVariable &&
-    variables.some(
-      (variable) =>
-        variable.id === 'sync_excluded_emails' || variable.id === 'sync_included_emails',
-    );
-
-  const shouldShowVariable = (variable: CheckVariable): boolean => {
-    if (variable.id === 'sync_excluded_emails' && hasSyncModeVariable) {
-      return effectiveSyncMode === 'exclude';
-    }
-
-    if (variable.id === 'sync_included_emails' && hasSyncModeVariable) {
-      return effectiveSyncMode === 'include';
-    }
-
-    return true;
-  };
-
   const variablesContent = hasVariables && (
     <div className="space-y-4">
       {!showTabs && <h4 className="text-sm font-medium">Configuration</h4>}
-      {hasSyncScopedFields && effectiveSyncMode === 'all' && (
-        <p className="text-xs text-muted-foreground">
-          Employee sync is set to all users. Include and exclude fields are hidden because they are
-          not used in this mode.
-        </p>
-      )}
-      {variables.filter(shouldShowVariable).map((variable) => {
-        const options = dynamicOptions[variable.id] || variable.options || [];
-        const isLoadingOptions = loadingDynamicOptions[variable.id];
-
-        return (
-          <div key={variable.id} className="space-y-2">
-            <Label htmlFor={variable.id}>
-              {variable.label}
-              {variable.required && <span className="text-destructive ml-1">*</span>}
-            </Label>
-            {variable.description && (
-              <p className="text-xs text-muted-foreground">{variable.description}</p>
-            )}
-            {variable.helpText && (
-              <p className="text-xs text-muted-foreground">{variable.helpText}</p>
-            )}
-            {variable.placeholder && !variable.description && !variable.helpText && (
-              <p className="text-xs text-muted-foreground">Example: {variable.placeholder}</p>
-            )}
-
-            {variable.type === 'multi-select' ? (
-              <MultiSelectWithBranches
-                variable={variable}
-                options={options}
-                isLoadingOptions={isLoadingOptions}
-                value={variableValues[variable.id]}
-                onChange={(val) =>
-                  setVariableValues((prev) => ({
-                    ...prev,
-                    [variable.id]: val,
-                  }))
-                }
-                onLoadOptions={() => fetchDynamicOptions(variable.id)}
-              />
-            ) : variable.type === 'select' ? (
-              <Select
-                value={String(variableValues[variable.id] || '')}
-                onValueChange={(val) =>
-                  setVariableValues((prev) => ({ ...prev, [variable.id]: val }))
-                }
-                onOpenChange={(isOpen) => {
-                  if (isOpen && variable.hasDynamicOptions && !options.length) {
-                    fetchDynamicOptions(variable.id);
-                  }
-                }}
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder={`Select ${variable.label.toLowerCase()}`} />
-                </SelectTrigger>
-                <SelectContent>
-                  {isLoadingOptions ? (
-                    <div className="py-2 px-3 text-sm text-muted-foreground flex items-center gap-2">
-                      <Loader2 className="h-3 w-3 animate-spin" />
-                      Loading options...
-                    </div>
-                  ) : options.length === 0 ? (
-                    <div className="py-2 px-3 text-sm text-muted-foreground">
-                      No options available
-                    </div>
-                  ) : (
-                    options.map((opt) => (
-                      <SelectItem key={opt.value} value={opt.value}>
-                        {opt.label}
-                      </SelectItem>
-                    ))
-                  )}
-                </SelectContent>
-              </Select>
-            ) : variable.type === 'boolean' ? (
-              <Select
-                value={String(variableValues[variable.id] ?? variable.default ?? 'false')}
-                onValueChange={(val) =>
-                  setVariableValues((prev) => ({
-                    ...prev,
-                    [variable.id]: val === 'true',
-                  }))
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="true">Yes</SelectItem>
-                  <SelectItem value="false">No</SelectItem>
-                </SelectContent>
-              </Select>
-            ) : (
-              <Input
-                id={variable.id}
-                type={variable.type === 'number' ? 'number' : 'text'}
-                value={String(variableValues[variable.id] || '')}
-                onChange={(e) =>
-                  setVariableValues((prev) => ({
-                    ...prev,
-                    [variable.id]:
-                      variable.type === 'number' ? Number(e.target.value) : e.target.value,
-                  }))
-                }
-                placeholder={`Enter ${variable.label.toLowerCase()}`}
-              />
-            )}
-          </div>
-        );
-      })}
+      <ConnectionVariablesFields
+        variables={variables}
+        variableValues={variableValues}
+        setVariableValues={setVariableValues}
+        dynamicOptions={dynamicOptions}
+        loadingOptions={loadingDynamicOptions}
+        fetchOptions={fetchDynamicOptions}
+      />
     </div>
   );
 
@@ -898,189 +720,6 @@ function ConfigurationFooterActions({
             'Update Credentials'
           )}
         </Button>
-      )}
-    </div>
-  );
-}
-
-/**
- * Parse a stored value like "owner/repo:branch" into parts.
- * Handles trailing colons, empty branches, and non-string values.
- */
-const parseRepoBranch = (value: unknown): { repo: string; branch: string } => {
-  // Safely convert to string to handle corrupted/migrated data
-  const stringValue = String(value ?? '');
-  // Remove trailing colon if present
-  const cleanValue = stringValue.endsWith(':') ? stringValue.slice(0, -1) : stringValue;
-  const colonIndex = cleanValue.lastIndexOf(':');
-
-  if (colonIndex > 0 && colonIndex < cleanValue.length - 1) {
-    return {
-      repo: cleanValue.substring(0, colonIndex),
-      branch: cleanValue.substring(colonIndex + 1),
-    };
-  }
-  // No branch specified - return empty string so user can type
-  return { repo: cleanValue, branch: '' };
-};
-
-/**
- * Format repo and branch into stored format.
- * If branch is empty, just store the repo (will default to main on parse).
- */
-const formatRepoBranch = (repo: string, branch: string): string => {
-  const trimmedBranch = branch.trim();
-  if (!trimmedBranch) {
-    return repo; // No colon when branch is empty
-  }
-  return `${repo}:${trimmedBranch}`;
-};
-
-/**
- * Multi-select with optional branch inputs for GitHub repos.
- * When variable.id is 'target_repos', shows branch input for each selected repo.
- */
-function MultiSelectWithBranches({
-  variable,
-  options,
-  isLoadingOptions,
-  value,
-  onChange,
-  onLoadOptions,
-}: {
-  variable: CheckVariable;
-  options: { value: string; label: string }[];
-  isLoadingOptions: boolean;
-  value: string | number | boolean | string[] | undefined;
-  onChange: (val: string[]) => void;
-  onLoadOptions: () => void;
-}) {
-  const selectedValues = Array.isArray(value) ? value : [];
-  const normalizedSelectedValues = selectedValues
-    .map((item) => String(item).trim())
-    .filter((item) => item.length > 0);
-  const hasLoadedRef = useRef(false);
-
-  // For target_repos, parse values to extract repos and branches
-  const isGitHubRepos = variable.id === 'target_repos';
-  const parsedConfigs = isGitHubRepos ? normalizedSelectedValues.map(parseRepoBranch) : [];
-
-  useEffect(() => {
-    if (
-      variable.hasDynamicOptions &&
-      options.length === 0 &&
-      !hasLoadedRef.current &&
-      !isLoadingOptions
-    ) {
-      hasLoadedRef.current = true;
-      onLoadOptions();
-    }
-  }, [variable.hasDynamicOptions, options.length, isLoadingOptions, onLoadOptions]);
-
-  // Handle repo selection change
-  const handleRepoSelectionChange = (selectedRepos: string[]) => {
-    if (!isGitHubRepos) {
-      onChange(selectedRepos);
-      return;
-    }
-
-    // For GitHub repos, preserve existing branches when repos are reselected
-    const newValues = selectedRepos
-      .map((repo) => repo.trim())
-      .filter(Boolean)
-      .map((repo) => {
-        // Check if this repo already exists in current values
-        const existing = parsedConfigs.find((c) => c.repo === repo);
-        // Use existing branch, or empty string for new repos (user will type it)
-        return formatRepoBranch(repo, existing?.branch || '');
-      });
-    onChange(newValues);
-  };
-
-  // Handle branch change for a specific repo
-  const handleBranchChange = (repo: string, branch: string) => {
-    const newValues = normalizedSelectedValues.map((v) => {
-      const parsed = parseRepoBranch(v);
-      if (parsed.repo === repo) {
-        // Allow empty string during editing - will default to main on save if empty
-        return formatRepoBranch(repo, branch);
-      }
-      return v;
-    });
-    onChange(newValues);
-  };
-
-  // Handle removing a repo
-  const handleRemoveRepo = (repo: string) => {
-    const newValues = normalizedSelectedValues.filter((v) => parseRepoBranch(v).repo !== repo);
-    onChange(newValues);
-  };
-
-  // Get repos from values for display in multi-select
-  const reposForSelector = isGitHubRepos
-    ? parsedConfigs.map((c) => c.repo)
-    : normalizedSelectedValues;
-  const isCreatable = isGitHubRepos || options.length === 0;
-
-  return (
-    <div className="space-y-3">
-      <MultipleSelector
-        value={reposForSelector.map((v) => ({
-          value: v,
-          label: options.find((o) => o.value === v)?.label || v,
-        }))}
-        onChange={(selected) => handleRepoSelectionChange(selected.map((s) => s.value))}
-        defaultOptions={options.map((o) => ({ value: o.value, label: o.label }))}
-        options={options.map((o) => ({ value: o.value, label: o.label }))}
-        placeholder={variable.placeholder || `Select ${variable.label.toLowerCase()}...`}
-        creatable={isCreatable}
-        emptyIndicator={
-          isLoadingOptions ? (
-            <div className="flex items-center gap-2 py-2 px-3 text-sm text-muted-foreground">
-              <Loader2 className="h-3 w-3 animate-spin" />
-              Loading options...
-            </div>
-          ) : isCreatable ? (
-            <p className="text-center text-sm text-muted-foreground">
-              Type a value and press Enter
-            </p>
-          ) : (
-            <p className="text-center text-sm text-muted-foreground">No options available</p>
-          )
-        }
-      />
-
-      {/* Branch inputs for GitHub repos */}
-      {isGitHubRepos && parsedConfigs.length > 0 && (
-        <div className="space-y-2 rounded-md border border-border bg-muted/30 p-3">
-          <p className="text-xs font-medium text-muted-foreground">
-            Optional: specify branches for each repository (comma-separated). Leave blank to use the
-            default branch (main).
-          </p>
-          {parsedConfigs.map((config) => {
-            return (
-              <div key={config.repo} className="flex items-center gap-2">
-                <span className="shrink-0 rounded bg-secondary px-2 py-1 font-mono text-xs">
-                  {config.repo}
-                </span>
-                <span className="text-muted-foreground">:</span>
-                <Input
-                  value={config.branch}
-                  onChange={(e) => handleBranchChange(config.repo, e.target.value)}
-                  placeholder="main, develop"
-                  className="h-8 flex-1 font-mono text-sm"
-                />
-                <button
-                  type="button"
-                  onClick={() => handleRemoveRepo(config.repo)}
-                  className="shrink-0 rounded p-1 hover:bg-destructive/10 text-muted-foreground hover:text-destructive"
-                >
-                  <X className="h-4 w-4" />
-                </button>
-              </div>
-            );
-          })}
-        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- move dynamic integration variable fields into shared components used by the integration detail settings sheet
- route old integrations-page settings/configure actions and OAuth return flows to the detail settings sheet
- show mapped evidence tasks on the integration detail page
- add search and pagination to task integration suggestions

## Validation
- targeted ESLint passed for touched files
- app/API build: user confirmed locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved integration account settings into the provider detail page and unified variable inputs with shared components. This consolidates OAuth flows and settings, shows mapped evidence tasks, and improves task integration suggestions.

- **New Features**
  - Settings now open in the provider detail sheet; old settings/configure actions and OAuth returns route here.
  - Mapped evidence tasks are shown on the integration detail page.
  - Task integration suggestions support search and pagination.

- **Refactors**
  - Introduced shared variable fields via `ConnectionVariablesForm` and `ConnectionVariableMultiSelect` (value normalization, empty input preserved, target repo validation).
  - Replaced bespoke OAuth variable forms with shared fields.
  - Simplified integrations list and `ManageIntegrationDialog` to use the detail page for manage flows.

<sup>Written for commit f3c5d57b32b14e41a36bfaffaac28163cadd741e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

