### PR TITLE
fix(api): pass explicit permission:undefined to better-auth hasPermis…

### DIFF
--- a/apps/api/src/auth/permission.guard.spec.ts
+++ b/apps/api/src/auth/permission.guard.spec.ts
@@ -197,10 +197,17 @@ describe('PermissionGuard', () => {
 
       const result = await guard.canActivate(context);
       expect(result).toBe(true);
+      // The body MUST include `permission: undefined` explicitly — zod 4 in
+      // better-auth's hasPermission schema requires both discriminated-union
+      // keys to be present, and treats omitted-vs-undefined as different.
+      // Without the explicit undefined, every cookie-authenticated request
+      // 403s with "Unable to verify permissions". Pin this in the test so
+      // a future refactor that drops the field gets caught.
       expect(mockHasPermission).toHaveBeenCalledWith({
         headers: expect.any(Headers),
         body: {
           permissions: { control: ['delete'] },
+          permission: undefined,
         },
       });
     });

--- a/apps/api/src/auth/permission.guard.ts
+++ b/apps/api/src/auth/permission.guard.ts
@@ -179,9 +179,19 @@ export class PermissionGuard implements CanActivate {
       return false;
     }
 
+    // better-auth 1.4.x's `hasPermission` body schema is a discriminated
+    // union that requires BOTH keys present, with the unused side set to
+    // an explicit `undefined`. zod 4 (which better-auth's plugin uses
+    // internally) rejects "key is absent" — only "key is undefined" passes
+    // the `z.undefined()` branch. Without the explicit `permission: undefined`,
+    // the schema rejects every request with `[body] Invalid input`, the
+    // catch in canActivate turns that into a generic "Unable to verify
+    // permissions" 403, and EVERY cookie-authenticated request returns 403.
+    // Reproduced repo-side via `bun run zod-repro.mjs`. Discovered on
+    // ENG-221 and the same fix applies here.
     const result = await auth.api.hasPermission({
       headers,
-      body: { permissions },
+      body: { permissions, permission: undefined },
     });
 
     return result.success === true;


### PR DESCRIPTION
…sion

Every cookie-authenticated request was 403'ing with "Unable to verify permissions" because better-auth 1.4.x's `hasPermission` body schema is a discriminated union that requires both keys present, with the unused side set to an explicit `undefined`. zod 4 (which better-auth's plugin uses internally) rejects "key is absent" — only "key is undefined" passes the `z.undefined()` branch:

  z.union([
    z.object({ permission:  z.record(...), permissions: z.undefined() }),
    z.object({ permission:  z.undefined(),  permissions: z.record(...) }),
  ])

Without `permission: undefined` in the body, the schema rejects every request with "[body] Invalid input"; the catch in canActivate turns that into a generic 403 and customers can't load the tasks page, findings, or any other endpoint protected by PermissionGuard.

API key requests aren't affected because they go through the scope-checking path earlier in the guard, which is why this only showed up for cookie sessions on customer accounts.

Test pins the body shape so a future refactor that drops the field gets caught.

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #XXXX (GitHub issue number)
- Fixes COMP-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://trycomp.ai/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/trycompai/comp/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix 403s for cookie-authenticated requests by sending `permission: undefined` alongside `permissions` to `better-auth` `hasPermission`. This satisfies the `zod` union schema and restores all PermissionGuard-protected endpoints; API key flows were unaffected.

- **Bug Fixes**
  - Pass `permission: undefined` in the `hasPermission` body to match `better-auth` 1.4.x schema and avoid “[body] Invalid input” 403s.
  - Add a test that pins the body shape to prevent regressions.

<sup>Written for commit 832afdb389e910ed3bf06bdfdffebfe420c650a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

