### PR TITLE
fix(billing): surface wallet credits to pentest + bg-check UIs

### DIFF
--- a/apps/api/src/billing/billing.service.spec.ts
+++ b/apps/api/src/billing/billing.service.spec.ts
@@ -208,6 +208,87 @@ describe('BillingService', () => {
     );
   });
 
+  it('aggregates wallet credit balances per product in getStatus', async () => {
+    // The customer-facing /v1/billing/status response is the only
+    // surface the pentest + BG-check UIs read from. If we ever stop
+    // including creditBalances here, both UIs silently regress to
+    // paywalling users whose admin-granted credits would be consumed
+    // by the create endpoint. Lock the contract with this test.
+    const listBalances = jest.fn().mockResolvedValue([
+      {
+        id: 'bcb_1',
+        productKey: 'pentest',
+        skuKey: null,
+        balance: 3,
+        totalGranted: 5,
+        totalConsumed: 2,
+        totalRefunded: 0,
+        lastSource: 'manual',
+        updatedAt: '2026-05-01T00:00:00.000Z',
+      },
+      {
+        id: 'bcb_2',
+        productKey: 'pentest',
+        skuKey: 'pentest_monthly_1',
+        balance: 2,
+        totalGranted: 2,
+        totalConsumed: 0,
+        totalRefunded: 0,
+        lastSource: 'topup',
+        updatedAt: '2026-05-01T00:00:00.000Z',
+      },
+      {
+        id: 'bcb_3',
+        productKey: 'background_check',
+        skuKey: null,
+        balance: 4,
+        totalGranted: 4,
+        totalConsumed: 0,
+        totalRefunded: 0,
+        lastSource: 'manual',
+        updatedAt: '2026-05-01T00:00:00.000Z',
+      },
+    ]);
+    const service = new BillingService(
+      mockStripeService({
+        invoices: { list: jest.fn().mockResolvedValue({ data: [] }) },
+        customers: { retrieve: jest.fn().mockResolvedValue({}) },
+        paymentMethods: { retrieve: jest.fn() },
+      }),
+      { syncSubscriptionItem: jest.fn() } as never,
+      { listBalances } as never,
+    );
+
+    const result = await service.getStatus('org_1');
+
+    expect(listBalances).toHaveBeenCalledWith('org_1');
+    expect(result.creditBalances).toEqual(
+      expect.arrayContaining([
+        { productKey: 'pentest', balance: 5 },
+        { productKey: 'background_check', balance: 4 },
+      ]),
+    );
+    expect(result.creditBalances).toHaveLength(2);
+  });
+
+  it('returns an empty creditBalances array when no credits service is wired in', async () => {
+    // BillingCreditsService is @Optional() so unit tests can keep
+    // hand-constructing BillingService without it. Verify the absent-
+    // dependency branch produces a typesafe empty array, not undefined.
+    const service = new BillingService(
+      mockStripeService({
+        invoices: { list: jest.fn().mockResolvedValue({ data: [] }) },
+        customers: { retrieve: jest.fn().mockResolvedValue({}) },
+        paymentMethods: { retrieve: jest.fn() },
+      }),
+      { syncSubscriptionItem: jest.fn() } as never,
+    );
+
+    const result = await service.getStatus('org_1');
+
+    expect(result.creditBalances).toEqual([]);
+  });
+
   it('marks trial eligibility false after any product subscription history', async () => {
     organizationBillingSubscriptionFindMany.mockResolvedValue([
       {

--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   Injectable,
   NotFoundException,
+  Optional,
 } from '@nestjs/common';
 import { db } from '@db';
 import {
@@ -12,6 +13,7 @@ import {
   isSubscriptionBillingSkuKey,
 } from '@trycompai/billing';
 import { StripeService } from '../stripe/stripe.service';
+import { BillingCreditsService } from './billing-credits.service';
 import { findOrCreateBillingCustomer } from './billing-customer';
 import { BillingEntitlementsService } from './billing-entitlements.service';
 import { listBillingInvoices } from './billing-invoices';
@@ -38,6 +40,10 @@ export class BillingService {
   constructor(
     private readonly stripeService: StripeService,
     private readonly entitlements: BillingEntitlementsService,
+    // Optional so existing unit tests that hand-construct BillingService
+    // (without a credits service) keep working. In production the
+    // BillingModule always provides it.
+    @Optional() private readonly credits?: BillingCreditsService,
   ) {}
 
   async getStatus(organizationId: string): Promise<BillingStatus> {
@@ -67,18 +73,31 @@ export class BillingService {
       db.backgroundCheckRequest.count({ where: { organizationId } }),
       db.securityPenetrationTestRun.count({ where: { organizationId } }),
     ]);
-    const [invoices, preferences, usageRows] = await Promise.all([
-      listBillingInvoices({
-        stripeService: this.stripeService,
-        stripeCustomerId: billing?.stripeCustomerId ?? null,
-      }),
-      getBillingPreferences({
-        stripeService: this.stripeService,
-        stripeCustomerId: billing?.stripeCustomerId ?? null,
-        fallbackCompanyName: organization.name,
-      }),
-      listBillingUsageRows({ organizationId, subscriptions }),
-    ]);
+    const [invoices, preferences, usageRows, creditBalances] =
+      await Promise.all([
+        listBillingInvoices({
+          stripeService: this.stripeService,
+          stripeCustomerId: billing?.stripeCustomerId ?? null,
+        }),
+        getBillingPreferences({
+          stripeService: this.stripeService,
+          stripeCustomerId: billing?.stripeCustomerId ?? null,
+          fallbackCompanyName: organization.name,
+        }),
+        listBillingUsageRows({ organizationId, subscriptions }),
+        // Sum wallet balances per product. There can be multiple
+        // BillingCreditBalance rows per (org, product) when grants are
+        // scoped to a specific SKU, so we aggregate before returning.
+        this.credits
+          ? this.credits.listBalances(organizationId)
+          : Promise.resolve([]),
+      ]);
+
+    const creditBalancesByProduct = new Map<BillingProductKey, number>();
+    for (const balance of creditBalances) {
+      const current = creditBalancesByProduct.get(balance.productKey) ?? 0;
+      creditBalancesByProduct.set(balance.productKey, current + balance.balance);
+    }
 
     return {
       hasBilling: !!billing,
@@ -98,6 +117,9 @@ export class BillingService {
         currentPeriodEnd: subscription.currentPeriodEnd?.toISOString() ?? null,
         cancelAtPeriodEnd: subscription.cancelAtPeriodEnd,
       })),
+      creditBalances: Array.from(creditBalancesByProduct.entries()).map(
+        ([productKey, balance]) => ({ productKey, balance }),
+      ),
       invoices,
     };
   }

--- a/apps/api/src/billing/billing.types.ts
+++ b/apps/api/src/billing/billing.types.ts
@@ -1,3 +1,4 @@
+import type { BillingProductKey } from '@trycompai/billing';
 import type { BillingInvoice } from './billing-invoices';
 import type { BillingPreferences } from './billing-preferences';
 
@@ -23,6 +24,15 @@ export interface BillingStatus {
     currentPeriodStart: string | null;
     currentPeriodEnd: string | null;
     cancelAtPeriodEnd: boolean;
+  }>;
+  // Aggregated wallet balance per product. Mirrors what
+  // `BillingEntitlementsService.tryConsumeIncludedUsageForProduct` falls
+  // back to when a Stripe subscription is missing or exhausted, so the UI
+  // can keep its allowance display in sync with the backend's actual
+  // consumption decision.
+  creditBalances: Array<{
+    productKey: BillingProductKey;
+    balance: number;
   }>;
   invoices: BillingInvoice[];
 }

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/backgroundCheckTypes.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/backgroundCheckTypes.ts
@@ -43,6 +43,13 @@ export interface BackgroundCheckBillingStatus {
     currentPeriodEnd: string | null;
     cancelAtPeriodEnd: boolean;
   }>;
+  // Wallet credits per product. Optional because older API responses
+  // and existing test fixtures don't set it; treated as zero balance
+  // when absent.
+  creditBalances?: Array<{
+    productKey: 'pentest' | 'background_check';
+    balance: number;
+  }>;
 }
 
 export function isCompletedBackgroundCheck(status: BackgroundCheckStatus): boolean {

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/useEmployeeBackgroundCheckData.test.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/useEmployeeBackgroundCheckData.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import type { BackgroundCheckBillingStatus } from './backgroundCheckTypes';
+import { getBackgroundChecksRemaining } from './useEmployeeBackgroundCheckData';
+
+function status(
+  overrides: Partial<BackgroundCheckBillingStatus> = {},
+): BackgroundCheckBillingStatus {
+  return {
+    hasPaymentMethod: false,
+    setupAt: null,
+    ...overrides,
+  };
+}
+
+describe('getBackgroundChecksRemaining', () => {
+  it('returns null when billing status has not loaded', () => {
+    expect(getBackgroundChecksRemaining({ billingStatus: undefined })).toBeNull();
+  });
+
+  it('returns null when no subscription and no wallet credits exist', () => {
+    expect(getBackgroundChecksRemaining({ billingStatus: status() })).toBeNull();
+  });
+
+  it('returns subscription remainder when an active subscription exists', () => {
+    expect(
+      getBackgroundChecksRemaining({
+        billingStatus: status({
+          subscriptions: [
+            {
+              skuKey: 'background_checks_monthly_3',
+              status: 'active',
+              includedQuantity: 3,
+              usedQuantity: 1,
+              currentPeriodStart: null,
+              currentPeriodEnd: null,
+              cancelAtPeriodEnd: false,
+            },
+          ],
+        }),
+      }),
+    ).toBe(2);
+  });
+
+  it('returns wallet balance when no subscription but wallet credits exist', () => {
+    // Admin grant flow: organization has no subscription, platform
+    // admin granted 5 BG-check credits. Backend would consume from
+    // wallet on POST, so the wizard must allow the request.
+    expect(
+      getBackgroundChecksRemaining({
+        billingStatus: status({
+          creditBalances: [{ productKey: 'background_check', balance: 5 }],
+        }),
+      }),
+    ).toBe(5);
+  });
+
+  it('sums subscription remainder and wallet credits', () => {
+    expect(
+      getBackgroundChecksRemaining({
+        billingStatus: status({
+          subscriptions: [
+            {
+              skuKey: 'background_checks_monthly_3',
+              status: 'trialing',
+              includedQuantity: 3,
+              usedQuantity: 3,
+              currentPeriodStart: null,
+              currentPeriodEnd: null,
+              cancelAtPeriodEnd: false,
+            },
+          ],
+          creditBalances: [{ productKey: 'background_check', balance: 5 }],
+        }),
+      }),
+    ).toBe(5);
+  });
+
+  it('ignores pentest wallet credits when computing background-check allowance', () => {
+    expect(
+      getBackgroundChecksRemaining({
+        billingStatus: status({
+          creditBalances: [{ productKey: 'pentest', balance: 10 }],
+        }),
+      }),
+    ).toBeNull();
+  });
+
+  it('ignores cancelled subscriptions', () => {
+    expect(
+      getBackgroundChecksRemaining({
+        billingStatus: status({
+          subscriptions: [
+            {
+              skuKey: 'background_checks_monthly_3',
+              status: 'canceled',
+              includedQuantity: 3,
+              usedQuantity: 0,
+              currentPeriodStart: null,
+              currentPeriodEnd: null,
+              cancelAtPeriodEnd: false,
+            },
+          ],
+          creditBalances: [{ productKey: 'background_check', balance: 2 }],
+        }),
+      }),
+    ).toBe(2);
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/useEmployeeBackgroundCheckData.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/useEmployeeBackgroundCheckData.ts
@@ -54,11 +54,31 @@ export function getBackgroundChecksRemaining({
 }: {
   billingStatus: BackgroundCheckBillingStatus | undefined;
 }): number | null {
-  const subscription = (billingStatus?.subscriptions ?? []).find(
+  if (!billingStatus) return null;
+  const subscription = (billingStatus.subscriptions ?? []).find(
     (item) =>
       getBillingSkuProductKey(item.skuKey) === 'background_check' &&
       (item.status === 'active' || item.status === 'trialing'),
   );
-  if (!subscription) return null;
-  return Math.max(subscription.includedQuantity - subscription.usedQuantity, 0);
+  // Wallet credits granted by platform admins. The backend's
+  // `BillingEntitlementsService.tryConsumeIncludedUsageForProduct`
+  // falls back to this wallet when no active subscription exists or
+  // the subscription's included usage is exhausted, so we mirror that
+  // logic here — otherwise the wizard paywalls users whose admin-
+  // granted credits would actually be consumed by the create call.
+  const walletBalance =
+    (billingStatus.creditBalances ?? []).find(
+      (entry) => entry.productKey === 'background_check',
+    )?.balance ?? 0;
+  if (!subscription) {
+    // Returning `null` keeps the existing "no allowance — go pick a
+    // plan" wizard path. We only have a positive allowance if there
+    // are wallet credits to consume.
+    return walletBalance > 0 ? walletBalance : null;
+  }
+  const subscriptionRemaining = Math.max(
+    subscription.includedQuantity - subscription.usedQuantity,
+    0,
+  );
+  return subscriptionRemaining + walletBalance;
 }

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/SplitView.tsx
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/SplitView.tsx
@@ -6,13 +6,16 @@ import type {
   PentestIssue,
   PentestRun,
 } from '@/lib/security/penetration-tests-client';
-import { getBillingSkuProductKey } from '@trycompai/billing';
 import { cn } from '@trycompai/design-system/cn';
 import { ArrowLeft } from '@trycompai/design-system/icons';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { toast } from 'sonner';
 import useSWR from 'swr';
+import {
+  getPentestAllowance,
+  type PentestBillingStatusInput,
+} from './pentest-allowance';
 import {
   useCreatePenetrationTest,
   usePenetrationTest,
@@ -26,15 +29,6 @@ import { EmptyState } from './EmptyState';
 import { OverviewPane } from './OverviewPane';
 import { RunList } from './RunList';
 import './pentest-tokens.css';
-
-interface BillingStatus {
-  subscriptions?: Array<{
-    skuKey: string;
-    status: string;
-    includedQuantity: number;
-    usedQuantity: number;
-  }>;
-}
 
 interface SplitViewProps {
   orgId: string;
@@ -61,28 +55,20 @@ export function SplitView({ orgId, selectedRunId, mode = 'default' }: SplitViewP
   const { issues } = usePenetrationTestIssues(orgId, selectedRunId ?? '', selectedRun?.status);
   const { events } = usePenetrationTestEvents(orgId, selectedRunId ?? '', selectedRun?.status);
   const { createReport, isCreating } = useCreatePenetrationTest(orgId);
-  const { data: billingStatus } = useSWR<BillingStatus>(
+  const { data: billingStatus } = useSWR<PentestBillingStatusInput>(
     orgId ? (['/v1/billing/status', orgId] as const) : null,
     async ([endpoint, organizationId]: readonly [string, string]) => {
-      const response = await api.get<BillingStatus>(endpoint, organizationId);
+      const response = await api.get<PentestBillingStatusInput>(
+        endpoint,
+        organizationId,
+      );
       if (response.status < 200 || response.status >= 300) {
         throw new Error(response.error ?? 'Failed to load billing status');
       }
       return response.data ?? {};
     },
   );
-  const pentestSubscription = (billingStatus?.subscriptions ?? []).find(
-    (subscription) =>
-      getBillingSkuProductKey(subscription.skuKey) === 'pentest' &&
-      (subscription.status === 'active' || subscription.status === 'trialing'),
-  );
-  const subscriptionBalance = pentestSubscription
-    ? Math.max(pentestSubscription.includedQuantity - pentestSubscription.usedQuantity, 0)
-    : null;
-  // Keep `balance` undefined while billing is loading so the page does not
-  // flash a blocked state before subscription allowance is known.
-  const balance = subscriptionBalance ?? (billingStatus === undefined ? undefined : 0);
-  const planRequired = subscriptionBalance === null && billingStatus !== undefined;
+  const { balance, planRequired } = getPentestAllowance(billingStatus);
   const quotaLabel = 'Plan';
 
   const showEmptyState =

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/pentest-allowance.test.ts
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/pentest-allowance.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { getPentestAllowance } from './pentest-allowance';
+
+describe('getPentestAllowance', () => {
+  it('returns undefined balance while billing status is loading', () => {
+    expect(getPentestAllowance(undefined)).toEqual({
+      balance: undefined,
+      planRequired: false,
+    });
+  });
+
+  it('reports plan required when neither subscription nor wallet credits exist', () => {
+    expect(getPentestAllowance({})).toEqual({
+      balance: 0,
+      planRequired: true,
+    });
+  });
+
+  it('uses subscription remainder when a trial is active', () => {
+    expect(
+      getPentestAllowance({
+        subscriptions: [
+          {
+            skuKey: 'pentest_monthly_1',
+            status: 'trialing',
+            includedQuantity: 1,
+            usedQuantity: 0,
+          },
+        ],
+      }),
+    ).toEqual({ balance: 1, planRequired: false });
+  });
+
+  it('uses wallet credits when no subscription exists', () => {
+    // The "platform admin granted credits to a paywalled org" case —
+    // backend falls back to wallet, so the UI must too.
+    expect(
+      getPentestAllowance({
+        creditBalances: [{ productKey: 'pentest', balance: 5 }],
+      }),
+    ).toEqual({ balance: 5, planRequired: false });
+  });
+
+  it('sums subscription remainder and wallet credits', () => {
+    // Trial used (0 remaining) + 5 wallet credits => 5 total. Without
+    // this fix the UI would compute balance=0 and reroute to billing.
+    expect(
+      getPentestAllowance({
+        subscriptions: [
+          {
+            skuKey: 'pentest_monthly_1',
+            status: 'trialing',
+            includedQuantity: 1,
+            usedQuantity: 1,
+          },
+        ],
+        creditBalances: [{ productKey: 'pentest', balance: 5 }],
+      }),
+    ).toEqual({ balance: 5, planRequired: false });
+  });
+
+  it('clamps negative subscription remainder to zero before adding wallet credits', () => {
+    // Defensive: if Stripe ever reports usedQuantity > includedQuantity
+    // (e.g. proration glitch), the UI should not subtract from wallet.
+    expect(
+      getPentestAllowance({
+        subscriptions: [
+          {
+            skuKey: 'pentest_monthly_1',
+            status: 'active',
+            includedQuantity: 1,
+            usedQuantity: 5,
+          },
+        ],
+        creditBalances: [{ productKey: 'pentest', balance: 3 }],
+      }),
+    ).toEqual({ balance: 3, planRequired: false });
+  });
+
+  it('ignores wallet credits for unrelated products', () => {
+    expect(
+      getPentestAllowance({
+        creditBalances: [
+          { productKey: 'background_check', balance: 10 },
+        ],
+      }),
+    ).toEqual({ balance: 0, planRequired: true });
+  });
+
+  it('ignores cancelled subscriptions', () => {
+    // Match the backend's access-status filter — only active/trialing
+    // subscriptions count toward subscription remainder.
+    expect(
+      getPentestAllowance({
+        subscriptions: [
+          {
+            skuKey: 'pentest_monthly_1',
+            status: 'canceled',
+            includedQuantity: 1,
+            usedQuantity: 0,
+          },
+        ],
+        creditBalances: [{ productKey: 'pentest', balance: 2 }],
+      }),
+    ).toEqual({ balance: 2, planRequired: false });
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/pentest-allowance.ts
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/pentest-allowance.ts
@@ -1,0 +1,71 @@
+import { getBillingSkuProductKey } from '@trycompai/billing';
+
+/**
+ * Shape of `/v1/billing/status` fields the pentest UI consumes. We only
+ * declare what we read so the type doesn't drift from the broader
+ * BillingStatus contract every time an unrelated billing field
+ * changes.
+ */
+export interface PentestBillingStatusInput {
+  subscriptions?: Array<{
+    skuKey: string;
+    status: string;
+    includedQuantity: number;
+    usedQuantity: number;
+  }>;
+  creditBalances?: Array<{
+    productKey: 'pentest' | 'background_check';
+    balance: number;
+  }>;
+}
+
+export interface PentestAllowance {
+  /**
+   * Total runs the user can start right now: subscription remainder +
+   * admin-granted wallet credits. `undefined` while billing is still
+   * loading so the page does not flash a paywalled state.
+   */
+  balance: number | undefined;
+  /**
+   * True only when neither an active subscription nor a wallet credit
+   * exists. The UI uses this to decide whether to show "+ New Scan" or
+   * "View plans".
+   */
+  planRequired: boolean;
+}
+
+/**
+ * Compute the user-visible pentest allowance from billing status.
+ *
+ * Mirrors `BillingEntitlementsService.tryConsumeIncludedUsageForProduct`:
+ * the backend consumes from the active Stripe subscription first and
+ * falls back to the per-product wallet (BillingCreditBalance). Surfacing
+ * both here keeps the UI's gating in lockstep with what the create
+ * endpoint will actually accept — without this, admin-granted credits
+ * are invisible to the customer and the New Scan button incorrectly
+ * redirects to billing.
+ */
+export function getPentestAllowance(
+  billingStatus: PentestBillingStatusInput | undefined,
+): PentestAllowance {
+  if (billingStatus === undefined) {
+    return { balance: undefined, planRequired: false };
+  }
+  const subscription = (billingStatus.subscriptions ?? []).find(
+    (item) =>
+      getBillingSkuProductKey(item.skuKey) === 'pentest' &&
+      (item.status === 'active' || item.status === 'trialing'),
+  );
+  const subscriptionRemaining = subscription
+    ? Math.max(subscription.includedQuantity - subscription.usedQuantity, 0)
+    : null;
+  const walletBalance =
+    (billingStatus.creditBalances ?? []).find(
+      (entry) => entry.productKey === 'pentest',
+    )?.balance ?? 0;
+
+  return {
+    balance: (subscriptionRemaining ?? 0) + walletBalance,
+    planRequired: subscriptionRemaining === null && walletBalance === 0,
+  };
+}

--- a/apps/app/src/app/(app)/[orgId]/settings/billing/emptyBillingStatus.ts
+++ b/apps/app/src/app/(app)/[orgId]/settings/billing/emptyBillingStatus.ts
@@ -9,6 +9,7 @@ export const emptyBillingStatus: BackgroundCheckBillingStatus = {
   },
   invoices: [],
   subscriptions: [],
+  creditBalances: [],
   trialEligibility: {
     pentest: false,
     background_check: false,

--- a/apps/app/src/app/(app)/[orgId]/settings/billing/types.ts
+++ b/apps/app/src/app/(app)/[orgId]/settings/billing/types.ts
@@ -34,6 +34,14 @@ export interface BackgroundCheckBillingStatus {
     currentPeriodEnd: string | null;
     cancelAtPeriodEnd: boolean;
   }>;
+  // Aggregated wallet credit balance per product. The API guarantees
+  // one entry per product key; an absent product means zero balance.
+  // Optional on the client so older payloads (and existing test
+  // fixtures) keep typechecking.
+  creditBalances?: Array<{
+    productKey: 'pentest' | 'background_check';
+    balance: number;
+  }>;
   invoices?: BillingInvoice[];
 }
 


### PR DESCRIPTION
## Summary
- `/v1/billing/status` now returns `creditBalances` (per-product wallet balances). Pentest page + BG-check wizard add wallet credits to their displayed allowance, matching the backend's actual consumption logic.
- Fixes the case: trial used → admin grants 5 credits → user still sees "View plans" and is rerouted to billing instead of being able to start a scan.

## Why this was wrong
- `BillingEntitlementsService.tryConsumeIncludedUsageForProduct` already falls back to `BillingCreditsService.tryConsumeForProduct` when the Stripe subscription is missing or exhausted (`apps/api/src/billing/billing-entitlements.service.ts:43-83`). The backend would happily run the scan.
- But `BillingService.getStatus` only returned `subscriptions`. Both the pentest `SplitView` and `getBackgroundChecksRemaining` computed allowance from subscription remainder alone, so admin grants were invisible to the customer UI.
- Result: New Scan button → `/billing/add-ons/penetration-tests`, blocking a request the API would have accepted.

## Fix
**API**
- `BillingStatus`: added `creditBalances: Array<{ productKey, balance }>`.
- `BillingService.getStatus`: injects `BillingCreditsService` (`@Optional()` so existing test ctors keep compiling), fetches balances, aggregates per product (multiple SKU-scoped rows can share a `productKey`).

**Pentest UI**
- New pure helper `getPentestAllowance(billingStatus)` — `subscriptionRemaining + walletBalance`. `planRequired` is true only when neither exists.
- `SplitView.tsx` now delegates to the helper.

**Background-check UI**
- `getBackgroundChecksRemaining` now adds wallet credits and returns wallet-only when no subscription exists (instead of `null`), so the wizard reaches the form step.
- Local `BackgroundCheckBillingStatus` mirror gained the optional `creditBalances` field.

## Non-breaking guarantees
- `creditBalances` is purely additive on the API and **optional** on every frontend type — every existing consumer keeps compiling.
- `BillingCreditsService` injection is `@Optional()`; the 11 existing `new BillingService(...)` test calls work unchanged.
- For users without wallet credits: `walletBalance = 0` → identical pre-fix behavior.

## Tests
- `apps/api/src/billing/billing.service.spec.ts` — 2 new jest cases:
  - `getStatus` aggregates wallet balances per product (multiple rows summed).
  - Returns `[]` when credits service is absent.
- `pentest-allowance.test.ts` — 8 vitest cases (loading, no plan, trial, wallet only, sub exhausted + wallet, negative-clamp, wrong product, cancelled subscription).
- `useEmployeeBackgroundCheckData.test.ts` — 7 vitest cases (mirrors above for BG check).

All 13 + 15 = 28 tests pass. No existing test was modified except adding new cases.

## Test plan
- [ ] Org with exhausted pentest trial: admin grants 5 pentest credits → reload pentest page → "+ New Scan (Plan)" button appears (not "View plans"). Click → routes to `/security/penetration-tests/new`. Submit → scan starts; wallet drops to 4.
- [ ] Same flow for background checks: exhausted BG-check subscription + admin grant via `POST /v1/admin/organizations/:orgId/credits` `{productKey:'background_check', quantity:5}` → BG-check wizard shows the request form and the request goes through.
- [ ] Org with no plan AND no credits: still sees "View plans" CTA on both surfaces.
- [ ] Org with active subscription + no credits: behavior unchanged from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaced admin-granted wallet credits in pentest and background-check UIs by adding aggregated credit balances to `/v1/billing/status` and updating allowance logic to match backend consumption. This fixes false paywalls when trials are exhausted but wallet credits exist.

- **Bug Fixes**
  - API: Added `creditBalances` to `BillingStatus`; `BillingService.getStatus` aggregates wallet balances per product; injected `BillingCreditsService` with `@Optional()`; returns `[]` when credits service is absent.
  - Pentest UI: New `getPentestAllowance` helper; `SplitView` now uses subscription remainder + wallet credits to choose between "+ New Scan" and "View plans".
  - Background-check UI: `getBackgroundChecksRemaining` adds wallet credits and enables wallet-only flows when no subscription exists; local billing types gained optional `creditBalances`.
  - Types/defaults: Updated settings billing types and `emptyBillingStatus` (`creditBalances: []`); field is optional on frontend types and treated as 0 when absent.
  - Tests: Added coverage for API aggregation and UI allowance logic (pentest + background-check).

<sup>Written for commit 672e901b695baefca072037abfb032a4a4671b18. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

