### PR TITLE
perf(app): pin Vercel SSR functions to iad1

### DIFF
--- a/apps/app/vercel.json
+++ b/apps/app/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "regions": ["iad1"]
+}


### PR DESCRIPTION
## Summary

- Pins `apps/app` Vercel serverless functions to `iad1` (us-east-1, same region as RDS).
- SSR is currently running in `lhr1` (London). Every `db.*` call inside a server component (e.g., `apps/app/src/app/(app)/[orgId]/layout.tsx`) crosses the Atlantic at ~90ms per query — pages with 5+ sequential queries pay ~450ms of pure network latency during render.
- Co-locating SSR with the database collapses those queries to local round-trips (~5ms each).

## Why now

Investigating EU-user latency complaints, `curl -I https://app.trycomp.ai/` returned `x-vercel-id: lhr1::...`. The Vercel project default had drifted to London at some point, which was the worst-of-both-worlds: SSR-to-DB queries cross the Atlantic on every render, regardless of where the user is.

## Expected impact

| User location | Before (lhr1 SSR) | After (iad1 SSR) |
|---|---|---|
| US (most customers) | ~630ms page-render time | ~50–70ms |
| EU | ~470ms | ~205ms |

Server-side P75 duration on `/[orgId]/overview` (currently ~535ms in observability) should drop substantially — most of that latency is the cross-Atlantic SSR-to-DB fan-out.

## Notes

- Pro plan allows up to 3 regions; we only need 1. Adding more would deploy the function to all listed regions and re-introduce cross-Atlantic SSR queries on whichever region isn't iad1.
- Per Next.js docs, route-level `preferredRegion` is Edge-runtime only on Vercel — not applicable here since the app uses Node.js runtime. Project-level `vercel.json` is the supported mechanism.
- Companion PR for `apps/portal` to follow.

## Test plan

- [ ] Vercel preview deploys successfully
- [ ] After production deploy, `curl -sI https://app.trycomp.ai/ | grep x-vercel-id` returns `iad1::...`
- [ ] Vercel Observability → Functions → P75 duration on `/[orgId]/overview` drops from ~535ms
- [ ] Smoke-test EU access (VPN or webpagetest.org Paris node) — TTFB improvement
- [ ] No regression in error rate or cold-start metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `apps/app` SSR functions to `iad1` (us‑east‑1) to co-locate with RDS and stop transatlantic DB calls during render. This adds `apps/app/vercel.json` with `regions: ["iad1"]` and should notably cut SSR latency, especially on `/[orgId]/overview`.

<sup>Written for commit ae20aaac161cd1766fac6aeacb6ee55fc717d74b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

