### PR TITLE
perf(portal): pin Vercel SSR functions to iad1

### DIFF
--- a/apps/portal/vercel.json
+++ b/apps/portal/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "regions": ["iad1"]
+}


### PR DESCRIPTION
## Summary

- Pins `apps/portal` Vercel serverless functions to `iad1` (us-east-1, same region as RDS).
- Companion to https://github.com/trycompai/comp/pull/2769 for `apps/app`.
- Co-locates SSR with the database so DB calls inside server components stay in-region (~5ms) instead of crossing the Atlantic from London (~90ms each).

## Why now

Investigating EU-user latency, the Vercel project default for these apps had drifted to `lhr1` (London) at some point. That's the worst-of-both-worlds: SSR-to-DB queries cross the Atlantic on every render regardless of where the user is. Moving to `iad1` collapses those queries to local round-trips.

## Notes

- Pro plan caps regions at 3; we use 1. Adding more would deploy to all listed regions and re-introduce cross-Atlantic SSR queries on whichever isn't iad1.
- Per Next.js docs, route-level `preferredRegion` is Edge-runtime only on Vercel — not applicable here. Project-level `vercel.json` is the supported mechanism.

## Test plan

- [ ] Vercel preview deploys successfully
- [ ] After production deploy, `curl -sI https://portal.trycomp.ai/ | grep x-vercel-id` returns `iad1::...`
- [ ] Portal smoke test: login, view policies, accept policy
- [ ] No regression in error rate or cold-start metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins portal SSR to Vercel region `iad1` (us-east-1) via `apps/portal/vercel.json` to co-locate with RDS. Keeps SSR-to-DB calls in-region (~5ms) instead of crossing the Atlantic from London (~90ms), matching the `apps/app` setup.

<sup>Written for commit 1a06cec285864ec7d1a34535e9eec5e99c96122f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

