### PR TITLE
fix: revert page-level hooks to useRealtimeRun to fix auth context error

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/overview/components/ToDoOverview.tsx
+++ b/apps/app/src/app/(app)/[orgId]/overview/components/ToDoOverview.tsx
@@ -5,7 +5,6 @@ import { Card, CardContent, CardHeader, CardTitle } from '@trycompai/ui/card';
 import { ScrollArea } from '@trycompai/ui/scroll-area';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@trycompai/ui/tabs';
 import { Policy, Task } from '@db';
-import { useRun } from '@trigger.dev/react-hooks';
 import {
   ArrowRight,
   CheckCircle2,
@@ -49,25 +48,7 @@ export function ToDoOverview({
   const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
-  const { run: onboardingRun } = useRun(onboardingTriggerJobId || '', {
-    refreshInterval: 1000,
-  });
-
-  const IN_PROGRESS_STATUSES = [
-    'QUEUED',
-    'EXECUTING',
-    'WAITING_FOR_DEPLOY',
-    'REATTEMPTING',
-    'FROZEN',
-    'DELAYED',
-    'WAITING',
-    'PENDING_VERSION',
-    'DEQUEUED',
-  ];
-
-  const isOnboardingInProgress = onboardingRun
-    ? IN_PROGRESS_STATUSES.includes(onboardingRun.status)
-    : false;
+  const isOnboardingInProgress = !!onboardingTriggerJobId;
 
   const formatStatus = (status: string) => {
     return status.replace('_', ' ').replace(/\b\w/g, (l) => l.toUpperCase());

--- a/apps/app/src/app/(app)/[orgId]/policies/(overview)/hooks/use-policy-onboarding-status.ts
+++ b/apps/app/src/app/(app)/[orgId]/policies/(overview)/hooks/use-policy-onboarding-status.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRun } from '@trigger.dev/react-hooks';
+import { useRealtimeRun } from '@trigger.dev/react-hooks';
 import { useMemo } from 'react';
 import type { PolicyTailoringStatus } from '../../all/components/policy-tailoring-context';
 
@@ -20,8 +20,8 @@ export function usePolicyOnboardingStatus(
   onboardingRunId: string | null | undefined,
 ) {
   const shouldSubscribe = Boolean(onboardingRunId);
-  const { run } = useRun(shouldSubscribe ? onboardingRunId! : '', {
-    refreshInterval: 1000,
+  const { run } = useRealtimeRun(shouldSubscribe ? onboardingRunId! : '', {
+    enabled: shouldSubscribe,
   });
 
   const itemStatuses = useMemo<Record<string, PolicyTailoringStatus>>(() => {

--- a/apps/app/src/app/(app)/[orgId]/policies/all/components/policies-table.tsx
+++ b/apps/app/src/app/(app)/[orgId]/policies/all/components/policies-table.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRun } from '@trigger.dev/react-hooks';
+import { useRealtimeRun } from '@trigger.dev/react-hooks';
 import { Download, Loader2 } from 'lucide-react';
 import * as React from 'react';
 import { toast } from 'sonner';
@@ -31,8 +31,8 @@ export function PoliciesTable({ promises, onboardingRunId }: PoliciesTableProps)
   const orgId = params.orgId as string;
 
   const shouldSubscribeToRun = Boolean(onboardingRunId);
-  const { run } = useRun(shouldSubscribeToRun ? onboardingRunId! : '', {
-    refreshInterval: 1000,
+  const { run } = useRealtimeRun(shouldSubscribeToRun ? onboardingRunId! : '', {
+    enabled: shouldSubscribeToRun,
   });
 
   const policyStatuses = React.useMemo<PolicyStatusMap>(() => {

--- a/apps/app/src/app/(app)/[orgId]/risk/(overview)/hooks/use-onboarding-status.ts
+++ b/apps/app/src/app/(app)/[orgId]/risk/(overview)/hooks/use-onboarding-status.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRun } from '@trigger.dev/react-hooks';
+import { useRealtimeRun } from '@trigger.dev/react-hooks';
 import { useMemo } from 'react';
 
 export type OnboardingItemStatus = 'pending' | 'processing' | 'created' | 'assessing' | 'completed';
@@ -15,8 +15,8 @@ export function useOnboardingStatus(
   itemType: 'risks' | 'vendors',
 ) {
   const shouldSubscribe = Boolean(onboardingRunId);
-  const { run } = useRun(shouldSubscribe ? onboardingRunId! : '', {
-    refreshInterval: 1000,
+  const { run } = useRealtimeRun(shouldSubscribe ? onboardingRunId! : '', {
+    enabled: shouldSubscribe,
   });
 
   const itemStatuses = useMemo<Record<string, OnboardingItemStatus>>(() => {


### PR DESCRIPTION
## Summary

Fixes the "Missing accessToken in TriggerAuthContext" error on staging that crashes the overview and policies pages.

- `useRun` requires a `TriggerProvider` context with an access token
- When there's no active onboarding (no `triggerJobId`), the `TriggerTokenProvider` renders children WITHOUT a `TriggerProvider`
- `useRun` throws; `useRealtimeRun` with `enabled: false` gracefully returns null

Changes:
- **policies-table.tsx**: `useRun` → `useRealtimeRun` with `enabled` flag
- **use-policy-onboarding-status.ts**: same
- **use-onboarding-status.ts**: same (covers both risks and vendors)
- **ToDoOverview.tsx**: removed trigger hook entirely — derives `isOnboardingInProgress` from the `triggerJobId` prop

Follow-up to #2777.

## Test plan
- [x] Overview page loads without error when no onboarding is active
- [x] Policies page loads without error when no onboarding is active
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the “Missing accessToken in TriggerAuthContext” crash by reverting page-level hooks to `useRealtimeRun` and removing an unnecessary trigger hook. Overview and Policies now load safely when no onboarding is active.

- **Bug Fixes**
  - Replaced `useRun` with `useRealtimeRun({ enabled })` from `@trigger.dev/react-hooks` in policies table and onboarding status hooks to avoid requiring a `TriggerProvider` when no `onboardingRunId`.
  - Simplified `ToDoOverview`: removed trigger hook and derive `isOnboardingInProgress` from `triggerJobId`.
  - Prevents crashes on Overview and Policies when onboarding isn’t running.

<sup>Written for commit a24baecf225e337b8743ad8be3e64170db0a5dcd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

