### PR TITLE
chore(trigger): change policy acknowledgment digest from daily to weekly

### DIFF
--- a/apps/api/src/email/dto/send-batch-email.dto.ts
+++ b/apps/api/src/email/dto/send-batch-email.dto.ts
@@ -1,5 +1,6 @@
 import {
   IsString,
+  IsEmail,
   IsOptional,
   IsArray,
   ValidateNested,
@@ -10,7 +11,7 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 class BatchEmailItemDto {
   @ApiProperty({ description: 'Recipient email address' })
-  @IsString()
+  @IsEmail()
   to: string;
 
   @ApiProperty({ description: 'Email subject line' })

--- a/apps/api/src/email/dto/send-batch-email.dto.ts
+++ b/apps/api/src/email/dto/send-batch-email.dto.ts
@@ -1,0 +1,44 @@
+import {
+  IsString,
+  IsOptional,
+  IsArray,
+  ValidateNested,
+  ArrayMinSize,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+class BatchEmailItemDto {
+  @ApiProperty({ description: 'Recipient email address' })
+  @IsString()
+  to: string;
+
+  @ApiProperty({ description: 'Email subject line' })
+  @IsString()
+  subject: string;
+
+  @ApiProperty({ description: 'Pre-rendered HTML content' })
+  @IsString()
+  html: string;
+
+  @ApiPropertyOptional({ description: 'Explicit FROM address override' })
+  @IsOptional()
+  @IsString()
+  from?: string;
+
+  @ApiPropertyOptional({ description: 'CC recipients' })
+  @IsOptional()
+  cc?: string | string[];
+}
+
+export class SendBatchEmailDto {
+  @ApiProperty({
+    description: 'Array of emails to send',
+    type: [BatchEmailItemDto],
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => BatchEmailItemDto)
+  emails: BatchEmailItemDto[];
+}

--- a/apps/api/src/email/email.controller.ts
+++ b/apps/api/src/email/email.controller.ts
@@ -11,7 +11,9 @@ import { HybridAuthGuard } from '../auth/hybrid-auth.guard';
 import { PermissionGuard } from '../auth/permission.guard';
 import { RequirePermission } from '../auth/require-permission.decorator';
 import { SendEmailDto } from './dto/send-email.dto';
+import { SendBatchEmailDto } from './dto/send-batch-email.dto';
 import type { sendEmailTask } from '../trigger/email/send-email';
+import type { sendBatchEmailTask } from '../trigger/email/send-batch-email';
 
 @ApiExcludeController()
 @ApiTags('Internal - Email')
@@ -40,6 +42,33 @@ export class EmailController {
       scheduledAt: dto.scheduledAt,
       attachments: dto.attachments,
     });
+
+    return { success: true, taskId: handle.id };
+  }
+
+  @Post('send-batch')
+  @HttpCode(200)
+  @RequirePermission('email', 'send')
+  @ApiOperation({
+    summary: 'Send a batch of emails via the centralized Trigger task (internal)',
+  })
+  @ApiResponse({ status: 200, description: 'Batch email task triggered' })
+  async sendBatchEmail(@Body() dto: SendBatchEmailDto) {
+    const fromAddress =
+      process.env.RESEND_FROM_SYSTEM ?? process.env.RESEND_FROM_DEFAULT;
+
+    const emails = dto.emails.map((email) => ({
+      to: email.to,
+      subject: email.subject,
+      html: email.html,
+      from: email.from ?? fromAddress,
+      cc: email.cc,
+    }));
+
+    const handle = await tasks.trigger<typeof sendBatchEmailTask>(
+      'send-batch-email',
+      { emails },
+    );
 
     return { success: true, taskId: handle.id };
   }

--- a/apps/api/src/trigger/email/send-batch-email.ts
+++ b/apps/api/src/trigger/email/send-batch-email.ts
@@ -1,0 +1,104 @@
+import { logger, queue, schemaTask } from '@trigger.dev/sdk';
+import { z } from 'zod';
+import { resend } from '../../email/resend';
+import { generateUnsubscribeToken } from '@trycompai/email';
+
+const RESEND_BATCH_LIMIT = 100;
+
+const batchEmailQueue = queue({
+  name: 'send-batch-email',
+  concurrencyLimit: 5,
+});
+
+const batchEmailItemSchema = z.object({
+  to: z.string(),
+  subject: z.string(),
+  html: z.string(),
+  from: z.string().optional(),
+  cc: z.union([z.string(), z.array(z.string())]).optional(),
+});
+
+export const sendBatchEmailTask = schemaTask({
+  id: 'send-batch-email',
+  queue: batchEmailQueue,
+  retry: {
+    maxAttempts: 3,
+  },
+  schema: z.object({
+    emails: z.array(batchEmailItemSchema).min(1),
+  }),
+  run: async (params) => {
+    if (!resend) {
+      logger.error('Resend not initialized - missing RESEND_API_KEY');
+      throw new Error('Resend not initialized - missing API key');
+    }
+
+    const fromDefault =
+      process.env.RESEND_FROM_SYSTEM ?? process.env.RESEND_FROM_DEFAULT;
+    const toTest = process.env.RESEND_TO_TEST;
+    const apiBaseUrl =
+      process.env.NEXT_PUBLIC_API_URL || 'https://api.trycomp.ai';
+
+    let totalSent = 0;
+    let totalFailed = 0;
+
+    for (let i = 0; i < params.emails.length; i += RESEND_BATCH_LIMIT) {
+      const chunk = params.emails.slice(i, i + RESEND_BATCH_LIMIT);
+
+      const payload = chunk.map((email) => {
+        const token = generateUnsubscribeToken(email.to);
+        const oneClickUrl = `${apiBaseUrl}/v1/email/unsubscribe?email=${encodeURIComponent(email.to)}&token=${encodeURIComponent(token)}`;
+
+        return {
+          from: email.from ?? fromDefault ?? '',
+          to: toTest ?? email.to,
+          cc: email.cc,
+          subject: email.subject,
+          html: email.html,
+          headers: {
+            'List-Unsubscribe': `<${oneClickUrl}>`,
+            'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+          },
+        };
+      });
+
+      const { data, error } = await resend.batch.send(payload, {
+        batchValidation: 'permissive',
+      });
+
+      if (error) {
+        logger.error('Resend batch API error', {
+          error,
+          chunkIndex: i,
+          chunkSize: chunk.length,
+        });
+        totalFailed += chunk.length;
+        continue;
+      }
+
+      const sent = data?.data?.length ?? 0;
+      totalSent += sent;
+
+      if ('errors' in data && Array.isArray(data.errors)) {
+        for (const err of data.errors) {
+          logger.warn('Batch email failed for recipient', {
+            index: err.index,
+            message: err.message,
+            to: chunk[err.index]?.to,
+          });
+          totalFailed += 1;
+          totalSent -= 1;
+        }
+      }
+
+      logger.info('Batch chunk sent', {
+        chunkIndex: i,
+        chunkSize: chunk.length,
+        sent,
+      });
+    }
+
+    logger.info('Batch email task complete', { totalSent, totalFailed });
+    return { totalSent, totalFailed };
+  },
+});

--- a/apps/api/src/trigger/email/send-batch-email.ts
+++ b/apps/api/src/trigger/email/send-batch-email.ts
@@ -35,6 +35,11 @@ export const sendBatchEmailTask = schemaTask({
 
     const fromDefault =
       process.env.RESEND_FROM_SYSTEM ?? process.env.RESEND_FROM_DEFAULT;
+
+    if (!fromDefault) {
+      throw new Error('Missing FROM address in environment variables');
+    }
+
     const toTest = process.env.RESEND_TO_TEST;
     const apiBaseUrl =
       process.env.NEXT_PUBLIC_API_URL || 'https://api.trycomp.ai';
@@ -50,7 +55,7 @@ export const sendBatchEmailTask = schemaTask({
         const oneClickUrl = `${apiBaseUrl}/v1/email/unsubscribe?email=${encodeURIComponent(email.to)}&token=${encodeURIComponent(token)}`;
 
         return {
-          from: email.from ?? fromDefault ?? '',
+          from: email.from ?? fromDefault,
           to: toTest ?? email.to,
           cc: email.cc,
           subject: email.subject,
@@ -87,7 +92,6 @@ export const sendBatchEmailTask = schemaTask({
             to: chunk[err.index]?.to,
           });
           totalFailed += 1;
-          totalSent -= 1;
         }
       }
 

--- a/apps/app/src/trigger/lib/send-email-via-api.ts
+++ b/apps/app/src/trigger/lib/send-email-via-api.ts
@@ -17,6 +17,19 @@ interface SendEmailViaApiParams {
   cc?: string | string[];
 }
 
+interface BatchEmailItem {
+  to: string;
+  subject: string;
+  html: string;
+  from?: string;
+  cc?: string | string[];
+}
+
+interface SendBatchEmailViaApiParams {
+  emails: BatchEmailItem[];
+  organizationId: string;
+}
+
 /**
  * Renders a React email template to HTML and sends it through the
  * API's centralized send-email Trigger task.
@@ -60,6 +73,45 @@ export async function sendEmailViaApi(
   const data = (await response.json()) as { taskId: string };
   logger.info('Email triggered via API', {
     to: params.to,
+    taskId: data.taskId,
+  });
+  return { taskId: data.taskId };
+}
+
+/**
+ * Sends a batch of pre-rendered HTML emails through the API's
+ * centralized send-batch-email Trigger task.
+ */
+export async function sendBatchEmailViaApi(
+  params: SendBatchEmailViaApiParams,
+): Promise<{ taskId: string }> {
+  const apiBaseUrl = getApiBaseUrl();
+  const token = process.env.SERVICE_TOKEN_TRIGGER;
+
+  const response = await fetch(`${apiBaseUrl}/v1/internal/email/send-batch`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token
+        ? {
+            'x-service-token': token,
+            'x-organization-id': params.organizationId,
+          }
+        : {}),
+    },
+    body: JSON.stringify({ emails: params.emails }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(
+      `Failed to send batch email via API (${response.status}): ${text}`,
+    );
+  }
+
+  const data = (await response.json()) as { taskId: string };
+  logger.info('Batch email triggered via API', {
+    count: params.emails.length,
     taskId: data.taskId,
   });
   return { taskId: data.taskId };

--- a/apps/app/src/trigger/tasks/task/policy-acknowledgment-digest.test.ts
+++ b/apps/app/src/trigger/tasks/task/policy-acknowledgment-digest.test.ts
@@ -14,8 +14,12 @@ vi.mock('./policy-acknowledgment-digest-helpers', async (importOriginal) => {
   };
 });
 
+vi.mock('@react-email/render', () => ({
+  render: vi.fn().mockResolvedValue('<html>mock</html>'),
+}));
+
 vi.mock('../../lib/send-email-via-api', () => ({
-  sendEmailViaApi: vi.fn(),
+  sendBatchEmailViaApi: vi.fn(),
 }));
 
 vi.mock('@trycompai/email/lib/check-unsubscribe', () => ({
@@ -31,7 +35,7 @@ vi.mock('@trigger.dev/sdk', () => ({
 
 import { db } from '@db/server';
 import { filterDigestMembersByCompliance } from './policy-acknowledgment-digest-helpers';
-import { sendEmailViaApi } from '../../lib/send-email-via-api';
+import { sendBatchEmailViaApi } from '../../lib/send-email-via-api';
 import { getUnsubscribedEmails } from '@trycompai/email/lib/check-unsubscribe';
 import { policyAcknowledgmentDigest } from './policy-acknowledgment-digest';
 
@@ -40,7 +44,7 @@ const mockDb = db as unknown as {
 };
 const mockFindMany = mockDb.organization.findMany;
 const mockFilterDigestMembersByCompliance = vi.mocked(filterDigestMembersByCompliance);
-const mockSendEmailViaApi = vi.mocked(sendEmailViaApi);
+const mockSendBatchEmailViaApi = vi.mocked(sendBatchEmailViaApi);
 const mockGetUnsubscribedEmails = vi.mocked(getUnsubscribedEmails);
 
 // The mock replaces schedules.task with a passthrough that returns the config
@@ -60,7 +64,7 @@ describe('policyAcknowledgmentDigest', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFilterDigestMembersByCompliance.mockImplementation(async (_db, members) => members);
-    mockSendEmailViaApi.mockResolvedValue({ taskId: 'run_fake' });
+    mockSendBatchEmailViaApi.mockResolvedValue({ taskId: 'run_fake' });
     mockGetUnsubscribedEmails.mockResolvedValue(new Set<string>());
   });
 
@@ -104,11 +108,12 @@ describe('policyAcknowledgmentDigest', () => {
       timestamp: new Date(),
     } as never);
 
-    expect(mockSendEmailViaApi).toHaveBeenCalledTimes(1);
-    const call = mockSendEmailViaApi.mock.calls[0][0];
-    expect(call.to).toBe('alice@example.com');
-    expect(call.subject).toBe('You have 1 policy to review at Acme');
+    expect(mockSendBatchEmailViaApi).toHaveBeenCalledTimes(1);
+    const call = mockSendBatchEmailViaApi.mock.calls[0][0];
     expect(call.organizationId).toBe('org_1');
+    expect(call.emails).toHaveLength(1);
+    expect(call.emails[0].to).toBe('alice@example.com');
+    expect(call.emails[0].subject).toBe('You have 1 policy to review at Acme');
     expect(result).toMatchObject({
       success: true,
       emailsSent: 1,
@@ -149,7 +154,7 @@ describe('policyAcknowledgmentDigest', () => {
       timestamp: new Date(),
     } as never);
 
-    expect(mockSendEmailViaApi).not.toHaveBeenCalled();
+    expect(mockSendBatchEmailViaApi).not.toHaveBeenCalled();
     expect(result).toMatchObject({ success: true, emailsSent: 0 });
   });
 
@@ -187,7 +192,7 @@ describe('policyAcknowledgmentDigest', () => {
       timestamp: new Date(),
     } as never);
 
-    expect(mockSendEmailViaApi).not.toHaveBeenCalled();
+    expect(mockSendBatchEmailViaApi).not.toHaveBeenCalled();
     expect(result).toMatchObject({ success: true, emailsSent: 0 });
   });
 
@@ -236,8 +241,8 @@ describe('policyAcknowledgmentDigest', () => {
 
     await taskUnderTest.run({ timestamp: new Date() } as never);
 
-    expect(mockSendEmailViaApi).toHaveBeenCalledTimes(1);
-    expect(mockSendEmailViaApi.mock.calls[0][0].subject).toBe(
+    expect(mockSendBatchEmailViaApi).toHaveBeenCalledTimes(1);
+    expect(mockSendBatchEmailViaApi.mock.calls[0][0].emails[0].subject).toBe(
       'You have 3 policies to review at Acme',
     );
   });
@@ -280,19 +285,18 @@ describe('policyAcknowledgmentDigest', () => {
         ],
       },
     ]);
-    mockSendEmailViaApi
-      .mockRejectedValueOnce(new Error('Resend 500'))
-      .mockResolvedValueOnce({ taskId: 'run_ok' });
+    mockSendBatchEmailViaApi.mockRejectedValueOnce(new Error('Resend 500'));
 
     const result = await taskUnderTest.run({
       timestamp: new Date(),
     } as never);
 
-    expect(mockSendEmailViaApi).toHaveBeenCalledTimes(2);
+    expect(mockSendBatchEmailViaApi).toHaveBeenCalledTimes(1);
+    expect(mockSendBatchEmailViaApi.mock.calls[0][0].emails).toHaveLength(2);
     expect(result).toMatchObject({
       success: true,
-      emailsSent: 1,
-      emailsFailed: 1,
+      emailsSent: 0,
+      emailsFailed: 2,
     });
   });
 
@@ -330,7 +334,7 @@ describe('policyAcknowledgmentDigest', () => {
 
     const result = await taskUnderTest.run({ timestamp: new Date() } as never);
 
-    expect(mockSendEmailViaApi).not.toHaveBeenCalled();
+    expect(mockSendBatchEmailViaApi).not.toHaveBeenCalled();
     expect(result).toMatchObject({
       success: true,
       emailsSent: 0,
@@ -401,17 +405,16 @@ describe('policyAcknowledgmentDigest', () => {
 
     const result = await taskUnderTest.run({ timestamp: new Date() } as never);
 
-    expect(mockSendEmailViaApi).toHaveBeenCalledTimes(1);
-    const call = mockSendEmailViaApi.mock.calls[0][0] as {
-      to: string;
-      subject: string;
+    expect(mockSendBatchEmailViaApi).toHaveBeenCalledTimes(1);
+    const call = mockSendBatchEmailViaApi.mock.calls[0][0] as {
+      emails: Array<{ to: string; subject: string }>;
       organizationId: string;
     };
-    expect(call.to).toBe('alice@example.com');
-    expect(call.subject).toBe(
+    expect(call.emails).toHaveLength(1);
+    expect(call.emails[0].to).toBe('alice@example.com');
+    expect(call.emails[0].subject).toBe(
       'You have 3 policies to review across 2 organizations',
     );
-    // x-organization-id falls back to the first org the user had policies in.
     expect(call.organizationId).toBe('org_1');
     expect(result).toMatchObject({
       success: true,
@@ -484,13 +487,12 @@ describe('policyAcknowledgmentDigest', () => {
 
     const result = await taskUnderTest.run({ timestamp: new Date() } as never);
 
-    expect(mockSendEmailViaApi).toHaveBeenCalledTimes(1);
-    const call = mockSendEmailViaApi.mock.calls[0][0] as {
-      to: string;
-      subject: string;
+    expect(mockSendBatchEmailViaApi).toHaveBeenCalledTimes(1);
+    const call = mockSendBatchEmailViaApi.mock.calls[0][0] as {
+      emails: Array<{ to: string; subject: string }>;
       organizationId: string;
     };
-    expect(call.subject).toBe(
+    expect(call.emails[0].subject).toBe(
       'You have 2 policies to review across 2 organizations',
     );
     expect(call.organizationId).toBe('org_1');
@@ -565,12 +567,12 @@ describe('policyAcknowledgmentDigest', () => {
 
     const result = await taskUnderTest.run({ timestamp: new Date() } as never);
 
-    expect(mockSendEmailViaApi).toHaveBeenCalledTimes(1);
-    const call = mockSendEmailViaApi.mock.calls[0][0] as {
-      subject: string;
+    expect(mockSendBatchEmailViaApi).toHaveBeenCalledTimes(1);
+    const call = mockSendBatchEmailViaApi.mock.calls[0][0] as {
+      emails: Array<{ subject: string }>;
       organizationId: string;
     };
-    expect(call.subject).toBe('You have 1 policy to review at Beta');
+    expect(call.emails[0].subject).toBe('You have 1 policy to review at Beta');
     expect(call.organizationId).toBe('org_2');
     expect(result).toMatchObject({
       success: true,
@@ -640,7 +642,7 @@ describe('policyAcknowledgmentDigest', () => {
 
     const result = await taskUnderTest.run({ timestamp: new Date() } as never);
 
-    expect(mockSendEmailViaApi).not.toHaveBeenCalled();
+    expect(mockSendBatchEmailViaApi).not.toHaveBeenCalled();
     expect(result).toMatchObject({
       success: true,
       recipients: 0,
@@ -682,12 +684,11 @@ describe('policyAcknowledgmentDigest', () => {
 
     const result = await taskUnderTest.run({ timestamp: new Date() } as never);
 
-    expect(mockSendEmailViaApi).not.toHaveBeenCalled();
+    expect(mockSendBatchEmailViaApi).not.toHaveBeenCalled();
     expect(result).toMatchObject({ success: true, emailsSent: 0 });
   });
 
-  it('sends emails in batches of up to 25', async () => {
-    // Create 60 members in one org, all with pending policies, all subscribed.
+  it('sends all emails for an org in a single batch call', async () => {
     const members = Array.from({ length: 60 }, (_, i) => ({
       id: `mem_${i}`,
       department: 'it',
@@ -716,12 +717,13 @@ describe('policyAcknowledgmentDigest', () => {
       },
     ]);
 
-    // All subscribed
     mockGetUnsubscribedEmails.mockResolvedValueOnce(new Set<string>());
 
     const result = await taskUnderTest.run({ timestamp: new Date() } as never);
 
-    expect(mockSendEmailViaApi).toHaveBeenCalledTimes(60);
+    expect(mockSendBatchEmailViaApi).toHaveBeenCalledTimes(1);
+    expect(mockSendBatchEmailViaApi.mock.calls[0][0].emails).toHaveLength(60);
+    expect(mockSendBatchEmailViaApi.mock.calls[0][0].organizationId).toBe('org_big');
     expect(result).toMatchObject({ success: true, emailsSent: 60 });
   });
 

--- a/apps/app/src/trigger/tasks/task/policy-acknowledgment-digest.ts
+++ b/apps/app/src/trigger/tasks/task/policy-acknowledgment-digest.ts
@@ -51,7 +51,7 @@ interface RollupEntry {
 export const policyAcknowledgmentDigest = schedules.task({
   id: 'policy-acknowledgment-digest',
   machine: 'large-1x',
-  cron: '0 14 * * 1', // Weekly on Mondays at 14:00 UTC
+  cron: '0 14 * * 2', // Weekly on Tuesdays at 14:00 UTC
   maxDuration: 1000 * 60 * 15, // 15 minutes
   run: async () => {
     const inactivityCutoff = new Date();

--- a/apps/app/src/trigger/tasks/task/policy-acknowledgment-digest.ts
+++ b/apps/app/src/trigger/tasks/task/policy-acknowledgment-digest.ts
@@ -51,7 +51,7 @@ interface RollupEntry {
 export const policyAcknowledgmentDigest = schedules.task({
   id: 'policy-acknowledgment-digest',
   machine: 'large-1x',
-  cron: '0 14 * * *', // Once daily at 14:00 UTC
+  cron: '0 14 * * 1', // Weekly on Mondays at 14:00 UTC
   maxDuration: 1000 * 60 * 15, // 15 minutes
   run: async () => {
     const inactivityCutoff = new Date();

--- a/apps/app/src/trigger/tasks/task/policy-acknowledgment-digest.ts
+++ b/apps/app/src/trigger/tasks/task/policy-acknowledgment-digest.ts
@@ -186,6 +186,8 @@ export const policyAcknowledgmentDigest = schedules.task({
     }
 
     // Render all emails and group by primaryOrgId for batch sending.
+    let emailsSent = 0;
+    let emailsFailed = 0;
     const emailsByOrg = new Map<
       string,
       Array<{ to: string; subject: string; html: string }>
@@ -200,14 +202,22 @@ export const policyAcknowledgmentDigest = schedules.task({
       });
       if (!emailElement) continue;
 
-      const html = await render(emailElement);
+      let html: string;
+      try {
+        html = await render(emailElement);
+      } catch (error) {
+        logger.warn('Failed to render digest email, skipping recipient', {
+          email: entry.email,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        emailsFailed += 1;
+        continue;
+      }
+
       const orgEmails = emailsByOrg.get(entry.primaryOrgId) ?? [];
       orgEmails.push({ to: entry.email, subject, html });
       emailsByOrg.set(entry.primaryOrgId, orgEmails);
     }
-
-    let emailsSent = 0;
-    let emailsFailed = 0;
 
     for (const [orgId, emails] of emailsByOrg) {
       try {

--- a/apps/app/src/trigger/tasks/task/policy-acknowledgment-digest.ts
+++ b/apps/app/src/trigger/tasks/task/policy-acknowledgment-digest.ts
@@ -8,7 +8,8 @@ import {
 } from '@trycompai/email';
 import { getUnsubscribedEmails } from '@trycompai/email/lib/check-unsubscribe';
 
-import { sendEmailViaApi } from '../../lib/send-email-via-api';
+import { render } from '@react-email/render';
+import { sendBatchEmailViaApi } from '../../lib/send-email-via-api';
 import {
   computePendingPolicies,
   filterDigestMembersByCompliance,
@@ -22,22 +23,9 @@ const getPortalBase = () =>
     '',
   );
 
-const EMAIL_BATCH_SIZE = 25;
 // Skip orgs that look abandoned — same threshold weekly-task-reminder uses so
 // we don't keep hitting dead addresses and burning domain reputation.
 const ORG_INACTIVITY_DAYS = 90;
-
-async function sendInBatches<T>(
-  sends: Array<() => Promise<T>>,
-): Promise<PromiseSettledResult<T>[]> {
-  const results: PromiseSettledResult<T>[] = [];
-  for (let i = 0; i < sends.length; i += EMAIL_BATCH_SIZE) {
-    const chunk = sends.slice(i, i + EMAIL_BATCH_SIZE);
-    const chunkResults = await Promise.allSettled(chunk.map((fn) => fn()));
-    results.push(...chunkResults);
-  }
-  return results;
-}
 
 interface RollupEntry {
   email: string;
@@ -197,8 +185,12 @@ export const policyAcknowledgmentDigest = schedules.task({
       }
     }
 
-    // Build one send per user.
-    const sends: Array<() => Promise<unknown>> = [];
+    // Render all emails and group by primaryOrgId for batch sending.
+    const emailsByOrg = new Map<
+      string,
+      Array<{ to: string; subject: string; html: string }>
+    >();
+
     for (const entry of rollup.values()) {
       const subject = computePolicyAcknowledgmentDigestSubject(entry.orgs);
       const emailElement = PolicyAcknowledgmentDigestEmail({
@@ -208,26 +200,25 @@ export const policyAcknowledgmentDigest = schedules.task({
       });
       if (!emailElement) continue;
 
-      sends.push(() =>
-        sendEmailViaApi({
-          to: entry.email,
-          subject,
-          organizationId: entry.primaryOrgId,
-          react: emailElement,
-        }),
-      );
+      const html = await render(emailElement);
+      const orgEmails = emailsByOrg.get(entry.primaryOrgId) ?? [];
+      orgEmails.push({ to: entry.email, subject, html });
+      emailsByOrg.set(entry.primaryOrgId, orgEmails);
     }
 
-    const results = await sendInBatches(sends);
     let emailsSent = 0;
     let emailsFailed = 0;
-    for (const r of results) {
-      if (r.status === 'fulfilled') emailsSent += 1;
-      else {
-        emailsFailed += 1;
-        logger.warn('Digest email failed', {
-          error:
-            r.reason instanceof Error ? r.reason.message : String(r.reason),
+
+    for (const [orgId, emails] of emailsByOrg) {
+      try {
+        await sendBatchEmailViaApi({ emails, organizationId: orgId });
+        emailsSent += emails.length;
+      } catch (error) {
+        emailsFailed += emails.length;
+        logger.warn('Batch email request failed', {
+          orgId,
+          count: emails.length,
+          error: error instanceof Error ? error.message : String(error),
         });
       }
     }


### PR DESCRIPTION
## Summary
- Changes the `policy-acknowledgment-digest` scheduled task from daily (`0 14 * * *`) to weekly on Mondays (`0 14 * * 1`) at 14:00 UTC
- Reduces notification fatigue for policy signature reminders

## Test plan
- [ ] Verify the trigger.dev schedule updates after deploy
- [ ] Confirm digest emails arrive on Monday instead of daily

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the `policy-acknowledgment-digest` to weekly and sends digests through a batch email pipeline to reduce noise and HTTP calls. Cron changed from `0 14 * * *` to `0 14 * * 2` (Tuesdays 14:00 UTC); digests render once and send in one batch per org via `resend.batch.send()`.

- **New Features**
  - Added `POST /v1/internal/email/send-batch`, `sendBatchEmailViaApi`, and a `send-batch-email` Trigger task (permissive validation, up to 100 emails, one‑click unsubscribe headers).
  - Digest now pre-renders HTML and groups recipients by org to send a single batch request per org.

- **Bug Fixes**
  - Validate `to` as an email and throw if the FROM env var is missing.
  - Catch per-recipient render errors so one bad template does not stop the run; fix `totalSent` to count only successes.

<sup>Written for commit 9be60ccdefc6e695bf8bd34cff98775dd28e6661. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

