### PR TITLE
feat(people): add option to trigger employee portal emails

### DIFF
--- a/apps/api/src/people/dto/invite-people.dto.ts
+++ b/apps/api/src/people/dto/invite-people.dto.ts
@@ -6,6 +6,8 @@ import {
   IsString,
   ValidateNested,
   ArrayMinSize,
+  IsBoolean,
+  IsOptional,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 
@@ -20,6 +22,11 @@ export class InviteItemDto {
   @IsString({ each: true })
   @ArrayMinSize(1)
   roles: string[];
+
+  @ApiProperty({ example: false, required: false })
+  @IsBoolean()
+  @IsOptional()
+  sendPortalEmail?: boolean;
 }
 
 export class InvitePeopleDto {

--- a/apps/api/src/people/people-invite.service.ts
+++ b/apps/api/src/people/people-invite.service.ts
@@ -72,15 +72,19 @@ export class PeopleInviteService {
         }
 
         const email = invite.email.toLowerCase();
-        const hasEmployeeRoleAndNoAdmin =
-          !invite.roles.includes('admin') &&
-          (invite.roles.includes('employee') ||
-            invite.roles.includes('contractor'));
+        const isPrivileged = invite.roles.some((role) =>
+          ['admin', 'owner', 'auditor'].includes(role),
+        );
+        const isEmployee = invite.roles.some((role) =>
+          ['employee', 'contractor'].includes(role),
+        );
+        const isStrictlyEmployee = isEmployee && !isPrivileged;
 
         const shouldSendPortalEmail =
-          invite.sendPortalEmail || !!hasPublishedPolicies;
+          (invite.sendPortalEmail || !!hasPublishedPolicies) &&
+          isStrictlyEmployee;
 
-        if (hasEmployeeRoleAndNoAdmin) {
+        if (isStrictlyEmployee) {
           const result = await this.addEmployeeWithoutInvite(
             email,
             invite.roles,

--- a/apps/api/src/people/people-invite.service.ts
+++ b/apps/api/src/people/people-invite.service.ts
@@ -45,6 +45,16 @@ export class PeopleInviteService {
 
     const results: InviteResult[] = [];
 
+    const hasPublishedPolicies = await db.policy.findFirst({
+      where: {
+        organizationId,
+        status: 'published',
+        isArchived: false,
+        archivedAt: null,
+      },
+      select: { id: true },
+    });
+
     for (const invite of invites) {
       try {
         // Auditors can only invite auditors
@@ -67,12 +77,15 @@ export class PeopleInviteService {
           (invite.roles.includes('employee') ||
             invite.roles.includes('contractor'));
 
+        const shouldSendPortalEmail =
+          invite.sendPortalEmail || !!hasPublishedPolicies;
+
         if (hasEmployeeRoleAndNoAdmin) {
           const result = await this.addEmployeeWithoutInvite(
             email,
             invite.roles,
             organizationId,
-            invite.sendPortalEmail,
+            shouldSendPortalEmail,
           );
           results.push({
             email: invite.email,
@@ -85,7 +98,7 @@ export class PeopleInviteService {
             invite.roles,
             organizationId,
             callerUserId,
-            invite.sendPortalEmail,
+            shouldSendPortalEmail,
           );
           results.push({ email: invite.email, success: true });
         }

--- a/apps/api/src/people/people-invite.service.ts
+++ b/apps/api/src/people/people-invite.service.ts
@@ -7,6 +7,7 @@ import {
 import { db } from '@db';
 import { triggerEmail } from '../email/trigger-email';
 import { InviteEmail } from '../email/templates/invite-member';
+import { InvitePortalEmail } from '@trycompai/email';
 import type { InviteItemDto } from './dto/invite-people.dto';
 import { checkAutoCompletePhases } from '../frameworks/frameworks-timeline.helper';
 import { TimelinesService } from '../timelines/timelines.service';
@@ -71,6 +72,7 @@ export class PeopleInviteService {
             email,
             invite.roles,
             organizationId,
+            invite.sendPortalEmail,
           );
           results.push({
             email: invite.email,
@@ -83,6 +85,7 @@ export class PeopleInviteService {
             invite.roles,
             organizationId,
             callerUserId,
+            invite.sendPortalEmail,
           );
           results.push({ email: invite.email, success: true });
         }
@@ -117,6 +120,7 @@ export class PeopleInviteService {
     email: string,
     roles: string[],
     organizationId: string,
+    sendPortalEmail?: boolean,
   ): Promise<{ emailSent: boolean }> {
     const organization = await db.organization.findUnique({
       where: { id: organizationId },
@@ -177,12 +181,25 @@ export class PeopleInviteService {
     // Send invite email (non-fatal)
     let emailSent = true;
     try {
-      const inviteLink = this.buildPortalUrl(organizationId);
-      await triggerEmail({
-        to: email,
-        subject: `You've been invited to join ${organization.name} on Comp AI`,
-        react: InviteEmail({ organizationName: organization.name, inviteLink }),
-      });
+      if (sendPortalEmail) {
+        const inviteLink = this.buildPortalUrl(organizationId);
+        await triggerEmail({
+          to: email,
+          subject: `You've been invited to join ${organization.name} on Comp AI`,
+          react: InvitePortalEmail({
+            organizationName: organization.name,
+            inviteLink,
+            email,
+          }),
+        });
+      } else {
+        const inviteLink = this.buildPortalUrl(organizationId);
+        await triggerEmail({
+          to: email,
+          subject: `You've been invited to join ${organization.name} on Comp AI`,
+          react: InviteEmail({ organizationName: organization.name, inviteLink }),
+        });
+      }
     } catch (emailErr) {
       emailSent = false;
       this.logger.error(
@@ -199,6 +216,7 @@ export class PeopleInviteService {
     roles: string[],
     organizationId: string,
     currentUserId: string,
+    sendPortalEmail?: boolean,
   ): Promise<void> {
     const existingUser = await db.user.findFirst({
       where: { email: { equals: email, mode: 'insensitive' } },
@@ -225,6 +243,7 @@ export class PeopleInviteService {
           roles,
           organizationId,
           currentUserId,
+          sendPortalEmail,
         );
         return;
       }
@@ -252,12 +271,25 @@ export class PeopleInviteService {
       },
     });
 
-    const inviteLink = this.buildInviteLink(invitation.id);
-    await triggerEmail({
-      to: email,
-      subject: `You've been invited to join ${organization.name} on Comp AI`,
-      react: InviteEmail({ organizationName: organization.name, inviteLink }),
-    });
+    if (sendPortalEmail) {
+      const inviteLink = this.buildPortalUrl(organizationId);
+      await triggerEmail({
+        to: email,
+        subject: `You've been invited to join ${organization.name} on Comp AI`,
+        react: InvitePortalEmail({
+          organizationName: organization.name,
+          inviteLink,
+          email,
+        }),
+      });
+    } else {
+      const inviteLink = this.buildInviteLink(invitation.id);
+      await triggerEmail({
+        to: email,
+        subject: `You've been invited to join ${organization.name} on Comp AI`,
+        react: InviteEmail({ organizationName: organization.name, inviteLink }),
+      });
+    }
   }
 
   private async sendInvitationEmailToExistingMember(
@@ -265,6 +297,7 @@ export class PeopleInviteService {
     roles: string[],
     organizationId: string,
     inviterId: string,
+    sendPortalEmail?: boolean,
   ): Promise<void> {
     const organization = await db.organization.findUnique({
       where: { id: organizationId },
@@ -286,12 +319,56 @@ export class PeopleInviteService {
       },
     });
 
-    const inviteLink = this.buildInviteLink(invitation.id);
-    await triggerEmail({
-      to: email.toLowerCase(),
-      subject: `You've been invited to join ${organization.name} on Comp AI`,
-      react: InviteEmail({ organizationName: organization.name, inviteLink }),
+    if (sendPortalEmail) {
+      const inviteLink = this.buildPortalUrl(organizationId);
+      await triggerEmail({
+        to: email.toLowerCase(),
+        subject: `You've been invited to join ${organization.name} on Comp AI`,
+        react: InvitePortalEmail({
+          organizationName: organization.name,
+          inviteLink,
+          email: email.toLowerCase(),
+        }),
+      });
+    } else {
+      const inviteLink = this.buildInviteLink(invitation.id);
+      await triggerEmail({
+        to: email.toLowerCase(),
+        subject: `You've been invited to join ${organization.name} on Comp AI`,
+        react: InviteEmail({ organizationName: organization.name, inviteLink }),
+      });
+    }
+  }
+
+  async resendPortalInvite(params: {
+    organizationId: string;
+    memberId: string;
+  }): Promise<{ success: boolean }> {
+    const { organizationId, memberId } = params;
+
+    const member = await db.member.findFirst({
+      where: { id: memberId, organizationId },
+      include: { user: true, organization: { select: { name: true } } },
     });
+
+    if (!member) {
+      throw new BadRequestException('Member not found.');
+    }
+
+    const email = member.user.email;
+    const inviteLink = this.buildPortalUrl(organizationId);
+
+    await triggerEmail({
+      to: email,
+      subject: `Access your ${member.organization.name} Employee Portal on Comp AI`,
+      react: InvitePortalEmail({
+        organizationName: member.organization.name,
+        inviteLink,
+        email,
+      }),
+    });
+
+    return { success: true };
   }
 
   private async createTrainingVideoEntries(

--- a/apps/api/src/people/people.controller.ts
+++ b/apps/api/src/people/people.controller.ts
@@ -450,6 +450,20 @@ export class PeopleController {
     };
   }
 
+  @Post(':id/resend-portal-invite')
+  @RequirePermission('member', 'update')
+  @ApiOperation({ summary: 'Resend portal invite email to a member' })
+  @ApiParam(PEOPLE_PARAMS.memberId)
+  async resendPortalInvite(
+    @Param('id') memberId: string,
+    @OrganizationId() organizationId: string,
+  ) {
+    return this.peopleInviteService.resendPortalInvite({
+      organizationId,
+      memberId,
+    });
+  }
+
   @Delete(':id')
   @RequirePermission('member', 'delete')
   @ApiOperation(PEOPLE_OPERATIONS.deleteMember)

--- a/apps/app/src/app/(app)/[orgId]/people/all/actions/resendPortalInvite.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/all/actions/resendPortalInvite.ts
@@ -1,0 +1,16 @@
+'use server';
+
+import { resendPortalInviteViaApi } from '@/lib/people-api';
+
+export const resendPortalInvite = async (memberId: string) => {
+  try {
+    const response = await resendPortalInviteViaApi({ memberId });
+    if (response.error) {
+      throw new Error(response.error);
+    }
+    return { success: true };
+  } catch (error) {
+    console.error('Error resending portal invite:', error);
+    throw error;
+  }
+};

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/InviteMembersModal.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/InviteMembersModal.tsx
@@ -30,6 +30,7 @@ import {
   FormMessage,
 } from '@trycompai/ui/form';
 import { Input } from '@trycompai/ui/input';
+import { Checkbox } from '@trycompai/ui/checkbox';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@trycompai/ui/tabs';
 import { MultiRoleCombobox } from './MultiRoleCombobox';
 
@@ -55,12 +56,14 @@ const createFormSchema = (allowedRoles: string[]) => {
     manualInvites: z
       .array(manualInviteSchema)
       .min(1, { message: 'Please add at least one invite.' }),
+    sendPortalEmail: z.boolean(),
     csvFile: z.any().optional(), // Optional here, validated by union
   });
 
   const csvModeSchema = z.object({
     mode: z.literal('csv'),
     manualInvites: z.array(manualInviteSchema).optional(), // Optional here
+    sendPortalEmail: z.boolean(),
     csvFile: z.any().refine((val) => val instanceof FileList && val.length === 1, {
       message: 'Please select a single CSV file.',
     }),
@@ -119,6 +122,7 @@ export function InviteMembersModal({
           roles: DEFAULT_ROLES,
         },
       ],
+      sendPortalEmail: false,
       csvFile: undefined,
     },
     mode: 'onChange',
@@ -161,6 +165,7 @@ export function InviteMembersModal({
         const invitePayload = values.manualInvites.map((invite) => ({
           email: invite.email.toLowerCase(),
           roles: invite.roles,
+          sendPortalEmail: values.sendPortalEmail,
         }));
 
         const { data, error } = await api.post<{
@@ -284,7 +289,7 @@ export function InviteMembersModal({
           }
 
           // Parse CSV rows into invite items, validating locally first
-          const csvInvites: Array<{ email: string; roles: string[] }> = [];
+          const csvInvites: Array<{ email: string; roles: string[]; sendPortalEmail: boolean }> = [];
           const clientErrors: { email: string; error: string }[] = [];
 
           for (const row of dataRows) {
@@ -320,7 +325,11 @@ export function InviteMembersModal({
               continue;
             }
 
-            csvInvites.push({ email: email.toLowerCase(), roles: validRoles });
+            csvInvites.push({
+              email: email.toLowerCase(),
+              roles: validRoles,
+              sendPortalEmail: values.sendPortalEmail,
+            });
           }
 
           if (clientErrors.length > 0) {
@@ -565,6 +574,24 @@ export function InviteMembersModal({
                 />
               </TabsContent>
             </Tabs>
+
+            <FormField
+              control={form.control}
+              name="sendPortalEmail"
+              render={({ field }) => (
+                <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border p-4">
+                  <FormControl>
+                    <Checkbox checked={field.value} onCheckedChange={field.onChange} />
+                  </FormControl>
+                  <div className="space-y-1 leading-none">
+                    <FormLabel>Send portal invite email</FormLabel>
+                    <FormDescription>
+                      If enabled, users will receive a direct link to the Employee Portal.
+                    </FormDescription>
+                  </div>
+                </FormItem>
+              )}
+            />
 
             <DialogFooter className="flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:gap-0 sm:space-x-2">
               <Button

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/MemberRow.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/MemberRow.tsx
@@ -32,6 +32,7 @@ import {
 import {
   Checkmark,
   Edit,
+  Email,
   Laptop,
   OverflowMenuVertical,
   TrashCan,
@@ -51,6 +52,7 @@ interface MemberRowProps {
   onRemoveDevice: (memberId: string) => void;
   onUpdateRole: (memberId: string, roles: string[]) => void;
   onReactivate: (memberId: string) => void;
+  onResendPortalInvite?: (memberId: string) => void;
   canEdit: boolean;
   isCurrentUserOwner: boolean;
   customRoles?: CustomRoleOption[];
@@ -116,6 +118,7 @@ export function MemberRow({
   onRemoveDevice,
   onUpdateRole,
   onReactivate,
+  onResendPortalInvite,
   canEdit,
   isCurrentUserOwner,
   customRoles = [],
@@ -136,6 +139,7 @@ export function MemberRow({
   const [isRemoving, setIsRemoving] = useState(false);
   const [isRemovingDevice, setIsRemovingDevice] = useState(false);
   const [isReactivating, setIsReactivating] = useState(false);
+  const [isSendingInvite, setIsSendingInvite] = useState(false);
 
   const memberName = member.user.name || member.user.email || 'Member';
   const memberEmail = member.user.email || '';
@@ -238,6 +242,20 @@ export function MemberRow({
       await onReactivate(memberId);
     } finally {
       setIsReactivating(false);
+    }
+  };
+
+  const handleResendPortalInviteClick = async () => {
+    if (!onResendPortalInvite) return;
+    setDropdownOpen(false);
+    setIsSendingInvite(true);
+    try {
+      await onResendPortalInvite(memberId);
+      toast.success('Portal invite email sent');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to send portal invite');
+    } finally {
+      setIsSendingInvite(false);
     }
   };
 
@@ -358,6 +376,15 @@ export function MemberRow({
                   <DropdownMenuItem onClick={handleEditRolesClick}>
                     <Edit size={16} className="mr-2" />
                     <span>Edit Roles</span>
+                  </DropdownMenuItem>
+                )}
+                {!isDeactivated && canEdit && (
+                  <DropdownMenuItem
+                    onClick={handleResendPortalInviteClick}
+                    disabled={isSendingInvite}
+                  >
+                    <Email size={16} className="mr-2" />
+                    <span>{isSendingInvite ? 'Sending...' : 'Resend Portal Invite'}</span>
                   </DropdownMenuItem>
                 )}
                 {!isDeactivated &&

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
@@ -84,7 +84,7 @@ export function TeamMembersClient({
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(25);
 
-  const { unlinkDevice, removeMember, reactivateMember } = usePeopleActions();
+  const { unlinkDevice, removeMember, reactivateMember, resendPortalInvite } = usePeopleActions();
   const api = useApi();
 
   // Fetch custom roles for the role combobox
@@ -475,6 +475,7 @@ export function TeamMembersClient({
                   onRemoveDevice={handleRemoveDevice}
                   onUpdateRole={handleUpdateRole}
                   onReactivate={handleReactivateMember}
+                  onResendPortalInvite={resendPortalInvite}
                   canEdit={canManageMembers}
                   isCurrentUserOwner={isCurrentUserOwner}
                   customRoles={customRoles}

--- a/apps/app/src/hooks/use-people-api.ts
+++ b/apps/app/src/hooks/use-people-api.ts
@@ -97,11 +97,25 @@ export function usePeopleActions() {
     [api],
   );
 
+  const resendPortalInvite = useCallback(
+    async (memberId: string) => {
+      const response = await api.post<{ success: boolean }>(
+        `/v1/people/${memberId}/resend-portal-invite`,
+      );
+      if (response.error) {
+        throw new Error(response.error);
+      }
+      return response.data!;
+    },
+    [api],
+  );
+
   return {
     unlinkDevice,
     removeMember,
     removeHostFromFleet,
     removeDeviceAgent,
     reactivateMember,
+    resendPortalInvite,
   };
 }

--- a/apps/app/src/lib/people-api.ts
+++ b/apps/app/src/lib/people-api.ts
@@ -60,3 +60,11 @@ export function removeMemberViaApi({
 }): Promise<ApiResponse<DeleteMemberApiResponse>> {
   return serverApi.delete<DeleteMemberApiResponse>(`/v1/people/${memberId}`);
 }
+
+export function resendPortalInviteViaApi({
+  memberId,
+}: {
+  memberId: string;
+}): Promise<ApiResponse<{ success: boolean }>> {
+  return serverApi.post<{ success: boolean }>(`/v1/people/${memberId}/resend-portal-invite`);
+}

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,24 @@
+{
+  "mcpServers": {
+    "trigger": {
+      "type": "stdio",
+      "command": "bunx",
+      "args": [
+        "trigger.dev@latest",
+        "mcp"
+      ]
+    },
+    "sentry": {
+      "type": "sse",
+      "url": "https://mcp.sentry.dev/mcp/comp-ai/comp"
+    },
+    "trycompai": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@trycompai/design-system-mcp@latest"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Added `sendPortalEmail` flag to member invitation DTO and service to support direct Employee Portal links.
- Implemented `POST /v1/people/:id/resend-portal-invite` endpoint to resend portal access emails to existing members.
- Added "Resend Portal Invite" action to the member dropdown menu in the team management page.
- Added a "Send portal invite email" checkbox to the "Add User" modal for better control over the onboarding experience.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an option to send Employee Portal emails when inviting members and a way to resend to existing members. Auto-sends the portal email for strictly employee roles when the org has published policies, addressing Linear CS-72.

- **New Features**
  - API: added `sendPortalEmail` in invite payload; sends `InvitePortalEmail` (from `@trycompai/email`) or the standard invite email, and auto-sends when policies are published.
  - API: new endpoint `POST /v1/people/:id/resend-portal-invite` to send the portal email to an existing member.
  - App: "Send portal invite email" checkbox in the Add User modal (manual and CSV).
  - App: "Resend Portal Invite" action in the member dropdown; added server action, hook, and client call for resend.

- **Bug Fixes**
  - Restrict auto-portal emails to strictly employee roles (employee/contractor without admin/owner/auditor).

<sup>Written for commit 69a92fc3ee0bcf4513e6045b687c8dbe45c5dcaf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

