### PR TITLE
fix(people): default portal email checkbox to checked, respect user choice

### DIFF
--- a/apps/api/src/people/people-invite.service.ts
+++ b/apps/api/src/people/people-invite.service.ts
@@ -45,16 +45,6 @@ export class PeopleInviteService {
 
     const results: InviteResult[] = [];
 
-    const hasPublishedPolicies = await db.policy.findFirst({
-      where: {
-        organizationId,
-        status: 'published',
-        isArchived: false,
-        archivedAt: null,
-      },
-      select: { id: true },
-    });
-
     for (const invite of invites) {
       try {
         // Auditors can only invite auditors
@@ -81,8 +71,7 @@ export class PeopleInviteService {
         const isStrictlyEmployee = isEmployee && !isPrivileged;
 
         const shouldSendPortalEmail =
-          (invite.sendPortalEmail || !!hasPublishedPolicies) &&
-          isStrictlyEmployee;
+          !!invite.sendPortalEmail && isStrictlyEmployee;
 
         if (isStrictlyEmployee) {
           const result = await this.addEmployeeWithoutInvite(
@@ -370,6 +359,19 @@ export class PeopleInviteService {
 
     if (!member) {
       throw new BadRequestException('Member not found.');
+    }
+
+    const roles = member.role.split(',').map((r) => r.trim());
+    const isPrivileged = roles.some((role) =>
+      ['admin', 'owner', 'auditor'].includes(role),
+    );
+    const isEmployee = roles.some((role) =>
+      ['employee', 'contractor'].includes(role),
+    );
+    if (!isEmployee || isPrivileged) {
+      throw new BadRequestException(
+        'Portal invites can only be sent to employee or contractor members.',
+      );
     }
 
     const email = member.user.email;

--- a/apps/api/src/people/people-invite.service.ts
+++ b/apps/api/src/people/people-invite.service.ts
@@ -8,6 +8,10 @@ import { db } from '@db';
 import { triggerEmail } from '../email/trigger-email';
 import { InviteEmail } from '../email/templates/invite-member';
 import { InvitePortalEmail } from '@trycompai/email';
+import {
+  BUILT_IN_ROLE_OBLIGATIONS,
+  RESTRICTED_ROLES,
+} from '@trycompai/auth';
 import type { InviteItemDto } from './dto/invite-people.dto';
 import { checkAutoCompletePhases } from '../frameworks/frameworks-timeline.helper';
 import { TimelinesService } from '../timelines/timelines.service';
@@ -62,16 +66,16 @@ export class PeopleInviteService {
         }
 
         const email = invite.email.toLowerCase();
-        const isPrivileged = invite.roles.some((role) =>
-          ['admin', 'owner', 'auditor'].includes(role),
-        );
-        const isEmployee = invite.roles.some((role) =>
-          ['employee', 'contractor'].includes(role),
-        );
-        const isStrictlyEmployee = isEmployee && !isPrivileged;
+        const restrictedRoles: readonly string[] = RESTRICTED_ROLES;
+        const isStrictlyEmployee =
+          invite.roles.every((role) => restrictedRoles.includes(role));
 
+        const hasCompliance = await this.rolesHaveComplianceObligation(
+          invite.roles,
+          organizationId,
+        );
         const shouldSendPortalEmail =
-          !!invite.sendPortalEmail && isStrictlyEmployee;
+          !!invite.sendPortalEmail && hasCompliance;
 
         if (isStrictlyEmployee) {
           const result = await this.addEmployeeWithoutInvite(
@@ -362,15 +366,13 @@ export class PeopleInviteService {
     }
 
     const roles = member.role.split(',').map((r) => r.trim());
-    const isPrivileged = roles.some((role) =>
-      ['admin', 'owner', 'auditor'].includes(role),
+    const hasCompliance = await this.rolesHaveComplianceObligation(
+      roles,
+      organizationId,
     );
-    const isEmployee = roles.some((role) =>
-      ['employee', 'contractor'].includes(role),
-    );
-    if (!isEmployee || isPrivileged) {
+    if (!hasCompliance) {
       throw new BadRequestException(
-        'Portal invites can only be sent to employee or contractor members.',
+        'Portal invites can only be sent to members with compliance obligations.',
       );
     }
 
@@ -412,6 +414,34 @@ export class PeopleInviteService {
         videoId,
       })),
       skipDuplicates: true,
+    });
+  }
+
+  private async rolesHaveComplianceObligation(
+    roles: string[],
+    organizationId: string,
+  ): Promise<boolean> {
+    for (const role of roles) {
+      if (BUILT_IN_ROLE_OBLIGATIONS[role]?.compliance) return true;
+    }
+
+    const customRoleNames = roles.filter((r) => !BUILT_IN_ROLE_OBLIGATIONS[r]);
+    if (customRoleNames.length === 0) return false;
+
+    const customRoles = await db.organizationRole.findMany({
+      where: {
+        organizationId,
+        name: { in: customRoleNames },
+      },
+      select: { obligations: true },
+    });
+
+    return customRoles.some((role) => {
+      const obligations =
+        typeof role.obligations === 'string'
+          ? JSON.parse(role.obligations)
+          : role.obligations || {};
+      return !!obligations.compliance;
     });
   }
 

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/InviteMembersModal.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/InviteMembersModal.tsx
@@ -122,7 +122,7 @@ export function InviteMembersModal({
           roles: DEFAULT_ROLES,
         },
       ],
-      sendPortalEmail: false,
+      sendPortalEmail: true,
       csvFile: undefined,
     },
     mode: 'onChange',


### PR DESCRIPTION
## Summary
- Default the "Send portal invite email" checkbox to **checked** so the UI reflects the intended behavior.
- Remove the `hasPublishedPolicies` auto-override — unchecking the checkbox now actually prevents the portal email from being sent.
- Guard `resendPortalInvite` endpoint to reject non-employee/contractor members (admin/owner/auditor roles).

Follow-up to #2800.

## Test plan
- [ ] Open Add User modal → checkbox should be checked by default
- [ ] Uncheck the checkbox, invite an employee → they should receive the standard invite email, not the portal email
- [ ] Leave checkbox checked, invite an employee → they should receive the portal email
- [ ] Try resending portal invite to an admin → should get a 400 error
- [ ] Resend portal invite to an employee → should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default the “Send portal invite email” checkbox to checked and make it respect the user’s choice. Switch invite/resend gating to RBAC-based compliance so only members with compliance obligations receive portal emails; aligns with Linear CS-72.

- **Bug Fixes**
  - UI: Checkbox in Invite Members modal now defaults to checked.
  - Backend: Removed auto-send tied to published policies; unchecking now blocks the portal email.
  - API: `resendPortalInvite` returns 400 for members without compliance obligations.

- **Refactors**
  - Use `BUILT_IN_ROLE_OBLIGATIONS` and custom role obligations from the DB to detect compliance.
  - Use `RESTRICTED_ROLES` to identify strictly-employee invites; removed hardcoded role checks.

<sup>Written for commit 10bcffbaef135f60196a5f376e13ec924fa3bb53. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

