### PR TITLE
fix(trigger): extend remediation preview timeout

### DIFF
--- a/apps/app/src/trigger/tasks/cloud-security/remediate-preview.ts
+++ b/apps/app/src/trigger/tasks/cloud-security/remediate-preview.ts
@@ -24,7 +24,7 @@ function sync(progress: PreviewProgress) {
 
 export const remediatePreview = task({
   id: 'remediate-preview',
-  maxDuration: 60 * 3, // 3 minutes
+  maxDuration: 60 * 10, // 10 minutes
   retry: { maxAttempts: 1 },
   run: async (payload: {
     connectionId: string;


### PR DESCRIPTION
## Summary
- Increase remediate-preview Trigger.dev maxDuration from 3 minutes to 10 minutes.
- Keeps the task behavior unchanged; this is a temporary buffer for slow AI/AWS remediation preview generation.

## Testing
- git diff --check
- bun run --filter '@trycompai/app' typecheck (fails on existing unrelated app type errors in test fixtures, AI SDK model type mismatches, and auth client dependency types)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extended `remediate-preview` `Trigger.dev` task `maxDuration` from 3 to 10 minutes to prevent timeouts during slow remediation preview generation. No functional changes; this adds buffer for slower AI/AWS runs.

<sup>Written for commit 32cf43995d590d3c40696c00899d8e6884e4df23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

