### PR TITLE
feat(admin): manage organization frameworks

### DIFF
--- a/apps/api/src/admin-organizations/admin-frameworks.controller.spec.ts
+++ b/apps/api/src/admin-organizations/admin-frameworks.controller.spec.ts
@@ -1,0 +1,121 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminFrameworksController } from './admin-frameworks.controller';
+import { FrameworksService } from '../frameworks/frameworks.service';
+
+jest.mock('../auth/platform-admin.guard', () => ({
+  PlatformAdminGuard: class {
+    canActivate() {
+      return true;
+    }
+  },
+}));
+
+jest.mock('../auth/auth.server', () => ({
+  auth: { api: {} },
+}));
+
+jest.mock('@db', () => ({
+  db: {},
+  AuditLogEntityType: {
+    organization: 'organization',
+    people: 'people',
+    control: 'control',
+    policy: 'policy',
+    task: 'task',
+    vendor: 'vendor',
+    risk: 'risk',
+    finding: 'finding',
+    framework: 'framework',
+    integration: 'integration',
+    trust: 'trust',
+    pentest: 'pentest',
+  },
+  CommentEntityType: {
+    task: 'task',
+    vendor: 'vendor',
+    risk: 'risk',
+    policy: 'policy',
+  },
+  FindingType: { soc2: 'soc2', iso27001: 'iso27001' },
+}));
+
+jest.mock('@trigger.dev/sdk', () => ({
+  tasks: { trigger: jest.fn() },
+}));
+
+jest.mock('../frameworks/frameworks-scores.helper', () => ({
+  getOverviewScores: jest.fn(),
+  getCurrentMember: jest.fn(),
+  computeFrameworkComplianceScore: jest.fn(),
+}));
+
+describe('AdminFrameworksController', () => {
+  let controller: AdminFrameworksController;
+
+  const mockService = {
+    findAll: jest.fn(),
+    findAvailable: jest.fn(),
+    addFrameworks: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AdminFrameworksController],
+      providers: [{ provide: FrameworksService, useValue: mockService }],
+    }).compile();
+
+    controller = module.get<AdminFrameworksController>(
+      AdminFrameworksController,
+    );
+    jest.clearAllMocks();
+  });
+
+  it('lists active frameworks and only unavailable platform frameworks', async () => {
+    const activeFramework = {
+      id: 'fi_1',
+      framework: { id: 'fw_soc2', name: 'SOC 2' },
+      customFramework: null,
+    };
+    mockService.findAll.mockResolvedValue([activeFramework]);
+    mockService.findAvailable.mockResolvedValue([
+      { id: 'fw_soc2', name: 'SOC 2', isCustom: false },
+      { id: 'fw_iso', name: 'ISO 27001', isCustom: false },
+      { id: 'cf_1', name: 'Custom', isCustom: true },
+    ]);
+
+    const result = await controller.list('org_1');
+
+    expect(mockService.findAll).toHaveBeenCalledWith('org_1');
+    expect(mockService.findAvailable).toHaveBeenCalledWith('org_1');
+    expect(result).toEqual({
+      frameworks: [activeFramework],
+      availableFrameworks: [
+        { id: 'fw_iso', name: 'ISO 27001', isCustom: false },
+      ],
+    });
+  });
+
+  it('adds frameworks to the requested organization', async () => {
+    const created = { success: true, frameworksAdded: 1 };
+    mockService.addFrameworks.mockResolvedValue(created);
+
+    const result = await controller.addFrameworks('org_1', {
+      frameworkIds: ['fw_soc2'],
+    });
+
+    expect(mockService.addFrameworks).toHaveBeenCalledWith('org_1', [
+      'fw_soc2',
+    ]);
+    expect(result).toEqual(created);
+  });
+
+  it('deletes framework instances from the requested organization', async () => {
+    mockService.delete.mockResolvedValue({ success: true });
+
+    const result = await controller.deleteFramework('org_1', 'fi_1');
+
+    expect(mockService.delete).toHaveBeenCalledWith('fi_1', 'org_1');
+    expect(result).toEqual({ success: true });
+  });
+});

--- a/apps/api/src/admin-organizations/admin-frameworks.controller.ts
+++ b/apps/api/src/admin-organizations/admin-frameworks.controller.ts
@@ -1,0 +1,79 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  UseGuards,
+  UseInterceptors,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
+import { ApiExcludeController, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { PlatformAdminGuard } from '../auth/platform-admin.guard';
+import { FrameworksService } from '../frameworks/frameworks.service';
+import { AddFrameworksDto } from '../frameworks/dto/add-frameworks.dto';
+import { AdminAuditLogInterceptor } from './admin-audit-log.interceptor';
+
+@ApiExcludeController()
+@ApiTags('Admin - Frameworks')
+@Controller({ path: 'admin/organizations', version: '1' })
+@UseGuards(PlatformAdminGuard)
+@UseInterceptors(AdminAuditLogInterceptor)
+@Throttle({ default: { ttl: 60000, limit: 30 } })
+export class AdminFrameworksController {
+  constructor(private readonly frameworksService: FrameworksService) {}
+
+  @Get(':orgId/frameworks')
+  @ApiOperation({ summary: 'List frameworks for an organization (admin)' })
+  async list(@Param('orgId') orgId: string) {
+    const [frameworks, availableFrameworks] = await Promise.all([
+      this.frameworksService.findAll(orgId),
+      this.frameworksService.findAvailable(orgId),
+    ]);
+
+    const activeFrameworkIds = new Set(
+      frameworks
+        .map(
+          (framework) =>
+            framework.framework?.id ?? framework.customFramework?.id,
+        )
+        .filter((id): id is string => Boolean(id)),
+    );
+
+    return {
+      frameworks,
+      availableFrameworks: availableFrameworks.filter(
+        (framework) =>
+          framework.isCustom === false && !activeFrameworkIds.has(framework.id),
+      ),
+    };
+  }
+
+  @Post(':orgId/frameworks')
+  @ApiOperation({ summary: 'Add frameworks to an organization (admin)' })
+  @UsePipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  )
+  async addFrameworks(
+    @Param('orgId') orgId: string,
+    @Body() dto: AddFrameworksDto,
+  ) {
+    return this.frameworksService.addFrameworks(orgId, dto.frameworkIds);
+  }
+
+  @Delete(':orgId/frameworks/:frameworkInstanceId')
+  @ApiOperation({ summary: 'Remove a framework from an organization (admin)' })
+  async deleteFramework(
+    @Param('orgId') orgId: string,
+    @Param('frameworkInstanceId') frameworkInstanceId: string,
+  ) {
+    return this.frameworksService.delete(frameworkInstanceId, orgId);
+  }
+}

--- a/apps/api/src/admin-organizations/admin-organizations.module.ts
+++ b/apps/api/src/admin-organizations/admin-organizations.module.ts
@@ -9,6 +9,7 @@ import { CommentsModule } from '../comments/comments.module';
 import { AttachmentsModule } from '../attachments/attachments.module';
 import { BillingModule } from '../billing/billing.module';
 import { SecurityPenetrationTestsModule } from '../security-penetration-tests/security-penetration-tests.module';
+import { FrameworksModule } from '../frameworks/frameworks.module';
 import { AdminBillingActionsService } from './admin-billing-actions.service';
 import { AdminBillingController } from './admin-billing.controller';
 import { AdminBillingService } from './admin-billing.service';
@@ -24,6 +25,7 @@ import { AdminVendorsController } from './admin-vendors.controller';
 import { AdminContextController } from './admin-context.controller';
 import { AdminEvidenceController } from './admin-evidence.controller';
 import { AdminPentestCreditsController } from './admin-pentest-credits.controller';
+import { AdminFrameworksController } from './admin-frameworks.controller';
 
 @Module({
   imports: [
@@ -37,6 +39,7 @@ import { AdminPentestCreditsController } from './admin-pentest-credits.controlle
     AttachmentsModule,
     BillingModule,
     SecurityPenetrationTestsModule,
+    FrameworksModule,
   ],
   controllers: [
     AdminOrganizationsController,
@@ -48,6 +51,7 @@ import { AdminPentestCreditsController } from './admin-pentest-credits.controlle
     AdminEvidenceController,
     AdminPentestCreditsController,
     AdminBillingController,
+    AdminFrameworksController,
   ],
   providers: [
     AdminOrganizationsService,

--- a/apps/api/src/admin-organizations/admin-security.spec.ts
+++ b/apps/api/src/admin-organizations/admin-security.spec.ts
@@ -12,6 +12,7 @@ import { AdminTasksController } from './admin-tasks.controller';
 import { AdminVendorsController } from './admin-vendors.controller';
 import { AdminContextController } from './admin-context.controller';
 import { AdminEvidenceController } from './admin-evidence.controller';
+import { AdminFrameworksController } from './admin-frameworks.controller';
 import { AdminIntegrationsController } from '../integration-platform/controllers/admin-integrations.controller';
 import { PlatformAuditLogInterceptor } from '../integration-platform/interceptors/platform-audit-log.interceptor';
 
@@ -21,6 +22,20 @@ jest.mock('../auth/auth.server', () => ({
 
 jest.mock('@db', () => ({
   db: {},
+  AuditLogEntityType: {
+    organization: 'organization',
+    people: 'people',
+    control: 'control',
+    policy: 'policy',
+    task: 'task',
+    vendor: 'vendor',
+    risk: 'risk',
+    finding: 'finding',
+    framework: 'framework',
+    integration: 'integration',
+    trust: 'trust',
+    pentest: 'pentest',
+  },
   FindingStatus: {
     open: 'open',
     ready_for_review: 'ready_for_review',
@@ -28,6 +43,12 @@ jest.mock('@db', () => ({
     closed: 'closed',
   },
   FindingType: { soc2: 'soc2', iso27001: 'iso27001' },
+  FindingSeverity: {
+    low: 'low',
+    medium: 'medium',
+    high: 'high',
+    critical: 'critical',
+  },
   TaskStatus: { todo: 'todo', in_progress: 'in_progress', done: 'done' },
   TaskFrequency: { daily: 'daily', weekly: 'weekly', monthly: 'monthly' },
   Departments: { none: 'none', engineering: 'engineering' },
@@ -36,6 +57,17 @@ jest.mock('@db', () => ({
   VendorCategory: { cloud: 'cloud', saas: 'saas' },
   VendorStatus: { active: 'active', inactive: 'inactive' },
   Prisma: {},
+}));
+
+jest.mock('@trycompai/auth', () => ({
+  RESTRICTED_ROLES: ['employee', 'contractor'],
+  PRIVILEGED_ROLES: ['owner', 'admin', 'auditor'],
+}));
+
+jest.mock('../frameworks/frameworks-scores.helper', () => ({
+  getOverviewScores: jest.fn(),
+  getCurrentMember: jest.fn(),
+  computeFrameworkComplianceScore: jest.fn(),
 }));
 
 jest.mock('@trigger.dev/sdk', () => ({
@@ -59,6 +91,7 @@ const ORG_ADMIN_CONTROLLERS = [
   { name: 'AdminVendorsController', controller: AdminVendorsController },
   { name: 'AdminContextController', controller: AdminContextController },
   { name: 'AdminEvidenceController', controller: AdminEvidenceController },
+  { name: 'AdminFrameworksController', controller: AdminFrameworksController },
 ];
 
 describe('Admin controllers security baseline', () => {
@@ -103,8 +136,8 @@ describe('Admin controllers security baseline', () => {
     });
   });
 
-  it('covers all 7 expected org-scoped admin controllers', () => {
-    expect(ORG_ADMIN_CONTROLLERS).toHaveLength(7);
+  it('covers all 8 expected org-scoped admin controllers', () => {
+    expect(ORG_ADMIN_CONTROLLERS).toHaveLength(8);
   });
 
   describe('AdminIntegrationsController', () => {
@@ -150,8 +183,8 @@ describe('Admin controllers security baseline', () => {
     });
   });
 
-  it('covers all 8 admin controllers (7 org-scoped + 1 platform-scoped)', () => {
-    expect(ORG_ADMIN_CONTROLLERS).toHaveLength(7);
+  it('covers all 9 admin controllers (8 org-scoped + 1 platform-scoped)', () => {
+    expect(ORG_ADMIN_CONTROLLERS).toHaveLength(8);
     expect(AdminIntegrationsController).toBeDefined();
   });
 

--- a/apps/app/src/app/(app)/[orgId]/admin/organizations/[adminOrgId]/components/AdminOrgTabs.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/admin/organizations/[adminOrgId]/components/AdminOrgTabs.test.tsx
@@ -6,6 +6,7 @@ vi.mock('@/lib/api-client', () => ({
     get: vi.fn().mockResolvedValue({ data: [] }),
     post: vi.fn().mockResolvedValue({ data: {} }),
     patch: vi.fn().mockResolvedValue({ data: {} }),
+    delete: vi.fn().mockResolvedValue({ data: {} }),
   },
 }));
 
@@ -63,6 +64,7 @@ describe('AdminOrgTabs', () => {
 
     expect(screen.getByRole('tab', { name: /overview/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /findings/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /frameworks/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /tasks/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /vendors/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /context/i })).toBeInTheDocument();

--- a/apps/app/src/app/(app)/[orgId]/admin/organizations/[adminOrgId]/components/AdminOrgTabs.tsx
+++ b/apps/app/src/app/(app)/[orgId]/admin/organizations/[adminOrgId]/components/AdminOrgTabs.tsx
@@ -7,6 +7,10 @@ import {
   PageHeader,
   PageHeaderDescription,
   PageLayout,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
   Tabs,
   TabsContent,
   TabsList,
@@ -21,6 +25,7 @@ import { ContextTab } from './ContextTab';
 import { EvidenceTab } from './EvidenceTab';
 import { FeatureFlagsTab } from './FeatureFlagsTab';
 import { FindingsTab } from './FindingsTab';
+import { FrameworksTab } from './FrameworksTab';
 import { MembersTab } from './MembersTab';
 import { OrganizationDetail } from './OrganizationDetail';
 import { PoliciesTab } from './PoliciesTab';
@@ -52,6 +57,21 @@ export interface AdminOrgDetail {
   backgroundCheckStepEnabled: boolean;
   members: OrgMember[];
 }
+
+const ADMIN_ORG_TABS = [
+  { value: 'overview', label: 'Overview' },
+  { value: 'members', label: 'Members' },
+  { value: 'policies', label: 'Policies' },
+  { value: 'findings', label: 'Findings' },
+  { value: 'frameworks', label: 'Frameworks' },
+  { value: 'tasks', label: 'Tasks' },
+  { value: 'vendors', label: 'Vendors' },
+  { value: 'context', label: 'Context' },
+  { value: 'evidence', label: 'Evidence' },
+  { value: 'timeline', label: 'Timeline' },
+  { value: 'billing', label: 'Billing' },
+  { value: 'feature-flags', label: 'Feature Flags' },
+];
 
 export function AdminOrgTabs({ org, currentOrgId }: { org: AdminOrgDetail; currentOrgId: string }) {
   const router = useRouter();
@@ -118,7 +138,7 @@ export function AdminOrgTabs({ org, currentOrgId }: { org: AdminOrgDetail; curre
               { label: org.name, isCurrent: true },
             ]}
             actions={
-              <div className="flex items-center gap-3">
+              <div className="flex flex-wrap items-center gap-3">
                 <Badge variant={hasAccess ? 'default' : 'destructive'}>
                   {hasAccess ? 'Active' : 'Inactive'}
                 </Badge>
@@ -143,19 +163,36 @@ export function AdminOrgTabs({ org, currentOrgId }: { org: AdminOrgDetail; curre
               </div>
             }
             tabs={
-              <TabsList variant="underline">
-                <TabsTrigger value="overview">Overview</TabsTrigger>
-                <TabsTrigger value="members">Members</TabsTrigger>
-                <TabsTrigger value="policies">Policies</TabsTrigger>
-                <TabsTrigger value="findings">Findings</TabsTrigger>
-                <TabsTrigger value="tasks">Tasks</TabsTrigger>
-                <TabsTrigger value="vendors">Vendors</TabsTrigger>
-                <TabsTrigger value="context">Context</TabsTrigger>
-                <TabsTrigger value="evidence">Evidence</TabsTrigger>
-                <TabsTrigger value="timeline">Timeline</TabsTrigger>
-                <TabsTrigger value="billing">Billing</TabsTrigger>
-                <TabsTrigger value="feature-flags">Feature Flags</TabsTrigger>
-              </TabsList>
+              <div className="w-full">
+                <div className="xl:hidden">
+                  <Select
+                    value={activeTab}
+                    onValueChange={(value) => {
+                      if (value) setActiveTab(value);
+                    }}
+                  >
+                    <SelectTrigger size="sm">
+                      {ADMIN_ORG_TABS.find((tab) => tab.value === activeTab)?.label ?? 'Overview'}
+                    </SelectTrigger>
+                    <SelectContent alignItemWithTrigger={false}>
+                      {ADMIN_ORG_TABS.map((tab) => (
+                        <SelectItem key={tab.value} value={tab.value}>
+                          {tab.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="hidden xl:block">
+                  <TabsList variant="underline">
+                    {ADMIN_ORG_TABS.map((tab) => (
+                      <TabsTrigger key={tab.value} value={tab.value}>
+                        {tab.label}
+                      </TabsTrigger>
+                    ))}
+                  </TabsList>
+                </div>
+              </div>
             }
           >
             {org.website && (
@@ -184,6 +221,9 @@ export function AdminOrgTabs({ org, currentOrgId }: { org: AdminOrgDetail; curre
         </TabsContent>
         <TabsContent value="findings">
           <FindingsTab orgId={org.id} />
+        </TabsContent>
+        <TabsContent value="frameworks">
+          <FrameworksTab orgId={org.id} />
         </TabsContent>
         <TabsContent value="tasks">
           <TasksTab orgId={org.id} />

--- a/apps/app/src/app/(app)/[orgId]/admin/organizations/[adminOrgId]/components/FrameworkConfirmationDialog.tsx
+++ b/apps/app/src/app/(app)/[orgId]/admin/organizations/[adminOrgId]/components/FrameworkConfirmationDialog.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@trycompai/design-system';
+import type { PendingAction } from './FrameworksTab';
+
+function getPendingActionFrameworkName(pendingAction: PendingAction) {
+  if (pendingAction.type === 'add') {
+    return pendingAction.framework.name;
+  }
+  const details = pendingAction.framework.framework ?? pendingAction.framework.customFramework;
+  return details?.name ?? 'Unknown framework';
+}
+
+export function FrameworkConfirmationDialog({
+  pendingAction,
+  submitting,
+  onOpenChange,
+  onConfirm,
+}: {
+  pendingAction: PendingAction | null;
+  submitting: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}) {
+  const frameworkName = pendingAction ? getPendingActionFrameworkName(pendingAction) : '';
+
+  return (
+    <AlertDialog open={pendingAction !== null} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {pendingAction?.type === 'add' ? `Add ${frameworkName}?` : `Remove ${frameworkName}?`}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {pendingAction?.type === 'add'
+              ? `This will add ${frameworkName} to this organization and create its related structure.`
+              : `This will remove ${frameworkName} from this organization only. The global framework will not be deleted.`}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            variant={pendingAction?.type === 'delete' ? 'destructive' : 'default'}
+            onClick={(event) => {
+              event.preventDefault();
+              onConfirm();
+            }}
+            disabled={submitting}
+          >
+            {submitting
+              ? 'Saving...'
+              : pendingAction?.type === 'delete'
+                ? 'Yes, remove framework'
+                : 'Yes, add framework'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/app/src/app/(app)/[orgId]/admin/organizations/[adminOrgId]/components/FrameworkMobileCards.tsx
+++ b/apps/app/src/app/(app)/[orgId]/admin/organizations/[adminOrgId]/components/FrameworkMobileCards.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { Badge, Button, Text } from '@trycompai/design-system';
+import { Add, TrashCan } from '@trycompai/design-system/icons';
+import type { ActiveFramework, FrameworkDetails } from './FrameworksTab';
+
+function getActiveDetails(framework: ActiveFramework) {
+  return framework.framework ?? framework.customFramework;
+}
+
+export function ActiveFrameworkCards({
+  frameworks,
+  onDelete,
+}: {
+  frameworks: ActiveFramework[];
+  onDelete: (framework: ActiveFramework) => void;
+}) {
+  return (
+    <div className="grid gap-3 md:hidden">
+      {frameworks.map((framework) => {
+        const details = getActiveDetails(framework);
+
+        return (
+          <div key={framework.id} className="rounded-lg border bg-card p-4">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0 space-y-1">
+                <Text size="sm" weight="medium">
+                  {details?.name ?? 'Unknown framework'}
+                </Text>
+                {details?.description && (
+                  <Text size="xs" variant="muted">
+                    {details.description}
+                  </Text>
+                )}
+              </div>
+              <Badge variant={framework.customFramework ? 'secondary' : 'default'}>
+                {framework.customFramework ? 'Custom' : 'Platform'}
+              </Badge>
+            </div>
+            <div className="mt-4 flex items-center justify-between gap-3">
+              <Badge variant="outline">v{details?.version ?? '--'}</Badge>
+              <Button
+                size="sm"
+                variant="destructive"
+                iconLeft={<TrashCan size={16} />}
+                onClick={() => onDelete(framework)}
+              >
+                Remove
+              </Button>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function AvailableFrameworkCards({
+  frameworks,
+  onAdd,
+}: {
+  frameworks: FrameworkDetails[];
+  onAdd: (framework: FrameworkDetails) => void;
+}) {
+  return (
+    <div className="grid gap-3 md:hidden">
+      {frameworks.map((framework) => (
+        <div key={framework.id} className="rounded-lg border bg-card p-4">
+          <div className="space-y-1">
+            <div className="flex items-start justify-between gap-3">
+              <Text size="sm" weight="medium">
+                {framework.name}
+              </Text>
+              <Badge variant="outline">v{framework.version}</Badge>
+            </div>
+            <Text size="xs" variant="muted">
+              {framework.description ?? 'No description provided.'}
+            </Text>
+          </div>
+          <div className="mt-4 flex justify-end">
+            <Button size="sm" iconLeft={<Add size={16} />} onClick={() => onAdd(framework)}>
+              Add
+            </Button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/app/src/app/(app)/[orgId]/admin/organizations/[adminOrgId]/components/FrameworksTab.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/admin/organizations/[adminOrgId]/components/FrameworksTab.test.tsx
@@ -1,0 +1,116 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGet = vi.fn();
+const mockPost = vi.fn();
+const mockDelete = vi.fn();
+
+vi.mock('@/lib/api-client', () => ({
+  api: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+import { FrameworksTab } from './FrameworksTab';
+
+const frameworkResponse = {
+  frameworks: [
+    {
+      id: 'fi_soc2',
+      framework: {
+        id: 'fw_soc2',
+        name: 'SOC 2',
+        description: 'Security framework',
+        version: '2024',
+        visible: true,
+      },
+      customFramework: null,
+    },
+  ],
+  availableFrameworks: [
+    {
+      id: 'fw_iso',
+      name: 'ISO 27001',
+      description: 'Security standard',
+      version: '2022',
+      visible: true,
+    },
+  ],
+};
+
+describe('FrameworksTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue({ data: frameworkResponse });
+    mockPost.mockResolvedValue({ data: { success: true } });
+    mockDelete.mockResolvedValue({ data: { success: true } });
+  });
+
+  it('loads admin frameworks endpoint', async () => {
+    render(<FrameworksTab orgId="org_1" />);
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith('/v1/admin/organizations/org_1/frameworks');
+    });
+  });
+
+  it('renders active and available frameworks', async () => {
+    render(<FrameworksTab orgId="org_1" />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('SOC 2').length).toBeGreaterThan(0);
+    });
+    expect(screen.getAllByText('ISO 27001').length).toBeGreaterThan(0);
+    expect(screen.getByText(/active frameworks \(1\)/i)).toBeInTheDocument();
+    expect(screen.getByText(/available frameworks \(1\)/i)).toBeInTheDocument();
+  });
+
+  it('confirms before adding a framework', async () => {
+    render(<FrameworksTab orgId="org_1" />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('ISO 27001').length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: /^add$/i })[0]);
+
+    const confirmButton = screen.getByRole('button', {
+      name: /yes, add framework/i,
+    });
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith('/v1/admin/organizations/org_1/frameworks', {
+        frameworkIds: ['fw_iso'],
+      });
+    });
+  });
+
+  it('confirms before removing a framework', async () => {
+    render(<FrameworksTab orgId="org_1" />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('SOC 2').length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: /remove/i })[0]);
+
+    const confirmButton = screen.getByRole('button', {
+      name: /yes, remove framework/i,
+    });
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(mockDelete).toHaveBeenCalledWith('/v1/admin/organizations/org_1/frameworks/fi_soc2');
+    });
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/admin/organizations/[adminOrgId]/components/FrameworksTab.tsx
+++ b/apps/app/src/app/(app)/[orgId]/admin/organizations/[adminOrgId]/components/FrameworksTab.tsx
@@ -1,0 +1,291 @@
+'use client';
+
+import { api } from '@/lib/api-client';
+import {
+  Badge,
+  Button,
+  Section,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Text,
+} from '@trycompai/design-system';
+import { Add, TrashCan } from '@trycompai/design-system/icons';
+import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { FrameworkConfirmationDialog } from './FrameworkConfirmationDialog';
+import { ActiveFrameworkCards, AvailableFrameworkCards } from './FrameworkMobileCards';
+
+export interface FrameworkDetails {
+  id: string;
+  name: string;
+  description: string | null;
+  version: string;
+  visible: boolean;
+}
+
+export interface ActiveFramework {
+  id: string;
+  framework: FrameworkDetails | null;
+  customFramework: FrameworkDetails | null;
+}
+
+interface AdminFrameworksResponse {
+  frameworks: ActiveFramework[];
+  availableFrameworks: FrameworkDetails[];
+}
+
+export type PendingAction =
+  | { type: 'add'; framework: FrameworkDetails }
+  | { type: 'delete'; framework: ActiveFramework };
+
+function getActiveFrameworkDetails(framework: ActiveFramework) {
+  return framework.framework ?? framework.customFramework;
+}
+
+export function getActiveFrameworkName(framework: ActiveFramework) {
+  return getActiveFrameworkDetails(framework)?.name ?? 'Unknown framework';
+}
+
+export function FrameworksTab({ orgId }: { orgId: string }) {
+  const [frameworks, setFrameworks] = useState<ActiveFramework[]>([]);
+  const [availableFrameworks, setAvailableFrameworks] = useState<FrameworkDetails[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
+
+  const fetchFrameworks = useCallback(async () => {
+    setLoading(true);
+    const res = await api.get<AdminFrameworksResponse>(
+      `/v1/admin/organizations/${orgId}/frameworks`,
+    );
+    if (res.error) {
+      toast.error(res.error);
+    }
+    if (res.data) {
+      setFrameworks(res.data.frameworks);
+      setAvailableFrameworks(res.data.availableFrameworks);
+    }
+    setLoading(false);
+  }, [orgId]);
+
+  useEffect(() => {
+    void fetchFrameworks();
+  }, [fetchFrameworks]);
+
+  const handleDialogOpenChange = (open: boolean) => {
+    if (submitting) return;
+    if (!open) {
+      setPendingAction(null);
+    }
+  };
+
+  const handleConfirm = async () => {
+    if (!pendingAction) return;
+
+    setSubmitting(true);
+    const response =
+      pendingAction.type === 'add'
+        ? await api.post(`/v1/admin/organizations/${orgId}/frameworks`, {
+            frameworkIds: [pendingAction.framework.id],
+          })
+        : await api.delete(
+            `/v1/admin/organizations/${orgId}/frameworks/${pendingAction.framework.id}`,
+          );
+
+    setSubmitting(false);
+
+    if (response.error) {
+      toast.error(response.error);
+      return;
+    }
+
+    toast.success(
+      pendingAction.type === 'add'
+        ? 'Framework added to organization'
+        : 'Framework removed from organization',
+    );
+    setPendingAction(null);
+    await fetchFrameworks();
+  };
+
+  const sortedFrameworks = [...frameworks].sort((a, b) =>
+    getActiveFrameworkName(a).localeCompare(getActiveFrameworkName(b)),
+  );
+  const sortedAvailableFrameworks = [...availableFrameworks].sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12 text-muted-foreground">
+        Loading frameworks...
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <Section title={`Active Frameworks (${frameworks.length})`}>
+        {frameworks.length === 0 ? (
+          <div className="rounded-lg border border-dashed py-8 text-center text-sm text-muted-foreground">
+            No frameworks have been added to this organization.
+          </div>
+        ) : (
+          <>
+            <ActiveFrameworkCards
+              frameworks={sortedFrameworks}
+              onDelete={(framework) => {
+                setPendingAction({ type: 'delete', framework });
+              }}
+            />
+            <div className="hidden overflow-x-auto md:block">
+              <Table variant="bordered">
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Name</TableHead>
+                    <TableHead>Version</TableHead>
+                    <TableHead>Type</TableHead>
+                    <TableHead>Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {sortedFrameworks.map((framework) => (
+                    <ActiveFrameworkRow
+                      key={framework.id}
+                      framework={framework}
+                      onDelete={(selectedFramework) => {
+                        setPendingAction({
+                          type: 'delete',
+                          framework: selectedFramework,
+                        });
+                      }}
+                    />
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          </>
+        )}
+      </Section>
+
+      <Section title={`Available Frameworks (${availableFrameworks.length})`}>
+        {availableFrameworks.length === 0 ? (
+          <div className="rounded-lg border border-dashed py-8 text-center text-sm text-muted-foreground">
+            No additional visible frameworks are available to add.
+          </div>
+        ) : (
+          <>
+            <AvailableFrameworkCards
+              frameworks={sortedAvailableFrameworks}
+              onAdd={(framework) => {
+                setPendingAction({ type: 'add', framework });
+              }}
+            />
+            <div className="hidden overflow-x-auto md:block">
+              <Table variant="bordered">
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Name</TableHead>
+                    <TableHead>Version</TableHead>
+                    <TableHead>Description</TableHead>
+                    <TableHead>Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {sortedAvailableFrameworks.map((framework) => (
+                    <TableRow key={framework.id}>
+                      <TableCell>
+                        <Text size="sm" weight="medium">
+                          {framework.name}
+                        </Text>
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="outline">v{framework.version}</Badge>
+                      </TableCell>
+                      <TableCell>
+                        <Text size="sm" variant="muted">
+                          {framework.description ?? '--'}
+                        </Text>
+                      </TableCell>
+                      <TableCell>
+                        <Button
+                          size="sm"
+                          iconLeft={<Add size={16} />}
+                          onClick={() => {
+                            setPendingAction({ type: 'add', framework });
+                          }}
+                        >
+                          Add
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          </>
+        )}
+      </Section>
+
+      <FrameworkConfirmationDialog
+        pendingAction={pendingAction}
+        submitting={submitting}
+        onOpenChange={handleDialogOpenChange}
+        onConfirm={handleConfirm}
+      />
+    </div>
+  );
+}
+
+function ActiveFrameworkRow({
+  framework,
+  onDelete,
+}: {
+  framework: ActiveFramework;
+  onDelete: (framework: ActiveFramework) => void;
+}) {
+  const details = getActiveFrameworkDetails(framework);
+
+  return (
+    <TableRow>
+      <TableCell>
+        <div className="max-w-[420px]">
+          <div className="truncate">
+            <Text size="sm" weight="medium">
+              {details?.name ?? 'Unknown framework'}
+            </Text>
+          </div>
+          {details?.description && (
+            <div className="truncate">
+              <Text size="xs" variant="muted">
+                {details.description}
+              </Text>
+            </div>
+          )}
+        </div>
+      </TableCell>
+      <TableCell>
+        <Badge variant="outline">v{details?.version ?? '--'}</Badge>
+      </TableCell>
+      <TableCell>
+        <Badge variant={framework.customFramework ? 'secondary' : 'default'}>
+          {framework.customFramework ? 'Custom' : 'Platform'}
+        </Badge>
+      </TableCell>
+      <TableCell>
+        <Button
+          size="sm"
+          variant="destructive"
+          iconLeft={<TrashCan size={16} />}
+          onClick={() => onDelete(framework)}
+        >
+          Remove
+        </Button>
+      </TableCell>
+    </TableRow>
+  );
+}


### PR DESCRIPTION
## Summary
- Add platform-admin scoped endpoints for listing, adding, and removing frameworks on a specific organization.
- Add an Admin Organizations Frameworks tab with adaptive mobile cards, desktop tables, and simple confirmation dialogs.
- Cover the admin framework controller and UI flow with focused tests.

## Test plan
- bunx jest src/admin-organizations/admin-frameworks.controller.spec.ts src/admin-organizations/admin-security.spec.ts --passWithNoTests
- bunx vitest run \"src/app/(app)/[orgId]/admin/organizations/[adminOrgId]/components/FrameworksTab.test.tsx\" \"src/app/(app)/[orgId]/admin/organizations/[adminOrgId]/components/AdminOrgTabs.test.tsx\"


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds platform-admin tooling to manage an organization’s frameworks, including new API endpoints and a Frameworks tab with add/remove flows. Admins can list, add, and remove org frameworks without changing global definitions.

- **New Features**
  - API (admin-scoped): list, add, and remove org frameworks at `/v1/admin/organizations/:orgId/frameworks` (GET/POST/DELETE), guarded by `PlatformAdminGuard`, audited via `AdminAuditLogInterceptor`, and throttled.
  - API response filters: returns active frameworks and only platform-visible, not-yet-added frameworks.
  - Admin UI: new “Frameworks” tab with mobile cards and desktop tables; confirmation dialog for add/remove; toast feedback.
  - Navigation: tabs made responsive with a dropdown on small screens; “Frameworks” tab added to `AdminOrgTabs`.
  - Tests: controller specs for admin endpoints; security baseline updated to include `AdminFrameworksController`; UI tests for Frameworks tab and tabs navigation.

<sup>Written for commit ae1b5fe09c75477f99cb4133f36d297ef2925326. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

