### PR TITLE
fix(background-check): align V1 tab content with tab strip and page header

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/BackgroundCheckV1Page.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/BackgroundCheckV1Page.tsx
@@ -74,7 +74,7 @@ export function BackgroundCheckV1Page(props: V1PageProps) {
   };
 
   return (
-    <div className="px-10 pt-8 pb-10">
+    <div>
       <BackgroundCheckStatusStrip
         status={statusForStrip(props)}
         creditsUsed={props.creditsUsed}


### PR DESCRIPTION
## Summary

Tiny visual bug fix follow-up to PR #2839. The V1 Background Check tab content was wrapped in a `px-10 pt-8 pb-10` container, which pushed the status strip + path picker inward so they no longer aligned with the tab labels (Details · Policies · …) or the H1 above them.

The 40px inner padding came from `SPEC.md` ("Container padding inside the tab content area: 32px top, 40px sides, 40px bottom"), but in our app the parent `<TabsContent>` already provides the page-level inset — so the padding stacked and shifted everything right.

Dropping the inner wrapper padding lets the V1 content sit flush with the tab strip, matching how every other tab (`EmployeeDetails`, `EmployeePolicies`, `EmployeeTraining`, `EmployeeDevice`) renders directly inside its `<TabsContent>`.

## Change

`apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/BackgroundCheckV1Page.tsx`:

```diff
- <div className="px-10 pt-8 pb-10">
+ <div>
```

One line. No behavior change. No new components.

## Test plan

- [ ] Open any employee's Background Check tab. The status strip's left edge should line up with the "Details" tab label and the H1 employee name above. Right edge should also align with the tab strip.
- [ ] Confirm vertical spacing still looks balanced — the status strip's existing `mb-6` and the parent layout's natural padding handle the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Background Check V1 tab layout so the status strip and path picker align with the tab labels and page header. Removed extra inner padding in `BackgroundCheckV1Page.tsx`, relying on the parent `TabsContent` inset to match the other tabs.

<sup>Written for commit 9d5454b8f3987462acb44c047a385901f21d88a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

