### PR TITLE
feat(trust-portal): dedicated FROM env var for Trust Portal emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ RESEND_API_KEY="" # API key from Resend for email authentication / invites
 RESEND_FROM_MARKETING=""
 RESEND_FROM_SYSTEM=""
 RESEND_FROM_DEFAULT=""
+RESEND_FROM_TRUST_PORTAL="" # Sender for Trust Portal access/NDA emails (falls back to RESEND_FROM_SYSTEM)
 RESEND_TO_TEST=""
 RESEND_REPLY_TO_MARKETING=""
 REVALIDATION_SECRET="" # openssl rand -base64 32

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -44,6 +44,7 @@ GROQ_API_KEY=
 RESEND_API_KEY=
 RESEND_FROM_SYSTEM= # e.g., noreply@mail.trycomp.ai
 RESEND_FROM_DEFAULT= # e.g., hello@mail.trycomp.ai
+RESEND_FROM_TRUST_PORTAL= # e.g., Comp AI <noreply@mail.trust.inc> — sender for Trust Portal access/NDA emails (falls back to RESEND_FROM_SYSTEM)
 
 # Background checks
 BACKGROUND_CHECK_API_BASE_URL=https://glad-sturgeon-729.convex.site

--- a/apps/api/src/email/trigger-email.ts
+++ b/apps/api/src/email/trigger-email.ts
@@ -10,6 +10,7 @@ export async function triggerEmail(params: {
   react: ReactElement;
   marketing?: boolean;
   system?: boolean;
+  trustPortal?: boolean;
   cc?: string | string[];
   scheduledAt?: string;
   attachments?: EmailAttachment[];
@@ -20,12 +21,15 @@ export async function triggerEmail(params: {
     const fromMarketing = process.env.RESEND_FROM_MARKETING;
     const fromSystem = process.env.RESEND_FROM_SYSTEM;
     const fromDefault = process.env.RESEND_FROM_DEFAULT;
+    const fromTrustPortal = process.env.RESEND_FROM_TRUST_PORTAL;
 
-    const fromAddress = params.marketing
-      ? fromMarketing
-      : params.system
-        ? fromSystem
-        : fromDefault;
+    const fromAddress = params.trustPortal
+      ? (fromTrustPortal ?? fromSystem)
+      : params.marketing
+        ? fromMarketing
+        : params.system
+          ? fromSystem
+          : fromDefault;
 
     const handle = await tasks.trigger<typeof sendEmailTask>('send-email', {
       to: params.to,

--- a/apps/api/src/trust-portal/email.service.ts
+++ b/apps/api/src/trust-portal/email.service.ts
@@ -25,7 +25,7 @@ export class TrustEmailService {
         organizationName,
         ndaSigningLink,
       }),
-      system: true,
+      trustPortal: true,
     });
 
     this.logger.log(`NDA signing email sent to ${toEmail} (ID: ${id})`);
@@ -49,7 +49,7 @@ export class TrustEmailService {
         expiresAt,
         portalUrl,
       }),
-      system: true,
+      trustPortal: true,
     });
 
     this.logger.log(`Access granted email sent to ${toEmail} (ID: ${id})`);
@@ -73,7 +73,7 @@ export class TrustEmailService {
         accessLink,
         expiresAt,
       }),
-      system: true,
+      trustPortal: true,
     });
 
     this.logger.log(`Access reclaim email sent to ${toEmail} (ID: ${id})`);
@@ -115,7 +115,7 @@ export class TrustEmailService {
         requestedDurationDays,
         reviewUrl,
       }),
-      system: true,
+      trustPortal: true,
     });
 
     this.logger.log(


### PR DESCRIPTION
## Summary

- Adds a dedicated `RESEND_FROM_TRUST_PORTAL` env var so Trust Portal access and NDA emails can send from a brand-specific sender (e.g. `Comp AI <noreply@mail.trust.inc>`), distinct from the generic system sender.
- `triggerEmail()` gets a new `trustPortal: true` flag that resolves `RESEND_FROM_TRUST_PORTAL`, with graceful fallback to `RESEND_FROM_SYSTEM` so prod keeps working until the env var is set in Trigger.dev / Render.
- `TrustEmailService` (NDA signing, access granted, access reclaim, access request notification) now passes `trustPortal: true` instead of `system: true`.

## Files

- `apps/api/src/email/trigger-email.ts` — adds optional flag + env resolution
- `apps/api/src/trust-portal/email.service.ts` — 4 callers switch to `trustPortal: true`
- `apps/api/.env.example` + root `.env.example` — documents the new var

## Deploy steps (after merge)

Set `RESEND_FROM_TRUST_PORTAL` in:

1. **Trigger.dev** project `proj_zhioyrusqertqgafqgpj` env (this is where the email actually sends from)
2. **Render** (API host) env so the value matches when enqueueing
3. Local `apps/api/.env` if testing locally

Value being used: `Comp AI <noreply@mail.trust.inc>`

Pre-reqs in Resend:
- `mail.trust.inc` domain verified (SPF, DKIM, DMARC green)
- API key authorized to send from that domain

If the env var isn't set, code falls back to `RESEND_FROM_SYSTEM` — safe to merge before the env is configured.

## Test plan

- [ ] Typecheck passes (`npx turbo run typecheck --filter=@trycompai/api`) — verified locally; pre-existing errors in unrelated modules only
- [ ] After deploy + env set, trigger an NDA signing email and confirm the `From:` header is `Comp AI <noreply@mail.trust.inc>`
- [ ] Trigger an access-granted, access-reclaim, and access-request-notification email and confirm same sender
- [ ] Verify other system emails (invites, finding notifications, etc.) still send from `RESEND_FROM_SYSTEM`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated `RESEND_FROM_TRUST_PORTAL` sender for Trust Portal emails (NDA, access flows) so they send from a brand-specific address (e.g., `Comp AI <noreply@mail.trust.inc>`). Falls back to `RESEND_FROM_SYSTEM` if not set.

- **New Features**
  - New `RESEND_FROM_TRUST_PORTAL` env var, with fallback to `RESEND_FROM_SYSTEM`.
  - `triggerEmail()` supports `trustPortal: true` to resolve the new sender.
  - `TrustEmailService` now passes `trustPortal: true` for NDA and access emails.

- **Migration**
  - Set `RESEND_FROM_TRUST_PORTAL` in `Trigger.dev` and `Render` (and local `.env` if testing).
  - Ensure the Resend domain is verified and the API key can send from it.
  - No breaking changes; emails use `RESEND_FROM_SYSTEM` until configured.

<sup>Written for commit 7ea05213de1a6712a73fdc307df0b2f6d3676c2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

