### PR TITLE
refactor(email): move FROM resolution into Trigger.dev task

### DIFF
--- a/apps/api/src/email/trigger-email.ts
+++ b/apps/api/src/email/trigger-email.ts
@@ -1,8 +1,21 @@
 import { render } from '@react-email/render';
 import { tasks } from '@trigger.dev/sdk';
 import type { ReactElement } from 'react';
-import type { sendEmailTask } from '../trigger/email/send-email';
+import type { EmailChannel, sendEmailTask } from '../trigger/email/send-email';
 import type { EmailAttachment } from './resend';
+
+type TriggerEmailFlags = {
+  marketing?: boolean;
+  system?: boolean;
+  trustPortal?: boolean;
+};
+
+function resolveChannel(flags: TriggerEmailFlags): EmailChannel {
+  if (flags.trustPortal) return 'trustPortal';
+  if (flags.marketing) return 'marketing';
+  if (flags.system) return 'system';
+  return 'default';
+}
 
 export async function triggerEmail(params: {
   to: string;
@@ -18,24 +31,13 @@ export async function triggerEmail(params: {
   try {
     const html = await render(params.react);
 
-    const fromMarketing = process.env.RESEND_FROM_MARKETING;
-    const fromSystem = process.env.RESEND_FROM_SYSTEM;
-    const fromDefault = process.env.RESEND_FROM_DEFAULT;
-    const fromTrustPortal = process.env.RESEND_FROM_TRUST_PORTAL;
-
-    const fromAddress = params.trustPortal
-      ? (fromTrustPortal ?? fromSystem)
-      : params.marketing
-        ? fromMarketing
-        : params.system
-          ? fromSystem
-          : fromDefault;
+    const channel = resolveChannel(params);
 
     const handle = await tasks.trigger<typeof sendEmailTask>('send-email', {
       to: params.to,
       subject: params.subject,
       html,
-      from: fromAddress ?? undefined,
+      channel,
       cc: params.cc,
       scheduledAt: params.scheduledAt,
       attachments: params.attachments?.map((att) => ({

--- a/apps/api/src/trigger/email/send-email.ts
+++ b/apps/api/src/trigger/email/send-email.ts
@@ -8,6 +8,36 @@ const emailQueue = queue({
   concurrencyLimit: 10,
 });
 
+export const emailChannelSchema = z.enum([
+  'marketing',
+  'system',
+  'trustPortal',
+  'default',
+]);
+export type EmailChannel = z.infer<typeof emailChannelSchema>;
+
+function resolveFromAddressForChannel(
+  channel: EmailChannel | undefined,
+): string | undefined {
+  const fromMarketing = process.env.RESEND_FROM_MARKETING;
+  const fromSystem = process.env.RESEND_FROM_SYSTEM;
+  const fromDefault = process.env.RESEND_FROM_DEFAULT;
+  const fromTrustPortal = process.env.RESEND_FROM_TRUST_PORTAL;
+
+  switch (channel) {
+    case 'trustPortal':
+      return fromTrustPortal ?? fromSystem;
+    case 'marketing':
+      return fromMarketing;
+    case 'system':
+      return fromSystem;
+    case 'default':
+      return fromDefault;
+    default:
+      return undefined;
+  }
+}
+
 export const sendEmailTask = schemaTask({
   id: 'send-email',
   queue: emailQueue,
@@ -18,6 +48,7 @@ export const sendEmailTask = schemaTask({
     to: z.string(),
     subject: z.string(),
     html: z.string(),
+    channel: emailChannelSchema.optional(),
     from: z.string().optional(),
     cc: z.union([z.string(), z.array(z.string())]).optional(),
     scheduledAt: z.string().optional(),
@@ -40,11 +71,15 @@ export const sendEmailTask = schemaTask({
       throw new Error('Resend not initialized - missing API key');
     }
 
+    const toTest = process.env.RESEND_TO_TEST;
     const fromSystem = process.env.RESEND_FROM_SYSTEM;
     const fromDefault = process.env.RESEND_FROM_DEFAULT;
-    const toTest = process.env.RESEND_TO_TEST;
 
-    const fromAddress = params.from ?? fromSystem ?? fromDefault;
+    const fromAddress =
+      params.from ??
+      resolveFromAddressForChannel(params.channel) ??
+      fromSystem ??
+      fromDefault;
     const toAddress = toTest ?? params.to;
 
     if (!fromAddress) {


### PR DESCRIPTION
## Summary

Follow-up to #2851. Moves email FROM-address resolution out of `triggerEmail()` (which runs on Render) and into the `send-email` Trigger.dev task, so **Trigger.dev becomes the single source of truth** for sender configuration. Render no longer needs `RESEND_FROM_*` env vars at all.

## What changed

**Before:** `triggerEmail()` read every `RESEND_FROM_*` env var on the API host, picked one based on flags, and shipped a literal address to the task. Sender env had to live on Render *and* Trigger.dev.

**After:** `triggerEmail()` passes a `channel: 'marketing' | 'system' | 'trustPortal' | 'default'` instead of a literal address. The task reads `RESEND_FROM_*` on the Trigger.dev side and resolves via a clean `switch`.

```ts
// triggerEmail.ts (Render-side)
const channel = resolveChannel(params); // boolean flags → channel
await tasks.trigger('send-email', { ..., channel });

// send-email.ts (Trigger.dev-side)
function resolveFromAddressForChannel(channel) {
  switch (channel) {
    case 'trustPortal': return fromTrustPortal ?? fromSystem;
    case 'marketing':   return fromMarketing;
    case 'system':      return fromSystem;
    case 'default':     return fromDefault;
    default:            return undefined;
  }
}
const fromAddress =
  params.from ??
  resolveFromAddressForChannel(params.channel) ??
  fromSystem ??
  fromDefault;
```

## Caller compatibility

`triggerEmail()`'s public API is **unchanged** — same `marketing` / `system` / `trustPortal` boolean flags. None of the 30+ call sites (task notifiers, training, findings, comments, people-invite, auth, trust portal, etc.) need to change.

`EmailController.sendEmail` calls the task directly with `from: <string>` and no `channel`. Still works — `params.from` is checked first in the fallback chain, and the default switch case returns `undefined` so the outer chain (`fromSystem ?? fromDefault`) preserves the prior behavior.

## Deploy notes

1. **Set `RESEND_FROM_TRUST_PORTAL` on Trigger.dev** (project `proj_zhioyrusqertqgafqgpj`) before merging. The task already reads `RESEND_FROM_SYSTEM` / `RESEND_FROM_DEFAULT` there.
2. After this merges and the Trigger.dev task redeploys, Render's `RESEND_FROM_*` vars become dead config — safe to remove from Render env once verified.
3. Backwards-compatible: if Trigger.dev's `RESEND_FROM_TRUST_PORTAL` isn't set, trust portal emails gracefully fall back to `RESEND_FROM_SYSTEM` (same as before).

## Test plan

- [ ] Typecheck passes (`npx turbo run typecheck --filter=@trycompai/api`) — verified locally
- [ ] After deploy + Trigger.dev env set, trigger an NDA signing email and confirm `From:` header is `Comp AI <noreply@mail.trust.inc>`
- [ ] Trigger access-granted, access-reclaim, and access-request-notification emails — confirm same sender
- [ ] Verify a system email (e.g., task assignment) still sends from `RESEND_FROM_SYSTEM`
- [ ] Verify a no-flag email (e.g., people-invite) still sends from `RESEND_FROM_DEFAULT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move email FROM-address resolution from `triggerEmail()` (Render) to the `send-email` Trigger.dev task. Trigger.dev is now the single source of truth for sender config, so Render no longer needs `RESEND_FROM_*` env vars.

- **Refactors**
  - `triggerEmail()` now passes a `channel: 'marketing' | 'system' | 'trustPortal' | 'default'` instead of a literal `from`.
  - The task resolves `from` via `RESEND_FROM_*` and still honors `params.from`.
  - Public API for callers is unchanged; direct task callers without `channel` keep prior behavior.

- **Migration**
  - Set `RESEND_FROM_TRUST_PORTAL` on Trigger.dev before deploy (falls back to `RESEND_FROM_SYSTEM`).
  - After deploy, remove `RESEND_FROM_*` from Render.

<sup>Written for commit 5f553ee2f218a6b9e5a35aa81550049d00300ba9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

