### PR TITLE
refactor(email): EmailController.sendEmail uses channel, removes Render env reads

### DIFF
--- a/apps/api/src/email/email.controller.ts
+++ b/apps/api/src/email/email.controller.ts
@@ -29,15 +29,12 @@ export class EmailController {
   })
   @ApiResponse({ status: 200, description: 'Email task triggered' })
   async sendEmail(@Body() dto: SendEmailDto) {
-    const fromAddress = dto.system
-      ? (process.env.RESEND_FROM_SYSTEM ?? process.env.RESEND_FROM_DEFAULT)
-      : (dto.from ?? process.env.RESEND_FROM_DEFAULT);
-
     const handle = await tasks.trigger<typeof sendEmailTask>('send-email', {
       to: dto.to,
       subject: dto.subject,
       html: dto.html,
-      from: fromAddress,
+      from: dto.from,
+      channel: dto.system ? 'system' : 'default',
       cc: dto.cc,
       scheduledAt: dto.scheduledAt,
       attachments: dto.attachments,


### PR DESCRIPTION
## Summary

Follow-up to #2853 (red-team finding). The internal \`/v1/internal/email/send\` endpoint was the last Render-side reader of \`RESEND_FROM_SYSTEM\` / \`RESEND_FROM_DEFAULT\` in the email flow — defeating the stated goal of #2853.

This makes \`EmailController.sendEmail\` pass a \`channel\` ('system' | 'default') instead of resolving the FROM address itself. The Trigger.dev task already knows how to map channel → env var.

## What changed

\`\`\`diff
 async sendEmail(@Body() dto: SendEmailDto) {
-  const fromAddress = dto.system
-    ? (process.env.RESEND_FROM_SYSTEM ?? process.env.RESEND_FROM_DEFAULT)
-    : (dto.from ?? process.env.RESEND_FROM_DEFAULT);
-
   const handle = await tasks.trigger<typeof sendEmailTask>('send-email', {
     to: dto.to,
     subject: dto.subject,
     html: dto.html,
-    from: fromAddress,
+    from: dto.from,
+    channel: dto.system ? 'system' : 'default',
     cc: dto.cc,
     scheduledAt: dto.scheduledAt,
     attachments: dto.attachments,
   });

   return { success: true, taskId: handle.id };
 }
\`\`\`

## Behavior

| dto.system | dto.from | Old behavior | New behavior |
|---|---|---|---|
| true | (any) | RESEND_FROM_SYSTEM ?? RESEND_FROM_DEFAULT (Render) | channel='system' → RESEND_FROM_SYSTEM (Trigger.dev) |
| false | set | dto.from | dto.from (params.from takes precedence) |
| false | unset | RESEND_FROM_DEFAULT (Render) | channel='default' → RESEND_FROM_DEFAULT (Trigger.dev) |

Equivalent semantics — just resolved on Trigger.dev instead of Render.

## What's still not done

\`sendBatchEmail\` (same controller) and the underlying \`send-batch-email\` task still read \`RESEND_FROM_*\` on Render. Out of scope here — that's a separate task with no channel concept yet. Track as a follow-up.

## Test plan

- [ ] Typecheck passes — verified locally
- [ ] Hit \`POST /v1/internal/email/send\` with \`{ system: true, ... }\` and verify the email sends from \`RESEND_FROM_SYSTEM\`
- [ ] Hit with \`{ from: "custom@x.com", ... }\` and verify it overrides
- [ ] After this lands, confirm \`RESEND_FROM_SYSTEM\` and \`RESEND_FROM_DEFAULT\` can be removed from Render env without breaking single-email sends (batch path still needs them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor EmailController.sendEmail to pass a `channel` ('system' | 'default') and stop reading `RESEND_FROM_*` on Render. Single-email behavior is unchanged, and `dto.from` still overrides.

- **Refactors**
  - Pass `channel` from `dto.system`; forward `dto.from` as-is.
  - FROM is resolved in the `send-email` task on Trigger.dev.
  - Render no longer needs `RESEND_FROM_*` for single-email sends; batch path still reads them.

<sup>Written for commit 30cdcbada906bccf569d3c75f417cc60f77cce4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

