### PR TITLE
fix(cloud-tests): cubic follow-ups from production deploy review

### DIFF
--- a/apps/api/src/cloud-security/ai-description.prompt.spec.ts
+++ b/apps/api/src/cloud-security/ai-description.prompt.spec.ts
@@ -69,6 +69,23 @@ describe('ai-description.prompt', () => {
       ).toMatchObject({ field: 'whyItMatters' });
     });
 
+    it('flags ISO 27001 control numbers in lowercase variants (a.5.1)', () => {
+      // The regex must be case-insensitive — auditors won't accept the
+      // model getting around the gate by lowercasing a citation.
+      expect(
+        findForbiddenContent({
+          ...baseline,
+          whyItMatters: 'Maps to a.9.4.3.',
+        }),
+      ).toMatchObject({ field: 'whyItMatters' });
+      expect(
+        findForbiddenContent({
+          ...baseline,
+          description: 'Control a.5.1.2 enforces this.',
+        }),
+      ).toMatchObject({ field: 'description' });
+    });
+
     it('flags HIPAA / NIST framework citations', () => {
       expect(
         findForbiddenContent({

--- a/apps/api/src/cloud-security/ai-description.prompt.ts
+++ b/apps/api/src/cloud-security/ai-description.prompt.ts
@@ -104,9 +104,10 @@ const FORBIDDEN_PATTERNS: readonly RegExp[] = [
   // prefixes — catches "CIS 1.8", "PCI 8.2.3", "NIST AC-2",
   // "HIPAA 164.312" even without the full framework name re-mentioned.
   /\b(CIS|PCI|NIST|HIPAA|HITRUST|FedRAMP) ?[A-Z]*[- ]?\d+(\.\d+){0,3}\b/i,
-  // SOC 2 / ISO control-number formats
+  // SOC 2 / ISO control-number formats — case-insensitive so lowercase
+  // variants (e.g. "a.5.1.2") are blocked too.
   /\bCC\d+\.\d+\b/i,
-  /\bA\.\d+\.\d+(\.\d+)?\b/,
+  /\bA\.\d+\.\d+(\.\d+)?\b/i,
   // URLs
   /https?:\/\//i,
   /www\./i,

--- a/apps/api/src/cloud-security/exception-expiry.utils.spec.ts
+++ b/apps/api/src/cloud-security/exception-expiry.utils.spec.ts
@@ -75,9 +75,25 @@ describe('parseExceptionExpiry', () => {
     );
   });
 
-  it('accepts strict ISO 8601 timestamps via the fallback', () => {
+  it('accepts strict ISO 8601 timestamps with an explicit timezone offset', () => {
     expect(parseExceptionExpiry('2026-08-13T23:59:59Z')).not.toBeNull();
     expect(parseExceptionExpiry('2026-08-13T23:59:59.999Z')).not.toBeNull();
     expect(parseExceptionExpiry('2026-08-13T23:59:59+02:00')).not.toBeNull();
+    expect(parseExceptionExpiry('2026-08-13T23:59:59-07:00')).not.toBeNull();
+  });
+
+  it('rejects timestamps without an explicit timezone offset', () => {
+    // No `Z`, no `+02:00` etc. — `new Date()` would parse these in server
+    // local time, giving inconsistent expiries across environments. Force
+    // the caller to commit to a timezone explicitly.
+    expect(() => parseExceptionExpiry('2026-08-13T23:59:59')).toThrow(
+      BadRequestException,
+    );
+    expect(() => parseExceptionExpiry('2026-08-13T23:59')).toThrow(
+      BadRequestException,
+    );
+    expect(() =>
+      parseExceptionExpiry('2026-08-13T23:59:59.999'),
+    ).toThrow(BadRequestException);
   });
 });

--- a/apps/api/src/cloud-security/exception-expiry.utils.ts
+++ b/apps/api/src/cloud-security/exception-expiry.utils.ts
@@ -45,12 +45,14 @@ export function parseExceptionExpiry(
 
   // Reject anything that isn't strict ISO 8601 — `new Date()` happily parses
   // locale-specific strings like "January 1, 2026" and "2026/08/13", which
-  // would silently bypass the documented contract.
+  // would silently bypass the documented contract. The timezone offset is
+  // REQUIRED — without it, `new Date("2026-08-13T23:59:59")` is parsed in
+  // server-local time, giving different expiries on UTC vs Pacific hosts.
   const ISO_8601 =
-    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?(\.\d+)?(Z|[+-]\d{2}:?\d{2})?$/;
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?(\.\d+)?(Z|[+-]\d{2}:?\d{2})$/;
   if (!ISO_8601.test(input)) {
     throw new BadRequestException(
-      'expiresAt must be a valid ISO date or YYYY-MM-DD calendar date.',
+      'expiresAt must be a YYYY-MM-DD calendar date or an ISO 8601 timestamp with an explicit timezone offset (e.g. "2026-08-13T23:59:59Z").',
     );
   }
   const parsed = new Date(input);

--- a/apps/api/src/cloud-security/reconciliation.service.ts
+++ b/apps/api/src/cloud-security/reconciliation.service.ts
@@ -124,8 +124,7 @@ export class CloudReconciliationService {
 
     // Resolutions: prior failed → current absent or passed.
     for (const [key, prior] of priorMap.entries()) {
-      if (!prior.passed === false) continue; // only interested in prior failures
-      if (prior.passed) continue;
+      if (prior.passed) continue; // only interested in prior failures
 
       const current = currentMap.get(key);
       if (current && !current.passed) continue; // still failing

--- a/apps/app/src/app/(app)/[orgId]/cloud-tests/components/CloudTestsSection.tsx
+++ b/apps/app/src/app/(app)/[orgId]/cloud-tests/components/CloudTestsSection.tsx
@@ -455,7 +455,12 @@ export function CloudTestsSection({
     if (!batchServiceId) return null;
     const group = serviceGroups.find((g) => g.serviceId === batchServiceId);
     if (!group) return null;
+    // `group.findings` is the merged failed+passed set — restrict the batch
+    // to failing findings only. `canFixFinding` doesn't gate on status, so
+    // without this filter a passing check could be targeted by "Fix All".
     const fixable = group.findings.filter((f) => {
+      const isFailed = f.status === 'failed' || f.status === 'FAILED';
+      if (!isFailed) return false;
       const match = canFixFinding(f);
       return match?.key && match.enabled;
     });


### PR DESCRIPTION
## Summary

Cubic flagged 5 issues on PR #2862 (the auto-generated `main → release` production deploy PR). 4 were real and are fixed here; 1 was a false positive (jest hoisting with ts-jest).

## Real bugs fixed

| Severity | File | Bug |
|---|---|---|
| **P1** | `CloudTestsSection.tsx` | "Fix All" could include passing findings in the batch target. Service groups merge failed+passed, and `canFixFinding` doesn't gate on status — so a passing check could be queued for remediation. Now filtered explicitly. |
| P2 | `exception-expiry.utils.ts` | ISO 8601 regex made the timezone offset optional; timestamps without `Z`/`+00:00` got parsed in server-local time, giving inconsistent expiries on UTC vs Pacific hosts. Offset now required. |
| P2 | `reconciliation.service.ts` | Dead `!prior.passed === false` line — identical to the next `if (prior.passed) continue`. Removed for clarity. |
| P2 | `ai-description.prompt.ts` | `\bA\.\d+\.\d+(\.\d+)?\b/` lacked `/i`, so lowercase ISO 27001 control citations (`a.5.1.2`) slipped past the forbidden-content guard. Added `/i` and a regression test. |

## False positive skipped

- **P1** Jest hoisting in `exception.service.spec.ts` / `reconciliation.service.spec.ts`: that rule is enforced by `babel-plugin-jest-hoist` (default in babel-jest). This project uses ts-jest, which doesn't enforce the strict `mock*` naming convention. CI is green and all 145 tests pass. Renaming would be cosmetic insurance against a future babel-jest migration; not blocking.

## Test plan

- [x] `npx jest src/cloud-security/exception-expiry src/cloud-security/ai-description src/cloud-security/reconciliation` — 32 tests pass
- [x] `npx tsc --noEmit` on both apps/api and apps/app — clean for changed files
- [ ] Visual: open a service group with only passing findings, confirm "Fix All" button doesn't appear (the existing `group.failed > 1` guard already gates the button, so this fix is belt-and-suspenders for any future code path that opens the batch dialog directly)
- [ ] Visual: try to mark an exception with `expiresAt = "2026-08-13T23:59:59"` (no TZ) and confirm the API rejects with a clear message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four issues flagged by Cubic in the production deploy review to prevent incorrect batch remediation and ensure consistent validation. One Jest hoisting warning was a false positive and skipped.

- **Bug Fixes**
  - Cloud tests: “Fix All” now only targets failing findings before applying `canFixFinding`.
  - Exception expiry: ISO 8601 timestamps now require an explicit timezone offset; timezone-less inputs are rejected.
  - Reconciliation: Removed redundant `!prior.passed === false` check for clarity; behavior unchanged.
  - AI description: ISO 27001 control regex is now case-insensitive to block lowercase citations (e.g., `a.5.1.2`).

<sup>Written for commit 33042e79918196f8c4e585844649622329e6f041. Summary will update on new commits. <a href="https://cubic.dev/pr/trycompai/comp/pull/2864?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

