### PR TITLE
fix(cloud-tests): sync findings + history caches on mark/revoke exception

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/cloud-tests/components/CloudTestsSection.tsx
+++ b/apps/app/src/app/(app)/[orgId]/cloud-tests/components/CloudTestsSection.tsx
@@ -35,6 +35,7 @@ import {
 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
+import { mutate as globalMutate } from 'swr';
 import { getActiveBatch } from '../actions/batch-fix';
 import { AzureSetupGuide } from './AzureSetupGuide';
 import { BatchRemediationDialog } from './BatchRemediationDialog';
@@ -1127,6 +1128,16 @@ export function CloudTestsSection({
         resourceLabel={exceptionTarget?.resourceLabel ?? null}
         onMarked={() => {
           findingsResponse.mutate();
+          // Invalidate the History tab's SWR cache so the new exception
+          // appears in "Active exceptions" immediately. The History hook
+          // keys on a tuple `[endpoint, organizationId]` (see useApiSWR),
+          // so we match by inspecting the endpoint string in the key.
+          globalMutate(
+            (key) =>
+              Array.isArray(key) &&
+              typeof key[0] === 'string' &&
+              key[0].startsWith('/v1/cloud-security/history'),
+          );
           setExceptionTarget(null);
         }}
       />

--- a/apps/app/src/app/(app)/[orgId]/cloud-tests/components/HistoryTab.tsx
+++ b/apps/app/src/app/(app)/[orgId]/cloud-tests/components/HistoryTab.tsx
@@ -5,6 +5,7 @@ import { usePermissions } from '@/hooks/use-permissions';
 import { Button } from '@trycompai/ui/button';
 import { Loader2, ShieldCheck, RotateCcw, X } from 'lucide-react';
 import { toast } from 'sonner';
+import { mutate as globalMutate } from 'swr';
 
 interface ResolutionRow {
   id: string;
@@ -105,6 +106,16 @@ export function HistoryTab({ connectionId }: HistoryTabProps) {
     }
     toast.success('Exception revoked');
     mutate();
+    // Invalidate the cloud-tests findings cache so the revoked exception's
+    // finding reappears in the active scan results immediately. Mirrors
+    // the mark-as-exception flow which invalidates history; both directions
+    // keep the two views in sync without a manual refresh.
+    globalMutate(
+      (key) =>
+        Array.isArray(key) &&
+        typeof key[0] === 'string' &&
+        key[0].startsWith('/v1/cloud-security/findings'),
+    );
   };
 
   if (isLoading) {


### PR DESCRIPTION
## Problem

When a user marked a finding as an exception, the new exception was correctly written to the DB and the active findings list refreshed, **but the History tab stayed stale** — the exception wouldn't appear in "Active exceptions" until the page was reloaded.

The mirror flow had the same bug: revoking an exception from the History tab refreshed history but **didn't refresh the findings list**, so the reopened finding stayed hidden from Scan Results until reload.

## Root cause

Both views are independent SWR caches. The mutation handlers were each calling `mutate()` on their own cache and assuming the other view would discover the change on its own — but `useApiSWR` is configured with `revalidateOnFocus: false`, so neither view ever picks it up without a hard reload.

## Fix

Use SWR's global `mutate` with a predicate, since `useApiSWR` keys on the tuple `[endpoint, organizationId]` — a plain string key won't match.

```ts
globalMutate(
  (key) =>
    Array.isArray(key) &&
    typeof key[0] === 'string' &&
    key[0].startsWith('/v1/cloud-security/history'),
);
```

- `CloudTestsSection.onMarked` → invalidate **history** caches
- `HistoryTab.handleRevoke` → invalidate **findings** caches

Each side keeps its existing local mutate, then triggers the cross-cache invalidation. Cleaner than threading callbacks through the tree, and matches SWR's intended pattern for cross-cache updates.

## Test plan

- [x] Existing tests: `MarkExceptionModal.test.tsx` (4) + `HistoryTab.test.tsx` (5) all pass
- [x] Typecheck clean for both changed files
- [ ] Manual: mark a finding as exception, switch to History tab without reloading → "Active exceptions" should now show the new row
- [ ] Manual: from History tab, revoke an exception, switch back to Scan Results → the finding should now reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale views when marking or revoking exceptions by syncing the Cloud Tests findings and History caches. Uses `swr` global mutate with a predicate so updates appear immediately without a page reload.

- **Bug Fixes**
  - After marking an exception in Scan Results, invalidate `/v1/cloud-security/history` caches to show it in Active exceptions.
  - After revoking from History, invalidate `/v1/cloud-security/findings` caches so the finding reappears in Scan Results.

<sup>Written for commit ae06acf262364776264b236717929e367d781bbb. Summary will update on new commits. <a href="https://cubic.dev/pr/trycompai/comp/pull/2868?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

