### PR TITLE
feat(cloud-tests): AWS Security Hub as alternative scan engine

### DIFF
--- a/apps/api/src/cloud-security/aws-scan-mode.service.ts
+++ b/apps/api/src/cloud-security/aws-scan-mode.service.ts
@@ -1,0 +1,104 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  Logger,
+} from '@nestjs/common';
+import { db, Prisma } from '@db';
+import {
+  type AwsScanMode,
+  resolveAwsScanMode,
+} from './aws-scan-mode';
+import { logCloudSecurityActivity } from './cloud-security-audit';
+
+/**
+ * Manages the AWS scan-engine choice on a connection. Lives separately
+ * from CloudSecurityService so the scan-mode concern has one obvious
+ * home — engineers grep for `aws-scan-mode.service` and find every
+ * read / write site at once.
+ */
+@Injectable()
+export class CloudAwsScanModeService {
+  private readonly logger = new Logger(CloudAwsScanModeService.name);
+
+  /**
+   * Update the scan engine on an AWS connection. Validates:
+   *   - The connection exists and belongs to the caller's org.
+   *   - The connection is an AWS provider (other providers don't have
+   *     a scan-mode concept).
+   *
+   * Idempotent — re-applying the same mode is a successful no-op.
+   *
+   * Writes an audit-log entry so a mode change is traceable later.
+   * Reconciliation reads `IntegrationCheckRun.scanMode` per run, so
+   * after this update the next scan automatically uses the new engine
+   * and reconciliation only diffs same-mode runs (see
+   * `reconciliation.service.ts`).
+   */
+  async updateMode(params: {
+    connectionId: string;
+    organizationId: string;
+    userId: string;
+    mode: AwsScanMode;
+  }): Promise<{ mode: AwsScanMode }> {
+    const connection = await db.integrationConnection.findFirst({
+      where: {
+        id: params.connectionId,
+        organizationId: params.organizationId,
+      },
+      select: {
+        id: true,
+        metadata: true,
+        provider: { select: { slug: true } },
+      },
+    });
+
+    if (!connection) {
+      throw new ForbiddenException(
+        'Connection not found or does not belong to your organization.',
+      );
+    }
+    if (connection.provider?.slug !== 'aws') {
+      throw new BadRequestException(
+        'Scan engine choice is only available for AWS connections.',
+      );
+    }
+
+    const metadata = (connection.metadata ?? {}) as Record<string, unknown>;
+    const previousMode = resolveAwsScanMode(metadata.awsScanMode);
+
+    if (previousMode === params.mode) {
+      // Idempotent no-op — return the current mode without writing.
+      return { mode: params.mode };
+    }
+
+    const nextMetadata: Record<string, unknown> = {
+      ...metadata,
+      awsScanMode: params.mode,
+    };
+
+    await db.integrationConnection.update({
+      where: { id: connection.id },
+      data: {
+        metadata: nextMetadata as unknown as Prisma.InputJsonValue,
+      },
+    });
+
+    await logCloudSecurityActivity({
+      organizationId: params.organizationId,
+      userId: params.userId,
+      connectionId: connection.id,
+      action: 'scan_mode_changed',
+      description: `Switched AWS scan engine: ${previousMode} → ${params.mode}`,
+      metadata: {
+        previousMode,
+        newMode: params.mode,
+      },
+    });
+
+    this.logger.log(
+      `Connection ${connection.id} scan mode: ${previousMode} → ${params.mode}`,
+    );
+    return { mode: params.mode };
+  }
+}

--- a/apps/api/src/cloud-security/aws-scan-mode.spec.ts
+++ b/apps/api/src/cloud-security/aws-scan-mode.spec.ts
@@ -1,0 +1,51 @@
+import {
+  DEFAULT_AWS_SCAN_MODE,
+  isSecurityHubMode,
+  resolveAwsScanMode,
+} from './aws-scan-mode';
+
+describe('aws-scan-mode', () => {
+  describe('resolveAwsScanMode', () => {
+    it('returns "security_hub" when the value is exactly that string', () => {
+      expect(resolveAwsScanMode('security_hub')).toBe('security_hub');
+    });
+
+    it('returns the default for "comp_scanners"', () => {
+      expect(resolveAwsScanMode('comp_scanners')).toBe('comp_scanners');
+    });
+
+    it('returns the default for unknown strings', () => {
+      // Defensive — typos / future modes / corrupted JSON variables must
+      // never accidentally activate Security Hub mode.
+      expect(resolveAwsScanMode('SECURITY_HUB')).toBe(DEFAULT_AWS_SCAN_MODE);
+      expect(resolveAwsScanMode('securityhub')).toBe(DEFAULT_AWS_SCAN_MODE);
+      expect(resolveAwsScanMode('xyz')).toBe(DEFAULT_AWS_SCAN_MODE);
+    });
+
+    it('returns the default for missing / non-string values', () => {
+      expect(resolveAwsScanMode(undefined)).toBe(DEFAULT_AWS_SCAN_MODE);
+      expect(resolveAwsScanMode(null)).toBe(DEFAULT_AWS_SCAN_MODE);
+      expect(resolveAwsScanMode(0)).toBe(DEFAULT_AWS_SCAN_MODE);
+      expect(resolveAwsScanMode({})).toBe(DEFAULT_AWS_SCAN_MODE);
+      expect(resolveAwsScanMode([])).toBe(DEFAULT_AWS_SCAN_MODE);
+    });
+  });
+
+  describe('isSecurityHubMode', () => {
+    it('is true only for the exact "security_hub" string', () => {
+      expect(isSecurityHubMode('security_hub')).toBe(true);
+      expect(isSecurityHubMode('comp_scanners')).toBe(false);
+      expect(isSecurityHubMode(undefined)).toBe(false);
+      expect(isSecurityHubMode('SECURITY_HUB')).toBe(false);
+    });
+  });
+
+  describe('DEFAULT_AWS_SCAN_MODE', () => {
+    it('is "comp_scanners" — today\'s behavior is the safe default', () => {
+      // This is intentionally guarded by a test: changing the default
+      // would silently shift production behavior for every existing
+      // connection that does not have an explicit scan mode set.
+      expect(DEFAULT_AWS_SCAN_MODE).toBe('comp_scanners');
+    });
+  });
+});

--- a/apps/api/src/cloud-security/aws-scan-mode.ts
+++ b/apps/api/src/cloud-security/aws-scan-mode.ts
@@ -1,0 +1,44 @@
+/**
+ * Determines which engine performs an AWS security scan for a given
+ * connection. This is the single source of truth for scan-mode strings —
+ * importers never spell the values themselves.
+ *
+ *   - 'comp_scanners' — run our service adapters directly against AWS
+ *                       APIs (today's default; full Fix button support).
+ *   - 'security_hub'  — call AWS Security Hub's GetFindings API and
+ *                       surface whatever findings the customer's
+ *                       Security Hub is configured to evaluate (CIS,
+ *                       NIST 800-53, PCI, etc.).
+ *
+ * Persisted in two places:
+ *   - `IntegrationConnection.metadata.awsScanMode` — the customer's
+ *     current choice for the connection. Stored in `metadata` (not
+ *     `variables`) because it's a non-secret display field that the
+ *     frontend reads via the connection endpoint; mirrors `awsType`,
+ *     `roleArn`, `regions` etc.
+ *   - `IntegrationCheckRun.scanMode` — which engine produced this run.
+ *     Read by reconciliation to diff like-for-like; findingKeys live
+ *     in different namespaces across modes, so cross-mode diffs would
+ *     produce false resolutions/regressions.
+ */
+export type AwsScanMode = 'comp_scanners' | 'security_hub';
+
+/** Default behavior for AWS connections with no scan-mode set (including
+ * every pre-feature connection that already exists in production). */
+export const DEFAULT_AWS_SCAN_MODE: AwsScanMode = 'comp_scanners';
+
+/**
+ * Coerces a value (typically from JSON variables) into a valid
+ * AwsScanMode. Unknown / missing / wrong-typed values fall back to the
+ * default. Use this everywhere instead of comparing strings inline.
+ */
+export function resolveAwsScanMode(value: unknown): AwsScanMode {
+  return value === 'security_hub' ? 'security_hub' : DEFAULT_AWS_SCAN_MODE;
+}
+
+/** True when the value, if persisted, would represent a SecHub-mode
+ * connection. Reads in one place — keeps `=== 'security_hub'` out of
+ * callers. */
+export function isSecurityHubMode(value: unknown): boolean {
+  return resolveAwsScanMode(value) === 'security_hub';
+}

--- a/apps/api/src/cloud-security/cloud-security-audit.ts
+++ b/apps/api/src/cloud-security/cloud-security-audit.ts
@@ -13,7 +13,8 @@ interface CloudSecurityAuditParams {
     | 'rollback_failed'
     | 'service_toggled'
     | 'exception_marked'
-    | 'exception_revoked';
+    | 'exception_revoked'
+    | 'scan_mode_changed';
   description: string;
   metadata?: Record<string, unknown>;
 }

--- a/apps/api/src/cloud-security/cloud-security.controller.ts
+++ b/apps/api/src/cloud-security/cloud-security.controller.ts
@@ -3,6 +3,7 @@ import {
   Post,
   Get,
   Delete,
+  Patch,
   Param,
   Query,
   Body,
@@ -27,8 +28,10 @@ import { CloudSecurityLegacyService } from './cloud-security-legacy.service';
 import { CheckDefinitionService } from './check-definition.service';
 import { CloudExceptionService } from './exception.service';
 import { CloudHistoryService } from './history.service';
+import { CloudAwsScanModeService } from './aws-scan-mode.service';
 import { parseExceptionExpiry } from './exception-expiry.utils';
 import { MarkExceptionDto } from './dto/mark-exception.dto';
+import { UpdateAwsScanModeDto } from './dto/update-scan-mode.dto';
 import { logCloudSecurityActivity } from './cloud-security-audit';
 import { CloudSecurityActivityService } from './cloud-security-activity.service';
 import {
@@ -52,6 +55,7 @@ export class CloudSecurityController {
     private readonly checkDefinitionService: CheckDefinitionService,
     private readonly exceptionService: CloudExceptionService,
     private readonly historyService: CloudHistoryService,
+    private readonly scanModeService: CloudAwsScanModeService,
   ) {}
 
   @Get('activity')
@@ -130,6 +134,34 @@ export class CloudSecurityController {
       reason: body.reason,
       reviewedBy: body.reviewedBy ?? null,
       expiresAt: parseExceptionExpiry(body.expiresAt),
+    });
+    return { data: result };
+  }
+
+  @Patch('connections/:connectionId/scan-mode')
+  @UseGuards(HybridAuthGuard, PermissionGuard)
+  @RequirePermission('integration', 'update')
+  @ApiOperation({
+    summary:
+      'Switch the AWS scan engine for a connection (Comp AI scanners ↔ Security Hub)',
+  })
+  async updateAwsScanMode(
+    @Param('connectionId') connectionId: string,
+    @Body() body: UpdateAwsScanModeDto,
+    @OrganizationId() organizationId: string,
+    @Req() req: { userId?: string },
+  ) {
+    if (!req.userId) {
+      throw new HttpException(
+        'Switching the scan engine requires session authentication.',
+        HttpStatus.UNAUTHORIZED,
+      );
+    }
+    const result = await this.scanModeService.updateMode({
+      connectionId,
+      organizationId,
+      userId: req.userId,
+      mode: body.mode,
     });
     return { data: result };
   }

--- a/apps/api/src/cloud-security/cloud-security.module.ts
+++ b/apps/api/src/cloud-security/cloud-security.module.ts
@@ -15,6 +15,7 @@ import { AiDescriptionService } from './ai-description.service';
 import { CheckDefinitionService } from './check-definition.service';
 import { CloudExceptionService } from './exception.service';
 import { CloudHistoryService } from './history.service';
+import { CloudAwsScanModeService } from './aws-scan-mode.service';
 import { CloudReconciliationService } from './reconciliation.service';
 import { CloudSecurityActivityService } from './cloud-security-activity.service';
 import { IntegrationPlatformModule } from '../integration-platform/integration-platform.module';
@@ -40,6 +41,7 @@ import { AuthModule } from '../auth/auth.module';
     CloudExceptionService,
     CloudReconciliationService,
     CloudHistoryService,
+    CloudAwsScanModeService,
   ],
   exports: [CloudSecurityService],
 })

--- a/apps/api/src/cloud-security/cloud-security.service.ts
+++ b/apps/api/src/cloud-security/cloud-security.service.ts
@@ -9,6 +9,7 @@ import { AWSSecurityService } from './providers/aws-security.service';
 import { AzureSecurityService } from './providers/azure-security.service';
 import { AWS_SERVICE_TASK_MAPPINGS } from './aws-task-mappings';
 import { CloudReconciliationService } from './reconciliation.service';
+import { type AwsScanMode, resolveAwsScanMode } from './aws-scan-mode';
 
 export interface SecurityFinding {
   id: string;
@@ -245,6 +246,11 @@ export class CloudSecurityService {
         }
       }
 
+      // AWS-only — which engine produced this scan. Persisted on the run
+      // so reconciliation only diffs like-for-like (cross-mode findingKeys
+      // live in different namespaces). Null for GCP / Azure runs.
+      let awsScanMode: AwsScanMode | null = null;
+
       switch (providerSlug) {
         case 'gcp':
           findings = await this.gcpService.scanSecurityFindings(
@@ -253,13 +259,21 @@ export class CloudSecurityService {
             enabledServices,
           );
           break;
-        case 'aws':
+        case 'aws': {
+          // AWS scan-mode lives on connection.metadata (non-secret, frontend-
+          // readable); credentials are encrypted blobs intended for the AWS
+          // SDK. Read from metadata so a single source of truth.
+          const metadata =
+            (connection.metadata as Record<string, unknown> | null) ?? {};
+          awsScanMode = resolveAwsScanMode(metadata.awsScanMode);
           findings = await this.awsService.scanSecurityFindings(
             credentials,
             variables,
             enabledServices,
+            awsScanMode,
           );
           break;
+        }
         case 'azure':
           findings = await this.azureService.scanSecurityFindings(
             credentials,
@@ -282,6 +296,7 @@ export class CloudSecurityService {
         connectionId,
         providerSlug,
         findings,
+        awsScanMode,
       );
 
       // Reconcile against the prior scan to record resolutions and regressions.
@@ -573,6 +588,9 @@ export class CloudSecurityService {
     connectionId: string,
     provider: string,
     findings: SecurityFinding[],
+    // AWS only — which engine produced these findings. Stored on the run so
+    // reconciliation can avoid cross-mode diffs. Null for GCP / Azure runs.
+    awsScanMode: AwsScanMode | null,
   ): Promise<string> {
     const passedCount = findings.filter((f) => f.passed).length;
     const failedCount = findings.filter((f) => !f.passed).length;
@@ -607,6 +625,7 @@ export class CloudSecurityService {
           passedCount,
           failedCount,
           scannedServices,
+          scanMode: awsScanMode,
         },
       });
 

--- a/apps/api/src/cloud-security/dto/update-scan-mode.dto.ts
+++ b/apps/api/src/cloud-security/dto/update-scan-mode.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsIn, IsString } from 'class-validator';
+import type { AwsScanMode } from '../aws-scan-mode';
+
+/**
+ * Request body for `PATCH /v1/cloud-security/connections/:id/scan-mode`.
+ *
+ * Only AWS connections accept this; the service layer validates the
+ * connection is AWS before applying the change.
+ */
+export class UpdateAwsScanModeDto {
+  @ApiProperty({
+    description: 'Which scan engine to use for this AWS connection.',
+    enum: ['comp_scanners', 'security_hub'],
+    example: 'security_hub',
+  })
+  @IsString()
+  @IsIn(['comp_scanners', 'security_hub'])
+  mode!: AwsScanMode;
+}

--- a/apps/api/src/cloud-security/providers/aws-security.service.ts
+++ b/apps/api/src/cloud-security/providers/aws-security.service.ts
@@ -64,8 +64,25 @@ import { EventBridgeAdapter } from './aws/eventbridge.adapter';
 import { TransferFamilyAdapter } from './aws/transfer-family.adapter';
 import { ElasticBeanstalkAdapter } from './aws/elastic-beanstalk.adapter';
 import { AppFlowAdapter } from './aws/appflow.adapter';
+import { SecurityHubAdapter } from './aws/security-hub.adapter';
+import {
+  type AwsScanMode,
+  DEFAULT_AWS_SCAN_MODE,
+} from '../aws-scan-mode';
 
 const GOVCLOUD_UNSUPPORTED_SERVICE_IDS = new Set(['cloudfront', 'shield']);
+
+/**
+ * Pre-computed scan context shared by both scan engines (adapter mode
+ * and Security Hub mode). Produced by `prepareScan`, consumed by
+ * `scanViaAdapters` / `scanViaSecurityHub`.
+ */
+interface AwsScanSetup {
+  awsCredentials: AwsCredentials;
+  configuredRegions: string[];
+  primaryRegion: string;
+  partition: AwsPartition;
+}
 
 @Injectable()
 export class AWSSecurityService {
@@ -118,11 +135,41 @@ export class AWSSecurityService {
     new AppFlowAdapter(),
   ];
 
+  /**
+   * Entry point — resolves credentials + regions, then dispatches to the
+   * chosen scan engine. The two engines are mutually exclusive:
+   *
+   *   - 'comp_scanners' → runs our ~49 service adapters (default).
+   *   - 'security_hub'  → runs ONLY the Security Hub adapter, per region.
+   *
+   * Engineers tracing this code can jump straight to `scanViaAdapters`
+   * or `scanViaSecurityHub` to see what each mode does — no nested
+   * branching.
+   */
   async scanSecurityFindings(
     credentials: Record<string, unknown>,
     variables: Record<string, unknown>,
     enabledServices?: string[],
+    mode: AwsScanMode = DEFAULT_AWS_SCAN_MODE,
   ): Promise<SecurityFinding[]> {
+    const setup = await this.prepareScan(credentials, variables);
+
+    if (mode === 'security_hub') {
+      return this.scanViaSecurityHub(setup);
+    }
+    return this.scanViaAdapters(setup, enabledServices);
+  }
+
+  /**
+   * Validates credentials, resolves the region list, and (for role
+   * auth) assumes the IAM role. Returns the shared context both scan
+   * engines need. Throws on any precondition failure — both engines
+   * skip out of an unhappy path before they begin.
+   */
+  private async prepareScan(
+    credentials: Record<string, unknown>,
+    variables: Record<string, unknown>,
+  ): Promise<AwsScanSetup> {
     const isRoleAuth = Boolean(credentials.roleArn && credentials.externalId);
     const isKeyAuth = Boolean(
       credentials.access_key_id && credentials.secret_access_key,
@@ -143,6 +190,7 @@ export class AWSSecurityService {
       partition,
     );
     const primaryRegion = configuredRegions[0];
+
     const mismatchedRegions = configuredRegions.filter(
       (region) => getAwsPartitionForRegion(region) !== partition,
     );
@@ -156,30 +204,64 @@ export class AWSSecurityService {
       `Scanning ${configuredRegions.length} ${partition} region(s): ${configuredRegions.join(', ')}`,
     );
 
-    // Assume role ONCE — IAM is global, credentials work across all regions
-    let awsCredentials: AwsCredentials;
-    if (isRoleAuth) {
-      const partitionErrors = validateAwsPartitionConfig({
-        partition,
-        roleArn: credentials.roleArn as string,
-        regions: configuredRegions,
-      });
-      if (partitionErrors.length > 0) {
-        throw new Error(partitionErrors.join(' '));
-      }
+    // Assume role ONCE — IAM is global, credentials work across all regions.
+    const awsCredentials: AwsCredentials = isRoleAuth
+      ? await this.resolveRoleCredentials({
+          roleArn: credentials.roleArn as string,
+          externalId: credentials.externalId as string,
+          partition,
+          regions: configuredRegions,
+          primaryRegion,
+        })
+      : {
+          accessKeyId: credentials.access_key_id as string,
+          secretAccessKey: credentials.secret_access_key as string,
+        };
 
-      awsCredentials = await this.assumeRole({
-        roleArn: credentials.roleArn as string,
-        externalId: credentials.externalId as string,
-        region: primaryRegion,
-        partition,
-      });
-    } else {
-      awsCredentials = {
-        accessKeyId: credentials.access_key_id as string,
-        secretAccessKey: credentials.secret_access_key as string,
-      };
+    return {
+      awsCredentials,
+      configuredRegions,
+      primaryRegion,
+      partition,
+    };
+  }
+
+  private async resolveRoleCredentials(params: {
+    roleArn: string;
+    externalId: string;
+    partition: AwsPartition;
+    regions: string[];
+    primaryRegion: string;
+  }): Promise<AwsCredentials> {
+    const partitionErrors = validateAwsPartitionConfig({
+      partition: params.partition,
+      roleArn: params.roleArn,
+      regions: params.regions,
+    });
+    if (partitionErrors.length > 0) {
+      throw new Error(partitionErrors.join(' '));
     }
+
+    return this.assumeRole({
+      roleArn: params.roleArn,
+      externalId: params.externalId,
+      region: params.primaryRegion,
+      partition: params.partition,
+    });
+  }
+
+  /**
+   * Today's default scan engine. Runs each registered service adapter
+   * (global once, regional per region) and aggregates the findings.
+   * Behavior is byte-for-byte identical to the pre-mode implementation —
+   * the SecurityHubAdapter is NOT in `this.adapters`, so it can never
+   * run on this path.
+   */
+  private async scanViaAdapters(
+    setup: AwsScanSetup,
+    enabledServices: string[] | undefined,
+  ): Promise<SecurityFinding[]> {
+    const { awsCredentials, configuredRegions, primaryRegion, partition } = setup;
 
     // undefined = scan all (no detection data), [] = scan nothing (all disabled), [...] = scan specific
     const activeAdaptersBeforePartitionFilter =
@@ -265,6 +347,59 @@ export class AWSSecurityService {
       );
     }
 
+    return allFindings;
+  }
+
+  /**
+   * Alternative scan engine. Pulls findings from AWS Security Hub
+   * `GetFindings` per region — does NOT touch any of the 49 service
+   * adapters. SecurityHubAdapter handles the "not subscribed" /
+   * "AccessDenied" cases gracefully (returns []).
+   *
+   * Activated by `awsScanMode: 'security_hub'` on the connection.
+   */
+  private async scanViaSecurityHub(
+    setup: AwsScanSetup,
+  ): Promise<SecurityFinding[]> {
+    const { awsCredentials, configuredRegions } = setup;
+    const adapter = new SecurityHubAdapter();
+
+    this.logger.log(
+      `Scanning Security Hub across ${configuredRegions.length} region(s)`,
+    );
+
+    const allFindings: SecurityFinding[] = [];
+    const successfulRegions = new Set<string>();
+    const failedRegions = new Set<string>();
+
+    for (const region of configuredRegions) {
+      try {
+        const findings = await adapter.scan({
+          credentials: awsCredentials,
+          region,
+        });
+        // Adapter already stamps evidence.serviceId — no need to re-stamp.
+        allFindings.push(...findings);
+        successfulRegions.add(region);
+        this.logger.log(
+          `[security-hub] ${findings.length} findings in ${region}`,
+        );
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        this.logger.warn(`[security-hub] Error in ${region}: ${msg}`);
+        failedRegions.add(region);
+      }
+    }
+
+    if (successfulRegions.size === 0 && failedRegions.size > 0) {
+      throw new Error(
+        `Security Hub scan failed in all ${failedRegions.size} region(s): ${[...failedRegions].join(', ')}`,
+      );
+    }
+
+    this.logger.log(
+      `Security Hub scan complete: ${allFindings.length} findings from ${successfulRegions.size} region(s)`,
+    );
     return allFindings;
   }
 

--- a/apps/api/src/cloud-security/providers/aws/security-hub.adapter.spec.ts
+++ b/apps/api/src/cloud-security/providers/aws/security-hub.adapter.spec.ts
@@ -1,0 +1,225 @@
+import {
+  buildRemediationText,
+  deriveFindingKey,
+  formatRelatedRequirements,
+  mapSecurityHubFinding,
+  SECURITY_HUB_SERVICE_ID,
+  type SecurityHubRawFinding,
+} from './security-hub.adapter';
+
+describe('security-hub.adapter helpers', () => {
+  describe('deriveFindingKey', () => {
+    it('extracts the trailing control id from a foundational best-practices GeneratorId', () => {
+      expect(
+        deriveFindingKey('aws-foundational-security-best-practices/v/1.0.0/EC2.13'),
+      ).toBe('aws-securityhub-ec2.13');
+    });
+
+    it('extracts the trailing control id from a CIS GeneratorId', () => {
+      expect(
+        deriveFindingKey('cis-aws-foundations-benchmark/v/1.2.0/1.1'),
+      ).toBe('aws-securityhub-1.1');
+    });
+
+    it('extracts the trailing control id from a NIST GeneratorId', () => {
+      expect(deriveFindingKey('nist-800-53/r/5/AC-2')).toBe(
+        'aws-securityhub-ac-2',
+      );
+    });
+
+    it('sanitizes characters not safe for use in identifiers', () => {
+      expect(deriveFindingKey('weird:control id with spaces!')).toMatch(
+        /^aws-securityhub-/,
+      );
+    });
+
+    it('produces a stable key (no timestamps / randomness) so reconciliation can diff scans', () => {
+      const a = deriveFindingKey('aws-foundational-security-best-practices/v/1.0.0/EC2.13');
+      const b = deriveFindingKey('aws-foundational-security-best-practices/v/1.0.0/EC2.13');
+      expect(a).toBe(b);
+    });
+
+    it('returns a sentinel key rather than throwing when GeneratorId is missing', () => {
+      // We must always produce SOME key — the Fix pipeline gates on
+      // findingKey existence, and silently disabling Fix on findings
+      // without GeneratorId would be a worse UX than an "unknown" key.
+      expect(deriveFindingKey(undefined)).toBe('aws-securityhub-unknown');
+      expect(deriveFindingKey('')).toBe('aws-securityhub-unknown');
+      expect(deriveFindingKey('   ')).toBe('aws-securityhub-unknown');
+    });
+  });
+
+  describe('formatRelatedRequirements', () => {
+    it('returns "" for empty/undefined input', () => {
+      expect(formatRelatedRequirements(undefined)).toBe('');
+      expect(formatRelatedRequirements([])).toBe('');
+    });
+
+    it('formats a NIST 800-53 requirement in parser-compatible form', () => {
+      expect(formatRelatedRequirements(['NIST.800-53.r5 AC-2'])).toMatch(
+        /nist.*AC-2/i,
+      );
+    });
+
+    it('joins multiple requirements with "; " so the parser splits them correctly', () => {
+      const result = formatRelatedRequirements([
+        'NIST.800-53.r5 AC-2',
+        'CIS AWS Foundations Benchmark v1.2.0 1.1',
+      ]);
+      expect(result).toContain('; ');
+    });
+
+    it('keeps unfamiliar requirement strings verbatim rather than dropping them', () => {
+      // We never want to silently lose a compliance reference — if SecHub
+      // adds a new framework format we don't recognize, we still surface
+      // the raw string so the auditor sees something.
+      const weird = 'SomeFutureFramework/CustomFormat#42';
+      const result = formatRelatedRequirements([weird]);
+      expect(result.toLowerCase()).toContain('somefutureframework');
+    });
+  });
+
+  describe('buildRemediationText', () => {
+    it('returns AWS text + reference URL + compliance section when all three are present', () => {
+      const result = buildRemediationText({
+        Remediation: {
+          Recommendation: {
+            Text: 'Enable encryption on the bucket.',
+            Url: 'https://docs.aws.amazon.com/whatever',
+          },
+        },
+        Compliance: { RelatedRequirements: ['NIST.800-53.r5 AC-2'] },
+      });
+      expect(result).toContain('Enable encryption on the bucket.');
+      expect(result).toContain('More info: https://docs.aws.amazon.com/whatever');
+      expect(result).toContain('Compliance:');
+    });
+
+    it('omits the More info section when no URL is present', () => {
+      const result = buildRemediationText({
+        Remediation: { Recommendation: { Text: 'Do the thing.' } },
+      });
+      expect(result).toContain('Do the thing.');
+      expect(result).not.toContain('More info:');
+    });
+
+    it('omits the Compliance section when no related requirements exist', () => {
+      const result = buildRemediationText({
+        Remediation: { Recommendation: { Text: 'Do the thing.' } },
+        Compliance: { RelatedRequirements: [] },
+      });
+      expect(result).not.toContain('Compliance:');
+    });
+
+    it('uses "\\n\\n" as the section separator — must match the parser contract', () => {
+      // `remediation-parser.ts` splits on `\n\n`. If we use any other
+      // separator, the chips disappear from the UI.
+      const result = buildRemediationText({
+        Remediation: {
+          Recommendation: { Text: 'Step one.', Url: 'https://example.com' },
+        },
+        Compliance: { RelatedRequirements: ['NIST.800-53.r5 AC-2'] },
+      });
+      const sections = result.split('\n\n');
+      expect(sections.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('returns a non-empty fallback when SecHub provides no remediation data', () => {
+      const result = buildRemediationText({});
+      expect(result.length).toBeGreaterThan(0);
+      // The fallback string isn't load-bearing — just make sure we don't
+      // surface an empty string (RemediationSection would hide the whole
+      // section, which is misleading for a SecHub finding).
+    });
+  });
+
+  describe('mapSecurityHubFinding', () => {
+    const baseFinding: SecurityHubRawFinding = {
+      Id: 'arn:aws:securityhub:us-east-1:123:finding/abc',
+      Title: 'EC2 default security group should not allow inbound traffic',
+      Description: 'A default security group allows broad ingress.',
+      Severity: { Label: 'HIGH' },
+      Resources: [{ Type: 'AwsEc2SecurityGroup', Id: 'sg-12345' }],
+      AwsAccountId: '013388577167',
+      Region: 'us-east-1',
+      Compliance: {
+        Status: 'FAILED',
+        RelatedRequirements: ['NIST.800-53.r5 AC-2'],
+      },
+      GeneratorId:
+        'aws-foundational-security-best-practices/v/1.0.0/EC2.13',
+      Remediation: {
+        Recommendation: {
+          Text: 'Update the security group rules.',
+          Url: 'https://docs.aws.amazon.com/securityhub/EC2.13',
+        },
+      },
+      CreatedAt: '2026-05-18T10:00:00.000Z',
+      UpdatedAt: '2026-05-18T10:00:00.000Z',
+    };
+
+    it('stamps evidence.findingKey so the Fix pipeline picks it up', () => {
+      const mapped = mapSecurityHubFinding(baseFinding, 'us-east-1');
+      expect(mapped.evidence?.findingKey).toBe('aws-securityhub-ec2.13');
+    });
+
+    it('stamps evidence.serviceId so the UI can detect SecHub findings', () => {
+      const mapped = mapSecurityHubFinding(baseFinding, 'us-east-1');
+      expect(mapped.evidence?.serviceId).toBe(SECURITY_HUB_SERVICE_ID);
+    });
+
+    it('builds remediation in the GCP-compatible format so the parser handles chips', () => {
+      const mapped = mapSecurityHubFinding(baseFinding, 'us-east-1');
+      expect(mapped.remediation).toContain('Update the security group rules.');
+      expect(mapped.remediation).toContain('More info:');
+      expect(mapped.remediation).toContain('Compliance:');
+    });
+
+    it('uses the finding-supplied region when available, falling back to the scan region', () => {
+      const mapped = mapSecurityHubFinding(
+        { ...baseFinding, Region: undefined },
+        'eu-west-1',
+      );
+      expect(mapped.evidence?.region).toBe('eu-west-1');
+    });
+
+    it('marks the finding as not-passed for non-PASSED compliance statuses', () => {
+      const mapped = mapSecurityHubFinding(baseFinding, 'us-east-1');
+      expect(mapped.passed).toBe(false);
+    });
+
+    it('marks the finding as passed when SecHub reports PASSED', () => {
+      const passing: SecurityHubRawFinding = {
+        ...baseFinding,
+        Compliance: { ...baseFinding.Compliance, Status: 'PASSED' },
+      };
+      const mapped = mapSecurityHubFinding(passing, 'us-east-1');
+      expect(mapped.passed).toBe(true);
+    });
+
+    it('maps SecHub severity labels to our internal severity levels', () => {
+      const expectations: Array<[string, string]> = [
+        ['INFORMATIONAL', 'info'],
+        ['LOW', 'low'],
+        ['MEDIUM', 'medium'],
+        ['HIGH', 'high'],
+        ['CRITICAL', 'critical'],
+      ];
+      for (const [sechubLabel, internalLevel] of expectations) {
+        const mapped = mapSecurityHubFinding(
+          { ...baseFinding, Severity: { Label: sechubLabel } },
+          'us-east-1',
+        );
+        expect(mapped.severity).toBe(internalLevel);
+      }
+    });
+
+    it('defaults to medium severity when SecHub omits or returns an unknown label', () => {
+      const mapped = mapSecurityHubFinding(
+        { ...baseFinding, Severity: undefined },
+        'us-east-1',
+      );
+      expect(mapped.severity).toBe('medium');
+    });
+  });
+});

--- a/apps/api/src/cloud-security/providers/aws/security-hub.adapter.spec.ts
+++ b/apps/api/src/cloud-security/providers/aws/security-hub.adapter.spec.ts
@@ -9,22 +9,55 @@ import {
 
 describe('security-hub.adapter helpers', () => {
   describe('deriveFindingKey', () => {
-    it('extracts the trailing control id from a foundational best-practices GeneratorId', () => {
+    it('combines standard + control for a foundational best-practices GeneratorId', () => {
       expect(
         deriveFindingKey('aws-foundational-security-best-practices/v/1.0.0/EC2.13'),
-      ).toBe('aws-securityhub-ec2.13');
+      ).toBe('aws-securityhub-aws-foundational-security-best-practices-ec2.13');
     });
 
-    it('extracts the trailing control id from a CIS GeneratorId', () => {
+    it('combines standard + control for a CIS GeneratorId', () => {
       expect(
         deriveFindingKey('cis-aws-foundations-benchmark/v/1.2.0/1.1'),
-      ).toBe('aws-securityhub-1.1');
+      ).toBe('aws-securityhub-cis-aws-foundations-benchmark-1.1');
     });
 
-    it('extracts the trailing control id from a NIST GeneratorId', () => {
+    it('combines standard + control for a NIST GeneratorId', () => {
       expect(deriveFindingKey('nist-800-53/r/5/AC-2')).toBe(
-        'aws-securityhub-ac-2',
+        'aws-securityhub-nist-800-53-ac-2',
       );
+    });
+
+    it('does NOT collide across standards that share a control id (P1 regression guard)', () => {
+      // The original implementation used only the trailing segment, so
+      // CIS 1.1 and PCI 1.1 produced the same findingKey and would have
+      // merged into one row in the UI — silently corrupting exception
+      // scoping and reconciliation. Cubic caught this on initial review;
+      // this test exists to prevent regression.
+      const cis11 = deriveFindingKey(
+        'cis-aws-foundations-benchmark/v/1.2.0/1.1',
+      );
+      const pci11 = deriveFindingKey('pci-dss/v/3.2.1/1.1');
+      expect(cis11).not.toBe(pci11);
+      expect(cis11).toContain('cis');
+      expect(pci11).toContain('pci');
+    });
+
+    it('produces the same key for two findings from the same standard + control', () => {
+      // Findings sharing both standard AND control SHOULD merge — that's
+      // the whole point of findingKey: group instances of the same check
+      // across resources.
+      const a = deriveFindingKey('aws-foundational-security-best-practices/v/1.0.0/EC2.13');
+      const b = deriveFindingKey('aws-foundational-security-best-practices/v/1.0.0/EC2.13');
+      expect(a).toBe(b);
+    });
+
+    it('ignores version/revision changes within the same standard + control', () => {
+      // SecHub bumping the standard version shouldn't fragment a finding's
+      // identity. CIS 1.2.0 → 4.0.0 with the same control 1.1 stays one key,
+      // so reconciliation can still diff before/after the version bump.
+      const v12 = deriveFindingKey('cis-aws-foundations-benchmark/v/1.2.0/1.1');
+      const v40 = deriveFindingKey('cis-aws-foundations-benchmark/v/4.0.0/1.1');
+      expect(v12).toBe(v40);
     });
 
     it('sanitizes characters not safe for use in identifiers', () => {
@@ -33,10 +66,10 @@ describe('security-hub.adapter helpers', () => {
       );
     });
 
-    it('produces a stable key (no timestamps / randomness) so reconciliation can diff scans', () => {
-      const a = deriveFindingKey('aws-foundational-security-best-practices/v/1.0.0/EC2.13');
-      const b = deriveFindingKey('aws-foundational-security-best-practices/v/1.0.0/EC2.13');
-      expect(a).toBe(b);
+    it('handles single-segment GeneratorIds (no path structure)', () => {
+      expect(deriveFindingKey('SimpleGenerator')).toBe(
+        'aws-securityhub-simplegenerator',
+      );
     });
 
     it('returns a sentinel key rather than throwing when GeneratorId is missing', () => {
@@ -160,7 +193,9 @@ describe('security-hub.adapter helpers', () => {
 
     it('stamps evidence.findingKey so the Fix pipeline picks it up', () => {
       const mapped = mapSecurityHubFinding(baseFinding, 'us-east-1');
-      expect(mapped.evidence?.findingKey).toBe('aws-securityhub-ec2.13');
+      expect(mapped.evidence?.findingKey).toBe(
+        'aws-securityhub-aws-foundational-security-best-practices-ec2.13',
+      );
     });
 
     it('stamps evidence.serviceId so the UI can detect SecHub findings', () => {

--- a/apps/api/src/cloud-security/providers/aws/security-hub.adapter.ts
+++ b/apps/api/src/cloud-security/providers/aws/security-hub.adapter.ts
@@ -6,8 +6,33 @@ import {
 import type { SecurityFinding } from '../../cloud-security.service';
 import type { AwsCredentials, AwsServiceAdapter } from './aws-service-adapter';
 
+/**
+ * Maximum number of findings we pull from Security Hub per scan, across
+ * all pages. Bounded to keep scan time + payload size predictable.
+ */
+const MAX_FINDINGS_PER_SCAN = 500;
+
+/** Page size for the SecHub GetFindings API. */
+const FINDINGS_PAGE_SIZE = 100;
+
+/** Service ID that this adapter stamps onto each finding's evidence so
+ * downstream code (UI banner, Fix dialog) can recognize SecHub-sourced
+ * findings without inspecting the findingKey format. */
+export const SECURITY_HUB_SERVICE_ID = 'security-hub';
+
+/**
+ * Reads findings from AWS Security Hub and maps them to our internal
+ * SecurityFinding shape so the rest of the system (Fix pipeline,
+ * History tab, compliance chips, UI) treats them like any other
+ * adapter's finding.
+ *
+ * This adapter is only instantiated when a connection's `awsScanMode`
+ * is `'security_hub'` — see `AWSSecurityService.scanViaSecurityHub`.
+ * It is NOT registered in the main adapters array; mode mutual
+ * exclusion is enforced by code structure, not runtime config.
+ */
 export class SecurityHubAdapter implements AwsServiceAdapter {
-  readonly serviceId = 'security-hub';
+  readonly serviceId = SECURITY_HUB_SERVICE_ID;
   readonly isGlobal = false;
 
   async scan(params: {
@@ -15,14 +40,16 @@ export class SecurityHubAdapter implements AwsServiceAdapter {
     region: string;
   }): Promise<SecurityFinding[]> {
     const { credentials, region } = params;
-
-    const securityHub = new SecurityHubClient({ region, credentials });
+    const client = new SecurityHubClient({ region, credentials });
 
     try {
-      return await this.fetchFindings(securityHub, region);
+      return await this.fetchFindings(client, region);
     } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
-      if (msg.includes('not subscribed') || msg.includes('AccessDenied')) {
+      const message = error instanceof Error ? error.message : String(error);
+      // Returning [] is the agreed graceful path when SecHub isn't subscribed
+      // or the role can't see findings — the cloud-security service surfaces
+      // a clearer onboarding error elsewhere when this happens consistently.
+      if (message.includes('not subscribed') || message.includes('AccessDenied')) {
         return [];
       }
       throw error;
@@ -35,7 +62,7 @@ export class SecurityHubAdapter implements AwsServiceAdapter {
   ): Promise<SecurityFinding[]> {
     const findings: SecurityFinding[] = [];
 
-    const params: GetFindingsCommandInput = {
+    const baseParams: GetFindingsCommandInput = {
       Filters: {
         WorkflowStatus: [
           { Value: 'NEW', Comparison: 'EQUALS' },
@@ -43,84 +70,229 @@ export class SecurityHubAdapter implements AwsServiceAdapter {
         ],
         RecordState: [{ Value: 'ACTIVE', Comparison: 'EQUALS' }],
       },
-      MaxResults: 100,
+      MaxResults: FINDINGS_PAGE_SIZE,
     };
 
-    let response = await client.send(new GetFindingsCommand(params));
-
-    if (response.Findings) {
-      for (const f of response.Findings) {
-        findings.push(this.mapFinding(f, region));
-      }
-    }
-
-    let nextToken = response.NextToken;
-    while (nextToken && findings.length < 500) {
-      response = await client.send(
-        new GetFindingsCommand({ ...params, NextToken: nextToken }),
+    let nextToken: string | undefined;
+    do {
+      const response = await client.send(
+        new GetFindingsCommand({ ...baseParams, NextToken: nextToken }),
       );
-
-      if (response.Findings) {
-        for (const f of response.Findings) {
-          if (findings.length >= 500) break;
-          findings.push(this.mapFinding(f, region));
-        }
+      for (const finding of response.Findings ?? []) {
+        if (findings.length >= MAX_FINDINGS_PER_SCAN) break;
+        findings.push(mapSecurityHubFinding(finding, region));
       }
-
       nextToken = response.NextToken;
-    }
+    } while (nextToken && findings.length < MAX_FINDINGS_PER_SCAN);
 
     return findings;
   }
+}
 
-  private mapFinding(
-    finding: {
-      Id?: string;
-      Title?: string;
-      Description?: string;
-      Remediation?: { Recommendation?: { Text?: string } };
-      Severity?: { Label?: string };
-      Resources?: Array<{ Type?: string; Id?: string }>;
-      AwsAccountId?: string;
-      Region?: string;
-      Compliance?: { Status?: string };
-      GeneratorId?: string;
-      CreatedAt?: string;
-      UpdatedAt?: string;
+/**
+ * Minimal shape we read from the Security Hub API. We don't type the
+ * full AWS response because we only consume a handful of fields and
+ * they're all optional — the AWS SDK types this very loosely anyway.
+ */
+export interface SecurityHubRawFinding {
+  Id?: string;
+  Title?: string;
+  Description?: string;
+  Remediation?: {
+    Recommendation?: { Text?: string; Url?: string };
+  };
+  Severity?: { Label?: string };
+  Resources?: Array<{ Type?: string; Id?: string }>;
+  AwsAccountId?: string;
+  Region?: string;
+  Compliance?: { Status?: string; RelatedRequirements?: string[] };
+  GeneratorId?: string;
+  CreatedAt?: string;
+  UpdatedAt?: string;
+}
+
+const SEVERITY_BY_SECHUB_LABEL: Record<string, SecurityFinding['severity']> = {
+  INFORMATIONAL: 'info',
+  LOW: 'low',
+  MEDIUM: 'medium',
+  HIGH: 'high',
+  CRITICAL: 'critical',
+};
+
+/**
+ * Maps a raw SecHub finding into our internal SecurityFinding shape.
+ * Exported so the unit tests can exercise it directly without a live
+ * AWS client.
+ *
+ * Key design choices:
+ *   - `evidence.findingKey` makes the finding visible to the Fix
+ *     pipeline (the frontend `canFixFinding` and the API ai-remediation
+ *     flow both gate on this). Derived from the SecHub control ID so
+ *     it's stable across scans of the same control.
+ *   - `evidence.serviceId` lets the UI recognize SecHub-sourced
+ *     findings without parsing the findingKey format.
+ *   - `remediation` is built in the same `<text>\n\nMore info: <url>\n\n
+ *     Compliance: <fwks>` format that GCP uses, so the existing
+ *     `RemediationSection` + `remediation-parser` render reference link
+ *     and compliance chips with zero frontend changes.
+ */
+export function mapSecurityHubFinding(
+  finding: SecurityHubRawFinding,
+  scanRegion: string,
+): SecurityFinding {
+  const region = finding.Region || scanRegion;
+  const passed = finding.Compliance?.Status === 'PASSED';
+  const title = `${finding.Title ?? 'Untitled Finding'} (${region})`;
+
+  return {
+    id: finding.Id ?? '',
+    title,
+    description: finding.Description ?? 'No description available',
+    severity: SEVERITY_BY_SECHUB_LABEL[finding.Severity?.Label ?? ''] ?? 'medium',
+    resourceType: finding.Resources?.[0]?.Type ?? 'unknown',
+    resourceId: finding.Resources?.[0]?.Id ?? 'unknown',
+    remediation: buildRemediationText(finding),
+    evidence: {
+      // Stamping serviceId here lets the UI banner + Fix dialog detect
+      // SecHub findings without parsing findingKey strings.
+      serviceId: SECURITY_HUB_SERVICE_ID,
+      // findingKey is the contract the Fix pipeline reads (see
+      // CloudTestsSection.canFixFinding and cloud-security-query.service
+      // findingKey extraction). Stable across scans of the same control.
+      findingKey: deriveFindingKey(finding.GeneratorId),
+      awsAccountId: finding.AwsAccountId,
+      region,
+      complianceStatus: finding.Compliance?.Status,
+      relatedRequirements: finding.Compliance?.RelatedRequirements ?? [],
+      generatorId: finding.GeneratorId,
+      updatedAt: finding.UpdatedAt,
     },
-    scanRegion: string,
-  ): SecurityFinding {
-    const severityMap: Record<string, SecurityFinding['severity']> = {
-      INFORMATIONAL: 'info',
-      LOW: 'low',
-      MEDIUM: 'medium',
-      HIGH: 'high',
-      CRITICAL: 'critical',
-    };
+    createdAt: finding.CreatedAt ?? new Date().toISOString(),
+    passed,
+  };
+}
 
-    const complianceStatus = finding.Compliance?.Status;
-    const passed = complianceStatus === 'PASSED';
-    const findingRegion = finding.Region || scanRegion;
-    const baseTitle = finding.Title || 'Untitled Finding';
+/**
+ * Produces a stable findingKey from a SecHub `GeneratorId` like
+ * `aws-foundational-security-best-practices/v/1.0.0/EC2.13` or
+ * `cis-aws-foundations-benchmark/v/1.2.0/1.1`.
+ *
+ * Strategy: take the trailing control identifier (last `/`-delimited
+ * segment) since that's what makes the finding semantically unique.
+ * Falls back to a sanitized form of the full GeneratorId, then to a
+ * generic key, so we ALWAYS produce a key — the Fix button gates on
+ * its existence, so missing findingKey would silently disable Fix.
+ */
+export function deriveFindingKey(generatorId: string | undefined): string {
+  if (!generatorId) return 'aws-securityhub-unknown';
+  const trimmed = generatorId.trim();
+  if (!trimmed) return 'aws-securityhub-unknown';
 
-    return {
-      id: finding.Id || '',
-      title: `${baseTitle} (${findingRegion})`,
-      description: finding.Description || 'No description available',
-      severity: severityMap[finding.Severity?.Label || 'INFO'] || 'medium',
-      resourceType: finding.Resources?.[0]?.Type || 'unknown',
-      resourceId: finding.Resources?.[0]?.Id || 'unknown',
-      remediation:
-        finding.Remediation?.Recommendation?.Text || 'No remediation available',
-      evidence: {
-        awsAccountId: finding.AwsAccountId,
-        region: findingRegion,
-        complianceStatus,
-        generatorId: finding.GeneratorId,
-        updatedAt: finding.UpdatedAt,
-      },
-      createdAt: finding.CreatedAt || new Date().toISOString(),
-      passed,
-    };
+  const lastSegment = trimmed.split('/').pop() ?? trimmed;
+  const sanitized = sanitizeKeySegment(lastSegment);
+  if (sanitized) return `aws-securityhub-${sanitized}`;
+
+  return `aws-securityhub-${sanitizeKeySegment(trimmed) || 'unknown'}`;
+}
+
+function sanitizeKeySegment(value: string): string {
+  // Keep alphanumerics, dots, hyphens — drop anything that would make the
+  // key awkward in URLs/logs. Collapse runs of separators.
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9.-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+/**
+ * Builds the remediation string for a SecHub finding. Output format
+ * matches `gcp-security.service.ts buildRemediation` exactly so the
+ * existing parser (`remediation-parser.ts`) extracts the reference URL
+ * and compliance chips with zero frontend changes:
+ *
+ *   <AWS-provided remediation text>
+ *
+ *   More info: <docs URL>
+ *
+ *   Compliance: nist 800-53 (AC-2); cis 1.2.0 (1.1)
+ */
+export function buildRemediationText(finding: SecurityHubRawFinding): string {
+  const parts: string[] = [];
+
+  const text = finding.Remediation?.Recommendation?.Text?.trim();
+  if (text) parts.push(text);
+
+  const url = finding.Remediation?.Recommendation?.Url?.trim();
+  if (url) parts.push(`More info: ${url}`);
+
+  const compliance = formatRelatedRequirements(
+    finding.Compliance?.RelatedRequirements,
+  );
+  if (compliance) parts.push(`Compliance: ${compliance}`);
+
+  return (
+    parts.join('\n\n') ||
+    'No remediation guidance was provided for this Security Hub finding.'
+  );
+}
+
+/**
+ * Converts SecHub's `RelatedRequirements` strings (e.g.
+ *   ["NIST.800-53.r5 AC-2", "CIS AWS Foundations Benchmark v1.2.0 1.1"])
+ * into the parser-compatible format used by GCP:
+ *   "nist 800-53 (AC-2); cis 1.2.0 (1.1)"
+ *
+ * Returns '' when there are no related requirements (caller skips the
+ * Compliance: prefix in that case). Each requirement parses into
+ * "<standard> <version> (<control>)" — `remediation-parser.ts`
+ * `parseComplianceLine` handles malformed entries gracefully if anything
+ * here doesn't match the expected pattern.
+ */
+export function formatRelatedRequirements(
+  requirements: string[] | undefined,
+): string {
+  if (!requirements || requirements.length === 0) return '';
+  return requirements
+    .map(formatSingleRequirement)
+    .filter((s) => s.length > 0)
+    .join('; ');
+}
+
+function formatSingleRequirement(requirement: string): string {
+  const cleaned = requirement.trim();
+  if (!cleaned) return '';
+
+  // SecHub uses several formats; the most common are:
+  //   "NIST.800-53.r5 AC-2"
+  //   "CIS AWS Foundations Benchmark v1.2.0 1.1"
+  //   "PCI DSS v3.2.1 8.2.3"
+  //   "AWS Foundational Security Best Practices v1.0.0/EC2.2"
+  // We try a few patterns then fall back to a sensible default so we
+  // surface SOMETHING rather than drop a real compliance mapping.
+
+  const standardMatch = cleaned.match(
+    /^([A-Z][A-Z0-9 .]+?)(?:\s+v?([\d.]+(?:[a-z]\d*)?))?\s+([A-Za-z0-9.\-]+)$/,
+  );
+  if (standardMatch) {
+    const [, rawStandard, version, control] = standardMatch;
+    const standard = normalizeStandardName(rawStandard);
+    const ver = version ?? 'unspecified';
+    return `${standard} ${ver} (${control})`;
   }
+
+  // Fallback — keep the raw string so we don't silently drop data.
+  return cleaned;
+}
+
+function normalizeStandardName(value: string): string {
+  // Compact common multi-word framework names so chips render cleanly.
+  return value
+    .toLowerCase()
+    .replace(/aws foundations benchmark/g, '')
+    .replace(/dss/g, 'dss')
+    .replace(/foundational security best practices/g, 'fsbp')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\.$/, '');
 }

--- a/apps/api/src/cloud-security/providers/aws/security-hub.adapter.ts
+++ b/apps/api/src/cloud-security/providers/aws/security-hub.adapter.ts
@@ -177,22 +177,46 @@ export function mapSecurityHubFinding(
  * `aws-foundational-security-best-practices/v/1.0.0/EC2.13` or
  * `cis-aws-foundations-benchmark/v/1.2.0/1.1`.
  *
- * Strategy: take the trailing control identifier (last `/`-delimited
- * segment) since that's what makes the finding semantically unique.
- * Falls back to a sanitized form of the full GeneratorId, then to a
- * generic key, so we ALWAYS produce a key — the Fix button gates on
- * its existence, so missing findingKey would silently disable Fix.
+ * Strategy: combine the standard prefix (first segment) with the control
+ * identifier (last segment) so distinct findings from different standards
+ * never collide under the same key. The middle segments (version /
+ * revision) are intentionally dropped — they shouldn't change a finding's
+ * identity within a standard.
+ *
+ *   aws-foundational-security-best-practices/v/1.0.0/EC2.13
+ *     → aws-securityhub-aws-foundational-security-best-practices-ec2.13
+ *
+ *   cis-aws-foundations-benchmark/v/1.2.0/1.1
+ *     → aws-securityhub-cis-aws-foundations-benchmark-1.1
+ *
+ *   pci-dss/v/3.2.1/1.1
+ *     → aws-securityhub-pci-dss-1.1   (no collision with the CIS 1.1 above)
+ *
+ * Falls back gracefully when the GeneratorId has no path structure or is
+ * missing entirely — we ALWAYS produce a key because the Fix button gates
+ * on its existence, and missing findingKey would silently disable Fix.
  */
 export function deriveFindingKey(generatorId: string | undefined): string {
   if (!generatorId) return 'aws-securityhub-unknown';
   const trimmed = generatorId.trim();
   if (!trimmed) return 'aws-securityhub-unknown';
 
-  const lastSegment = trimmed.split('/').pop() ?? trimmed;
-  const sanitized = sanitizeKeySegment(lastSegment);
-  if (sanitized) return `aws-securityhub-${sanitized}`;
+  const segments = trimmed.split('/').filter((s) => s.length > 0);
+  if (segments.length === 0) return 'aws-securityhub-unknown';
 
-  return `aws-securityhub-${sanitizeKeySegment(trimmed) || 'unknown'}`;
+  if (segments.length === 1) {
+    // No path structure — sanitize the whole thing.
+    const sanitized = sanitizeKeySegment(segments[0]);
+    return `aws-securityhub-${sanitized || 'unknown'}`;
+  }
+
+  // Combine first segment (standard identifier — namespaces the key) with
+  // the last segment (control identifier — uniquely identifies WHICH check
+  // within that standard). This prevents collisions like CIS 1.1 ↔ PCI 1.1.
+  const standard = sanitizeKeySegment(segments[0]);
+  const control = sanitizeKeySegment(segments[segments.length - 1]);
+  const combined = [standard, control].filter(Boolean).join('-');
+  return `aws-securityhub-${combined || 'unknown'}`;
 }
 
 function sanitizeKeySegment(value: string): string {

--- a/apps/api/src/cloud-security/providers/aws/security-hub.adapter.ts
+++ b/apps/api/src/cloud-security/providers/aws/security-hub.adapter.ts
@@ -287,10 +287,11 @@ function formatSingleRequirement(requirement: string): string {
 
 function normalizeStandardName(value: string): string {
   // Compact common multi-word framework names so chips render cleanly.
+  // ("PCI DSS" → "pci dss" via lowercase; the full "DSS" token stays
+  // as-is intentionally — the parser handles whitespace-separated parts.)
   return value
     .toLowerCase()
     .replace(/aws foundations benchmark/g, '')
-    .replace(/dss/g, 'dss')
     .replace(/foundational security best practices/g, 'fsbp')
     .replace(/\s+/g, ' ')
     .trim()

--- a/apps/api/src/cloud-security/reconciliation.service.spec.ts
+++ b/apps/api/src/cloud-security/reconciliation.service.spec.ts
@@ -333,9 +333,11 @@ describe('CloudReconciliationService.reconcile', () => {
       );
     });
 
-    it('passes null scanMode for legacy / non-AWS runs so they reconcile against each other', async () => {
-      // Pre-feature runs and GCP/Azure runs have scanMode = null. They
-      // must still reconcile against each other (null === null).
+    it('passes null scanMode for GCP / Azure runs so they reconcile against each other', async () => {
+      // GCP / Azure runs have scanMode = null (no scan-mode concept). They
+      // must reconcile against each other (null === null). AWS rows
+      // ALWAYS have an explicit scanMode — pre-feature rows were
+      // backfilled to 'comp_scanners' by the schema migration.
       dbMock.integrationCheckRun.findUnique.mockResolvedValueOnce({
         id: 'icr_current',
         connectionId: 'icn_gcp',
@@ -357,6 +359,50 @@ describe('CloudReconciliationService.reconcile', () => {
           where: expect.objectContaining({ scanMode: null }),
         }),
       );
+    });
+
+    it('reconciles comp_scanners runs against backfilled comp_scanners history (post-deploy continuity)', async () => {
+      // After the deploy, every existing AWS customer's first scan should
+      // continue diffing against their prior history seamlessly. The
+      // migration backfills pre-feature AWS rows to 'comp_scanners', so
+      // the new scan (also 'comp_scanners') finds matching prior runs.
+      // Locks in that we DO NOT skip History events on the first post-
+      // deploy scan for existing customers.
+      setupRuns({
+        currentResults: [
+          makeResult({ findingKey: 'iam-no-mfa-john', resourceId: 'john', passed: true }),
+        ],
+        priorResults: [
+          makeResult({ findingKey: 'iam-no-mfa-john', resourceId: 'john', passed: false }),
+        ],
+      });
+      // Override findUnique to set scanMode explicitly on the current run.
+      dbMock.integrationCheckRun.findUnique.mockReset();
+      dbMock.integrationCheckRun.findUnique.mockResolvedValueOnce({
+        id: 'icr_current',
+        connectionId: 'icn_aws',
+        status: 'success',
+        startedAt: CURRENT_RUN_TIME,
+        completedAt: CURRENT_RUN_TIME,
+        scannedServices: [],
+        scanMode: 'comp_scanners',
+        connection: { organizationId: 'org_1' },
+        results: [
+          makeResult({ findingKey: 'iam-no-mfa-john', resourceId: 'john', passed: true }),
+        ],
+      });
+
+      const service = new CloudReconciliationService(makeExceptionsStub());
+      const result = await service.reconcile({ currentRunId: 'icr_current' });
+
+      expect(dbMock.integrationCheckRun.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ scanMode: 'comp_scanners' }),
+        }),
+      );
+      // Resolution should still be detected — backfilled prior run had
+      // scanMode='comp_scanners', matches the new run's scanMode.
+      expect(result.resolutions).toBe(1);
     });
 
     it('returns 0/0 when no prior run of the same mode exists (post-switch baseline)', async () => {

--- a/apps/api/src/cloud-security/reconciliation.service.spec.ts
+++ b/apps/api/src/cloud-security/reconciliation.service.spec.ts
@@ -301,4 +301,89 @@ describe('CloudReconciliationService.reconcile', () => {
       }),
     );
   });
+
+  describe('scanMode safety — only diffs same-mode runs', () => {
+    it('passes scanMode from current run into the prior-run lookup', async () => {
+      // When SecHub mode is active, reconciliation must look up the prior
+      // SecHub run — not the prior comp_scanners run, which would mark
+      // every SecHub finding as "new" and every comp_scanners finding as
+      // "resolved" (both wrong).
+      dbMock.integrationCheckRun.findUnique.mockResolvedValueOnce({
+        id: 'icr_current',
+        connectionId: 'icn_aws',
+        status: 'success',
+        startedAt: CURRENT_RUN_TIME,
+        completedAt: CURRENT_RUN_TIME,
+        scannedServices: [],
+        scanMode: 'security_hub',
+        connection: { organizationId: 'org_1' },
+        results: [],
+      });
+      dbMock.integrationCheckRun.findFirst.mockResolvedValueOnce(null);
+
+      const service = new CloudReconciliationService(makeExceptionsStub());
+      await service.reconcile({ currentRunId: 'icr_current' });
+
+      // findFirst is called once: the prior-run lookup. Its where clause
+      // MUST scope by the same scanMode as the current run.
+      expect(dbMock.integrationCheckRun.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ scanMode: 'security_hub' }),
+        }),
+      );
+    });
+
+    it('passes null scanMode for legacy / non-AWS runs so they reconcile against each other', async () => {
+      // Pre-feature runs and GCP/Azure runs have scanMode = null. They
+      // must still reconcile against each other (null === null).
+      dbMock.integrationCheckRun.findUnique.mockResolvedValueOnce({
+        id: 'icr_current',
+        connectionId: 'icn_gcp',
+        status: 'success',
+        startedAt: CURRENT_RUN_TIME,
+        completedAt: CURRENT_RUN_TIME,
+        scannedServices: [],
+        scanMode: null,
+        connection: { organizationId: 'org_1' },
+        results: [],
+      });
+      dbMock.integrationCheckRun.findFirst.mockResolvedValueOnce(null);
+
+      const service = new CloudReconciliationService(makeExceptionsStub());
+      await service.reconcile({ currentRunId: 'icr_current' });
+
+      expect(dbMock.integrationCheckRun.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ scanMode: null }),
+        }),
+      );
+    });
+
+    it('returns 0/0 when no prior run of the same mode exists (post-switch baseline)', async () => {
+      // After a customer switches modes, the next scan finds no matching
+      // prior run and returns a clean baseline. This is the same code
+      // path as a first-ever scan — confirmed here to lock in the
+      // contract that mode switches are safe.
+      dbMock.integrationCheckRun.findUnique.mockResolvedValueOnce({
+        id: 'icr_current',
+        connectionId: 'icn_aws',
+        status: 'success',
+        startedAt: CURRENT_RUN_TIME,
+        completedAt: CURRENT_RUN_TIME,
+        scannedServices: [],
+        scanMode: 'security_hub',
+        connection: { organizationId: 'org_1' },
+        results: [],
+      });
+      // Simulate no prior SecHub run found (only comp_scanners runs exist).
+      dbMock.integrationCheckRun.findFirst.mockResolvedValueOnce(null);
+
+      const service = new CloudReconciliationService(makeExceptionsStub());
+      const result = await service.reconcile({ currentRunId: 'icr_current' });
+
+      expect(result).toEqual({ resolutions: 0, regressions: 0, skipped: false });
+      expect(dbMock.findingResolution.create).not.toHaveBeenCalled();
+      expect(dbMock.findingRegression.create).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/api/src/cloud-security/reconciliation.service.ts
+++ b/apps/api/src/cloud-security/reconciliation.service.ts
@@ -47,6 +47,11 @@ export class CloudReconciliationService {
         startedAt: true,
         status: true,
         scannedServices: true,
+        // Used below to scope the prior-run lookup. AWS connections can
+        // switch between 'comp_scanners' and 'security_hub' modes; the two
+        // engines produce findingKeys in completely different namespaces,
+        // so cross-mode diffs would produce garbage resolutions.
+        scanMode: true,
         connection: { select: { organizationId: true } },
         results: {
           select: {
@@ -90,6 +95,16 @@ export class CloudReconciliationService {
         id: { not: currentRun.id },
         status: 'success',
         completedAt: { lt: currentRun.completedAt ?? currentRun.startedAt ?? new Date() },
+        // Only compare runs that used the same scan engine. The two AWS
+        // modes ('comp_scanners' vs 'security_hub') emit findingKeys in
+        // different namespaces — cross-mode diffs would mark every
+        // prior-mode finding as "resolved", which would be a lie. After a
+        // mode switch, the next scan finds no matching prior run and is
+        // treated as a fresh baseline (same as a first-ever scan).
+        //
+        // Null scanMode matches null scanMode — pre-feature historical
+        // runs (and all GCP/Azure runs) reconcile against each other.
+        scanMode: currentRun.scanMode,
       },
       orderBy: { completedAt: 'desc' },
       select: {

--- a/apps/api/src/integration-platform/controllers/connections.controller.ts
+++ b/apps/api/src/integration-platform/controllers/connections.controller.ts
@@ -463,6 +463,17 @@ export class ConnectionsController {
       if (Array.isArray(credentials.regions)) {
         metadata.regions = credentials.regions;
       }
+      // AWS only — which scan engine the customer chose at onboarding
+      // (Comp AI scanners vs Security Hub). Read on every scan by
+      // cloud-security.service.ts. Customers can change it later from
+      // CloudSettingsModal via aws-scan-mode.service.updateMode.
+      if (
+        typeof credentials.awsScanMode === 'string' &&
+        (credentials.awsScanMode === 'comp_scanners' ||
+          credentials.awsScanMode === 'security_hub')
+      ) {
+        metadata.awsScanMode = credentials.awsScanMode;
+      }
       // Store roleArn and externalId in metadata for pre-filling the configure form
       // These are not secrets - roleArn is visible in AWS console, externalId is typically the org ID
       if (typeof credentials.roleArn === 'string') {

--- a/apps/app/src/app/(app)/[orgId]/cloud-tests/components/CloudSettingsModal.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/cloud-tests/components/CloudSettingsModal.test.tsx
@@ -22,10 +22,17 @@ vi.mock('@/hooks/use-api', () => ({
   }),
 }));
 
-// Mock useIntegrationMutations
+// Mock useIntegrationMutations + useIntegrationConnection (the latter is
+// used by the AWS scan-mode settings section).
 vi.mock('@/hooks/use-integration-platform', () => ({
   useIntegrationMutations: () => ({
     deleteConnection: vi.fn(),
+  }),
+  useIntegrationConnection: () => ({
+    connection: { id: 'conn_test', metadata: {} },
+    isLoading: false,
+    error: undefined,
+    refresh: vi.fn(),
   }),
 }));
 

--- a/apps/app/src/app/(app)/[orgId]/cloud-tests/components/CloudSettingsModal.tsx
+++ b/apps/app/src/app/(app)/[orgId]/cloud-tests/components/CloudSettingsModal.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import { useApi } from '@/hooks/use-api';
-import { useIntegrationMutations } from '@/hooks/use-integration-platform';
+import {
+  useIntegrationConnection,
+  useIntegrationMutations,
+} from '@/hooks/use-integration-platform';
 import { usePermissions } from '@/hooks/use-permissions';
 import {
   Dialog,
@@ -20,6 +23,8 @@ import {
 import { TrashCan } from '@trycompai/design-system/icons';
 import { useState } from 'react';
 import { toast } from 'sonner';
+import { ScanModeSwitchDialog } from './ScanModeSwitchDialog';
+import type { AwsScanModeChoice } from '../../integrations/[slug]/components/AwsScanModeStep';
 
 interface CloudProvider {
   id: string;
@@ -177,6 +182,14 @@ function ConnectionTab({
             : 'To update credentials, disconnect and reconnect with your Microsoft account.'}
       </p>
 
+      {/* AWS-only — scan engine switcher. Lets the customer change between
+          Comp AI scanners and Security Hub on an existing connection.
+          Surfaces the current mode + a "Change" button that opens
+          ScanModeSwitchDialog with the right confirmation copy. */}
+      {provider.id === 'aws' && !provider.isLegacy && (
+        <AwsScanModeSection connectionId={provider.connectionId} canEdit={canDelete} />
+      )}
+
       {canDelete && (
         <Button
           variant="destructive"
@@ -189,5 +202,76 @@ function ConnectionTab({
         </Button>
       )}
     </div>
+  );
+}
+
+// ─── AWS Scan Mode Section ──────────────────────────────────────────────
+
+const SCAN_MODE_LABEL: Record<AwsScanModeChoice, string> = {
+  comp_scanners: 'Comp AI Scanners',
+  security_hub: 'AWS Security Hub',
+};
+
+/**
+ * Renders the current scan engine for an AWS connection and a "Change"
+ * button that opens the switch dialog. Reads the connection's
+ * `variables.awsScanMode` to determine the current mode, falling back
+ * to 'comp_scanners' when the field is missing (pre-feature connections).
+ */
+function AwsScanModeSection({
+  connectionId,
+  canEdit,
+}: {
+  connectionId: string;
+  canEdit: boolean;
+}) {
+  const { connection, isLoading, refresh } = useIntegrationConnection(connectionId);
+  const [switchDialogOpen, setSwitchDialogOpen] = useState(false);
+
+  if (isLoading || !connection) {
+    return null;
+  }
+
+  // awsScanMode lives in metadata (non-secret, frontend-readable),
+  // mirroring how `awsType`, `roleArn`, `regions` are surfaced. Missing
+  // field = today's default = comp_scanners.
+  const metadata = (connection.metadata ?? {}) as Record<string, unknown>;
+  const currentMode: AwsScanModeChoice =
+    metadata.awsScanMode === 'security_hub' ? 'security_hub' : 'comp_scanners';
+  const targetMode: AwsScanModeChoice =
+    currentMode === 'comp_scanners' ? 'security_hub' : 'comp_scanners';
+
+  return (
+    <>
+      <div className="rounded-lg border p-4 space-y-3">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium">Scan engine</p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {SCAN_MODE_LABEL[currentMode]}
+            </p>
+          </div>
+          {canEdit && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setSwitchDialogOpen(true)}
+            >
+              Switch to {SCAN_MODE_LABEL[targetMode]}
+            </Button>
+          )}
+        </div>
+      </div>
+      <ScanModeSwitchDialog
+        open={switchDialogOpen}
+        onOpenChange={setSwitchDialogOpen}
+        connectionId={connectionId}
+        currentMode={currentMode}
+        targetMode={targetMode}
+        onSwitched={() => {
+          refresh();
+        }}
+      />
+    </>
   );
 }

--- a/apps/app/src/app/(app)/[orgId]/cloud-tests/components/CloudTestsSection.tsx
+++ b/apps/app/src/app/(app)/[orgId]/cloud-tests/components/CloudTestsSection.tsx
@@ -205,6 +205,11 @@ export function CloudTestsSection({
     guidedSteps?: string[];
     risk?: string;
     description?: string;
+    // Set when the finding came from AWS Security Hub — surfaces a
+    // disclosure banner in the Fix dialog since the AI plan is generated
+    // from AWS's remediation text (quality varies) and SecHub re-evaluates
+    // findings on its own schedule.
+    fromSecurityHub?: boolean;
   } | null>(null);
   const [showSetupDialog, setShowSetupDialog] = useState(false);
   const { hasPermission } = usePermissions();
@@ -813,6 +818,7 @@ export function CloudTestsSection({
                                   checkResultId: finding.id,
                                   remediationKey: key,
                                   findingTitle: finding.title ?? 'Finding',
+                                  fromSecurityHub: finding.serviceId === 'security-hub',
                                 })
                               }
                               onSetup={() => setShowSetupDialog(true)}
@@ -918,6 +924,7 @@ export function CloudTestsSection({
                                   checkResultId: finding.id,
                                   remediationKey: key,
                                   findingTitle: finding.title ?? 'Finding',
+                                  fromSecurityHub: finding.serviceId === 'security-hub',
                                 })
                               }
                               onSetup={() => setShowSetupDialog(true)}
@@ -1066,6 +1073,7 @@ export function CloudTestsSection({
           guidedSteps={remediationTarget.guidedSteps}
           risk={remediationTarget.risk}
           description={remediationTarget.description}
+          fromSecurityHub={remediationTarget.fromSecurityHub}
           onComplete={() => {
             toast.message('Re-scanning to verify fix...');
             handleRunScan();

--- a/apps/app/src/app/(app)/[orgId]/cloud-tests/components/RemediationDialog.tsx
+++ b/apps/app/src/app/(app)/[orgId]/cloud-tests/components/RemediationDialog.tsx
@@ -42,6 +42,14 @@ interface RemediationDialogProps {
   guidedSteps?: string[];
   risk?: string;
   description?: string;
+  /**
+   * True when the underlying finding came from AWS Security Hub rather
+   * than one of our service adapters. Surfaces a disclosure banner —
+   * SecHub remediation text quality varies and SecHub re-evaluates
+   * findings on its own schedule, so the customer should verify in the
+   * AWS console after applying.
+   */
+  fromSecurityHub?: boolean;
   onComplete?: () => void;
 }
 
@@ -85,6 +93,33 @@ function RichText({ text }: { text: string }) {
         ) : (<span key={i}>{part}</span>),
       )}
     </p>
+  );
+}
+
+/**
+ * Disclosure shown in the Fix dialog when the underlying finding came
+ * from AWS Security Hub. Two things customers need to know that aren't
+ * true for our own adapter findings:
+ *
+ *   1. AI fix plans are generated from AWS's remediation text, which
+ *      varies in specificity. The plan may need adjustment after
+ *      reviewing in the AWS console.
+ *   2. Security Hub re-evaluates findings on its own schedule (hours,
+ *      not minutes). After a successful Fix, the SecHub-side finding
+ *      may take time to clear even though the underlying issue is gone.
+ */
+function SecurityHubFixDisclosure() {
+  return (
+    <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-xs text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-200">
+      <p className="font-medium">Security Hub finding</p>
+      <p className="mt-1 leading-relaxed">
+        This fix was generated from AWS Security Hub remediation
+        guidance. Verify the result in your AWS console after applying —
+        Security Hub re-evaluates findings on its own schedule, so the
+        finding may take a few hours to clear there even after a
+        successful fix.
+      </p>
+    </div>
   );
 }
 
@@ -270,6 +305,7 @@ export function RemediationDialog({
   guidedSteps,
   risk,
   description,
+  fromSecurityHub,
   onComplete,
 }: RemediationDialogProps) {
   const [preview, setPreview] = useState<PreviewData | null>(null);
@@ -467,6 +503,8 @@ export function RemediationDialog({
             {findingTitle}
           </DialogDescription>
         </DialogHeader>
+
+        {fromSecurityHub && <SecurityHubFixDisclosure />}
 
         <div className="space-y-3 min-w-0">
           {/* Applying state — shown while executing */}

--- a/apps/app/src/app/(app)/[orgId]/cloud-tests/components/ScanModeSwitchDialog.tsx
+++ b/apps/app/src/app/(app)/[orgId]/cloud-tests/components/ScanModeSwitchDialog.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useApi } from '@/hooks/use-api';
+import { Button } from '@trycompai/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@trycompai/ui/dialog';
+import { Loader2 } from 'lucide-react';
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { mutate as globalMutate } from 'swr';
+
+import {
+  type AwsScanModeChoice,
+} from '../../integrations/[slug]/components/AwsScanModeStep';
+
+const MODE_LABEL: Record<AwsScanModeChoice, string> = {
+  comp_scanners: 'Comp AI Scanners',
+  security_hub: 'AWS Security Hub',
+};
+
+export interface ScanModeSwitchDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  connectionId: string;
+  currentMode: AwsScanModeChoice;
+  targetMode: AwsScanModeChoice;
+  /** Called after a successful switch so the parent can refetch. */
+  onSwitched?: () => void;
+}
+
+/**
+ * Confirmation dialog for switching the AWS scan engine on an existing
+ * connection. Posts to `PATCH /v1/cloud-security/connections/:id/scan-mode`
+ * and invalidates SWR caches so the findings list + history tab pick up
+ * the change on the next scan.
+ *
+ * Switching is non-destructive but has real consequences worth flagging:
+ *   1. The next scan is a fresh baseline — reconciliation only diffs
+ *      same-mode runs (see reconciliation.service.ts), so the customer
+ *      shouldn't expect "resolved" events from the prior engine.
+ *   2. Existing exceptions stay in the database but may not match
+ *      findings from the new engine (different checkId namespaces).
+ */
+export function ScanModeSwitchDialog({
+  open,
+  onOpenChange,
+  connectionId,
+  currentMode,
+  targetMode,
+  onSwitched,
+}: ScanModeSwitchDialogProps) {
+  const api = useApi();
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleConfirm = async () => {
+    setSubmitting(true);
+    const response = await api.patch(
+      `/v1/cloud-security/connections/${connectionId}/scan-mode`,
+      { mode: targetMode },
+    );
+    setSubmitting(false);
+
+    if (response.error) {
+      const message =
+        typeof response.error === 'string'
+          ? response.error
+          : 'Could not switch scan engine — please try again.';
+      toast.error(message);
+      return;
+    }
+
+    toast.success(`Scan engine switched to ${MODE_LABEL[targetMode]}`);
+    // Invalidate any cached findings + history for this connection so the
+    // UI re-fetches with the new mode on the next access.
+    globalMutate(
+      (key) =>
+        Array.isArray(key) &&
+        typeof key[0] === 'string' &&
+        (key[0].startsWith('/v1/cloud-security/findings') ||
+          key[0].startsWith('/v1/cloud-security/history') ||
+          key[0].startsWith('/v1/cloud-security/providers')),
+    );
+    onSwitched?.();
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !submitting && onOpenChange(next)}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Switch scan engine?</DialogTitle>
+          <DialogDescription>
+            Change which engine produces findings for this AWS connection.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 py-2">
+          <div className="flex items-center justify-between rounded-md border bg-muted/30 p-3 text-sm">
+            <div>
+              <p className="text-xs text-muted-foreground">From</p>
+              <p className="font-medium">{MODE_LABEL[currentMode]}</p>
+            </div>
+            <span className="text-muted-foreground">→</span>
+            <div className="text-right">
+              <p className="text-xs text-muted-foreground">To</p>
+              <p className="font-medium">{MODE_LABEL[targetMode]}</p>
+            </div>
+          </div>
+
+          <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-xs leading-relaxed text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-200">
+            <p className="font-medium">What changes:</p>
+            <ul className="mt-1.5 list-disc space-y-1 pl-4">
+              <li>
+                The next scan is a fresh baseline — resolutions and
+                regressions only compare same-engine runs.
+              </li>
+              <li>
+                Existing exceptions stay marked but may not match findings
+                from the new engine (different control identifiers).
+              </li>
+              <li>
+                In-flight remediations from the previous engine continue
+                independently.
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-2 border-t pt-3">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onOpenChange(false)}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button size="sm" onClick={handleConfirm} disabled={submitting}>
+            {submitting && (
+              <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+            )}
+            Switch to {MODE_LABEL[targetMode]}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/AwsScanModeStep.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/AwsScanModeStep.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  AwsScanModeStep,
+  DEFAULT_AWS_SCAN_MODE_CHOICE,
+} from './AwsScanModeStep';
+
+describe('AwsScanModeStep', () => {
+  it('renders both scan engine options', () => {
+    render(
+      <AwsScanModeStep value={DEFAULT_AWS_SCAN_MODE_CHOICE} onChange={() => {}} />,
+    );
+    expect(screen.getByText('Comp AI Scanners')).toBeInTheDocument();
+    expect(screen.getByText('AWS Security Hub')).toBeInTheDocument();
+  });
+
+  it('marks the value prop as selected (controlled component)', () => {
+    const { rerender } = render(
+      <AwsScanModeStep value="comp_scanners" onChange={() => {}} />,
+    );
+
+    const compRadio = screen.getByRole('radio', { name: /comp ai scanners/i });
+    const sechubRadio = screen.getByRole('radio', { name: /aws security hub/i });
+    expect(compRadio).toBeChecked();
+    expect(sechubRadio).not.toBeChecked();
+
+    rerender(<AwsScanModeStep value="security_hub" onChange={() => {}} />);
+    expect(compRadio).not.toBeChecked();
+    expect(sechubRadio).toBeChecked();
+  });
+
+  it('calls onChange with the new mode when the customer picks the other option', () => {
+    const onChange = vi.fn();
+    render(<AwsScanModeStep value="comp_scanners" onChange={onChange} />);
+
+    fireEvent.click(
+      screen.getByRole('radio', { name: /aws security hub/i }),
+    );
+    expect(onChange).toHaveBeenCalledWith('security_hub');
+  });
+
+  it('does not call onChange when re-selecting the same option', () => {
+    // Defensive — re-clicking the selected radio fires onChange with the
+    // same value (browser semantics), which is fine but worth noting.
+    const onChange = vi.fn();
+    render(<AwsScanModeStep value="comp_scanners" onChange={onChange} />);
+
+    // Click on the already-selected one — radio onChange does NOT fire
+    // when re-selecting the checked option, so onChange stays at 0.
+    fireEvent.click(
+      screen.getByRole('radio', { name: /comp ai scanners/i }),
+    );
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('disables all radios when the disabled prop is true', () => {
+    render(
+      <AwsScanModeStep
+        value="comp_scanners"
+        onChange={() => {}}
+        disabled
+      />,
+    );
+    const radios = screen.getAllByRole('radio');
+    radios.forEach((radio) => expect(radio).toBeDisabled());
+  });
+
+  it('exposes a single source of truth for the default mode', () => {
+    // Guarded with a test so changing the default is intentional —
+    // shifting it would silently flip every new connection's scan
+    // engine choice.
+    expect(DEFAULT_AWS_SCAN_MODE_CHOICE).toBe('comp_scanners');
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/AwsScanModeStep.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/AwsScanModeStep.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { Cloud, ShieldCheck } from 'lucide-react';
+
+/**
+ * String constants for the two AWS scan-engine modes. Mirrors the
+ * AwsScanMode type in apps/api/src/cloud-security/aws-scan-mode.ts —
+ * the single source of truth for these values lives on the API side
+ * (because that's what gets validated server-side), but we duplicate
+ * the literals here so the onboarding UI doesn't import API code.
+ *
+ * If you add a new mode, update BOTH files and the type assertion in
+ * the parent EmptyStateOnboarding that passes this to createConnection.
+ */
+export type AwsScanModeChoice = 'comp_scanners' | 'security_hub';
+
+export const DEFAULT_AWS_SCAN_MODE_CHOICE: AwsScanModeChoice = 'comp_scanners';
+
+interface AwsScanModeStepProps {
+  /** Currently-selected mode. */
+  value: AwsScanModeChoice;
+  /** Called when the customer picks a different option. */
+  onChange: (next: AwsScanModeChoice) => void;
+  /** When true, disables interaction (e.g., during connection creation). */
+  disabled?: boolean;
+}
+
+/**
+ * AWS-onboarding step that lets the customer choose which engine
+ * performs their cloud security scans. Two radio cards, mutually
+ * exclusive:
+ *
+ *   1. Comp AI Scanners (default) — our service adapters, free,
+ *      full Fix button support.
+ *   2. AWS Security Hub — read findings from the customer's existing
+ *      Security Hub deployment, surface native NIST 800-53 / CIS / PCI
+ *      mapping, Fix button available with a small disclosure.
+ *
+ * Pure UI — no API calls, no side effects. The parent owns state and
+ * passes the choice into the createConnection payload via the
+ * `awsScanMode` variable.
+ */
+export function AwsScanModeStep({
+  value,
+  onChange,
+  disabled,
+}: AwsScanModeStepProps) {
+  return (
+    <fieldset className="space-y-3" disabled={disabled}>
+      <legend className="sr-only">AWS scan engine</legend>
+      <ScanModeCard
+        modeValue="comp_scanners"
+        selected={value === 'comp_scanners'}
+        onSelect={() => onChange('comp_scanners')}
+        icon={<Cloud className="h-4 w-4" />}
+        title="Comp AI Scanners"
+        subtitle="Recommended"
+        description={
+          'Run our security checks directly against your AWS account. ' +
+          'No additional AWS cost. Full Fix button support. Covers IAM, ' +
+          'CloudTrail, S3, EC2, RDS, KMS, GuardDuty, and 40+ other services.'
+        }
+        badges={['Free', 'Fix button supported']}
+      />
+      <ScanModeCard
+        modeValue="security_hub"
+        selected={value === 'security_hub'}
+        onSelect={() => onChange('security_hub')}
+        icon={<ShieldCheck className="h-4 w-4" />}
+        title="AWS Security Hub"
+        subtitle="Read findings from your existing Security Hub"
+        description={
+          'Use the findings your Security Hub deployment already produces. ' +
+          'Surfaces NIST 800-53 / CIS / PCI control mappings natively. ' +
+          'Requires Security Hub to be enabled in your AWS account ' +
+          '(AWS bills per finding ingested + per control checked).'
+        }
+        badges={[
+          'Native NIST / CIS / PCI mapping',
+          'Requires Security Hub subscription',
+        ]}
+      />
+    </fieldset>
+  );
+}
+
+function ScanModeCard({
+  modeValue,
+  selected,
+  onSelect,
+  icon,
+  title,
+  subtitle,
+  description,
+  badges,
+}: {
+  modeValue: AwsScanModeChoice;
+  selected: boolean;
+  onSelect: () => void;
+  icon: React.ReactNode;
+  title: string;
+  subtitle: string;
+  description: string;
+  badges: string[];
+}) {
+  return (
+    <label
+      className={`flex cursor-pointer items-start gap-3 rounded-lg border p-4 transition-colors ${
+        selected
+          ? 'border-primary bg-primary/[0.03] ring-1 ring-primary/30'
+          : 'border-border hover:border-primary/40 hover:bg-muted/30'
+      }`}
+    >
+      <input
+        type="radio"
+        name="aws-scan-mode"
+        value={modeValue}
+        checked={selected}
+        onChange={onSelect}
+        className="mt-1 h-4 w-4 accent-primary"
+      />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-primary">{icon}</span>
+          <span className="text-sm font-semibold">{title}</span>
+          <span className="text-xs text-muted-foreground">{subtitle}</span>
+        </div>
+        <p className="mt-1.5 text-xs text-muted-foreground leading-relaxed">
+          {description}
+        </p>
+        {badges.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {badges.map((badge) => (
+              <span
+                key={badge}
+                className="inline-flex items-center rounded border bg-background px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
+              >
+                {badge}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </label>
+  );
+}

--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/EmptyStateOnboarding.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/EmptyStateOnboarding.tsx
@@ -14,6 +14,11 @@ import {
 import { ArrowRight, Shield } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { toast } from 'sonner';
+import {
+  AwsScanModeStep,
+  DEFAULT_AWS_SCAN_MODE_CHOICE,
+  type AwsScanModeChoice,
+} from './AwsScanModeStep';
 
 // ─── Primitives ─────────────────────────────────────────────────────────
 
@@ -497,6 +502,12 @@ function CloudSetup({
   const [connecting, setConnecting] = useState(false);
   const [credentials, setCredentials] = useState<Record<string, string | string[]>>({});
   const [errors, setErrors] = useState<Record<string, string>>({});
+  // AWS only — which scan engine the customer is choosing for this
+  // connection. Sent in createConnection's credentials payload as the
+  // `awsScanMode` variable, then read on every scan in cloud-security.service.
+  const [awsScanMode, setAwsScanMode] = useState<AwsScanModeChoice>(
+    DEFAULT_AWS_SCAN_MODE_CHOICE,
+  );
 
   const allFields = provider.credentialFields ?? [];
   const visibleFields = allFields.filter(
@@ -524,6 +535,13 @@ function CloudSetup({
     if (!finalCredentials.connectionName) {
       const arnMatch = String(finalCredentials.roleArn ?? '').match(/:(\d{12}):/);
       finalCredentials.connectionName = arnMatch ? `AWS ${arnMatch[1]}` : 'AWS Account';
+    }
+    // AWS only — persist the customer's scan engine choice on the
+    // connection. The scan service reads this from variables on every
+    // run. resolveAwsScanMode() handles the missing-field case for
+    // every other provider and for pre-feature historical connections.
+    if (provider.id === 'aws') {
+      finalCredentials.awsScanMode = awsScanMode;
     }
 
     const newErrors: Record<string, string> = {};
@@ -558,7 +576,7 @@ function CloudSetup({
     } finally {
       setConnecting(false);
     }
-  }, [allFields, credentials, createConnection, provider, orgId, onConnected]);
+  }, [allFields, awsScanMode, credentials, createConnection, provider, orgId, onConnected]);
 
   const connectionFields = visibleFields.filter(
     (f) => f.id !== 'remediationRoleArn' && f.id !== 'regions' && f.id !== 'awsType',
@@ -601,25 +619,42 @@ function CloudSetup({
       >
         {/* ─── Left: Unified setup flow ─── */}
         <div className="rounded-xl border bg-background shadow-sm">
-          {awsTypeFields.length > 0 && (
+          {/* Step 1 — AWS only — Scan engine choice. Mutually exclusive
+              between Comp AI scanners (default) and AWS Security Hub.
+              Customers can switch later from CloudSettingsModal. */}
+          {provider.id === 'aws' && (
             <div className="p-6 space-y-4">
-              {/* Step 1 */}
-              <StepHeader step={1} title="AWS Environment" />
-              {awsTypeFields.map((field) => (
-                <FieldRow
-                  key={field.id}
-                  field={field}
-                  value={credentials[field.id] || ''}
-                  error={errors[field.id]}
-                  onChange={(v) => updateCredential(field.id, v)}
-                />
-              ))}
+              <StepHeader step={1} title="Scan Engine" />
+              <AwsScanModeStep
+                value={awsScanMode}
+                onChange={setAwsScanMode}
+                disabled={connecting}
+              />
             </div>
           )}
-          {/* Step 2 */}
+
+          {/* Step 2 — AWS only — Commercial vs GovCloud */}
+          {awsTypeFields.length > 0 && (
+            <>
+              {provider.id === 'aws' && <div className="border-t" />}
+              <div className="p-6 space-y-4">
+                <StepHeader step={2} title="AWS Environment" />
+                {awsTypeFields.map((field) => (
+                  <FieldRow
+                    key={field.id}
+                    field={field}
+                    value={credentials[field.id] || ''}
+                    error={errors[field.id]}
+                    onChange={(v) => updateCredential(field.id, v)}
+                  />
+                ))}
+              </div>
+            </>
+          )}
+          {/* Step 3 — AWS only — IAM role creation script */}
           {provider.setupScript && (
             <div className="p-6 space-y-4">
-              <StepHeader step={2} title="Create IAM Role" />
+              <StepHeader step={3} title="Create IAM Role" />
               <CloudShellSetup
                 script={setupScript}
                 externalId={orgId}
@@ -635,9 +670,9 @@ function CloudSetup({
 
           <div className="border-t" />
 
-          {/* Step 3 */}
+          {/* Step 4 — Connection details (Role ARN etc.) */}
           <div className="p-6 space-y-4">
-            <StepHeader step={3} title="Connection Details" />
+            <StepHeader step={4} title="Connection Details" />
             {connectionFields.map((field) => (
               <FieldRow
                 key={field.id}
@@ -649,12 +684,12 @@ function CloudSetup({
             ))}
           </div>
 
-          {/* Step 4 */}
+          {/* Step 5 — Scan configuration (regions) */}
           {regionFields.length > 0 && (
             <>
               <div className="border-t" />
               <div className="p-6 space-y-4">
-                <StepHeader step={4} title="Scan Configuration" />
+                <StepHeader step={5} title="Scan Configuration" />
                 {regionFields.map((field) => (
                   <FieldRow
                     key={field.id}

--- a/packages/db/prisma/migrations/20260519143715_integration_check_run_scan_mode/migration.sql
+++ b/packages/db/prisma/migrations/20260519143715_integration_check_run_scan_mode/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "IntegrationCheckRun" ADD COLUMN     "scanMode" TEXT;

--- a/packages/db/prisma/migrations/20260519143715_integration_check_run_scan_mode/migration.sql
+++ b/packages/db/prisma/migrations/20260519143715_integration_check_run_scan_mode/migration.sql
@@ -1,2 +1,23 @@
 -- AlterTable
 ALTER TABLE "IntegrationCheckRun" ADD COLUMN     "scanMode" TEXT;
+
+-- Backfill: label pre-feature AWS cloud-security runs as 'comp_scanners'.
+-- That was the only scan engine in existence when those runs executed, so
+-- the label is truthful — we're filling in metadata that didn't exist
+-- before, not changing semantics. Lets the new reconciliation lookup
+-- (which scopes by scanMode) match historical AWS runs against the first
+-- post-deploy scan instead of treating it as a fresh baseline and
+-- silently dropping one cycle of resolution / regression events.
+--
+-- WHY this WHERE clause is precise:
+--   - 'aws-security-scan' is the only checkId pattern used by cloud-
+--     security scans (cloud-security.service.ts:619 — verified by grep).
+--   - Other IntegrationCheckRun rows (connection-level checks with
+--     checkId='all', task-based checks with manifest IDs) do NOT have a
+--     scan-mode concept and correctly stay NULL.
+--   - GCP / Azure cloud-security runs ('gcp-security-scan' /
+--     'azure-security-scan') also stay NULL — scan mode is AWS-only.
+UPDATE "IntegrationCheckRun"
+SET "scanMode" = 'comp_scanners'
+WHERE "checkId" = 'aws-security-scan'
+  AND "scanMode" IS NULL;

--- a/packages/db/prisma/schema/integration-platform.prisma
+++ b/packages/db/prisma/schema/integration-platform.prisma
@@ -347,11 +347,14 @@ model IntegrationCheckRun {
   failedServices String[] @default([])
 
   /// AWS-only: which scan engine produced this run.
-  ///   'comp_scanners' — our 49 service adapters (today's default).
+  ///   'comp_scanners' — our service adapters (default).
   ///   'security_hub' — AWS Security Hub findings.
-  /// Null for non-AWS runs and pre-feature historical rows. Reconciliation
-  /// uses this to only diff like-for-like — findingKeys live in different
-  /// namespaces across modes, so cross-mode diffs would produce false
+  /// Null for GCP / Azure runs (no scan-mode concept). Pre-feature AWS
+  /// rows were backfilled to 'comp_scanners' in the
+  /// 20260519143715_integration_check_run_scan_mode migration, so every
+  /// AWS run has an explicit value. Reconciliation uses this to only
+  /// diff like-for-like — findingKeys live in different namespaces
+  /// across modes, so cross-mode diffs would produce false
   /// resolutions/regressions.
   scanMode String?
 

--- a/packages/db/prisma/schema/integration-platform.prisma
+++ b/packages/db/prisma/schema/integration-platform.prisma
@@ -346,6 +346,15 @@ model IntegrationCheckRun {
   /// are NOT considered for resolution detection on this run.
   failedServices String[] @default([])
 
+  /// AWS-only: which scan engine produced this run.
+  ///   'comp_scanners' — our 49 service adapters (today's default).
+  ///   'security_hub' — AWS Security Hub findings.
+  /// Null for non-AWS runs and pre-feature historical rows. Reconciliation
+  /// uses this to only diff like-for-like — findingKeys live in different
+  /// namespaces across modes, so cross-mode diffs would produce false
+  /// resolutions/regressions.
+  scanMode String?
+
   createdAt DateTime @default(now())
 
   /// Results from this check run


### PR DESCRIPTION
## Summary

Adds **AWS Security Hub** as a first-class alternative scan engine to our existing 49-adapter scanning. Customer Blazestack (via Joe in CX) uses Security Hub for NIST 800-53 compliance and wants Comp AI to read findings from their existing Security Hub deployment.

At AWS connect time the customer picks one of two engines (mutually exclusive per connection):
- **Comp AI Scanners** (default) — today's behavior, full Fix support, no AWS cost
- **AWS Security Hub** — read findings from their existing SecHub, native NIST/CIS/PCI mapping, Fix button still works through the same AI pipeline (with a disclosure banner)

Customers can switch engines later from Cloud Settings. The next scan after a switch is treated as a fresh baseline.

## What's safe about existing AWS logic

- **Default for missing field is `comp_scanners`** — every existing connection in production keeps today's behavior byte-for-byte. No migration needed for them.
- **`SecurityHubAdapter` is NOT in the 49-adapters array** — it can only run when the customer explicitly opts in. Cannot leak into Comp AI mode.
- **Reconciliation only diffs same-mode runs** — a mode switch produces a clean baseline instead of fake "resolved" rows in the History tab.
- **AI fix pipeline is input-agnostic** (verified) — SecHub findings flow through the same code path with no prompt changes.
- **Compliance chips render with zero frontend changes** — SecHub adapter emits remediation in the existing `More info: / Compliance:` text format used by GCP, so `remediation-parser.ts` extracts URL + chips automatically.

## File map for engineers reading the diff

**API plumbing (single source of truth on the API side):**
- `apps/api/src/cloud-security/aws-scan-mode.ts` — the `AwsScanMode` type + `resolveAwsScanMode` helper. **Importers never spell the string literals themselves.**
- `apps/api/src/cloud-security/aws-scan-mode.service.ts` — settings switcher service
- `apps/api/src/cloud-security/dto/update-scan-mode.dto.ts` — validated request body

**Scan routing — clean split, easy to follow:**
- `cloud-security.service.ts` — reads mode from `connection.metadata.awsScanMode`, persists `IntegrationCheckRun.scanMode` per run
- `providers/aws-security.service.ts` — `scanSecurityFindings()` branches on mode → either `scanViaAdapters` (existing 49 adapters, renamed only) OR `scanViaSecurityHub` (new). Two methods, two file regions, no nested branching.

**SecHub adapter wiring:**
- `providers/aws/security-hub.adapter.ts` — adds `findingKey` and `serviceId` to evidence (unlocks Fix pipeline), emits remediation in parser-compatible format with `More info:` + `Compliance:` sections

**Reconciliation safety:**
- `reconciliation.service.ts` — prior-run lookup now scopes by `scanMode` so cross-mode diffs never happen
- DB: new `IntegrationCheckRun.scanMode String?` column (single migration)

**API endpoint:**
- `cloud-security.controller.ts` — `PATCH /v1/cloud-security/connections/:id/scan-mode`
- `integration-platform/controllers/connections.controller.ts` — copies `awsScanMode` from credentials → `metadata` at connection creation

**Frontend:**
- `integrations/[slug]/components/AwsScanModeStep.tsx` — new "Step 1: Scan Engine" radio cards
- `integrations/[slug]/components/EmptyStateOnboarding.tsx` — inserts Step 1 for AWS, renumbers existing steps (2-5)
- `cloud-tests/components/CloudSettingsModal.tsx` — new `AwsScanModeSection` shows current mode + "Switch" button (AWS only)
- `cloud-tests/components/ScanModeSwitchDialog.tsx` — new confirmation dialog with what-changes copy
- `cloud-tests/components/RemediationDialog.tsx` — new `SecurityHubFixDisclosure` banner when `finding.serviceId === 'security-hub'`
- `cloud-tests/components/CloudTestsSection.tsx` — passes `fromSecurityHub` flag to the Fix dialog

## Tests

| File | Coverage |
|---|---|
| `aws-scan-mode.spec.ts` | 6 tests — resolve helper, defaults, type safety |
| `security-hub.adapter.spec.ts` | 23 tests — findingKey derivation, compliance formatting, mapFinding edge cases |
| `reconciliation.service.spec.ts` | +3 tests — same-mode safety + post-switch baseline |
| `AwsScanModeStep.test.tsx` | 6 tests — radio cards render + onChange |

**API:** 157 cloud-security tests pass (1 pre-existing TLS-env failure in `remediation.controller.spec.ts` unchanged — verified in prior sessions).

**Typecheck:** clean for all changed files in both `apps/api` and `apps/app`.

## Test plan

- [ ] **Regression check (most important):** create a new AWS connection without switching the Step 1 default. Confirm scan behaves identically to today — all 49 adapters run, findings + Fix flow + History tab work as before.
- [ ] **SecHub happy path:** create another AWS connection, pick Security Hub at Step 1, connect with a role that has `securityhub:GetFindings`, trigger scan. Confirm findings appear with `aws-securityhub-*` `findingKey`s, NIST/CIS chips render in the expanded view, Fix button shows.
- [ ] **SecHub not subscribed:** pick Security Hub for a role that doesn't have SecHub enabled — confirm scan returns 0 findings gracefully (no crash, no garbage rows).
- [ ] **SecHub Fix path — concrete remediation:** click Fix on a SecHub finding with specific text like "EC2.2 — Default security group should not allow inbound traffic". Confirm AI generates a plan, the amber disclosure banner appears, execute succeeds.
- [ ] **SecHub Fix path — vague remediation:** click Fix on a SecHub finding with only a doc URL. Confirm UI falls back to manual remediation guidance (same as some current adapter findings).
- [ ] **Settings switch:** open Cloud Settings on an existing comp_scanners AWS connection, click "Switch to AWS Security Hub". Confirm confirmation dialog appears with the what-changes copy, click confirm. Verify the next scan returns SecHub findings and the History tab doesn't show false "resolved" rows.
- [ ] **Existing connection backward-compat:** any AWS connection in production today (no `awsScanMode` field in DB) continues to scan with comp_scanners — verified via `resolveAwsScanMode` test.
- [ ] **DB sanity:** `SELECT id, "scanMode" FROM "IntegrationCheckRun" ORDER BY "createdAt" DESC LIMIT 10;` — modes correctly recorded per run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AWS Security Hub as an alternative scan engine for AWS connections, selectable during onboarding and switchable later in Cloud Settings. Scans and History are isolated per engine, with a migration to backfill prior AWS runs for continuity; Security Hub findingKeys are now namespaced by standard to prevent collisions.

- New Features
  - Engine choice: `comp_scanners` (default) or `security_hub`, stored on connection metadata and persisted per run (`IntegrationCheckRun.scanMode`) so reconciliation only diffs same-mode runs.
  - API: `PATCH /v1/cloud-security/connections/:id/scan-mode` to switch engines (idempotent; audited as `scan_mode_changed`).
  - Security Hub engine: pulls via `GetFindings`, derives stable findingKeys namespaced by standard (version changes don’t change the key), stamps `serviceId: 'security-hub'`, and emits remediation in “More info:” / “Compliance:” format; Fix pipeline unchanged. Fix dialog shows a Security Hub disclosure.
  - UI: New “Scan Engine” step in AWS onboarding and a switch in Cloud Settings (with confirmation dialog).
  - Code quality: removed a no-op replace in Security Hub requirement normalization; behavior unchanged.

- Migration
  - DB: adds `IntegrationCheckRun.scanMode` and backfills pre-feature AWS runs (`checkId='aws-security-scan'`) to `comp_scanners` so the first post-deploy scan diffs against history; GCP/Azure stay null.
  - Existing connections default to `comp_scanners`. To use Security Hub, the AWS role needs `securityhub:GetFindings` and Security Hub must be enabled.

<sup>Written for commit 744814fb344e4f6a754d569ea69698b915026645. Summary will update on new commits. <a href="https://cubic.dev/pr/trycompai/comp/pull/2871?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- comp-ai-pr-review:start -->
> [!WARNING]
> Comp AI's PR review failed to run. Tag the bot to retry.

<details><summary>Details</summary>

```
Clone failed: Cloning into '/workspace/repo'...
warning: Could not find remote branch tofik/aws-security-hub-mode to clone.
fatal: Remote branch tofik/aws-security-hub-mode not found in upstream origin

```

</details>
<!-- comp-ai-pr-review:end -->