### PR TITLE
fix(db): remove duplicate add-finding-to-CommentEntityType migration

### DIFF
--- a/packages/db/prisma/migrations/20260512120000_add_finding_to_comment_entity_type/migration.sql
+++ b/packages/db/prisma/migrations/20260512120000_add_finding_to_comment_entity_type/migration.sql
@@ -1,2 +1,0 @@
--- AlterEnum
-ALTER TYPE "CommentEntityType" ADD VALUE 'finding';


### PR DESCRIPTION
## Summary

Fixes the failing **Run Database Migrations** check on PR #2869 (main → release).

Two parallel branches independently added `'finding'` to the `CommentEntityType` enum:

- `20260513220233_comment_entity_type_finding` — from `feat(cloud-tests): auditor visibility improvements (phases 1-5)` (`34566555f`), merged May 13. Already deployed to staging and on `release`.
- `20260512120000_add_finding_to_comment_entity_type` — from `fix(db): add finding to CommentEntityType` (`42357e3d3`), merged in PR #2827 on May 19.

Because Prisma orders migrations by filename timestamp, when the main → release deploy ran `prisma migrate deploy` against staging, it tried to apply the earlier-timestamped May 12 migration after the May 13 one was already applied. The result:

```
Applying migration `20260512120000_add_finding_to_comment_entity_type`
Error: P3018
Database error code: 42710
ERROR: enum label "finding" already exists
```

Both migrations were identical (`ALTER TYPE "CommentEntityType" ADD VALUE 'finding';`). Keeping the one that's already deployed (May 13) and removing the duplicate is the cleanest fix. The Prisma schema is unchanged — the post-migration enum is identical.

## Required manual step (staging)

The failed `migrate deploy` left a row in `_prisma_migrations` for the May 12 migration with `finished_at = NULL`. Even after this PR removes the file, `migrate deploy` will refuse to continue on staging until that record is cleared. Run **once** against staging (and any other env that hit the error):

```sh
bunx prisma migrate resolve --rolled-back 20260512120000_add_finding_to_comment_entity_type
```

After that, `prisma migrate deploy` is a no-op for this change — the only remaining migration (May 13) is already applied on staging and `release`.

## Why not make the migration idempotent (`ADD VALUE IF NOT EXISTS`)?

That would still require the same manual `migrate resolve` step (to clear the failed-migration record), and would leave a redundant migration in source forever. Removing the duplicate is simpler and leaves the history clean.

## Test plan

- [ ] CI **Run Database Migrations** check passes on this PR
- [ ] After merge + the manual `migrate resolve` step on staging, the main → release production-deploy PR's database-migrations check passes
- [ ] Fresh local DB (`prisma migrate reset`) applies cleanly — only the May 13 migration runs to add the `finding` enum value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes a duplicate Prisma migration that added "finding" to the `CommentEntityType` enum, unblocking `prisma migrate deploy`. The schema is unchanged; we keep the already-applied migration.

- **Migration**
  - If staging (or any env) has a failed record for this migration, clear it once: bunx prisma migrate resolve --rolled-back 20260512120000_add_finding_to_comment_entity_type
  - After that, `prisma migrate deploy` is a no-op for this change.

<sup>Written for commit 2c6267d85d64c6cf9a952cfc2ed310248009775c. Summary will update on new commits. <a href="https://cubic.dev/pr/trycompai/comp/pull/2872?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

