### PR TITLE
fix(cloud-tests): gate AWS scan-mode switch by integration:update, not delete

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/cloud-tests/components/CloudSettingsModal.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/cloud-tests/components/CloudSettingsModal.test.tsx
@@ -211,4 +211,37 @@ describe('CloudSettingsModal permission gating', () => {
     render(<CloudSettingsModal {...defaultProps} open={false} />);
     expect(screen.queryByTestId('dialog')).not.toBeInTheDocument();
   });
+
+  it('shows the AWS scan-mode switch button when the user has integration:update', () => {
+    // Regression guard for the cubic P2: the switch button is an UPDATE
+    // operation and must be gated by integration:update, NOT
+    // integration:delete. Admin has both, so the button shows.
+    setMockPermissions(ADMIN_PERMISSIONS);
+    render(<CloudSettingsModal {...defaultProps} />);
+    expect(
+      screen.getByRole('button', { name: /switch to/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('hides the AWS scan-mode switch button for users without integration:update', () => {
+    // Auditor has read-only permissions — should not see Switch.
+    setMockPermissions(AUDITOR_PERMISSIONS);
+    render(<CloudSettingsModal {...defaultProps} />);
+    expect(
+      screen.queryByRole('button', { name: /switch to/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the AWS scan-mode switch for update-only users (NOT delete users)', () => {
+    // The exact regression cubic flagged: a user with integration:update
+    // but WITHOUT integration:delete must still see the Switch button,
+    // because the API gates this endpoint on integration:update only.
+    setMockPermissions({ integration: ['read', 'update'] });
+    render(<CloudSettingsModal {...defaultProps} />);
+    expect(
+      screen.getByRole('button', { name: /switch to/i }),
+    ).toBeInTheDocument();
+    // ...and they correctly DO NOT see Disconnect (delete permission required).
+    expect(screen.queryByText('Disconnect')).not.toBeInTheDocument();
+  });
 });

--- a/apps/app/src/app/(app)/[orgId]/cloud-tests/components/CloudSettingsModal.tsx
+++ b/apps/app/src/app/(app)/[orgId]/cloud-tests/components/CloudSettingsModal.tsx
@@ -63,6 +63,12 @@ export function CloudSettingsModal({
   const api = useApi();
   const { hasPermission } = usePermissions();
   const canDelete = hasPermission('integration', 'delete');
+  // Scan-mode switch is an UPDATE operation (the API endpoint is
+  // gated by integration:update — see CloudSecurityController.updateAwsScanMode),
+  // so the UI must use update permission, NOT delete permission. Using
+  // canDelete here would silently block valid update users from seeing
+  // the "Switch" button even though the API would accept their request.
+  const canUpdate = hasPermission('integration', 'update');
   const [activeProvider, setActiveProvider] = useState<string>(connectedProviders[0]?.connectionId || '');
   const [isDeleting, setIsDeleting] = useState(false);
   const { deleteConnection } = useIntegrationMutations();
@@ -129,6 +135,7 @@ export function CloudSettingsModal({
           <ConnectionTab
             provider={currentProvider}
             canDelete={canDelete}
+            canUpdate={canUpdate}
             isDeleting={isDeleting}
             onDisconnect={handleDisconnect}
           />
@@ -143,11 +150,13 @@ export function CloudSettingsModal({
 function ConnectionTab({
   provider,
   canDelete,
+  canUpdate,
   isDeleting,
   onDisconnect,
 }: {
   provider: CloudProvider;
   canDelete: boolean;
+  canUpdate: boolean;
   isDeleting: boolean;
   onDisconnect: (p: CloudProvider) => void;
 }) {
@@ -185,9 +194,14 @@ function ConnectionTab({
       {/* AWS-only — scan engine switcher. Lets the customer change between
           Comp AI scanners and Security Hub on an existing connection.
           Surfaces the current mode + a "Change" button that opens
-          ScanModeSwitchDialog with the right confirmation copy. */}
+          ScanModeSwitchDialog with the right confirmation copy.
+
+          Gated by `canUpdate` (integration:update) — matches the API
+          endpoint at PATCH /v1/cloud-security/connections/:id/scan-mode.
+          Using canDelete here would silently block users who legitimately
+          have update permission. */}
       {provider.id === 'aws' && !provider.isLegacy && (
-        <AwsScanModeSection connectionId={provider.connectionId} canEdit={canDelete} />
+        <AwsScanModeSection connectionId={provider.connectionId} canEdit={canUpdate} />
       )}
 
       {canDelete && (


### PR DESCRIPTION
## Summary

Cubic flagged a real P2 in the merged PR #2871. The AWS scan-mode switch in `CloudSettingsModal` was gated by `integration:delete` but the API endpoint it calls requires `integration:update`. Users with the appropriate (update) permission but without delete permission were silently blocked from seeing the Switch button even though the backend would have accepted their request.

## Root cause

In `CloudSettingsModal.tsx`:
```tsx
<AwsScanModeSection connectionId={provider.connectionId} canEdit={canDelete} />
```

The `canDelete` boolean was reused for the scan-mode switcher because there was only one permission boolean in scope. The switch is an UPDATE operation, not a DELETE one — using `canDelete` is wrong.

## Fix

Thread a separate `canUpdate = hasPermission('integration', 'update')` boolean through `CloudSettingsModal` → `ConnectionTab` → `AwsScanModeSection`. Use it for the scan-mode switch button. Disconnect button keeps using `canDelete` because that IS a delete action.

```tsx
const canUpdate = hasPermission('integration', 'update');
// ...
<AwsScanModeSection connectionId={...} canEdit={canUpdate} />
```

## API alignment

The API endpoint (`CloudSecurityController.updateAwsScanMode`) is gated by `@RequirePermission('integration', 'update')`. With this fix the UI matches the API — no more mismatch.

## Test plan

- [x] Added 3 regression tests covering the exact scenarios cubic flagged:
  - Admin (has both perms) — switch button shows ✅
  - Auditor (read-only) — switch button hidden ✅
  - **Update-only user (the cubic scenario)** — switch button shows AND Disconnect hidden ✅
- [x] Pre-existing 2 test failures in same file are unchanged (string expectations don't match current component, present before this PR — confirmed in earlier sessions)
- [x] Typecheck clean
- [ ] Manual: log in as a custom-role user with `integration:update` but not `integration:delete`, open Cloud Settings on an AWS connection, confirm Switch button appears

## Why a separate PR

PR #2871 was already merged when cubic surfaced this finding, so I'm shipping the fix as a follow-up off main instead of amending. The diff is minimal (2 files, 49 insertions / 2 deletions) so easy to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the AWS scan-mode switch in Cloud Settings to use `integration:update` instead of `integration:delete`, so update-only users can switch scan modes. Aligns the UI with the API gate and prevents valid users from being blocked.

- **Bug Fixes**
  - Thread `canUpdate = hasPermission('integration','update')` through `CloudSettingsModal` → `ConnectionTab` → `AwsScanModeSection`, and use it for the switch.
  - Keep Disconnect button gated by `integration:delete`.
  - Add regression tests: shows for admin, hides for auditor, and shows for update-only users while hiding Disconnect.

<sup>Written for commit 8ec0eea4a3b746d949babd721cde6a33ccc25c3e. Summary will update on new commits. <a href="https://cubic.dev/pr/trycompai/comp/pull/2874?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

