### PR TITLE
fix(cloud-tests): remove misleading 'Fix button supported' from scan-engine picker

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/AwsScanModeStep.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/AwsScanModeStep.tsx
@@ -30,11 +30,15 @@ interface AwsScanModeStepProps {
  * performs their cloud security scans. Two radio cards, mutually
  * exclusive:
  *
- *   1. Comp AI Scanners (default) — our service adapters, free,
- *      full Fix button support.
+ *   1. Comp AI Scanners (default) — our service adapters running
+ *      directly against AWS APIs, free.
  *   2. AWS Security Hub — read findings from the customer's existing
  *      Security Hub deployment, surface native NIST 800-53 / CIS / PCI
- *      mapping, Fix button available with a small disclosure.
+ *      mapping.
+ *
+ * Note: Fix button works for findings from BOTH modes (Security Hub
+ * findings just get a small disclosure banner in the Fix dialog).
+ * Fix support isn't a differentiator and isn't listed as a card badge.
  *
  * Pure UI — no API calls, no side effects. The parent owns state and
  * passes the choice into the createConnection payload via the
@@ -57,10 +61,10 @@ export function AwsScanModeStep({
         subtitle="Recommended"
         description={
           'Run our security checks directly against your AWS account. ' +
-          'No additional AWS cost. Full Fix button support. Covers IAM, ' +
-          'CloudTrail, S3, EC2, RDS, KMS, GuardDuty, and 40+ other services.'
+          'No additional AWS cost. Covers IAM, CloudTrail, S3, EC2, RDS, ' +
+          'KMS, GuardDuty, and 40+ other services.'
         }
-        badges={['Free', 'Fix button supported']}
+        badges={['Free']}
       />
       <ScanModeCard
         modeValue="security_hub"


### PR DESCRIPTION
## Summary

The Comp AI Scanners card in the AWS onboarding scan-engine picker listed *"Fix button supported"* as a badge and *"Full Fix button support."* in the description. Both implied the Fix button was a differentiator vs Security Hub mode — but it isn't.

When we built the SecHub mode we wired `evidence.findingKey` on the adapter and confirmed the AI fix pipeline is input-agnostic, so SecHub findings flow through the same Fix code path as adapter findings (with a small amber disclosure banner explaining that AWS re-evaluates findings on its own schedule).

## Change

Removed the misleading bits from the Comp AI Scanners card:
- Badge: `'Fix button supported'` → removed
- Description text: `"Full Fix button support."` → removed

Also updated the file-level docstring to reflect that Fix works for both modes and isn't surfaced as a card-level differentiator.

The actual differentiators stay on the cards:
- **Comp AI Scanners**: Free
- **AWS Security Hub**: Native NIST / CIS / PCI mapping, Requires Security Hub subscription

## Test plan

- [x] 6 existing `AwsScanModeStep` tests pass
- [x] Typecheck clean
- [ ] Visual: open the AWS onboarding step, confirm only "Free" badge shows on Comp AI Scanners card and the description no longer mentions Fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed misleading Fix button messaging from the AWS scan-engine picker. Fix works for both Comp AI Scanners and Security Hub, so it isn’t a differentiator.

- **Bug Fixes**
  - Removed "Fix button supported" badge and "Full Fix button support." from the Comp AI Scanners card; kept only "Free".
  - Updated component docstring to clarify Fix parity across both modes.

<sup>Written for commit 23bb1bbda3deb221c552b2ea4ea94b73c75dc899. Summary will update on new commits. <a href="https://cubic.dev/pr/trycompai/comp/pull/2876?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

