### PR TITLE
feat(api): unblock cloud-tests mutations for API key + service token callers

### DIFF
--- a/apps/api/src/auth/acting-user.service.spec.ts
+++ b/apps/api/src/auth/acting-user.service.spec.ts
@@ -1,0 +1,208 @@
+// Mock @db before importing the service so the Prisma client doesn't try
+// to connect at import time in this unit-test env.
+const mockDb = {
+  member: {
+    findFirst: jest.fn(),
+  },
+};
+
+jest.mock('@db', () => ({ db: mockDb }));
+
+import { ActingUserResolver } from './acting-user.service';
+import type { AuthenticatedRequest } from './types';
+
+function makeReq(overrides: Partial<AuthenticatedRequest> = {}): AuthenticatedRequest {
+  return {
+    organizationId: 'org_1',
+    authType: 'session',
+    isApiKey: false,
+    isServiceToken: false,
+    isPlatformAdmin: false,
+    userRoles: null,
+    ...overrides,
+  } as unknown as AuthenticatedRequest;
+}
+
+describe('ActingUserResolver', () => {
+  let resolver: ActingUserResolver;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resolver = new ActingUserResolver();
+  });
+
+  describe('session caller (short-circuit)', () => {
+    it('returns req.userId without a DB query', async () => {
+      const req = makeReq({
+        userId: 'usr_session_alice',
+        authType: 'session',
+      });
+
+      const result = await resolver.resolve(req, 'org_1');
+
+      expect(result).toEqual({
+        userId: 'usr_session_alice',
+        source: 'session',
+      });
+      // Critical regression guard — session auth must NEVER hit the DB
+      // for owner lookup. That would be a perf regression on every UI call.
+      expect(mockDb.member.findFirst).not.toHaveBeenCalled();
+    });
+
+    it('does NOT include a callerLabel for session callers', async () => {
+      // Session actions don't need automation-marker text in the audit log.
+      const req = makeReq({ userId: 'usr_session_alice' });
+      const result = await resolver.resolve(req, 'org_1');
+      expect(result.callerLabel).toBeUndefined();
+    });
+  });
+
+  describe('service token acting on behalf of a specific user', () => {
+    it('returns the x-user-id userId set by HybridAuthGuard, source service-token-acting', async () => {
+      // HybridAuthGuard already validated the x-user-id header against
+      // Member and set req.userId. We classify it differently from session
+      // for telemetry but don't need to re-validate.
+      const req = makeReq({
+        userId: 'usr_acting_bob',
+        authType: 'service',
+        isApiKey: false,
+        isServiceToken: true,
+        serviceName: 'Trigger.dev',
+      });
+
+      const result = await resolver.resolve(req, 'org_1');
+
+      expect(result).toEqual({
+        userId: 'usr_acting_bob',
+        source: 'service-token-acting',
+      });
+      expect(mockDb.member.findFirst).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('API key caller (owner fallback)', () => {
+    it('resolves to the org owner and labels the caller for the audit log', async () => {
+      mockDb.member.findFirst.mockResolvedValueOnce({
+        userId: 'usr_owner_carol',
+      });
+
+      const req = makeReq({
+        userId: undefined,
+        authType: 'api-key',
+        isApiKey: true,
+        apiKeyId: 'apk_1',
+        apiKeyName: 'CI Pipeline',
+      });
+
+      const result = await resolver.resolve(req, 'org_1');
+
+      expect(result.userId).toBe('usr_owner_carol');
+      expect(result.source).toBe('org-owner-fallback');
+      expect(result.callerLabel).toBe('via API key "CI Pipeline"');
+    });
+
+    it('scopes the owner lookup to the calling org (cross-tenant safety)', async () => {
+      mockDb.member.findFirst.mockResolvedValueOnce({ userId: 'usr_owner' });
+      const req = makeReq({
+        userId: undefined,
+        authType: 'api-key',
+        isApiKey: true,
+        apiKeyName: 'X',
+      });
+
+      await resolver.resolve(req, 'org_target');
+
+      expect(mockDb.member.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            organizationId: 'org_target',
+            role: { contains: 'owner' },
+          }),
+        }),
+      );
+    });
+
+    it('picks the OLDEST owner deterministically (orderBy createdAt asc)', async () => {
+      // Determinism matters — re-running the same automation should always
+      // attribute to the same user, even if newer owners are added/removed.
+      mockDb.member.findFirst.mockResolvedValueOnce({ userId: 'usr_oldest' });
+      const req = makeReq({
+        userId: undefined,
+        isApiKey: true,
+        apiKeyName: 'X',
+      });
+
+      await resolver.resolve(req, 'org_1');
+
+      expect(mockDb.member.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { createdAt: 'asc' },
+        }),
+      );
+    });
+
+    it('returns null userId (not throw) when the org has no owner-role members', async () => {
+      // Soft failure — the controller surfaces a 400 with an actionable
+      // message ("ensure your org has an owner"). Throwing here would
+      // 500 instead, which is worse UX.
+      mockDb.member.findFirst.mockResolvedValueOnce(null);
+      const req = makeReq({
+        userId: undefined,
+        isApiKey: true,
+        apiKeyName: 'X',
+      });
+
+      const result = await resolver.resolve(req, 'org_no_owner');
+
+      expect(result.userId).toBeNull();
+      expect(result.source).toBe('org-owner-fallback');
+      // callerLabel still populated so the eventual 400 message can mention
+      // which API key tried (helpful in customer support).
+      expect(result.callerLabel).toBe('via API key "X"');
+    });
+
+    it('falls back to "via API key" when the key name is missing (defensive)', async () => {
+      mockDb.member.findFirst.mockResolvedValueOnce({ userId: 'usr_owner' });
+      const req = makeReq({
+        userId: undefined,
+        isApiKey: true,
+        apiKeyName: undefined,
+      });
+
+      const result = await resolver.resolve(req, 'org_1');
+
+      expect(result.callerLabel).toBe('via API key');
+    });
+  });
+
+  describe('service token without x-user-id (owner fallback)', () => {
+    it('resolves to the org owner with a service-flavored caller label', async () => {
+      mockDb.member.findFirst.mockResolvedValueOnce({ userId: 'usr_owner' });
+      const req = makeReq({
+        userId: undefined,
+        authType: 'service',
+        isServiceToken: true,
+        serviceName: 'Trigger.dev',
+      });
+
+      const result = await resolver.resolve(req, 'org_1');
+
+      expect(result.userId).toBe('usr_owner');
+      expect(result.source).toBe('org-owner-fallback');
+      expect(result.callerLabel).toBe('via service "Trigger.dev"');
+    });
+
+    it('falls back to "via service token" when the service name is missing', async () => {
+      mockDb.member.findFirst.mockResolvedValueOnce({ userId: 'usr_owner' });
+      const req = makeReq({
+        userId: undefined,
+        isServiceToken: true,
+        serviceName: undefined,
+      });
+
+      const result = await resolver.resolve(req, 'org_1');
+
+      expect(result.callerLabel).toBe('via service token');
+    });
+  });
+});

--- a/apps/api/src/auth/acting-user.service.ts
+++ b/apps/api/src/auth/acting-user.service.ts
@@ -1,0 +1,140 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { db } from '@db';
+import type { AuthenticatedRequest } from './types';
+
+/**
+ * The auth flow that produced the userId we'll attribute a mutation to.
+ *
+ *   - 'session' — req.userId set by better-auth from a session cookie / bearer token.
+ *   - 'service-token-acting' — service token caller passed an `x-user-id` header
+ *     which HybridAuthGuard validated against Member and set on req.userId.
+ *   - 'org-owner-fallback' — API key (or service token without x-user-id)
+ *     resolved to the org's oldest owner. This keeps mutations API-callable
+ *     without forcing callers to manage user IDs themselves.
+ */
+export type ActingUserSource =
+  | 'session'
+  | 'service-token-acting'
+  | 'org-owner-fallback';
+
+export interface ResolvedActingUser {
+  /** User ID to attribute the mutation to. Null only when no fallback was
+   *  available (e.g. an org with zero owner-role members — caller should
+   *  surface a 400 with an actionable message). */
+  userId: string | null;
+  source: ActingUserSource;
+  /** Short label for audit log descriptions. Only set when source is
+   *  'org-owner-fallback' — session and explicit service-token acting
+   *  don't need to call out automation in the audit trail. */
+  callerLabel?: string;
+}
+
+/**
+ * Resolves the user that a mutation should be attributed to, accepting any
+ * supported auth method. This is the single, shared way for write endpoints
+ * to answer "whose userId should I record on this audit log / row?".
+ *
+ * Rules:
+ *   1. Session callers — `req.userId` is already set by HybridAuthGuard.
+ *      We return it without a DB query (zero overhead for the common UI path).
+ *   2. Service tokens calling on behalf of a specific user — HybridAuthGuard
+ *      sets `req.userId` from the `x-user-id` header after Member validation.
+ *      Same short-circuit as session.
+ *   3. API keys, or service tokens without `x-user-id` — no per-user identity
+ *      exists. We attribute to the org's OLDEST owner (deterministic + stable
+ *      across deletes of newer owners). This is consistent with how 19+
+ *      other places in the codebase already look up org owners
+ *      (`Member.role.contains('owner')`).
+ *
+ * Returning null userId is a soft failure — callers must surface a 400 with
+ * the org-needs-an-owner message rather than 500-ing on a Prisma FK error.
+ */
+@Injectable()
+export class ActingUserResolver {
+  private readonly logger = new Logger(ActingUserResolver.name);
+
+  async resolve(
+    req: AuthenticatedRequest,
+    organizationId: string,
+  ): Promise<ResolvedActingUser> {
+    // Path 1 + 2 — session caller, or service token acting on behalf of a
+    // specific user. HybridAuthGuard already set req.userId for both, so we
+    // just classify which one and short-circuit. No DB query.
+    if (req.userId) {
+      return {
+        userId: req.userId,
+        source: req.isServiceToken ? 'service-token-acting' : 'session',
+      };
+    }
+
+    // Path 3 — fall back to the org's owner.
+    const ownerUserId = await this.findOrgOwnerUserId(organizationId);
+    if (!ownerUserId) {
+      // No owner found. Don't invent one — the caller should reject the
+      // mutation with a clear message so the customer can fix the role
+      // assignment themselves.
+      this.logger.warn(
+        `No owner-role member found for org ${organizationId}; mutation cannot be attributed.`,
+      );
+      return {
+        userId: null,
+        source: 'org-owner-fallback',
+        callerLabel: this.buildCallerLabel(req),
+      };
+    }
+
+    return {
+      userId: ownerUserId,
+      source: 'org-owner-fallback',
+      callerLabel: this.buildCallerLabel(req),
+    };
+  }
+
+  /**
+   * Find the oldest owner of an organization. Oldest is deterministic and
+   * stable: removing a recently-added owner doesn't change the attribution
+   * target, removing the oldest one just promotes the next one. Matches the
+   * pattern used elsewhere (e.g. tasks/task-notifier.service.ts).
+   *
+   * Member.role is a comma-separated string (e.g. "owner,admin"), so we use
+   * Prisma's `contains` filter — same query shape as the 19+ other owner
+   * lookups in this codebase.
+   */
+  private async findOrgOwnerUserId(
+    organizationId: string,
+  ): Promise<string | null> {
+    const owner = await db.member.findFirst({
+      where: {
+        organizationId,
+        role: { contains: 'owner' },
+      },
+      orderBy: { createdAt: 'asc' },
+      select: { userId: true },
+    });
+    return owner?.userId ?? null;
+  }
+
+  /**
+   * Produces the short string that downstream audit-log descriptions
+   * prepend (e.g. `[via API key "CI Pipeline"]`). The caller decides where
+   * to put it; this helper just standardises the wording.
+   *
+   * Returns 'via API key' / 'via service token' / 'via API' as a graceful
+   * fallback so we always emit SOMETHING rather than drop attribution.
+   */
+  private buildCallerLabel(req: AuthenticatedRequest): string {
+    if (req.isApiKey) {
+      return req.apiKeyName
+        ? `via API key "${req.apiKeyName}"`
+        : 'via API key';
+    }
+    if (req.isServiceToken) {
+      return req.serviceName
+        ? `via service "${req.serviceName}"`
+        : 'via service token';
+    }
+    // Should never reach here — Path 1/2 would have short-circuited — but
+    // we return a sane default rather than throw.
+    return 'via API';
+  }
+}

--- a/apps/api/src/auth/api-key.service.ts
+++ b/apps/api/src/auth/api-key.service.ts
@@ -10,6 +10,13 @@ import { createHash, randomBytes } from 'node:crypto';
 
 /** Result from validating an API key */
 export interface ApiKeyValidationResult {
+  /** API key row primary key — exposed on the request so downstream
+   *  attribution logic (audit logs, owner-fallback resolver) can reference
+   *  the exact key used without an extra DB lookup. */
+  apiKeyId: string;
+  /** Human-readable name set when the key was created (e.g. "CI Pipeline").
+   *  Surfaced in audit log descriptions for API-key-initiated mutations. */
+  apiKeyName: string;
   organizationId: string;
   scopes: string[];
 }
@@ -187,6 +194,7 @@ export class ApiKeyService {
         },
         select: {
           id: true,
+          name: true,
           key: true,
           salt: true,
           organizationId: true,
@@ -214,6 +222,7 @@ export class ApiKeyService {
             },
             select: {
               id: true,
+              name: true,
               key: true,
               salt: true,
               organizationId: true,
@@ -234,6 +243,8 @@ export class ApiKeyService {
               data: { keyPrefix, lastUsedAt: new Date() },
             });
             return {
+              apiKeyId: legacyMatch.id,
+              apiKeyName: legacyMatch.name,
               organizationId: legacyMatch.organizationId,
               scopes: legacyMatch.scopes,
             };
@@ -258,6 +269,8 @@ export class ApiKeyService {
       );
 
       return {
+        apiKeyId: matchingRecord.id,
+        apiKeyName: matchingRecord.name,
         organizationId: matchingRecord.organizationId,
         scopes: matchingRecord.scopes,
       };

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { AuthModule as BetterAuthModule } from '@thallesp/nestjs-better-auth';
 import { auth } from './auth.server';
+import { ActingUserResolver } from './acting-user.service';
 import { ApiKeyGuard } from './api-key.guard';
 import { ApiKeyService } from './api-key.service';
 import { AuthController } from './auth.controller';
@@ -24,12 +25,19 @@ import { PermissionGuard } from './permission.guard';
     }),
   ],
   controllers: [AuthController],
-  providers: [ApiKeyService, ApiKeyGuard, HybridAuthGuard, PermissionGuard],
+  providers: [
+    ApiKeyService,
+    ApiKeyGuard,
+    HybridAuthGuard,
+    PermissionGuard,
+    ActingUserResolver,
+  ],
   exports: [
     ApiKeyService,
     ApiKeyGuard,
     HybridAuthGuard,
     PermissionGuard,
+    ActingUserResolver,
     BetterAuthModule,
   ],
 })

--- a/apps/api/src/auth/hybrid-auth.guard.ts
+++ b/apps/api/src/auth/hybrid-auth.guard.ts
@@ -72,6 +72,11 @@ export class HybridAuthGuard implements CanActivate {
     request.isServiceToken = false;
     request.isPlatformAdmin = false;
     request.apiKeyScopes = result.scopes;
+    // Surface the key's id + name on the request so downstream attribution
+    // (ActingUserResolver, audit logs) can record "via API key '<name>'"
+    // without an extra DB lookup.
+    request.apiKeyId = result.apiKeyId;
+    request.apiKeyName = result.apiKeyName;
     // API keys are organization-scoped and are not tied to a specific user/member.
     request.userRoles = null;
 

--- a/apps/api/src/auth/types.ts
+++ b/apps/api/src/auth/types.ts
@@ -15,6 +15,8 @@ export interface AuthenticatedRequest extends Request {
   memberId?: string; // Member ID for assignment filtering (only available for session auth)
   memberDepartment?: Departments; // Member department for visibility filtering (only available for session auth)
   apiKeyScopes?: string[]; // Scopes for API key auth (empty = legacy full access)
+  apiKeyId?: string; // ApiKey row id — only set for API key auth. Used by ActingUserResolver / audit log attribution.
+  apiKeyName?: string; // Human-readable API key name (e.g. "CI Pipeline") — only set for API key auth.
   impersonatedBy?: string; // User ID of the admin who initiated impersonation (only set during impersonation sessions)
   sessionId?: string; // Session ID (only set for session auth)
   sessionDeviceAgent?: boolean; // Whether the session is a device-agent session (only set for session auth)

--- a/apps/api/src/cloud-security/aws-scan-mode.service.spec.ts
+++ b/apps/api/src/cloud-security/aws-scan-mode.service.spec.ts
@@ -1,0 +1,131 @@
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+
+// Mock @db before importing the service so the Prisma client doesn't try
+// to connect at import time in this unit-test env.
+const mockDb = {
+  integrationConnection: {
+    findFirst: jest.fn(),
+    update: jest.fn(),
+  },
+};
+jest.mock('@db', () => ({ db: mockDb }));
+
+// Mock the activity logger so we can assert on the description it receives.
+const mockAuditLog = jest.fn().mockResolvedValue(undefined);
+jest.mock('./cloud-security-audit', () => ({
+  logCloudSecurityActivity: mockAuditLog,
+}));
+
+import { CloudAwsScanModeService } from './aws-scan-mode.service';
+
+function buildService() {
+  return new CloudAwsScanModeService();
+}
+
+function withAwsConnection(opts: { currentMode?: string } = {}) {
+  mockDb.integrationConnection.findFirst.mockResolvedValueOnce({
+    id: 'icn_aws',
+    metadata: opts.currentMode ? { awsScanMode: opts.currentMode } : {},
+    provider: { slug: 'aws' },
+  });
+}
+
+describe('CloudAwsScanModeService.updateMode', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 403 when the connection does not exist / belongs to a different org', async () => {
+    mockDb.integrationConnection.findFirst.mockResolvedValueOnce(null);
+
+    await expect(
+      buildService().updateMode({
+        connectionId: 'icn_missing',
+        organizationId: 'org_1',
+        userId: 'usr_1',
+        mode: 'security_hub',
+      }),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('returns 400 when the connection is not AWS', async () => {
+    mockDb.integrationConnection.findFirst.mockResolvedValueOnce({
+      id: 'icn_gcp',
+      metadata: {},
+      provider: { slug: 'gcp' },
+    });
+
+    await expect(
+      buildService().updateMode({
+        connectionId: 'icn_gcp',
+        organizationId: 'org_1',
+        userId: 'usr_1',
+        mode: 'security_hub',
+      }),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('is idempotent when the target mode equals the current mode', async () => {
+    withAwsConnection({ currentMode: 'security_hub' });
+
+    const result = await buildService().updateMode({
+      connectionId: 'icn_aws',
+      organizationId: 'org_1',
+      userId: 'usr_1',
+      mode: 'security_hub',
+    });
+
+    expect(result).toEqual({ mode: 'security_hub' });
+    expect(mockDb.integrationConnection.update).not.toHaveBeenCalled();
+    expect(mockAuditLog).not.toHaveBeenCalled();
+  });
+
+  it('writes the new mode + audit log on a successful switch (session call)', async () => {
+    withAwsConnection({ currentMode: 'comp_scanners' });
+
+    await buildService().updateMode({
+      connectionId: 'icn_aws',
+      organizationId: 'org_1',
+      userId: 'usr_human',
+      mode: 'security_hub',
+    });
+
+    expect(mockDb.integrationConnection.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'icn_aws' },
+        data: expect.objectContaining({
+          metadata: expect.objectContaining({ awsScanMode: 'security_hub' }),
+        }),
+      }),
+    );
+    const auditCall = mockAuditLog.mock.calls[0][0];
+    expect(auditCall.action).toBe('scan_mode_changed');
+    // No bracket prefix when callerLabel is undefined (session call).
+    expect(auditCall.description).toMatch(/^Switched AWS scan engine: /);
+    expect(auditCall.metadata.callerLabel).toBeNull();
+  });
+
+  it('prepends callerLabel to the audit description when set (API key call)', async () => {
+    // Regression guard for the fix: when an API key triggers this mutation
+    // via ActingUserResolver's owner-fallback, the audit description must
+    // make the automation source visible — auditors otherwise see only the
+    // org owner's name and have no idea it was an automated change.
+    withAwsConnection({ currentMode: 'comp_scanners' });
+
+    await buildService().updateMode({
+      connectionId: 'icn_aws',
+      organizationId: 'org_1',
+      userId: 'usr_owner',
+      mode: 'security_hub',
+      callerLabel: 'via API key "CI Pipeline"',
+    });
+
+    const auditCall = mockAuditLog.mock.calls[0][0];
+    expect(auditCall.description).toMatch(
+      /^\[via API key "CI Pipeline"\] Switched AWS scan engine: /,
+    );
+    expect(auditCall.metadata).toEqual(
+      expect.objectContaining({ callerLabel: 'via API key "CI Pipeline"' }),
+    );
+  });
+});

--- a/apps/api/src/cloud-security/aws-scan-mode.service.ts
+++ b/apps/api/src/cloud-security/aws-scan-mode.service.ts
@@ -38,8 +38,13 @@ export class CloudAwsScanModeService {
   async updateMode(params: {
     connectionId: string;
     organizationId: string;
+    /** Session user, or org owner for API key / service token callers
+     *  (resolved by ActingUserResolver in the controller). */
     userId: string;
     mode: AwsScanMode;
+    /** Optional audit-log description prefix when userId came from
+     *  owner-fallback (e.g. `via API key "CI Pipeline"`). */
+    callerLabel?: string;
   }): Promise<{ mode: AwsScanMode }> {
     const connection = await db.integrationConnection.findFirst({
       where: {
@@ -84,15 +89,20 @@ export class CloudAwsScanModeService {
       },
     });
 
+    const description = params.callerLabel
+      ? `[${params.callerLabel}] Switched AWS scan engine: ${previousMode} → ${params.mode}`
+      : `Switched AWS scan engine: ${previousMode} → ${params.mode}`;
+
     await logCloudSecurityActivity({
       organizationId: params.organizationId,
       userId: params.userId,
       connectionId: connection.id,
       action: 'scan_mode_changed',
-      description: `Switched AWS scan engine: ${previousMode} → ${params.mode}`,
+      description,
       metadata: {
         previousMode,
         newMode: params.mode,
+        callerLabel: params.callerLabel ?? null,
       },
     });
 

--- a/apps/api/src/cloud-security/cloud-security.controller.spec.ts
+++ b/apps/api/src/cloud-security/cloud-security.controller.spec.ts
@@ -1,0 +1,311 @@
+// Stub out the dependencies pulled in transitively by HybridAuthGuard so
+// the controller can be imported in this unit-test env without booting
+// Prisma or loading better-auth's ESM modules. We only test the
+// controller's orchestration logic — the guards themselves are tested
+// elsewhere.
+jest.mock('@db', () => ({ db: {} }));
+jest.mock('@trycompai/auth', () => ({
+  statement: {},
+  ac: { newRole: () => ({}) },
+}));
+jest.mock('../auth/auth.server', () => ({
+  auth: { api: { getSession: jest.fn() } },
+}));
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+import { CloudSecurityController } from './cloud-security.controller';
+import { CloudSecurityService } from './cloud-security.service';
+import { CloudSecurityQueryService } from './cloud-security-query.service';
+import { CloudSecurityLegacyService } from './cloud-security-legacy.service';
+import { CloudSecurityActivityService } from './cloud-security-activity.service';
+import { GCPSecurityService } from './providers/gcp-security.service';
+import { AzureSecurityService } from './providers/azure-security.service';
+import { CheckDefinitionService } from './check-definition.service';
+import { CloudExceptionService } from './exception.service';
+import { CloudHistoryService } from './history.service';
+import { CloudAwsScanModeService } from './aws-scan-mode.service';
+import { ActingUserResolver } from '../auth/acting-user.service';
+import { HybridAuthGuard } from '../auth/hybrid-auth.guard';
+import { PermissionGuard } from '../auth/permission.guard';
+import type { AuthenticatedRequest } from '../auth/types';
+
+/**
+ * Controller-level tests for the 3 mutation endpoints that previously
+ * required session auth. They now accept API key + service token callers
+ * via the ActingUserResolver owner-fallback path. These tests lock in:
+ *
+ *   1. Session call → service called with req.userId, no callerLabel.
+ *   2. API key call (resolver returns org owner) → service called with the
+ *      owner's userId + a callerLabel for the audit log description.
+ *   3. Org with no owner → 400 with the actionable error message.
+ *
+ * Guards are mocked to `canActivate: () => true` because they're tested
+ * elsewhere — these specs focus on the new orchestration logic added in
+ * this PR.
+ */
+describe('CloudSecurityController — API-key mutation support', () => {
+  let controller: CloudSecurityController;
+  let exceptionService: jest.Mocked<CloudExceptionService>;
+  let scanModeService: jest.Mocked<CloudAwsScanModeService>;
+  let actingUser: jest.Mocked<ActingUserResolver>;
+
+  const mockExceptionService = {
+    markAsException: jest.fn(),
+    revokeException: jest.fn(),
+  };
+  const mockScanModeService = {
+    updateMode: jest.fn(),
+  };
+  const mockActingUser = {
+    resolve: jest.fn(),
+  };
+  const mockGuard = { canActivate: jest.fn().mockReturnValue(true) };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CloudSecurityController],
+      providers: [
+        // Only mock the deps actually invoked by the methods under test.
+        // The rest are wired with empty stubs so Nest's DI can build the
+        // controller without complaining.
+        { provide: CloudSecurityService, useValue: {} },
+        { provide: CloudSecurityQueryService, useValue: {} },
+        { provide: CloudSecurityLegacyService, useValue: {} },
+        { provide: CloudSecurityActivityService, useValue: {} },
+        { provide: GCPSecurityService, useValue: {} },
+        { provide: AzureSecurityService, useValue: {} },
+        { provide: CheckDefinitionService, useValue: {} },
+        { provide: CloudExceptionService, useValue: mockExceptionService },
+        { provide: CloudHistoryService, useValue: {} },
+        { provide: CloudAwsScanModeService, useValue: mockScanModeService },
+        { provide: ActingUserResolver, useValue: mockActingUser },
+      ],
+    })
+      .overrideGuard(HybridAuthGuard)
+      .useValue(mockGuard)
+      .overrideGuard(PermissionGuard)
+      .useValue(mockGuard)
+      .compile();
+
+    controller = module.get(CloudSecurityController);
+    exceptionService = module.get(CloudExceptionService) as jest.Mocked<CloudExceptionService>;
+    scanModeService = module.get(CloudAwsScanModeService) as jest.Mocked<CloudAwsScanModeService>;
+    actingUser = module.get(ActingUserResolver) as jest.Mocked<ActingUserResolver>;
+
+    jest.clearAllMocks();
+  });
+
+  function sessionReq(): AuthenticatedRequest {
+    return {
+      userId: 'usr_alice',
+      organizationId: 'org_1',
+      authType: 'session',
+      isApiKey: false,
+      isServiceToken: false,
+    } as unknown as AuthenticatedRequest;
+  }
+
+  function apiKeyReq(): AuthenticatedRequest {
+    return {
+      userId: undefined,
+      organizationId: 'org_1',
+      authType: 'api-key',
+      isApiKey: true,
+      isServiceToken: false,
+      apiKeyId: 'apk_1',
+      apiKeyName: 'CI Pipeline',
+    } as unknown as AuthenticatedRequest;
+  }
+
+  // ─── markFindingAsException ─────────────────────────────────────────────
+
+  describe('markFindingAsException', () => {
+    const validBody = {
+      reason: 'Documented exception with twenty-plus non-whitespace characters here.',
+      reviewedBy: 'person@example.com',
+    };
+
+    it('passes req.userId through to the service for session callers (no callerLabel)', async () => {
+      actingUser.resolve.mockResolvedValueOnce({
+        userId: 'usr_alice',
+        source: 'session',
+      });
+      exceptionService.markAsException.mockResolvedValueOnce({ id: 'fex_1' });
+
+      await controller.markFindingAsException(
+        'icx_1',
+        validBody,
+        'org_1',
+        sessionReq(),
+      );
+
+      expect(exceptionService.markAsException).toHaveBeenCalledWith(
+        expect.objectContaining({
+          findingId: 'icx_1',
+          organizationId: 'org_1',
+          userId: 'usr_alice',
+          callerLabel: undefined,
+        }),
+      );
+    });
+
+    it('uses the resolved owner + callerLabel for API key callers', async () => {
+      actingUser.resolve.mockResolvedValueOnce({
+        userId: 'usr_owner_carol',
+        source: 'org-owner-fallback',
+        callerLabel: 'via API key "CI Pipeline"',
+      });
+      exceptionService.markAsException.mockResolvedValueOnce({ id: 'fex_2' });
+
+      await controller.markFindingAsException(
+        'icx_1',
+        validBody,
+        'org_1',
+        apiKeyReq(),
+      );
+
+      expect(actingUser.resolve).toHaveBeenCalledWith(
+        expect.objectContaining({ isApiKey: true }),
+        'org_1',
+      );
+      expect(exceptionService.markAsException).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'usr_owner_carol',
+          callerLabel: 'via API key "CI Pipeline"',
+        }),
+      );
+    });
+
+    it('returns 400 with an actionable message when the org has no owner', async () => {
+      actingUser.resolve.mockResolvedValueOnce({
+        userId: null,
+        source: 'org-owner-fallback',
+        callerLabel: 'via API key "CI Pipeline"',
+      });
+
+      const error = await controller
+        .markFindingAsException('icx_1', validBody, 'org_1', apiKeyReq())
+        .catch((e) => e);
+
+      expect(error).toBeInstanceOf(HttpException);
+      expect((error as HttpException).getStatus()).toBe(HttpStatus.BAD_REQUEST);
+      expect((error as HttpException).message).toMatch(/at least one user with the "owner" role/);
+      expect(exceptionService.markAsException).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── updateAwsScanMode ──────────────────────────────────────────────────
+
+  describe('updateAwsScanMode', () => {
+    const validBody = { mode: 'security_hub' as const };
+
+    it('passes req.userId through to the service for session callers', async () => {
+      actingUser.resolve.mockResolvedValueOnce({
+        userId: 'usr_alice',
+        source: 'session',
+      });
+      scanModeService.updateMode.mockResolvedValueOnce({ mode: 'security_hub' });
+
+      await controller.updateAwsScanMode('icn_aws', validBody, 'org_1', sessionReq());
+
+      expect(scanModeService.updateMode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          connectionId: 'icn_aws',
+          userId: 'usr_alice',
+          mode: 'security_hub',
+          callerLabel: undefined,
+        }),
+      );
+    });
+
+    it('uses the resolved owner + callerLabel for API key callers', async () => {
+      actingUser.resolve.mockResolvedValueOnce({
+        userId: 'usr_owner',
+        source: 'org-owner-fallback',
+        callerLabel: 'via API key "CI Pipeline"',
+      });
+      scanModeService.updateMode.mockResolvedValueOnce({ mode: 'security_hub' });
+
+      await controller.updateAwsScanMode('icn_aws', validBody, 'org_1', apiKeyReq());
+
+      expect(scanModeService.updateMode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'usr_owner',
+          callerLabel: 'via API key "CI Pipeline"',
+        }),
+      );
+    });
+
+    it('returns 400 when org has no owner', async () => {
+      actingUser.resolve.mockResolvedValueOnce({
+        userId: null,
+        source: 'org-owner-fallback',
+      });
+
+      const error = await controller
+        .updateAwsScanMode('icn_aws', validBody, 'org_1', apiKeyReq())
+        .catch((e) => e);
+
+      expect(error).toBeInstanceOf(HttpException);
+      expect((error as HttpException).getStatus()).toBe(HttpStatus.BAD_REQUEST);
+      expect(scanModeService.updateMode).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── revokeException ────────────────────────────────────────────────────
+
+  describe('revokeException', () => {
+    it('passes req.userId through to the service for session callers', async () => {
+      actingUser.resolve.mockResolvedValueOnce({
+        userId: 'usr_alice',
+        source: 'session',
+      });
+      exceptionService.revokeException.mockResolvedValueOnce(undefined);
+
+      await controller.revokeException('fex_1', 'org_1', sessionReq());
+
+      expect(exceptionService.revokeException).toHaveBeenCalledWith(
+        expect.objectContaining({
+          exceptionId: 'fex_1',
+          userId: 'usr_alice',
+          callerLabel: undefined,
+        }),
+      );
+    });
+
+    it('uses the resolved owner + callerLabel for API key callers', async () => {
+      actingUser.resolve.mockResolvedValueOnce({
+        userId: 'usr_owner',
+        source: 'org-owner-fallback',
+        callerLabel: 'via API key "CI Pipeline"',
+      });
+      exceptionService.revokeException.mockResolvedValueOnce(undefined);
+
+      await controller.revokeException('fex_1', 'org_1', apiKeyReq());
+
+      expect(exceptionService.revokeException).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'usr_owner',
+          callerLabel: 'via API key "CI Pipeline"',
+        }),
+      );
+    });
+
+    it('returns 400 when org has no owner', async () => {
+      actingUser.resolve.mockResolvedValueOnce({
+        userId: null,
+        source: 'org-owner-fallback',
+      });
+
+      const error = await controller
+        .revokeException('fex_1', 'org_1', apiKeyReq())
+        .catch((e) => e);
+
+      expect(error).toBeInstanceOf(HttpException);
+      expect((error as HttpException).getStatus()).toBe(HttpStatus.BAD_REQUEST);
+      expect(exceptionService.revokeException).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/cloud-security/cloud-security.controller.ts
+++ b/apps/api/src/cloud-security/cloud-security.controller.ts
@@ -32,6 +32,8 @@ import { CloudAwsScanModeService } from './aws-scan-mode.service';
 import { parseExceptionExpiry } from './exception-expiry.utils';
 import { MarkExceptionDto } from './dto/mark-exception.dto';
 import { UpdateAwsScanModeDto } from './dto/update-scan-mode.dto';
+import { ActingUserResolver } from '../auth/acting-user.service';
+import type { AuthenticatedRequest } from '../auth/types';
 import { logCloudSecurityActivity } from './cloud-security-audit';
 import { CloudSecurityActivityService } from './cloud-security-activity.service';
 import {
@@ -56,6 +58,7 @@ export class CloudSecurityController {
     private readonly exceptionService: CloudExceptionService,
     private readonly historyService: CloudHistoryService,
     private readonly scanModeService: CloudAwsScanModeService,
+    private readonly actingUser: ActingUserResolver,
   ) {}
 
   @Get('activity')
@@ -114,26 +117,32 @@ export class CloudSecurityController {
   @ApiOperation({
     summary:
       'Mark a finding as an exception so it no longer appears in the active Scan Results list',
+    description:
+      'Accepts session, API key, or service token auth. For API key / service token callers ' +
+      'without an explicit user attribution, the action is attributed to the org\'s owner and ' +
+      'the audit log description records the calling key/service name.',
   })
   async markFindingAsException(
     @Param('findingId') findingId: string,
     @Body() body: MarkExceptionDto,
     @OrganizationId() organizationId: string,
-    @Req() req: { userId?: string },
+    @Req() req: AuthenticatedRequest,
   ) {
-    if (!req.userId) {
+    const acting = await this.actingUser.resolve(req, organizationId);
+    if (!acting.userId) {
       throw new HttpException(
-        'Marking an exception requires session authentication.',
-        HttpStatus.UNAUTHORIZED,
+        'Cannot attribute this action — your organization must have at least one user with the "owner" role.',
+        HttpStatus.BAD_REQUEST,
       );
     }
     const result = await this.exceptionService.markAsException({
       findingId,
       organizationId,
-      userId: req.userId,
+      userId: acting.userId,
       reason: body.reason,
       reviewedBy: body.reviewedBy ?? null,
       expiresAt: parseExceptionExpiry(body.expiresAt),
+      callerLabel: acting.callerLabel,
     });
     return { data: result };
   }
@@ -144,24 +153,29 @@ export class CloudSecurityController {
   @ApiOperation({
     summary:
       'Switch the AWS scan engine for a connection (Comp AI scanners ↔ Security Hub)',
+    description:
+      'Accepts session, API key, or service token auth. For API key / service token callers ' +
+      'without an explicit user attribution, the action is attributed to the org\'s owner.',
   })
   async updateAwsScanMode(
     @Param('connectionId') connectionId: string,
     @Body() body: UpdateAwsScanModeDto,
     @OrganizationId() organizationId: string,
-    @Req() req: { userId?: string },
+    @Req() req: AuthenticatedRequest,
   ) {
-    if (!req.userId) {
+    const acting = await this.actingUser.resolve(req, organizationId);
+    if (!acting.userId) {
       throw new HttpException(
-        'Switching the scan engine requires session authentication.',
-        HttpStatus.UNAUTHORIZED,
+        'Cannot attribute this action — your organization must have at least one user with the "owner" role.',
+        HttpStatus.BAD_REQUEST,
       );
     }
     const result = await this.scanModeService.updateMode({
       connectionId,
       organizationId,
-      userId: req.userId,
+      userId: acting.userId,
       mode: body.mode,
+      callerLabel: acting.callerLabel,
     });
     return { data: result };
   }
@@ -169,22 +183,29 @@ export class CloudSecurityController {
   @Delete('exceptions/:exceptionId')
   @UseGuards(HybridAuthGuard, PermissionGuard)
   @RequirePermission('integration', 'update')
-  @ApiOperation({ summary: 'Revoke an exception, reopening the finding' })
+  @ApiOperation({
+    summary: 'Revoke an exception, reopening the finding',
+    description:
+      'Accepts session, API key, or service token auth. For API key / service token callers ' +
+      'without an explicit user attribution, the action is attributed to the org\'s owner.',
+  })
   async revokeException(
     @Param('exceptionId') exceptionId: string,
     @OrganizationId() organizationId: string,
-    @Req() req: { userId?: string },
+    @Req() req: AuthenticatedRequest,
   ) {
-    if (!req.userId) {
+    const acting = await this.actingUser.resolve(req, organizationId);
+    if (!acting.userId) {
       throw new HttpException(
-        'Revoking an exception requires session authentication.',
-        HttpStatus.UNAUTHORIZED,
+        'Cannot attribute this action — your organization must have at least one user with the "owner" role.',
+        HttpStatus.BAD_REQUEST,
       );
     }
     await this.exceptionService.revokeException({
       exceptionId,
       organizationId,
-      userId: req.userId,
+      userId: acting.userId,
+      callerLabel: acting.callerLabel,
     });
     return { success: true };
   }

--- a/apps/api/src/cloud-security/exception.service.spec.ts
+++ b/apps/api/src/cloud-security/exception.service.spec.ts
@@ -130,6 +130,56 @@ describe('CloudExceptionService.markAsException', () => {
     );
   });
 
+  it('prepends callerLabel to audit description when set (API key / service token attribution)', async () => {
+    // When the userId came from ActingUserResolver's owner-fallback path,
+    // the controller forwards a callerLabel so the audit log makes it
+    // clear this was automation, not a UI click.
+    withFinding({
+      findingKey: 'iam-no-mfa-john',
+      resourceId: 'john',
+      connectionId: 'icn_aws',
+    });
+    dbMock.findingException.upsert.mockResolvedValueOnce({ id: 'fex_new' });
+
+    await buildService().markAsException({
+      findingId: 'icx_1',
+      organizationId: 'org_1',
+      userId: 'usr_owner',
+      reason: 'CI pipeline marking this finding under approved exception policy.',
+      callerLabel: 'via API key "CI Pipeline"',
+    });
+
+    const auditCall = auditLogMock.mock.calls[0][0];
+    expect(auditCall.description).toMatch(
+      /^\[via API key "CI Pipeline"\] Marked finding /,
+    );
+    expect(auditCall.metadata).toEqual(
+      expect.objectContaining({ callerLabel: 'via API key "CI Pipeline"' }),
+    );
+  });
+
+  it('omits the [callerLabel] prefix when callerLabel is not provided (session calls)', async () => {
+    withFinding({
+      findingKey: 'iam-no-mfa-john',
+      resourceId: 'john',
+      connectionId: 'icn_aws',
+    });
+    dbMock.findingException.upsert.mockResolvedValueOnce({ id: 'fex_new' });
+
+    await buildService().markAsException({
+      findingId: 'icx_1',
+      organizationId: 'org_1',
+      userId: 'usr_human',
+      reason: 'Documented exception with sufficient supporting rationale here.',
+      // no callerLabel — this is a session call
+    });
+
+    const auditCall = auditLogMock.mock.calls[0][0];
+    // No bracket prefix — description begins directly with "Marked finding"
+    expect(auditCall.description).toMatch(/^Marked finding /);
+    expect(auditCall.metadata.callerLabel).toBeNull();
+  });
+
   it('rejects findings that lack a stable check/resource identity', async () => {
     dbMock.integrationCheckResult.findFirst.mockResolvedValueOnce({
       resourceId: null,

--- a/apps/api/src/cloud-security/exception.service.ts
+++ b/apps/api/src/cloud-security/exception.service.ts
@@ -17,10 +17,17 @@ export const MIN_EXCEPTION_REASON_LENGTH = 20;
 export interface MarkExceptionInput {
   findingId: string;
   organizationId: string;
+  /** User to attribute the mutation to. For session callers this is the
+   *  signed-in user; for API key / service token callers this is the org's
+   *  owner (resolved by ActingUserResolver). */
   userId: string;
   reason: string;
   reviewedBy?: string | null;
   expiresAt?: Date | null;
+  /** Optional audit-log description prefix when the userId came from
+   *  owner-fallback (e.g. `via API key "CI Pipeline"`). Undefined for
+   *  session callers so the description is unchanged. */
+  callerLabel?: string;
 }
 
 @Injectable()
@@ -86,18 +93,24 @@ export class CloudExceptionService {
     });
     const exceptionId = upserted.id;
 
+    const reasonPreview = `${input.reason.slice(0, 80)}${input.reason.length > 80 ? '…' : ''}`;
+    const description = input.callerLabel
+      ? `[${input.callerLabel}] Marked finding ${lookup.checkId}:${lookup.resourceId} as exception — ${reasonPreview}`
+      : `Marked finding ${lookup.checkId}:${lookup.resourceId} as exception — ${reasonPreview}`;
+
     await logCloudSecurityActivity({
       organizationId: input.organizationId,
       userId: input.userId,
       connectionId: lookup.connectionId,
       action: 'exception_marked',
-      description: `Marked finding ${lookup.checkId}:${lookup.resourceId} as exception — ${input.reason.slice(0, 80)}${input.reason.length > 80 ? '…' : ''}`,
+      description,
       metadata: {
         findingId: input.findingId,
         exceptionId,
         checkId: lookup.checkId,
         resourceId: lookup.resourceId,
         expiresAt: input.expiresAt?.toISOString() ?? null,
+        callerLabel: input.callerLabel ?? null,
       },
     });
 
@@ -108,6 +121,8 @@ export class CloudExceptionService {
     exceptionId: string;
     organizationId: string;
     userId: string;
+    /** Optional audit-log prefix for owner-fallback callers (see MarkExceptionInput). */
+    callerLabel?: string;
   }): Promise<void> {
     const existing = await db.findingException.findFirst({
       where: { id: params.exceptionId, organizationId: params.organizationId },
@@ -122,16 +137,21 @@ export class CloudExceptionService {
       data: { revokedAt: new Date(), revokedById: params.userId },
     });
 
+    const description = params.callerLabel
+      ? `[${params.callerLabel}] Revoked exception on ${existing.checkId}:${existing.resourceId}.`
+      : `Revoked exception on ${existing.checkId}:${existing.resourceId}.`;
+
     await logCloudSecurityActivity({
       organizationId: params.organizationId,
       userId: params.userId,
       connectionId: existing.connectionId,
       action: 'exception_revoked',
-      description: `Revoked exception on ${existing.checkId}:${existing.resourceId}.`,
+      description,
       metadata: {
         exceptionId: params.exceptionId,
         checkId: existing.checkId,
         resourceId: existing.resourceId,
+        callerLabel: params.callerLabel ?? null,
       },
     });
   }


### PR DESCRIPTION
## Summary

Customer Josh hit a 401 calling `POST /v1/cloud-security/findings/:id/exception` with an X-API-Key from his automation pipeline. The same restriction existed on `revokeException` and `updateAwsScanMode`. With MCP integration coming next, we want the full cloud-tests mutation surface to be callable via API key + service token, not session only.

This PR removes the inline session-only wall on all three endpoints by introducing a shared **`ActingUserResolver`** that attributes API key / service token mutations to the **org's oldest owner** — keeping the audit trail intact without forcing callers to manage user IDs themselves. The audit log description prepends `[via API key "<name>"]` so reviewers see at a glance that it was automation.

## What's preserved (regression safety)

- **Authentication unchanged** — HybridAuthGuard runs as before. Invalid keys still rejected.
- **RBAC unchanged** — PermissionGuard runs as before. Caller still needs `integration:update` scope.
- **Cross-tenant isolation preserved** — owner lookup scoped to the calling org via `Member.organizationId` filter.
- **Session callers: ZERO behavior change.** The resolver short-circuits to `req.userId` with **no DB query**, and the audit description is exactly the same as today (no `[via ...]` prefix).
- **Other write endpoints untouched** — vendor:create, risk:create, evidence:create work exactly as before.

## What changes

| Caller | Before | After |
|---|---|---|
| Session | ✅ Works (no audit prefix) | ✅ Works (no audit prefix) — IDENTICAL behavior |
| Service token + `x-user-id` | ✅ Works (no audit prefix) | ✅ Works (no audit prefix) — IDENTICAL behavior |
| Service token without `x-user-id` | ❌ 401 | ✅ Works, attributed to org owner, audit description prefixed `[via service "X"]` |
| API key | ❌ 401 | ✅ Works, attributed to org owner, audit description prefixed `[via API key "X"]` |
| API key, org has no owner-role member | ❌ 401 | ❌ 400 with actionable message ("ensure your org has an owner") |

## Files

**New (4):**
- `apps/api/src/auth/acting-user.service.ts` — shared resolver, single source of truth for "who do I attribute this mutation to?"
- `apps/api/src/auth/acting-user.service.spec.ts` — 10 tests
- `apps/api/src/cloud-security/aws-scan-mode.service.spec.ts` — 5 tests (none existed)
- `apps/api/src/cloud-security/cloud-security.controller.spec.ts` — 9 tests (none existed for these endpoints)

**Modified (8):**
- `apps/api/src/auth/auth.module.ts` — register `ActingUserResolver`
- `apps/api/src/auth/api-key.service.ts` — `ApiKeyValidationResult` now includes `apiKeyId, apiKeyName`
- `apps/api/src/auth/hybrid-auth.guard.ts` — populate `request.apiKeyId` + `request.apiKeyName`
- `apps/api/src/auth/types.ts` — type additions
- `apps/api/src/cloud-security/cloud-security.controller.ts` — replace 3 inline 401 walls with resolver calls; better OpenAPI descriptions
- `apps/api/src/cloud-security/exception.service.ts` — accept `callerLabel`, use it in audit description
- `apps/api/src/cloud-security/aws-scan-mode.service.ts` — accept `callerLabel`, use it in audit description
- `apps/api/src/cloud-security/exception.service.spec.ts` — +2 tests for callerLabel propagation

## Tests

**253 cloud-security + auth tests pass.** Three pre-existing failures unchanged (same suites fail on `main` — Postgres TLS env issues, unrelated to this PR).

Key regression guards added:
- Session caller MUST NOT hit the DB for owner lookup (perf regression guard)
- Cross-tenant: owner lookup scoped to calling org (security regression guard)
- Oldest-owner pick is deterministic (`orderBy: { createdAt: 'asc' }`) — stable attribution across owner add/remove
- No-owner case returns 400 NOT 500 (Prisma FK error would otherwise leak as 500)

## Reply to send the customer after merge

> "Fixed. Your call works as-is now — no header changes needed. The exception is attributed to your org's owner, and the audit log records that it came from your API key '<name>'. If you want finer-grained attribution per call, pass `X-User-Id` with a valid user ID from your org and we'll use that instead."

## Test plan

- [x] 10 acting-user.service tests pass
- [x] 12 exception.service tests pass (+2 callerLabel)
- [x] 5 aws-scan-mode.service tests pass (NEW)
- [x] 9 cloud-security.controller tests pass (NEW)
- [x] 253 cloud-security + auth tests pass overall
- [x] Typecheck clean for changed files
- [ ] Manual: hit `POST /v1/cloud-security/findings/:id/exception` with X-API-Key + valid body → expect 201, exception created with `markedById = <owner user>`, audit log contains `[via API key "<key name>"]`
- [ ] Manual: same call against an org with no owner-role member → expect 400 with actionable message
- [ ] Manual: same call from UI (session) → audit description unchanged (no `[via ...]` prefix), behavior identical to today

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocked cloud-security mutations for API keys and service tokens by attributing actions to the org’s oldest owner via a new `ActingUserResolver`, with clear audit labels. Removes the session-only wall on exception create/revoke and AWS scan mode updates while keeping auth and RBAC intact.

- **New Features**
  - Unblocks exception create/revoke and AWS scan mode mutations for API keys and service tokens.
  - Adds `ActingUserResolver` for attribution: short-circuits for session or `X-User-Id`; otherwise falls back to the oldest org owner; prefixes audit text with `[via API key "<name>"]` or `[via service "<name>"]`; returns 400 if no owner.
  - Updates controllers/services to pass an optional `callerLabel` so audit logs show automation; session behavior is unchanged and does not query the DB.
  - Exposes `apiKeyId` and `apiKeyName` on the request via `api-key.service` and `hybrid-auth.guard` for accurate audit context.

<sup>Written for commit 26e53dae1bead19de84f27562f52b41cb40c4238. Summary will update on new commits. <a href="https://cubic.dev/pr/trycompai/comp/pull/2883?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

