### PR TITLE
fix(cloud-tests): auto-remediate null AWSServiceName + empty state diff

### DIFF
--- a/apps/api/src/cloud-security/ai-remediation.prompt.ts
+++ b/apps/api/src/cloud-security/ai-remediation.prompt.ts
@@ -178,6 +178,20 @@ A human will ALWAYS review your plan before execution. Be precise and correct.
 - Service delivery roles MUST have a trust policy for the AWS service principal (e.g., cloudtrail.amazonaws.com, config.amazonaws.com).
 - Service-linked roles (GuardDuty, Config, Inspector, Macie): use CreateServiceLinkedRole — AWS manages them.
 
+## SERVICE-LINKED ROLE AWSServiceName VALUES (MANDATORY)
+When emitting iam:CreateServiceLinkedRoleCommand you MUST populate the
+AWSServiceName param. Leaving it null or empty causes AWS to reject the
+call with "Member must not be null". Use exactly these values:
+- AWS Config           → "config.amazonaws.com"
+- GuardDuty            → "guardduty.amazonaws.com"
+- Inspector v2         → "inspector2.amazonaws.com"
+- Macie                → "macie.amazonaws.com"
+- IAM Access Analyzer  → "access-analyzer.amazonaws.com"
+- Security Hub         → "securityhub.amazonaws.com"
+- Detective            → "detective.amazonaws.com"
+- AWS Backup           → "backup.amazonaws.com"
+NEVER omit AWSServiceName, leave it as null, or use a placeholder string.
+
 ## NAMING CONVENTIONS FOR NEW RESOURCES (FOLLOW EXACTLY)
 - S3 bucket names MUST: be lowercase only, no underscores, 3-63 chars, globally unique
   - Format: compai-{purpose}-{accountId}-{region} (e.g., compai-cloudtrail-013388577167-us-east-1)

--- a/apps/api/src/cloud-security/ai-remediation.service.spec.ts
+++ b/apps/api/src/cloud-security/ai-remediation.service.spec.ts
@@ -8,7 +8,7 @@ jest.mock('ai', () => ({
   generateObject: jest.fn(),
 }));
 
-import type { FixPlan } from './ai-remediation.prompt';
+import type { AwsCommandStep, FixPlan } from './ai-remediation.prompt';
 import { AiRemediationService } from './ai-remediation.service';
 
 // `enrichEmptyState` isn't exported — exercise it through the service's
@@ -247,5 +247,155 @@ describe('AiRemediationService.generateFixPlan empty-state backstop', () => {
 
     expect(plan.currentState).toEqual({ someField: 'X' });
     expect(plan.proposedState).toEqual({});
+  });
+});
+
+describe('AiRemediationService.refineStepFromError', () => {
+  const generateObjectMock = generateObject as unknown as jest.Mock;
+
+  const findingContext = {
+    title: 'AWS Config recorder not configured',
+    description: 'Config recorder is missing',
+    severity: 'high',
+    resourceType: 'AwsAccount',
+    resourceId: 'account-level',
+    remediation: 'Create configuration recorder',
+    findingKey: 'config-no-recorder',
+    evidence: { awsAccountId: '123456789012', region: 'us-east-1' },
+  };
+
+  function makeStep(overrides: Partial<AwsCommandStep> = {}): AwsCommandStep {
+    return {
+      service: overrides.service ?? 'iam',
+      command: overrides.command ?? 'CreateServiceLinkedRoleCommand',
+      params: overrides.params ?? {},
+      purpose: overrides.purpose ?? 'create SLR',
+    };
+  }
+
+  beforeEach(() => {
+    generateObjectMock.mockReset();
+  });
+
+  it('returns the refined step when AI proposes corrected params for the same command', async () => {
+    const refined: AwsCommandStep = {
+      service: 'iam',
+      command: 'CreateServiceLinkedRoleCommand',
+      params: { AWSServiceName: 'config.amazonaws.com' },
+      purpose: 'create SLR for AWS Config',
+    };
+    generateObjectMock.mockResolvedValueOnce({ object: refined });
+
+    const result = await new AiRemediationService().refineStepFromError({
+      step: makeStep(),
+      awsError:
+        "1 validation error detected: Value at 'aWSServiceName' failed to satisfy constraint: Member must not be null",
+      finding: findingContext,
+      planContext: { fixSteps: [], readSteps: [] },
+    });
+
+    expect(result).toEqual(refined);
+  });
+
+  it('returns null when the AI swaps to a different service (defensive — refusing to retry a different API)', async () => {
+    generateObjectMock.mockResolvedValueOnce({
+      object: {
+        service: 'config-service', // ← different from original 'iam'
+        command: 'CreateServiceLinkedRoleCommand',
+        params: { AWSServiceName: 'config.amazonaws.com' },
+        purpose: 'mismatched service',
+      },
+    });
+
+    const result = await new AiRemediationService().refineStepFromError({
+      step: makeStep({ service: 'iam' }),
+      awsError: 'Member must not be null',
+      finding: findingContext,
+      planContext: { fixSteps: [], readSteps: [] },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the AI swaps to a different command (defensive)', async () => {
+    generateObjectMock.mockResolvedValueOnce({
+      object: {
+        service: 'iam',
+        command: 'CreateRoleCommand', // ← different from original
+        params: { RoleName: 'foo' },
+        purpose: 'mismatched command',
+      },
+    });
+
+    const result = await new AiRemediationService().refineStepFromError({
+      step: makeStep({ command: 'CreateServiceLinkedRoleCommand' }),
+      awsError: 'Member must not be null',
+      finding: findingContext,
+      planContext: { fixSteps: [], readSteps: [] },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the AI call throws — caller surfaces the original error', async () => {
+    generateObjectMock.mockRejectedValueOnce(new Error('AI provider down'));
+
+    const result = await new AiRemediationService().refineStepFromError({
+      step: makeStep(),
+      awsError: 'Member must not be null',
+      finding: findingContext,
+      planContext: { fixSteps: [], readSteps: [] },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('passes the failing step, AWS error, and finding context to the model in the prompt', async () => {
+    generateObjectMock.mockResolvedValueOnce({
+      object: {
+        service: 'iam',
+        command: 'CreateServiceLinkedRoleCommand',
+        params: { AWSServiceName: 'guardduty.amazonaws.com' },
+        purpose: 'fixed',
+      },
+    });
+
+    await new AiRemediationService().refineStepFromError({
+      step: makeStep({
+        command: 'CreateServiceLinkedRoleCommand',
+        params: {},
+        purpose: 'create SLR for GuardDuty',
+      }),
+      awsError:
+        "1 validation error detected: Value at 'aWSServiceName' failed to satisfy constraint: Member must not be null",
+      finding: findingContext,
+      planContext: {
+        fixSteps: [
+          {
+            service: 'guardduty',
+            command: 'CreateDetectorCommand',
+            params: { Enable: true },
+            purpose: 'enable detector',
+          },
+        ],
+        readSteps: [],
+      },
+    });
+
+    const callArgs = generateObjectMock.mock.calls[0][0];
+    // The system prompt should make the role clear.
+    expect(callArgs.system).toMatch(/repair/i);
+    expect(callArgs.system).toMatch(/SAME service/);
+    expect(callArgs.system).toMatch(/SAME command/);
+    // The user prompt should include the failing AWS error verbatim.
+    expect(callArgs.prompt).toContain(
+      "Value at 'aWSServiceName' failed to satisfy constraint",
+    );
+    // ... and the failing command name.
+    expect(callArgs.prompt).toContain('CreateServiceLinkedRoleCommand');
+    // ... and the neighbor step's service so the AI can use cross-step context.
+    expect(callArgs.prompt).toContain('guardduty');
+    // Temperature is 0 for deterministic repair.
+    expect(callArgs.temperature).toBe(0);
   });
 });

--- a/apps/api/src/cloud-security/ai-remediation.service.spec.ts
+++ b/apps/api/src/cloud-security/ai-remediation.service.spec.ts
@@ -69,12 +69,11 @@ describe('AiRemediationService.generateFixPlan empty-state backstop', () => {
     });
   });
 
-  it('leaves both states empty when AI returns {}/{} for an update-style plan (no Create* commands)', async () => {
-    // Previously this test asserted the backstop fabricated
-    // `{ exists: false }` / `{ exists: true }` even for updates, which
-    // misrepresented the diff in the UI ("we'll create it" when the truth
-    // was "we'll update the existing one"). The backstop now only fires
-    // when at least one `Create*` command is present.
+  it('emits configured:false → configured:true with willChange for update/configure-style plans (Bug B fix)', async () => {
+    // Customers reported the Auto-Remediate dialog showed `{} → {}` for
+    // findings whose fix is a configure-only flow (Put*/Start*/Update*).
+    // The backstop now derives a meaningful diff from the actionable
+    // steps instead of leaving both states blank.
     generateObjectMock.mockResolvedValueOnce({
       object: basePlan({
         fixSteps: [
@@ -92,6 +91,75 @@ describe('AiRemediationService.generateFixPlan empty-state backstop', () => {
       resourceId: 'account-level',
       remediation: null,
       findingKey: 'iam-weak-password',
+      evidence: {},
+    });
+
+    expect(plan.currentState).toEqual({ configured: false });
+    expect(plan.proposedState).toEqual({
+      configured: true,
+      willChange: ['iam:AccountPasswordPolicy'],
+    });
+  });
+
+  it('emits configured:false → configured:true for the Config-recorder fix (Put + Start, no Create)', async () => {
+    // The exact plan shape that caused the customer-reported `{} → {}`
+    // bug on "AWS Config recorder not configured". No Create* steps;
+    // only Put*/Start*. Backstop now produces a meaningful diff.
+    generateObjectMock.mockResolvedValueOnce({
+      object: basePlan({
+        fixSteps: [
+          { service: 'iam', command: 'CreateServiceLinkedRoleCommand', params: { AWSServiceName: 'config.amazonaws.com' }, purpose: 'Create SLR for AWS Config' },
+          { service: 'config-service', command: 'PutConfigurationRecorderCommand', params: {}, purpose: 'Create recorder' },
+          { service: 'config-service', command: 'PutDeliveryChannelCommand', params: {}, purpose: 'Configure delivery' },
+          { service: 'config-service', command: 'StartConfigurationRecorderCommand', params: {}, purpose: 'Start recorder' },
+        ],
+      }),
+    });
+
+    const service = new AiRemediationService();
+    const plan = await service.generateFixPlan({
+      title: 'AWS Config recorder not configured',
+      description: null,
+      severity: 'high',
+      resourceType: 'AwsAccount',
+      resourceId: 'account-level',
+      remediation: null,
+      findingKey: 'config-no-recorder',
+      evidence: {},
+    });
+
+    // CreateServiceLinkedRoleCommand IS a Create — so the plan is still
+    // treated as create-from-scratch (the SLR step). The willCreate list
+    // surfaces only the resource being created (iam:ServiceLinkedRole),
+    // and the Put/Start configure steps drop into the diff via the
+    // create-from-scratch path.
+    expect(plan.currentState).toEqual({ exists: false });
+    expect(plan.proposedState).toEqual({
+      exists: true,
+      willCreate: ['iam:ServiceLinkedRole'],
+    });
+  });
+
+  it('leaves the plan untouched when AI returns {}/{} but the plan has no actionable steps', async () => {
+    // Verify-only plans (only readSteps) should still be left alone —
+    // we never fabricate state when there's nothing to act on.
+    generateObjectMock.mockResolvedValueOnce({
+      object: basePlan({
+        readSteps: [
+          { service: 's3', command: 'GetBucketVersioningCommand', params: {}, purpose: 'check' },
+        ],
+      }),
+    });
+
+    const service = new AiRemediationService();
+    const plan = await service.generateFixPlan({
+      title: 'Read-only',
+      description: null,
+      severity: null,
+      resourceType: 'X',
+      resourceId: 'y',
+      remediation: null,
+      findingKey: 'fk-readonly',
       evidence: {},
     });
 
@@ -121,6 +189,40 @@ describe('AiRemediationService.generateFixPlan empty-state backstop', () => {
 
     expect(plan.currentState).toEqual({ versioning: 'Disabled' });
     expect(plan.proposedState).toEqual({ versioning: 'Enabled' });
+  });
+
+  it('runs normalizeFixPlan after enrichEmptyState — SLR AWSServiceName is backfilled (Bug A fix)', async () => {
+    // The AI sometimes omits AWSServiceName on CreateServiceLinkedRoleCommand,
+    // which AWS rejects with "Member must not be null". The service must
+    // wire normalizeFixPlan after enrichEmptyState so the param is
+    // backfilled from cross-step context before the plan reaches the UI
+    // or the executor.
+    generateObjectMock.mockResolvedValueOnce({
+      object: basePlan({
+        currentState: { recorder: 'not configured' },
+        proposedState: { recorder: 'configured' },
+        fixSteps: [
+          { service: 'iam', command: 'CreateServiceLinkedRoleCommand', params: {}, purpose: 'Create SLR for AWS Config' },
+          { service: 'config-service', command: 'PutConfigurationRecorderCommand', params: { ConfigurationRecorder: {} }, purpose: 'Create recorder' },
+        ],
+      }),
+    });
+
+    const service = new AiRemediationService();
+    const plan = await service.generateFixPlan({
+      title: 'AWS Config recorder not configured',
+      description: null,
+      severity: 'high',
+      resourceType: 'AwsAccount',
+      resourceId: 'account-level',
+      remediation: null,
+      findingKey: 'config-no-recorder',
+      evidence: {},
+    });
+
+    expect(plan.fixSteps[0].params).toEqual({
+      AWSServiceName: 'config.amazonaws.com',
+    });
   });
 
   it('leaves a plan alone when only one side is empty (legitimate verify-only case)', async () => {

--- a/apps/api/src/cloud-security/ai-remediation.service.ts
+++ b/apps/api/src/cloud-security/ai-remediation.service.ts
@@ -24,6 +24,7 @@ import {
   AZURE_SYSTEM_PROMPT,
   buildAzureFixPlanPrompt,
 } from './azure-ai-remediation.prompt';
+import { normalizeFixPlan } from './plan-normalizer';
 
 const MODEL = anthropic('claude-opus-4-6');
 const REMEDIATION_ROLE_NAME = 'CompAI-Remediator';
@@ -57,7 +58,7 @@ export class AiRemediationService {
       this.logger.log(
         `AI plan for ${finding.findingKey}: canAutoFix=${object.canAutoFix}, risk=${object.risk}`,
       );
-      return enrichEmptyState(object);
+      return normalizeFixPlan(enrichEmptyState(object));
     } catch (err) {
       this.logger.error(
         `AI plan failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -99,13 +100,13 @@ Generate the complete fix plan with EXACT values from the real AWS state.`,
       });
 
       this.logger.log(`AI refined plan for ${params.finding.findingKey}`);
-      return enrichEmptyState(object);
+      return normalizeFixPlan(enrichEmptyState(object));
     } catch (err) {
       this.logger.error(
         `AI refine failed: ${err instanceof Error ? err.message : String(err)}`,
       );
       // Fall back to original plan
-      return enrichEmptyState(params.originalPlan);
+      return normalizeFixPlan(enrichEmptyState(params.originalPlan));
     }
   }
 
@@ -445,14 +446,32 @@ Generate the complete fix plan with EXACT values from the real Azure state.`,
   }
 }
 
+/** Action-style prefixes the AI uses for steps that change AWS state. */
+const ACTIONABLE_PREFIXES = [
+  'Create',
+  'Put',
+  'Update',
+  'Modify',
+  'Start',
+  'Enable',
+  'Attach',
+  'Set',
+] as const;
+
 /**
  * Deterministic backstop: if the AI returns BOTH currentState and
- * proposedState as empty (which is what was rendering as `{} → {}` in the
- * Auto-Remediate dialog for "No CloudTrail trails configured" and similar
- * create-from-scratch findings), fill in a basic `{ exists: false }` →
- * `{ exists: true, willCreate: [...] }` derived from the plan's Create*
- * fix steps. Guarantees the user sees a meaningful diff regardless of
- * model behavior.
+ * proposedState as empty (rendering as `{} → {}` in the Auto-Remediate
+ * dialog), derive a meaningful diff from the plan's actionable fix steps.
+ *
+ * - When the plan contains `Create*` commands, emit
+ *   `{ exists: false }` → `{ exists: true, willCreate: [...] }` so the UI
+ *   keeps the existing create-from-scratch language for findings like
+ *   "No CloudTrail trails configured".
+ * - When the plan contains only configure/enable-style commands
+ *   (`PutConfigurationRecorderCommand`, `StartConfigurationRecorderCommand`,
+ *   `EnableMacieCommand`, ...), emit
+ *   `{ configured: false }` → `{ configured: true, willChange: [...] }`
+ *   instead of claiming creation.
  *
  * Only kicks in when BOTH states are empty — verify-only plans that
  * legitimately have one side blank are untouched.
@@ -463,26 +482,47 @@ function enrichEmptyState(plan: FixPlan): FixPlan {
   if (!currentEmpty || !proposedEmpty) return plan;
 
   const willCreate: string[] = [];
+  const willChange: string[] = [];
   for (const step of plan.fixSteps ?? []) {
     const command = typeof step?.command === 'string' ? step.command : '';
-    if (!command.startsWith('Create')) continue;
-    const resource = command.replace(/Command$/, '').replace(/^Create/, '');
+    const prefix = ACTIONABLE_PREFIXES.find((p) => command.startsWith(p));
+    if (!prefix) continue;
+    const resource = command.replace(/Command$/, '').replace(/^[A-Z][a-z]+/, '');
     const label = step.service ? `${step.service}:${resource}` : resource;
-    if (!willCreate.includes(label)) willCreate.push(label);
+    if (prefix === 'Create') {
+      if (!willCreate.includes(label)) willCreate.push(label);
+    } else if (!willChange.includes(label)) {
+      willChange.push(label);
+    }
   }
 
-  // Only enrich when we have actual `Create*` commands — otherwise we'd
-  // fabricate "exists: false → exists: true" for updates/reads (e.g.
-  // UpdateAccountPasswordPolicy), which misrepresents the diff in the UI.
-  // For non-create remediations we leave the AI's (admittedly empty) output
-  // alone rather than inventing state.
-  if (willCreate.length === 0) return plan;
+  // Create-from-scratch plan: emit exists:false → exists:true so the UI
+  // keeps the existing "we'll create this" language for findings like
+  // "No CloudTrail trails configured". Non-Create steps in the same plan
+  // (e.g., StartLoggingCommand on the just-created trail) are bundled
+  // into the resource being created, so we don't double-list them.
+  if (willCreate.length > 0) {
+    return {
+      ...plan,
+      currentState: { exists: false },
+      proposedState: { exists: true, willCreate },
+    };
+  }
 
-  return {
-    ...plan,
-    currentState: { exists: false },
-    proposedState: { exists: true, willCreate },
-  };
+  // Pure configure / enable / update flow: surface what will change
+  // without claiming creation. This is the Bug B fix — previously plans
+  // with only Put*/Start*/Update* steps left both states empty.
+  if (willChange.length > 0) {
+    return {
+      ...plan,
+      currentState: { configured: false },
+      proposedState: { configured: true, willChange },
+    };
+  }
+
+  // No actionable steps detected — leave the plan alone rather than
+  // fabricating state.
+  return plan;
 }
 
 function isEmptyState(

--- a/apps/api/src/cloud-security/ai-remediation.service.ts
+++ b/apps/api/src/cloud-security/ai-remediation.service.ts
@@ -6,6 +6,7 @@ import {
   type PermissionFix,
   type AwsCommandStep,
   fixPlanSchema,
+  awsCommandStepSchema,
   permissionFixSchema,
   completePermissionsSchema,
   SYSTEM_PROMPT,
@@ -223,6 +224,97 @@ OVERESTIMATE. Better to have 5 extra permissions than to miss one.`,
         },
         fixScript: `aws iam put-role-policy --role-name ${REMEDIATION_ROLE_NAME} --policy-name CompAI-AutoFix --policy-document '${policy}'`,
       };
+    }
+  }
+
+  /**
+   * Universal step-level repair. Called by the executor when AWS rejects
+   * a step with a validation-class error AND the rules-based fixer in
+   * `tryAutoFixValidationError` couldn't resolve it.
+   *
+   * The AI sees the failing step, AWS's exact error message, the
+   * surrounding plan, and the finding context, and returns a corrected
+   * step (same service + command, refined params). Returns null when the
+   * model declines to refine — the executor then surfaces AWS's error
+   * unchanged.
+   *
+   * This is the universal escape hatch for "AI omitted a required AWS
+   * param" bugs: no per-command map, no hardcoded principal table — the
+   * AI uses AWS's own validation message as ground truth.
+   */
+  async refineStepFromError(params: {
+    step: AwsCommandStep;
+    awsError: string;
+    finding: FindingContext;
+    planContext: Pick<FixPlan, 'fixSteps' | 'readSteps'>;
+  }): Promise<AwsCommandStep | null> {
+    try {
+      const neighbors = [
+        ...params.planContext.readSteps.map((s) => ({ role: 'read', ...s })),
+        ...params.planContext.fixSteps.map((s) => ({ role: 'fix', ...s })),
+      ].filter((s) => s.command !== params.step.command || s.purpose !== params.step.purpose);
+
+      const { object } = await generateObject({
+        model: MODEL,
+        schema: awsCommandStepSchema,
+        system:
+          'You are repairing a single AWS auto-remediation step that the AWS SDK rejected with a validation error. Return a corrected step with the SAME service and SAME command — only the params should change. Use the AWS error message to identify exactly which field is wrong and why. Use neighbor steps and the finding context to infer the right value. If you cannot fix it without external information, return the original step unchanged.',
+        prompt: `FAILING STEP:
+service: ${params.step.service}
+command: ${params.step.command}
+purpose: ${params.step.purpose}
+params: ${JSON.stringify(params.step.params ?? {}, null, 2)}
+
+AWS SDK ERROR (verbatim):
+${params.awsError}
+
+OTHER STEPS IN THE SAME PLAN (for context — DO NOT include their params in the output):
+${JSON.stringify(neighbors, null, 2)}
+
+FINDING BEING FIXED:
+title: ${params.finding.title}
+description: ${params.finding.description ?? '(none)'}
+resourceType: ${params.finding.resourceType}
+resourceId: ${params.finding.resourceId}
+remediation guidance: ${params.finding.remediation ?? '(none)'}
+evidence: ${JSON.stringify(params.finding.evidence ?? {}, null, 2)}
+
+INSTRUCTIONS:
+1. Read the AWS error carefully — it tells you which field is wrong.
+2. If the error says "Member must not be null" or "must not be empty" for a field X, populate X with the correct value (from finding evidence, neighbor steps, or AWS conventions like service principals).
+3. If the error says "failed to satisfy constraint" or "regular expression pattern", fix the value to match.
+4. Keep the same service and command — do not switch to a different API.
+5. Return a complete AwsCommandStep with all required schema fields.`,
+        temperature: 0,
+      });
+
+      this.logger.log(
+        `Step repair for ${params.step.command}: returned ${JSON.stringify(
+          object.params ?? {},
+        ).slice(0, 200)}`,
+      );
+
+      // Defensive: if the AI swapped the service or command (against
+      // instructions), discard the refinement — the executor would
+      // reject it anyway and we don't want to retry with a different API.
+      if (
+        object.service !== params.step.service ||
+        object.command !== params.step.command
+      ) {
+        this.logger.warn(
+          `Step repair returned a different service/command — ` +
+            `expected ${params.step.service}:${params.step.command}, got ` +
+            `${object.service}:${object.command}. Discarding refinement.`,
+        );
+        return null;
+      }
+
+      return object;
+    } catch (err) {
+      this.logger.error(
+        `AI step repair failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return null;
     }
   }
 

--- a/apps/api/src/cloud-security/aws-command-executor.spec.ts
+++ b/apps/api/src/cloud-security/aws-command-executor.spec.ts
@@ -1,0 +1,152 @@
+import type { AwsCommandStep } from './ai-remediation.prompt';
+import { REQUIRED_PARAMS, validatePlanSteps } from './aws-command-executor';
+
+function step(overrides: Partial<AwsCommandStep>): AwsCommandStep {
+  return {
+    service: overrides.service ?? 's3',
+    command: overrides.command ?? 'PutBucketVersioningCommand',
+    params: overrides.params ?? {},
+    purpose: overrides.purpose ?? 'test step',
+  };
+}
+
+/**
+ * Focused tests for the REQUIRED_PARAMS branch added to validatePlanSteps.
+ * The non-null-param checks defend against AWS's confusing
+ * "Member must not be null" errors by failing fast with a clear message.
+ */
+describe('validatePlanSteps — REQUIRED_PARAMS', () => {
+  it('reports a clear error when CreateServiceLinkedRoleCommand is missing AWSServiceName', () => {
+    const errors = validatePlanSteps([
+      step({
+        service: 'iam',
+        command: 'CreateServiceLinkedRoleCommand',
+        params: {},
+      }),
+    ]);
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(
+          /Step 1 \(CreateServiceLinkedRoleCommand\): Required param "AWSServiceName" is missing or empty/,
+        ),
+      ]),
+    );
+  });
+
+  it('does NOT error when AWSServiceName is populated', () => {
+    const errors = validatePlanSteps([
+      step({
+        service: 'iam',
+        command: 'CreateServiceLinkedRoleCommand',
+        params: { AWSServiceName: 'config.amazonaws.com' },
+      }),
+    ]);
+    expect(
+      errors.filter((e) => e.includes('AWSServiceName')),
+    ).toHaveLength(0);
+  });
+
+  it.each(['', null, undefined])(
+    'treats %p as missing for required-param checks',
+    (badValue) => {
+      const errors = validatePlanSteps([
+        step({
+          service: 'iam',
+          command: 'CreateServiceLinkedRoleCommand',
+          params: { AWSServiceName: badValue },
+        }),
+      ]);
+      expect(
+        errors.some((e) =>
+          /Required param "AWSServiceName" is missing or empty/.test(e),
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it('reports both missing required params for PutBucketPolicyCommand', () => {
+    const errors = validatePlanSteps([
+      step({
+        service: 's3',
+        command: 'PutBucketPolicyCommand',
+        params: {},
+      }),
+    ]);
+    expect(
+      errors.filter((e) => /Required param "Bucket"/.test(e)),
+    ).toHaveLength(1);
+    expect(
+      errors.filter((e) => /Required param "Policy"/.test(e)),
+    ).toHaveLength(1);
+  });
+
+  it('does NOT apply required-param checks to commands not in REQUIRED_PARAMS', () => {
+    // PutBucketVersioningCommand isn't in REQUIRED_PARAMS — should pass
+    // even with no params (the AWS SDK will surface its own errors then).
+    const errors = validatePlanSteps([
+      step({
+        service: 's3',
+        command: 'PutBucketVersioningCommand',
+        params: {},
+      }),
+    ]);
+    // It might still error on other things (e.g., placeholder check),
+    // but it must NOT report a "Required param" error.
+    expect(errors.some((e) => /Required param /.test(e))).toBe(false);
+  });
+
+  it('uses the step index in the error message so customers know which step is broken', () => {
+    const errors = validatePlanSteps([
+      step({ service: 's3', command: 'PutBucketVersioningCommand', params: { Bucket: 'b', VersioningConfiguration: { Status: 'Enabled' } } }),
+      step({
+        service: 'iam',
+        command: 'CreateServiceLinkedRoleCommand',
+        params: {},
+      }),
+    ]);
+    expect(
+      errors.find((e) =>
+        e.startsWith('Step 2 (CreateServiceLinkedRoleCommand)'),
+      ),
+    ).toBeDefined();
+  });
+
+  it('exports a REQUIRED_PARAMS map that includes the SLR + Config-recorder bug-report commands', () => {
+    expect(REQUIRED_PARAMS.CreateServiceLinkedRoleCommand).toEqual([
+      'AWSServiceName',
+    ]);
+    expect(REQUIRED_PARAMS.PutConfigurationRecorderCommand).toContain(
+      'ConfigurationRecorder',
+    );
+    expect(REQUIRED_PARAMS.StartConfigurationRecorderCommand).toContain(
+      'ConfigurationRecorderName',
+    );
+    expect(REQUIRED_PARAMS.PutDeliveryChannelCommand).toContain(
+      'DeliveryChannel',
+    );
+  });
+});
+
+describe('validatePlanSteps — pre-existing behavior preserved', () => {
+  it('still reports unknown services', () => {
+    const errors = validatePlanSteps([
+      step({ service: 'not-a-real-service', command: 'WhateverCommand' }),
+    ]);
+    expect(
+      errors.find((e) => /Unknown service "not-a-real-service"/.test(e)),
+    ).toBeDefined();
+  });
+
+  it('still reports placeholder values', () => {
+    const errors = validatePlanSteps([
+      step({
+        service: 's3',
+        command: 'PutBucketVersioningCommand',
+        params: { Bucket: '{{BUCKET_NAME}}' },
+      }),
+    ]);
+    expect(
+      errors.find((e) => /Contains placeholder values/.test(e)),
+    ).toBeDefined();
+  });
+});

--- a/apps/api/src/cloud-security/aws-command-executor.spec.ts
+++ b/apps/api/src/cloud-security/aws-command-executor.spec.ts
@@ -1,5 +1,9 @@
 import type { AwsCommandStep } from './ai-remediation.prompt';
-import { REQUIRED_PARAMS, validatePlanSteps } from './aws-command-executor';
+import {
+  REQUIRED_PARAMS,
+  looksLikeValidationError,
+  validatePlanSteps,
+} from './aws-command-executor';
 
 function step(overrides: Partial<AwsCommandStep>): AwsCommandStep {
   return {
@@ -124,6 +128,31 @@ describe('validatePlanSteps — REQUIRED_PARAMS', () => {
     expect(REQUIRED_PARAMS.PutDeliveryChannelCommand).toContain(
       'DeliveryChannel',
     );
+  });
+});
+
+describe('looksLikeValidationError', () => {
+  it.each([
+    "1 validation error detected: Value at 'aWSServiceName' failed to satisfy constraint: Member must not be null",
+    'ValidationException: The Bucket parameter is required',
+    'InvalidParameterValue: Value (foo) for parameter X is invalid',
+    'Member must not be null',
+    'failed to satisfy constraint: Member must have length less than or equal to 64',
+    'Missing required parameter Bucket',
+    'is required',
+    'must be a valid ARN',
+  ])('detects %p as a validation-class error', (msg) => {
+    expect(looksLikeValidationError(msg)).toBe(true);
+  });
+
+  it.each([
+    'AccessDeniedException: User is not authorized to perform iam:CreateRole',
+    'ThrottlingException: Rate exceeded',
+    'ResourceNotFoundException: detector not found',
+    'NoSuchBucket: The specified bucket does not exist',
+    '',
+  ])('rejects %p as a non-validation error', (msg) => {
+    expect(looksLikeValidationError(msg)).toBe(false);
   });
 });
 

--- a/apps/api/src/cloud-security/aws-command-executor.ts
+++ b/apps/api/src/cloud-security/aws-command-executor.ts
@@ -391,6 +391,32 @@ function isValidationError(errName: string, errMsg: string): boolean {
 }
 
 /**
+ * Message-only detector for the broader class of validation-style errors
+ * that AWS may surface after the rules-based retry inside
+ * `sendWithAutoRetry` has given up. Used by `executePlanSteps` to decide
+ * whether to invoke the AI step-repair callback.
+ *
+ * Universal by design — pattern-matches AWS's standard error wording
+ * rather than enumerating per-command error names.
+ */
+export function looksLikeValidationError(message: string): boolean {
+  if (!message) return false;
+  const lower = message.toLowerCase();
+  return (
+    lower.includes('validationexception') ||
+    lower.includes('validation error') ||
+    lower.includes('failed to satisfy constraint') ||
+    lower.includes('member must not be null') ||
+    lower.includes('invalidparametervalue') ||
+    lower.includes('invalidparameter ') ||
+    lower.includes('invalid parameter') ||
+    lower.includes('must be a valid') ||
+    lower.includes('is required') ||
+    lower.includes('missing required')
+  );
+}
+
+/**
  * Parse the AWS validation error, fix the offending param, return true if fixed.
  * AWS error format: "Value at 'fieldName' failed to satisfy constraint: ..."
  *
@@ -530,6 +556,27 @@ export interface PlanExecutionResult {
 }
 
 /**
+ * Optional per-step repair callback. Invoked at most ONCE per step when:
+ *   1. The SDK call failed with a validation-class error
+ *      (`looksLikeValidationError`), AND
+ *   2. The existing rules-based `tryAutoFixValidationError` could not fix it.
+ *
+ * The callback is expected to return a refined `AwsCommandStep` to retry
+ * with, or `null` if it cannot repair the step. Returning the same step
+ * unchanged also counts as "cannot repair" (we won't loop forever).
+ *
+ * Universal contract — the callback decides HOW to refine (typically by
+ * asking an LLM with the failing step + AWS error + plan context). The
+ * executor only cares about the in/out shape, so this scales to any
+ * future AWS command without per-command changes here.
+ */
+export type StepRepairFn = (args: {
+  step: AwsCommandStep;
+  awsError: string;
+  stepIndex: number;
+}) => Promise<AwsCommandStep | null>;
+
+/**
  * Execute a single AWS SDK v3 command.
  * Uses static imports — no dynamic require, no version mismatches.
  */
@@ -640,22 +687,91 @@ export async function executePlanSteps(params: {
   region: string;
   isRollback?: boolean;
   autoRollbackSteps?: AwsCommandStep[];
+  repairStep?: StepRepairFn;
 }): Promise<PlanExecutionResult> {
   const results: StepResult[] = [];
 
   for (let i = 0; i < params.steps.length; i++) {
-    const step = params.steps[i];
-    try {
-      const output = await executeAwsCommand({
-        service: step.service,
-        command: step.command,
-        input: structuredClone(step.params),
-        credentials: params.credentials,
-        region: params.region,
-        isRollback: params.isRollback,
-      });
-      results.push({ step, output });
-    } catch (err) {
+    const originalStep = params.steps[i];
+    let stepToRun = originalStep;
+    let repairAttempted = false;
+    let success = false;
+    let lastError: Error | null = null;
+
+    // Inner attempt loop: 1 initial attempt + at most 1 AI repair retry.
+    // The AI repair fires only on validation-class errors AND only when
+    // a repair callback is provided. This keeps reads/rollbacks/no-AI
+    // call sites at the same single-attempt behavior they had before.
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        const output = await executeAwsCommand({
+          service: stepToRun.service,
+          command: stepToRun.command,
+          input: structuredClone(stepToRun.params),
+          credentials: params.credentials,
+          region: params.region,
+          isRollback: params.isRollback,
+        });
+        results.push({ step: stepToRun, output });
+        success = true;
+        lastError = null;
+        break;
+      } catch (err) {
+        lastError = err instanceof Error ? err : new Error(String(err));
+        const message = lastError.message;
+
+        if (
+          !repairAttempted &&
+          params.repairStep &&
+          looksLikeValidationError(message)
+        ) {
+          repairAttempted = true;
+          console.log(
+            `Step ${i + 1} (${originalStep.service}:${originalStep.command}) ` +
+              `failed with validation error — attempting AI step repair`,
+          );
+          const refined = await params.repairStep({
+            step: originalStep,
+            awsError: message,
+            stepIndex: i,
+          });
+          if (
+            refined &&
+            JSON.stringify(refined.params ?? {}) !==
+              JSON.stringify(originalStep.params ?? {})
+          ) {
+            console.log(
+              `AI returned refined step for ${originalStep.command} — retrying once`,
+            );
+            stepToRun = refined;
+            continue;
+          }
+          console.log(
+            `AI repair returned no change for ${originalStep.command} — ` +
+              `surfacing original AWS error`,
+          );
+        }
+        break;
+      }
+    }
+
+    if (success) continue;
+
+    // lastError must be set when !success — keep TS happy with a guard.
+    if (!lastError) {
+      return {
+        results,
+        error: {
+          stepIndex: i,
+          message: 'Unknown execution failure',
+          step: originalStep,
+        },
+      };
+    }
+
+    const step = stepToRun;
+    const err: unknown = lastError;
+    {
       const message = err instanceof Error ? err.message : String(err);
 
       // If a prior step was a no-op (already exists / duplicate content),

--- a/apps/api/src/cloud-security/aws-command-executor.ts
+++ b/apps/api/src/cloud-security/aws-command-executor.ts
@@ -149,6 +149,24 @@ const JSON_STRING_PARAMS = new Set([
   'Definition',
 ]);
 
+/**
+ * Commands where AWS rejects the call with a confusing
+ * "Member must not be null" error if a top-level param is missing.
+ * We surface a clear, actionable error BEFORE the SDK call so the
+ * remediation pipeline fails fast and the customer sees what's wrong.
+ *
+ * Keep this list narrow — only commands where we've seen the AI omit a
+ * required param in practice and the resulting AWS error is unhelpful.
+ */
+export const REQUIRED_PARAMS: Record<string, readonly string[]> = {
+  CreateServiceLinkedRoleCommand: ['AWSServiceName'],
+  PutConfigurationRecorderCommand: ['ConfigurationRecorder'],
+  PutDeliveryChannelCommand: ['DeliveryChannel'],
+  StartConfigurationRecorderCommand: ['ConfigurationRecorderName'],
+  PutBucketPolicyCommand: ['Bucket', 'Policy'],
+  CreateTrailCommand: ['Name', 'S3BucketName'],
+};
+
 function normalizeArnPartition(value: string, partition: AwsPartition): string {
   if (partition === 'aws-us-gov') {
     return value.replace(/\barn:aws:/g, 'arn:aws-us-gov:');
@@ -480,6 +498,21 @@ export function validatePlanSteps(steps: AwsCommandStep[]): string[] {
       errors.push(
         `${prefix}: Contains placeholder values: ${placeholders.join(', ')}`,
       );
+    }
+
+    // Check required top-level params for commands AWS rejects with
+    // cryptic "Member must not be null" errors. Fail fast with a clear
+    // message instead of letting the SDK return its uninformative one.
+    const required = REQUIRED_PARAMS[step.command];
+    if (required) {
+      for (const key of required) {
+        const value = step.params?.[key];
+        if (value === undefined || value === null || value === '') {
+          errors.push(
+            `${prefix}: Required param "${key}" is missing or empty`,
+          );
+        }
+      }
     }
   }
 

--- a/apps/api/src/cloud-security/plan-normalizer.spec.ts
+++ b/apps/api/src/cloud-security/plan-normalizer.spec.ts
@@ -1,0 +1,300 @@
+import type { AwsCommandStep, FixPlan } from './ai-remediation.prompt';
+import {
+  AWS_SERVICE_LINKED_ROLE_PRINCIPAL,
+  normalizeFixPlan,
+} from './plan-normalizer';
+
+function makeStep(overrides: Partial<AwsCommandStep> = {}): AwsCommandStep {
+  return {
+    service: overrides.service ?? 'iam',
+    command: overrides.command ?? 'CreateRoleCommand',
+    params: overrides.params ?? {},
+    purpose: overrides.purpose ?? 'test step',
+  };
+}
+
+function makePlan(
+  opts: {
+    fixSteps?: AwsCommandStep[];
+    rollbackSteps?: AwsCommandStep[];
+  } = {},
+): FixPlan {
+  return {
+    canAutoFix: true,
+    risk: 'medium',
+    description: 'test plan',
+    currentState: {},
+    proposedState: {},
+    requiredPermissions: [],
+    readSteps: [],
+    fixSteps: opts.fixSteps ?? [],
+    rollbackSteps: opts.rollbackSteps ?? [],
+    rollbackSupported: true,
+    requiresAcknowledgment: false,
+  };
+}
+
+describe('normalizeFixPlan — CreateServiceLinkedRoleCommand backfill', () => {
+  it('is a no-op for a plan with no SLR steps', () => {
+    const plan = makePlan({
+      fixSteps: [
+        makeStep({ service: 's3', command: 'PutBucketVersioningCommand' }),
+      ],
+    });
+    expect(normalizeFixPlan(plan)).toEqual(plan);
+  });
+
+  it('preserves AWSServiceName when already set to a non-empty string', () => {
+    const plan = makePlan({
+      fixSteps: [
+        makeStep({
+          service: 'iam',
+          command: 'CreateServiceLinkedRoleCommand',
+          params: { AWSServiceName: 'config.amazonaws.com' },
+        }),
+        makeStep({
+          service: 'config-service',
+          command: 'PutConfigurationRecorderCommand',
+        }),
+      ],
+    });
+    const result = normalizeFixPlan(plan);
+    expect(result.fixSteps[0].params).toEqual({
+      AWSServiceName: 'config.amazonaws.com',
+    });
+  });
+
+  describe('backfills the right principal for each known service', () => {
+    const cases: ReadonlyArray<{
+      siblingService: string;
+      expectedPrincipal: string;
+    }> = [
+      {
+        siblingService: 'config-service',
+        expectedPrincipal: 'config.amazonaws.com',
+      },
+      { siblingService: 'config', expectedPrincipal: 'config.amazonaws.com' },
+      {
+        siblingService: 'guardduty',
+        expectedPrincipal: 'guardduty.amazonaws.com',
+      },
+      {
+        siblingService: 'inspector2',
+        expectedPrincipal: 'inspector2.amazonaws.com',
+      },
+      { siblingService: 'macie2', expectedPrincipal: 'macie.amazonaws.com' },
+      {
+        siblingService: 'accessanalyzer',
+        expectedPrincipal: 'access-analyzer.amazonaws.com',
+      },
+      {
+        siblingService: 'securityhub',
+        expectedPrincipal: 'securityhub.amazonaws.com',
+      },
+    ];
+
+    for (const { siblingService, expectedPrincipal } of cases) {
+      it(`infers "${expectedPrincipal}" when neighbor service is "${siblingService}"`, () => {
+        const plan = makePlan({
+          fixSteps: [
+            makeStep({
+              service: 'iam',
+              command: 'CreateServiceLinkedRoleCommand',
+              params: {},
+            }),
+            makeStep({
+              service: siblingService,
+              command: 'EnableSomethingCommand',
+            }),
+          ],
+        });
+        const result = normalizeFixPlan(plan);
+        expect(result.fixSteps[0].params).toEqual({
+          AWSServiceName: expectedPrincipal,
+        });
+      });
+    }
+  });
+
+  it('treats empty-string AWSServiceName as missing and backfills', () => {
+    const plan = makePlan({
+      fixSteps: [
+        makeStep({
+          service: 'iam',
+          command: 'CreateServiceLinkedRoleCommand',
+          params: { AWSServiceName: '' },
+        }),
+        makeStep({ service: 'guardduty', command: 'CreateDetectorCommand' }),
+      ],
+    });
+    const result = normalizeFixPlan(plan);
+    expect(result.fixSteps[0].params).toEqual({
+      AWSServiceName: 'guardduty.amazonaws.com',
+    });
+  });
+
+  it('treats explicit null AWSServiceName as missing and backfills', () => {
+    const plan = makePlan({
+      fixSteps: [
+        makeStep({
+          service: 'iam',
+          command: 'CreateServiceLinkedRoleCommand',
+          params: { AWSServiceName: null },
+        }),
+        makeStep({
+          service: 'macie2',
+          command: 'EnableOrganizationAdminAccountCommand',
+        }),
+      ],
+    });
+    const result = normalizeFixPlan(plan);
+    expect(result.fixSteps[0].params).toEqual({
+      AWSServiceName: 'macie.amazonaws.com',
+    });
+  });
+
+  it('leaves the step untouched when no neighbor has a known SLR principal', () => {
+    const plan = makePlan({
+      fixSteps: [
+        makeStep({
+          service: 'iam',
+          command: 'CreateServiceLinkedRoleCommand',
+          params: {},
+        }),
+        makeStep({ service: 'sts', command: 'AssumeRoleCommand' }),
+        makeStep({ service: 'kms', command: 'CreateKeyCommand' }),
+      ],
+    });
+    const result = normalizeFixPlan(plan);
+    expect(result.fixSteps[0].params).toEqual({});
+  });
+
+  it('skips IAM/STS siblings when searching for the principal', () => {
+    const plan = makePlan({
+      fixSteps: [
+        makeStep({ service: 'iam', command: 'AttachRolePolicyCommand' }),
+        makeStep({
+          service: 'iam',
+          command: 'CreateServiceLinkedRoleCommand',
+          params: {},
+        }),
+        makeStep({
+          service: 'config-service',
+          command: 'PutConfigurationRecorderCommand',
+        }),
+      ],
+    });
+    const result = normalizeFixPlan(plan);
+    expect(result.fixSteps[1].params).toEqual({
+      AWSServiceName: 'config.amazonaws.com',
+    });
+  });
+
+  it('backfills each SLR step independently via nearest-neighbor in a multi-SLR plan', () => {
+    // Layout: [SLR-A, guardduty, SLR-B, config]
+    // SLR-A (idx 0) nearest non-IAM = guardduty (offset 1).
+    // SLR-B (idx 2) nearest non-IAM = config (offset 1 to the right beats
+    //   guardduty at offset 1 to the left because we check right first).
+    const plan = makePlan({
+      fixSteps: [
+        makeStep({
+          service: 'iam',
+          command: 'CreateServiceLinkedRoleCommand',
+          params: {},
+        }),
+        makeStep({ service: 'guardduty', command: 'CreateDetectorCommand' }),
+        makeStep({
+          service: 'iam',
+          command: 'CreateServiceLinkedRoleCommand',
+          params: {},
+        }),
+        makeStep({
+          service: 'config-service',
+          command: 'PutConfigurationRecorderCommand',
+        }),
+      ],
+    });
+    const result = normalizeFixPlan(plan);
+    expect(result.fixSteps[0].params).toEqual({
+      AWSServiceName: 'guardduty.amazonaws.com',
+    });
+    expect(result.fixSteps[2].params).toEqual({
+      AWSServiceName: 'config.amazonaws.com',
+    });
+  });
+
+  it('also normalizes rollback steps', () => {
+    const plan = makePlan({
+      fixSteps: [
+        makeStep({
+          service: 'config-service',
+          command: 'PutConfigurationRecorderCommand',
+        }),
+      ],
+      rollbackSteps: [
+        makeStep({
+          service: 'iam',
+          command: 'CreateServiceLinkedRoleCommand',
+          params: {},
+        }),
+        makeStep({
+          service: 'config-service',
+          command: 'DeleteConfigurationRecorderCommand',
+        }),
+      ],
+    });
+    const result = normalizeFixPlan(plan);
+    expect(result.rollbackSteps[0].params).toEqual({
+      AWSServiceName: 'config.amazonaws.com',
+    });
+  });
+
+  it('is idempotent — running twice equals running once', () => {
+    const plan = makePlan({
+      fixSteps: [
+        makeStep({
+          service: 'iam',
+          command: 'CreateServiceLinkedRoleCommand',
+          params: {},
+        }),
+        makeStep({ service: 'guardduty', command: 'CreateDetectorCommand' }),
+      ],
+    });
+    const once = normalizeFixPlan(plan);
+    const twice = normalizeFixPlan(once);
+    expect(twice).toEqual(once);
+  });
+
+  it('does not mutate the input plan', () => {
+    const slrStep = makeStep({
+      service: 'iam',
+      command: 'CreateServiceLinkedRoleCommand',
+      params: {},
+    });
+    const plan = makePlan({
+      fixSteps: [
+        slrStep,
+        makeStep({ service: 'guardduty', command: 'CreateDetectorCommand' }),
+      ],
+    });
+    normalizeFixPlan(plan);
+    expect(slrStep.params).toEqual({});
+  });
+
+  it('exports a non-empty AWS_SERVICE_LINKED_ROLE_PRINCIPAL map covering core services', () => {
+    expect(AWS_SERVICE_LINKED_ROLE_PRINCIPAL.config).toBe('config.amazonaws.com');
+    expect(AWS_SERVICE_LINKED_ROLE_PRINCIPAL.guardduty).toBe(
+      'guardduty.amazonaws.com',
+    );
+    expect(AWS_SERVICE_LINKED_ROLE_PRINCIPAL.inspector2).toBe(
+      'inspector2.amazonaws.com',
+    );
+    expect(AWS_SERVICE_LINKED_ROLE_PRINCIPAL.macie2).toBe('macie.amazonaws.com');
+    expect(AWS_SERVICE_LINKED_ROLE_PRINCIPAL.securityhub).toBe(
+      'securityhub.amazonaws.com',
+    );
+    expect(AWS_SERVICE_LINKED_ROLE_PRINCIPAL.accessanalyzer).toBe(
+      'access-analyzer.amazonaws.com',
+    );
+  });
+});

--- a/apps/api/src/cloud-security/plan-normalizer.ts
+++ b/apps/api/src/cloud-security/plan-normalizer.ts
@@ -1,0 +1,95 @@
+import type { AwsCommandStep, FixPlan } from './ai-remediation.prompt';
+
+/**
+ * Maps an AWS service prefix (as it appears in `AwsCommandStep.service`)
+ * to the `AWSServiceName` value AWS expects when creating a service-linked
+ * role (SLR).
+ *
+ * Background: when a fix plan needs an SLR, the AI sometimes generates a
+ * `CreateServiceLinkedRoleCommand` step without populating `AWSServiceName`.
+ * AWS rejects the call with a cryptic "Member must not be null" error. This
+ * map lets us backfill the right principal deterministically from
+ * cross-step context inside the same plan.
+ *
+ * Keys include common AI-emitted spellings (with/without hyphens, legacy
+ * names). Extend as new adapters add SLR-requiring services.
+ */
+export const AWS_SERVICE_LINKED_ROLE_PRINCIPAL: Record<string, string> = {
+  'config-service': 'config.amazonaws.com',
+  config: 'config.amazonaws.com',
+  guardduty: 'guardduty.amazonaws.com',
+  inspector2: 'inspector2.amazonaws.com',
+  inspector: 'inspector2.amazonaws.com',
+  macie2: 'macie.amazonaws.com',
+  macie: 'macie.amazonaws.com',
+  accessanalyzer: 'access-analyzer.amazonaws.com',
+  'access-analyzer': 'access-analyzer.amazonaws.com',
+  securityhub: 'securityhub.amazonaws.com',
+  'security-hub': 'securityhub.amazonaws.com',
+  detective: 'detective.amazonaws.com',
+  backup: 'backup.amazonaws.com',
+};
+
+const SLR_COMMAND = 'CreateServiceLinkedRoleCommand';
+const IAM_LIKE_SERVICES = new Set(['iam', 'sts']);
+
+/**
+ * Deterministic post-processing for an AI-generated fix plan. Runs after
+ * the model returns to backfill cross-step values the AI does not reliably
+ * emit. Today the only backfill is `AWSServiceName` on SLR steps; the
+ * function is intentionally extensible so future plan-shape fixes can live
+ * here too.
+ *
+ * Pure, idempotent, and a no-op when the plan is already well-formed.
+ */
+export function normalizeFixPlan(plan: FixPlan): FixPlan {
+  return {
+    ...plan,
+    fixSteps: backfillServiceLinkedRoleParams(plan.fixSteps),
+    rollbackSteps: backfillServiceLinkedRoleParams(plan.rollbackSteps),
+  };
+}
+
+function backfillServiceLinkedRoleParams(
+  steps: AwsCommandStep[],
+): AwsCommandStep[] {
+  return steps.map((step, idx) => {
+    if (step.command !== SLR_COMMAND) return step;
+    const existing = step.params?.AWSServiceName;
+    if (typeof existing === 'string' && existing.length > 0) return step;
+    const inferred = inferServiceLinkedRolePrincipal(steps, idx);
+    if (!inferred) return step;
+    return {
+      ...step,
+      params: { ...(step.params ?? {}), AWSServiceName: inferred },
+    };
+  });
+}
+
+/**
+ * Search outward from `selfIndex` for the nearest non-IAM/STS step whose
+ * `service` prefix has a known SLR principal. The right-side neighbor is
+ * preferred at equal distance because the SLR step usually appears
+ * immediately before the service step that needs it.
+ *
+ * This nearest-neighbor strategy handles plans with multiple SLR steps
+ * targeting different services (e.g., Config + GuardDuty) — each SLR picks
+ * up its closest service-step rather than a global "first match" that
+ * would assign both to the same principal.
+ */
+function inferServiceLinkedRolePrincipal(
+  allSteps: AwsCommandStep[],
+  selfIndex: number,
+): string | null {
+  const maxOffset = Math.max(selfIndex, allSteps.length - 1 - selfIndex);
+  for (let offset = 1; offset <= maxOffset; offset++) {
+    for (const candidateIdx of [selfIndex + offset, selfIndex - offset]) {
+      if (candidateIdx < 0 || candidateIdx >= allSteps.length) continue;
+      const sibling = allSteps[candidateIdx];
+      if (IAM_LIKE_SERVICES.has(sibling.service)) continue;
+      const principal = AWS_SERVICE_LINKED_ROLE_PRINCIPAL[sibling.service];
+      if (principal) return principal;
+    }
+  }
+  return null;
+}

--- a/apps/api/src/cloud-security/remediation.service.ts
+++ b/apps/api/src/cloud-security/remediation.service.ts
@@ -533,13 +533,36 @@ export class RemediationService {
         throw new Error(`Invalid fix steps: ${fixErrors.join('; ')}`);
       }
 
-      // Phase 3: Execute the refined fix steps (now with REAL values)
-      // Pass rollback steps for automatic undo on partial failure
+      // Phase 3: Execute the refined fix steps (now with REAL values).
+      // Pass rollback steps for automatic undo on partial failure.
+      // Pass a repairStep callback so that when AWS rejects any step with
+      // a validation error the AI can self-repair the step once before
+      // we give up — universal fix for "AI omitted a required param"
+      // bugs that no per-command map can fully cover.
       const fixResult = await executePlanSteps({
         steps: refinedPlan.fixSteps,
         credentials: remediationCreds,
         region,
         autoRollbackSteps: refinedPlan.rollbackSteps,
+        repairStep: async ({ step, awsError }) =>
+          this.aiRemediationService.refineStepFromError({
+            step,
+            awsError,
+            finding: {
+              title: finding.title ?? 'Unknown',
+              description: finding.description,
+              severity: finding.severity,
+              resourceType: finding.resourceType,
+              resourceId: finding.resourceId,
+              remediation: finding.remediation,
+              findingKey: evidence.findingKey as string,
+              evidence,
+            },
+            planContext: {
+              fixSteps: refinedPlan.fixSteps,
+              readSteps: refinedPlan.readSteps,
+            },
+          }),
       });
 
       if (fixResult.error) {


### PR DESCRIPTION
## Summary

Fixes two coordinated bugs in the AWS Auto-Remediate dialog that customers hit on the *AWS Config recorder not configured* finding (and others requiring a service-linked role or a configure-only plan):

- **Bug A — Null required AWS SDK param:** the AI sometimes generates `CreateServiceLinkedRoleCommand` without populating `AWSServiceName`. AWS rejects the call with the cryptic "Member must not be null". Affects Config, GuardDuty, Inspector, Macie, Access Analyzer, Security Hub, Detective, AWS Backup.
- **Bug B — Empty `{} → {}` diff in the Auto-Remediate dialog:** `enrichEmptyState` only fired when `fixSteps` contained `Create*` commands. For plans whose actionable steps are mostly `Put*`/`Start*`/`Update*` (e.g., Config recorder configure flow), the dialog showed no meaningful state diff.

Both fixes are systemic, not Config-recorder-specific. The change is fully behind the existing AI remediation pipeline — no schema changes, no migrations, no shared-infra mutations.

## What changed (commit-by-commit)

1. **`feat(cloud-tests): add deterministic AWS plan normalizer for SLR params`** — new pure module `plan-normalizer.ts` that runs after AI plan generation. Backfills `AWSServiceName` from the nearest non-IAM/STS neighbor service step. Idempotent, doesn't mutate input. 18 unit tests.
2. **`feat(cloud-tests): fail fast on missing required AWS command params`** — extends `validatePlanSteps` with a narrow `REQUIRED_PARAMS` check (CreateServiceLinkedRole, PutConfigurationRecorder, PutDeliveryChannel, StartConfigurationRecorder, PutBucketPolicy, CreateTrail). Replaces AWS's cryptic null error with `Step N (CommandName): Required param "X" is missing or empty`. 11 unit tests.
3. **`fix(cloud-tests): show meaningful Auto-Remediate diff for configure-only plans`** — broadens `enrichEmptyState` to emit `configured:false → configured:true` + `willChange: [...]` for plans whose only actionable steps are non-`Create*`. Wires `normalizeFixPlan` into all three plan-producing sites (`generateFixPlan` happy, `refineFixPlan` happy, `refineFixPlan` catch). Existing `Create*` behavior preserved exactly.
4. **`docs(cloud-tests): add SLR AWSServiceName mapping to the remediation prompt`** — adds an explicit mandatory mapping table to the AI system prompt for the 8 SLR-requiring services. Belt-and-suspenders on top of the deterministic normalizer.

## Why this is safe

- **No schema / migration changes.** Pure code change inside the AI remediation path.
- **Pure functions, idempotent.** Running the normalizer twice produces the same result (test in place).
- **Happy path preserved.** When the AI gets the plan right, normalizer is a no-op; when state is non-empty, enrichEmptyState short-circuits; when required params are present, validatePlanSteps adds no errors. Existing `willCreate` shape for Create-from-scratch plans is unchanged.
- **Fail-closed defense.** If the normalizer can't infer `AWSServiceName`, `validatePlanSteps` blocks the call with a clear error BEFORE we make a billed AWS request. Old behavior would surface AWS's cryptic message after the call.

## Test plan

- [x] `cd apps/api && npx jest src/cloud-security --passWithNoTests` → 215/215 pass (one suite failure is the pre-existing `remediation.controller.spec.ts` Postgres-TLS env issue, identical on `main`, unrelated to this change)
- [x] No new typecheck errors introduced (the existing failures in `integration-platform`, `offboarding-checklist.service.spec`, `risks.controller.spec`, `timelines.service.spec`, `training-certificate-pdf.service.spec` are pre-existing on `main`)
- [ ] **Manual:** click Fix on `AWS Config recorder not configured` → preview shows non-empty state, Fix succeeds (no `aWSServiceName` null error)
- [ ] **Manual regression:** click Fix on a known-working finding (e.g., `S3 bucket versioning disabled`) → behavior unchanged
- [ ] **Manual:** click Fix on other SLR-requiring findings (GuardDuty / Inspector / Macie) if available → same expectation
- [ ] **DB sanity:** confirm `RemediationAction.status` ends in `success` and the next scan writes a `FindingResolution` row

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes null `AWSServiceName` on service-linked roles and `{}` → `{}` preview diffs, and adds a one-shot repair that retries validation failures with corrected params before failing.

- **Bug Fixes**
  - Added `normalizeFixPlan` to backfill `AWSServiceName` for `CreateServiceLinkedRoleCommand` by inferring from nearby non‑IAM steps; supports Config, GuardDuty, Inspector, Macie, Access Analyzer, Security Hub, Detective, Backup; idempotent and applied in all plan paths.
  - Made configure‑only plans show meaningful diffs: emit `configured:false → configured:true` with `willChange:[...]`; preserve existing `exists:false → exists:true` for create‑from‑scratch.
  - Added `REQUIRED_PARAMS` checks in `validatePlanSteps` to fail fast with clear messages (step index + command) for missing top‑level params on SLR, Config recorder, S3 bucket policy, and CloudTrail commands; updated the remediation prompt with mandatory SLR mappings.

- **New Features**
  - Introduced one‑shot step repair on validation errors: the executor detects errors with `looksLikeValidationError` and uses a `repairStep` callback to retry once with corrected params; guardrails enforce same service/command; wired only for fix‑step execution.
  - Implemented `refineStepFromError` to return a corrected step (same service + command) using the failing error and plan context; added focused tests for detection and repair flow alongside normalizer/validator tests.

<sup>Written for commit 5cffaff6b3aa145e72928a56c8216ead4e901c34. Summary will update on new commits. <a href="https://cubic.dev/pr/trycompai/comp/pull/2885?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

