### PR TITLE
fix(ui): unblock sibling form controls hidden by open MultipleSelector dropdown (hotfix → release)

### DIFF
--- a/packages/ui/src/components/multiple-selector.tsx
+++ b/packages/ui/src/components/multiple-selector.tsx
@@ -512,9 +512,16 @@ const MultipleSelector = React.forwardRef<MultipleSelectorRef, MultipleSelectorP
                 inputProps?.onValueChange?.(value);
               }}
               onBlur={(event) => {
-                if (!onScrollbar) {
-                  setOpen(false);
-                }
+                // Close the dropdown whenever the input loses focus. The previous
+                // `if (!onScrollbar)` guard kept the dropdown open while the user's
+                // mouse was hovering the CommandList — but that left the absolutely
+                // positioned CommandList floating over sibling form controls below
+                // (e.g. a Select inside the same form), trapping their clicks and
+                // making them appear unresponsive. Closing on every blur restores
+                // the natural focus contract: clicking anywhere outside the input
+                // dismisses the dropdown immediately, so the next form control
+                // receives the click as expected.
+                setOpen(false);
                 inputProps?.onBlur?.(event);
               }}
               onFocus={(event) => {
@@ -562,9 +569,16 @@ const MultipleSelector = React.forwardRef<MultipleSelectorRef, MultipleSelectorP
               onMouseEnter={() => {
                 setOnScrollbar(true);
               }}
-              onMouseUp={() => {
-                inputRef?.current?.focus();
-              }}
+              // Intentionally no onMouseUp re-focus here.
+              // Previously, releasing the mouse anywhere on the CommandList
+              // (including its bounds while it floated over sibling form fields)
+              // re-focused the input and re-opened the dropdown. That trapped
+              // clicks meant for elements below it (e.g. a `@base-ui/react` Select
+              // trigger sitting under the popup), making them appear unresponsive —
+              // base-ui's trigger cancels its open if `mouseup` lands outside its
+              // bounds, so the captured `mouseup` would also cancel the next
+              // dropdown's open. Focus on items is already preserved because
+              // `CommandItem.onMouseDown` calls `e.preventDefault()`.
             >
               {isLoading ? (
                 <>{loadingIndicator}</>


### PR DESCRIPTION
## Summary

**Hotfix targeting `release`.** Same code change as PR #2886 (which targets `main`), branched off `release` so it doesn't drag unverified main commits along.

Fixes the customer report where the **"Fail on open alerts at severity" dropdown in the GitHub integration setup becomes unresponsive after selecting any repository**. Customer workaround was to pick severity *before* repos.

Two small changes in `packages/ui/src/components/multiple-selector.tsx`:

1. Input `onBlur` always closes the dropdown — removed the `if (!onScrollbar)` guard.
2. `CommandList` no longer re-focuses the input on `mouseup`.

## Root cause (verified, not guessed)

`MultipleSelector`'s `CommandList` renders as `absolute top-1 z-10 max-h-[200px]`, so when several repos are selected and the option list is open it visually floats over the form fields below it — including the severity Select on the same setup page.

Two interacting behaviors trapped clicks on that overlapping popup:

- `onBlur` was gated on `onScrollbar`; because the mouse was over the popup (by definition, when the popup covers the click target), the gate kept `setOpen(false)` from firing.
- `CommandList` re-focused the input on every `mouseup`, immediately reopening the dropdown after any click captured on it.

The Select component below is `@base-ui/react/select` (not Radix). Its `SelectTrigger` registers a one-shot document `mouseup` listener on `mousedown` and **cancels the open if the mouseup lands outside the trigger's bounds**:

```js
// node_modules/@base-ui/react/select/trigger/SelectTrigger.js
onMouseDown(event) {
  if (open) return;
  function handleMouseUp(mouseEvent) {
    const t = mouseEvent.target;
    if (contains(triggerRef.current, t) ||
        contains(positionerRef.current, t) ||
        t === triggerRef.current) return;
    // ... bounds check ...
    setOpen(false, ...REASONS.cancelOpen, mouseEvent);
  }
  doc.addEventListener('mouseup', handleMouseUp, { once: true });
}
```

The `MultipleSelector` popup intercepts the `mouseup`, base-ui sees that as "outside the trigger" and cancels its own open. Severity dropdown never appears — matching the customer's symptom exactly.

## Why this fix is safe

- `CommandItem.onMouseDown` already calls `e.preventDefault()`, so clicks on actual items still keep the input focused. Multi-selection behavior preserved.
- The removed `onMouseUp` re-focus was an internal `CommandList` prop, not part of `MultipleSelector`'s public API — none of the 6 consumers in this repo depend on it (`CreateTaskSheet`, `CreateControlSheet`, `EmptyState`, `ConnectionVariableMultiSelect`, `ManageIntegrationDialog`, `CredentialInput`).
- `packages/ui` typecheck + build pass.

## Relationship with PR #2886

This is the **same diff** as #2886 but branched off `release`. After this is merged and deployed as a hotfix, the existing #2886 against `main` should still be reviewed/merged on the normal flow — when `main → release` merges later, the file content will be identical on both sides so no conflicts.

## Test plan

- [ ] Pull this branch, run dev, open GitHub integration setup.
- [ ] Pick one or more repositories.
- [ ] Click "Fail on open alerts at severity" — should open on first click.
- [ ] Selecting multiple items in a row still works (item clicks should NOT close the dropdown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hotfix to stop the `MultipleSelector` dropdown from blocking clicks on fields underneath. Fixes the unresponsive "Fail on open alerts at severity" dropdown in GitHub integration setup after selecting repositories.

- **Bug Fixes**
  - Always close the dropdown on input `onBlur` (removed `onScrollbar` guard) so clicks reach sibling controls like `@base-ui/react/select`.
  - Removed `CommandList` `onMouseUp` refocus to prevent immediate reopening; item clicks still keep focus via `preventDefault()`.

<sup>Written for commit 3d7fc3f68c3e21b552c8d4eefb44d29aac2d4aa0. Summary will update on new commits. <a href="https://cubic.dev/pr/trycompai/comp/pull/2887?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

