### PR TITLE
fix(people): address third round of cubic review findings

### DIFF
--- a/apps/api/src/integration-platform/controllers/sync.controller.ts
+++ b/apps/api/src/integration-platform/controllers/sync.controller.ts
@@ -383,10 +383,14 @@ export class SyncController {
 
         if (existingMember) {
           if (!existingMember.onboardDate && gwUser.creationTime) {
-            await db.member.update({
-              where: { id: existingMember.id },
-              data: { onboardDate: new Date(gwUser.creationTime) },
-            });
+            const parsed = new Date(gwUser.creationTime);
+            const onboardDate = isNaN(parsed.getTime()) ? undefined : parsed;
+            if (onboardDate) {
+              await db.member.update({
+                where: { id: existingMember.id },
+                data: { onboardDate },
+              });
+            }
           }
           results.skipped++;
           results.details.push({
@@ -400,13 +404,15 @@ export class SyncController {
         }
 
         // Create member - always as employee, admins can be promoted manually
+        const gwParsed = gwUser.creationTime ? new Date(gwUser.creationTime) : null;
+        const gwOnboardDate = gwParsed && !isNaN(gwParsed.getTime()) ? gwParsed : undefined;
         await db.member.create({
           data: {
             organizationId,
             userId,
             role: 'employee',
             isActive: true,
-            ...(gwUser.creationTime ? { onboardDate: new Date(gwUser.creationTime) } : {}),
+            ...(gwOnboardDate ? { onboardDate: gwOnboardDate } : {}),
           },
         });
 
@@ -845,10 +851,14 @@ export class SyncController {
 
         if (existingMember) {
           if (!existingMember.onboardDate && worker.start_date) {
-            await db.member.update({
-              where: { id: existingMember.id },
-              data: { onboardDate: new Date(worker.start_date) },
-            });
+            const parsed = new Date(worker.start_date);
+            const onboardDate = isNaN(parsed.getTime()) ? undefined : parsed;
+            if (onboardDate) {
+              await db.member.update({
+                where: { id: existingMember.id },
+                data: { onboardDate },
+              });
+            }
           }
           if (existingMember.deactivated) {
             await db.member.update({
@@ -870,13 +880,15 @@ export class SyncController {
             });
           }
         } else {
+          const ripplingParsed = worker.start_date ? new Date(worker.start_date) : null;
+          const ripplingOnboardDate = ripplingParsed && !isNaN(ripplingParsed.getTime()) ? ripplingParsed : undefined;
           await db.member.create({
             data: {
               organizationId,
               userId,
               role: 'employee',
               isActive: true,
-              ...(worker.start_date ? { onboardDate: new Date(worker.start_date) } : {}),
+              ...(ripplingOnboardDate ? { onboardDate: ripplingOnboardDate } : {}),
             },
           });
           results.imported++;
@@ -1346,10 +1358,14 @@ export class SyncController {
 
         if (existingMember) {
           if (!existingMember.onboardDate && jcUser.created) {
-            await db.member.update({
-              where: { id: existingMember.id },
-              data: { onboardDate: new Date(jcUser.created) },
-            });
+            const parsed = new Date(jcUser.created);
+            const onboardDate = isNaN(parsed.getTime()) ? undefined : parsed;
+            if (onboardDate) {
+              await db.member.update({
+                where: { id: existingMember.id },
+                data: { onboardDate },
+              });
+            }
           }
           if (existingMember.deactivated) {
             await db.member.update({
@@ -1376,13 +1392,15 @@ export class SyncController {
         }
 
         // Create member - always as employee, admins can be promoted manually
+        const jcParsed = jcUser.created ? new Date(jcUser.created) : null;
+        const jcOnboardDate = jcParsed && !isNaN(jcParsed.getTime()) ? jcParsed : undefined;
         await db.member.create({
           data: {
             organizationId,
             userId,
             role: 'employee',
             isActive: true,
-            ...(jcUser.created ? { onboardDate: new Date(jcUser.created) } : {}),
+            ...(jcOnboardDate ? { onboardDate: jcOnboardDate } : {}),
           },
         });
 

--- a/apps/api/src/offboarding-checklist/access-revocation.service.ts
+++ b/apps/api/src/offboarding-checklist/access-revocation.service.ts
@@ -73,6 +73,14 @@ export class AccessRevocationService {
     notes?: string;
     evidence?: { fileName: string; fileType: string; fileData: string };
   }) {
+    const member = await db.member.findFirst({
+      where: { id: memberId, organizationId },
+    });
+
+    if (!member) {
+      throw new NotFoundException('Member not found in this organization');
+    }
+
     const vendor = await db.vendor.findFirst({
       where: { id: vendorId, organizationId },
     });
@@ -173,6 +181,14 @@ export class AccessRevocationService {
     memberId: string;
     revokedById: string;
   }) {
+    const member = await db.member.findFirst({
+      where: { id: memberId, organizationId },
+    });
+
+    if (!member) {
+      throw new NotFoundException('Member not found in this organization');
+    }
+
     const vendors = await db.vendor.findMany({
       where: { organizationId },
       select: { id: true },

--- a/apps/api/src/offboarding-checklist/offboarding-checklist.controller.ts
+++ b/apps/api/src/offboarding-checklist/offboarding-checklist.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Controller,
   Get,
   Post,
@@ -33,6 +34,13 @@ export class OffboardingChecklistController {
     private readonly offboardingChecklistService: OffboardingChecklistService,
     private readonly offboardingExportService: OffboardingExportService,
   ) {}
+
+  private requireUserId(authContext: AuthContextType): string {
+    if (!authContext.userId) {
+      throw new BadRequestException('User context required');
+    }
+    return authContext.userId;
+  }
 
   @Get('pending')
   @RequirePermission('member', 'read')
@@ -169,7 +177,7 @@ export class OffboardingChecklistController {
       organizationId,
       memberId,
       templateItemId,
-      completedById: authContext.userId!,
+      completedById: this.requireUserId(authContext),
       dto,
     });
   }
@@ -202,7 +210,7 @@ export class OffboardingChecklistController {
       memberId,
       templateItemId,
       uploadDto,
-      userId: authContext.userId!,
+      userId: this.requireUserId(authContext),
     });
   }
 
@@ -234,7 +242,7 @@ export class OffboardingChecklistController {
     return this.offboardingChecklistService.revokeAllVendorAccess({
       organizationId,
       memberId,
-      revokedById: authContext.userId!,
+      revokedById: this.requireUserId(authContext),
     });
   }
 
@@ -250,6 +258,11 @@ export class OffboardingChecklistController {
     @AuthContext() authContext: AuthContextType,
     @Body() body: { notes?: string; fileName?: string; fileType?: string; fileData?: string },
   ) {
+    const evidenceFields = [body?.fileName, body?.fileType, body?.fileData];
+    const providedCount = evidenceFields.filter(Boolean).length;
+    if (providedCount > 0 && providedCount < 3) {
+      throw new BadRequestException('fileName, fileType, and fileData must all be provided together');
+    }
     const evidence = body?.fileName && body?.fileType && body?.fileData
       ? { fileName: body.fileName, fileType: body.fileType, fileData: body.fileData }
       : undefined;
@@ -257,7 +270,7 @@ export class OffboardingChecklistController {
       organizationId,
       memberId,
       vendorId,
-      revokedById: authContext.userId!,
+      revokedById: this.requireUserId(authContext),
       notes: body?.notes,
       evidence,
     });

--- a/apps/api/src/offboarding-checklist/offboarding-checklist.service.spec.ts
+++ b/apps/api/src/offboarding-checklist/offboarding-checklist.service.spec.ts
@@ -509,7 +509,7 @@ describe('OffboardingChecklistService', () => {
 
   describe('undoVendorRevocation', () => {
     it('deletes revocation record', async () => {
-      mockDb.offboardingAccessRevocation.findUnique.mockResolvedValue({
+      mockDb.offboardingAccessRevocation.findFirst.mockResolvedValue({
         id: 'oar_1',
       });
       mockDb.offboardingAccessRevocation.delete.mockResolvedValue({});

--- a/apps/api/src/people/people.controller.ts
+++ b/apps/api/src/people/people.controller.ts
@@ -596,6 +596,9 @@ export class PeopleController {
     @AuthContext() authContext: AuthContextType,
     @Body() uploadDto: UploadAttachmentDto,
   ) {
+    if (!authContext.userId) {
+      throw new BadRequestException('User context required for this operation');
+    }
     const entityType = this.resolveEventType(eventType);
     await this.peopleService.findById(memberId, organizationId);
     return this.attachmentsService.uploadAttachment(

--- a/apps/app/src/app/(app)/[orgId]/overview/components/OffboardingBanner.tsx
+++ b/apps/app/src/app/(app)/[orgId]/overview/components/OffboardingBanner.tsx
@@ -17,13 +17,13 @@ interface PendingResponse {
 
 export function OffboardingBanner() {
   const params = useParams<{ orgId: string }>();
-  const { data } = useApiSWR<PendingResponse>(
+  const { data, error } = useApiSWR<PendingResponse>(
     '/v1/offboarding-checklist/pending',
   );
   const members = data?.data?.members ?? [];
   const [dismissed, setDismissed] = useState(false);
 
-  if (dismissed || members.length === 0) return null;
+  if (error || dismissed || members.length === 0) return null;
 
   const link = members.length === 1
     ? `/${params.orgId}/people/${members[0].memberId}?tab=offboarding`

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/AccessRevocationList.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/AccessRevocationList.tsx
@@ -263,8 +263,9 @@ function VendorRow({ vendor, canEdit, isProcessing, onRevoke }: VendorRowProps) 
             <Button
               variant="outline"
               size="sm"
-              onClick={() => fileInputRef.current?.click()}
+              onClick={() => !isProcessing && fileInputRef.current?.click()}
               iconLeft={<DocumentAttachment size={12} />}
+              disabled={isProcessing}
             >
               Attach evidence
             </Button>

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/OffboardingSummaryCard.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/OffboardingSummaryCard.tsx
@@ -86,6 +86,7 @@ export function OffboardingSummaryCard({
             window.open(
               `/api/offboarding-export?memberId=${encodeURIComponent(memberId)}`,
               '_blank',
+              'noopener,noreferrer',
             );
           }}
         >

--- a/apps/app/src/app/(app)/[orgId]/people/components/PeoplePageTabs.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/components/PeoplePageTabs.tsx
@@ -162,7 +162,7 @@ export function PeoplePageTabs({
                   <DropdownMenuContent align="end">
                     <DropdownMenuItem
                       onClick={() => {
-                        window.open('/api/offboarding-export?all=true', '_blank');
+                        window.open('/api/offboarding-export?all=true', '_blank', 'noopener,noreferrer');
                       }}
                     >
                       <Download size={14} className="mr-2" />

--- a/packages/db/prisma/schema/offboarding-checklist.prisma
+++ b/packages/db/prisma/schema/offboarding-checklist.prisma
@@ -23,14 +23,14 @@ model OffboardingChecklistCompletion {
   organizationId String
   memberId       String
   templateItemId String?
-  completedById  String
+  completedById  String?
   completedAt    DateTime @default(now())
   notes          String?
 
   organization Organization                  @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   member       Member                        @relation(fields: [memberId], references: [id], onDelete: Cascade)
   templateItem OffboardingChecklistTemplate? @relation(fields: [templateItemId], references: [id], onDelete: SetNull)
-  completedBy  User                          @relation("OffboardingChecklistCompletedBy", fields: [completedById], references: [id], onDelete: Cascade)
+  completedBy  User?                         @relation("OffboardingChecklistCompletedBy", fields: [completedById], references: [id], onDelete: SetNull)
 
   @@unique([memberId, templateItemId])
   @@index([organizationId])
@@ -42,14 +42,14 @@ model OffboardingAccessRevocation {
   organizationId String
   memberId       String
   vendorId       String
-  revokedById    String
+  revokedById    String?
   revokedAt      DateTime @default(now())
   notes          String?
 
   organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   member       Member       @relation(fields: [memberId], references: [id], onDelete: Cascade)
   vendor       Vendor       @relation(fields: [vendorId], references: [id], onDelete: Cascade)
-  revokedBy    User         @relation("AccessRevocationRevokedBy", fields: [revokedById], references: [id], onDelete: Cascade)
+  revokedBy    User?        @relation("AccessRevocationRevokedBy", fields: [revokedById], references: [id], onDelete: SetNull)
 
   @@unique([memberId, vendorId])
   @@index([organizationId])


### PR DESCRIPTION
## Summary
Fixes all remaining Cubic findings from #2878 (third review pass), focusing on security hardening and edge cases:

**Security (P1):**
- Guard all mutation endpoints against missing `userId` (API key/service token auth)
- Validate `memberId` belongs to `organizationId` before revocation operations (cross-tenant prevention)
- Change `User` `onDelete` from `Cascade` to `SetNull` on completions/revocations (preserve audit trail)
- Guard `uploadEmploymentEvidence` against missing user context
- Reject partial evidence payloads (require all 3 fields or none)

**Bug fixes (P2):**
- Fix test mock: `findUnique` → `findFirst` for `undoVendorRevocation`
- Validate provider date strings before `Date` conversion in sync controller
- Add `noopener,noreferrer` to all `window.open('_blank')` calls
- Disable "Attach evidence" button while row is processing
- Handle API error state in OffboardingBanner

## Test plan
- [ ] Call offboarding endpoints with API key auth (no session) — should get 400, not crash
- [ ] Attempt cross-tenant revocation — should get 404
- [ ] Delete a user who completed offboarding items — completions should remain (completedById set to null)
- [ ] Send partial evidence payload to revoke endpoint — should get 400
- [ ] Sync employees with invalid date strings — should skip gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens offboarding and people flows to close the third round of Cubic review findings. Supports CS-312 by safely importing onboard dates from integrations and making evidence uploads reliable.

- **Bug Fixes**
  - Require user context for all offboarding mutations and employment evidence uploads; return 400 if missing.
  - Validate `memberId` belongs to `organizationId` before any vendor revocation; return 404 on cross-tenant attempts.
  - Preserve audit trail by changing `User` FKs on completions/revocations to SetNull instead of Cascade.
  - Reject partial evidence payloads in `revokeVendorAccess`; `fileName`, `fileType`, and `fileData` must be provided together.
  - Only set `onboardDate` when provider date strings are valid in Google Workspace, Rippling, and JumpCloud imports.
  - UI safety: disable “Attach evidence” while processing, add `noopener,noreferrer` to exports, and hide OffboardingBanner on API error.

<sup>Written for commit 1eff642cd339616c5b925f971d0190580a9620bf. Summary will update on new commits. <a href="https://cubic.dev/pr/trycompai/comp/pull/2891?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

