### PR TITLE
fix(people): address fourth round of cubic review findings

### DIFF
--- a/apps/api/src/offboarding-checklist/access-revocation.service.ts
+++ b/apps/api/src/offboarding-checklist/access-revocation.service.ts
@@ -119,11 +119,13 @@ export class AccessRevocationService {
       }
     }
 
-    await this.syncAccessRevocationCompletion(
-      organizationId,
-      memberId,
-      revokedById,
-    );
+    try {
+      await this.syncAccessRevocationCompletion(
+        organizationId,
+        memberId,
+        revokedById,
+      );
+    } catch {}
 
     return revocation;
   }

--- a/apps/api/src/offboarding-checklist/access-revocation.service.ts
+++ b/apps/api/src/offboarding-checklist/access-revocation.service.ts
@@ -1,6 +1,7 @@
 import {
   BadRequestException,
   Injectable,
+  Logger,
   NotFoundException,
 } from '@nestjs/common';
 import { AttachmentEntityType, db } from '@db';
@@ -8,6 +9,8 @@ import { AttachmentsService } from '../attachments/attachments.service';
 
 @Injectable()
 export class AccessRevocationService {
+  private readonly logger = new Logger(AccessRevocationService.name);
+
   constructor(private readonly attachmentsService: AttachmentsService) {}
   async getAccessRevocations(organizationId: string, memberId: string) {
     const vendors = await db.vendor.findMany({
@@ -133,7 +136,9 @@ export class AccessRevocationService {
         memberId,
         revokedById,
       );
-    } catch {}
+    } catch (err) {
+      this.logger.warn(`Failed to sync access revocation completion for member ${memberId}`, err);
+    }
 
     return revocation;
   }

--- a/apps/api/src/offboarding-checklist/offboarding-checklist.service.spec.ts
+++ b/apps/api/src/offboarding-checklist/offboarding-checklist.service.spec.ts
@@ -19,6 +19,7 @@ const mockDb = {
   },
   offboardingAccessRevocation: {
     findMany: jest.fn(),
+    findFirst: jest.fn(),
     findUnique: jest.fn(),
     create: jest.fn(),
     delete: jest.fn(),
@@ -52,7 +53,7 @@ describe('OffboardingChecklistService', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    accessRevocationService = new AccessRevocationService();
+    accessRevocationService = new AccessRevocationService(mockAttachmentsService as never);
     service = new OffboardingChecklistService(
       mockAttachmentsService as never,
       accessRevocationService,
@@ -509,10 +510,11 @@ describe('OffboardingChecklistService', () => {
 
   describe('undoVendorRevocation', () => {
     it('deletes revocation record', async () => {
-      mockDb.offboardingAccessRevocation.findUnique.mockResolvedValue({
+      mockDb.offboardingAccessRevocation.findFirst.mockResolvedValue({
         id: 'oar_1',
       });
       mockDb.offboardingAccessRevocation.delete.mockResolvedValue({});
+      mockAttachmentsService.getAttachments.mockResolvedValue([]);
       // syncAccessRevocationCompletion mocks
       mockDb.offboardingChecklistTemplate.findFirst.mockResolvedValue(null);
 
@@ -529,7 +531,7 @@ describe('OffboardingChecklistService', () => {
     });
 
     it('throws if revocation not found', async () => {
-      mockDb.offboardingAccessRevocation.findUnique.mockResolvedValue(null);
+      mockDb.offboardingAccessRevocation.findFirst.mockResolvedValue(null);
 
       await expect(
         service.undoVendorRevocation({

--- a/apps/api/src/offboarding-checklist/offboarding-export.service.ts
+++ b/apps/api/src/offboarding-checklist/offboarding-export.service.ts
@@ -139,7 +139,7 @@ export class OffboardingExportService {
         if (!buffer) continue;
         const safeName = sanitizeFileName(file.name);
         archive.append(buffer, {
-          name: `${prefix}checklist-items/${folderNum}-${folderName}/${safeName}`,
+          name: `${prefix}checklist-items/${folderNum}-${folderName}/${file.id}-${safeName}`,
         });
       }
     }

--- a/apps/app/src/app/(app)/[orgId]/overview/components/ToDoOverview.tsx
+++ b/apps/app/src/app/(app)/[orgId]/overview/components/ToDoOverview.tsx
@@ -19,7 +19,7 @@ import {
 import { usePermissions } from '@/hooks/use-permissions';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import { ConfirmActionDialog } from './ConfirmActionDialog';
 
@@ -62,6 +62,9 @@ export function ToDoOverview({
   const { hasPermission } = usePermissions();
   const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [activeTab, setActiveTab] = useState(
+    unpublishedPolicies.length === 0 ? 'tasks' : 'policies',
+  );
 
   const {
     data: pendingData,
@@ -69,6 +72,12 @@ export function ToDoOverview({
     error: pendingError,
   } = useApiSWR<PendingOffboardingResponse>('/v1/offboarding-checklist/pending');
   const pendingOffboardings = pendingData?.data?.members ?? [];
+
+  useEffect(() => {
+    if (!isPendingLoading && pendingOffboardings.length > 0) {
+      setActiveTab('offboarding');
+    }
+  }, [isPendingLoading, pendingOffboardings.length]);
 
   const isOnboardingInProgress = !!onboardingTriggerJobId;
 
@@ -135,16 +144,7 @@ export function ToDoOverview({
         </div>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
-        <Tabs
-          defaultValue={
-            pendingOffboardings.length > 0
-              ? 'offboarding'
-              : unpublishedPolicies.length === 0
-                ? 'tasks'
-                : 'policies'
-          }
-          className="w-full"
-        >
+        <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
           <TabsList className="grid w-full grid-cols-3">
             <TabsTrigger
               value="policies"

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/OffboardingChecklistItem.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/OffboardingChecklistItem.tsx
@@ -223,7 +223,7 @@ export function OffboardingChecklistItem({
     item.isAccessRevocation || item.evidenceRequired || canEdit;
 
   return (
-    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+    <Collapsible open={isExpandable ? isOpen : false} onOpenChange={isExpandable ? setIsOpen : undefined}>
       <div className="overflow-hidden rounded-lg border bg-background">
         <CollapsibleTrigger className="flex w-full items-center gap-2 px-3.5 py-3 text-left transition-colors hover:bg-muted/50">
           <ChecklistStatusCircle item={item} memberId={memberId} />

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
@@ -147,8 +147,10 @@ export function TeamMembersClient({
     statusFilter: effectiveStatusFilter,
   });
 
+  const hasAnyDateFilter = !!(onboardFrom || onboardTo || offboardFrom || offboardTo);
+
   const dateFilteredItems = filteredItems.filter((item) => {
-    if (item.type !== 'member') return true;
+    if (item.type !== 'member') return !hasAnyDateFilter;
     const member = item as MemberWithUser;
 
     if (onboardFrom || onboardTo) {
@@ -581,6 +583,7 @@ function getPresetRange(days: number): { from: Date | undefined; to: Date | unde
   const to = new Date();
   const from = new Date();
   from.setDate(from.getDate() - days);
+  from.setHours(0, 0, 0, 0);
   return { from, to };
 }
 

--- a/apps/app/src/app/(app)/[orgId]/people/settings/components/OffboardingChecklistSettings.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/settings/components/OffboardingChecklistSettings.tsx
@@ -54,7 +54,6 @@ export function OffboardingChecklistSettings() {
     item: TemplateItem;
     next: boolean;
   }) => {
-    const previous = items;
     mutate(
       (current) => {
         if (!current) return current;
@@ -76,16 +75,7 @@ export function OffboardingChecklistSettings() {
     );
 
     if (res.error) {
-      mutate(
-        (current) => {
-          if (!current) return current;
-          return {
-            ...current,
-            data: previous,
-          };
-        },
-        { revalidate: false },
-      );
+      mutate();
       toast.error('Failed to update checklist item');
       return;
     }


### PR DESCRIPTION
## Summary
Fixes remaining Cubic findings from #2878 (fourth review pass):

**P1:**
- Fix test spec: add `findFirst` mock to `offboardingAccessRevocation` and fix `AccessRevocationService` instantiation
- Prefix checklist evidence filenames with attachment ID to prevent ZIP collisions

**P2:**
- Wrap `syncAccessRevocationCompletion` in try/catch so revocation stands even if sync fails
- Prevent non-expandable checklist rows from toggling open (empty expanded panel)
- Normalize preset date ranges to start of day (prevents excluding early-day records)
- Hide pending invitations when date filters are active (they have no dates)
- Use controlled tab value in ToDoOverview so async offboarding data activates the tab
- Revalidate from server on settings error instead of restoring stale snapshot

## Test plan
- [ ] Click a non-expandable checklist item — should not expand
- [ ] Apply "Last 7 days" preset — records from start of that day should be included
- [ ] Apply date filter — pending invitations should be hidden
- [ ] Load overview with pending offboardings — offboarding tab should auto-select
- [ ] Toggle a setting, simulate error — should revalidate from server, not restore stale data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes offboarding and people filtering issues from the Cubic review to make revocations reliable, evidence exports collision-free, and overview tabs select correctly. Supports CS-312 by making employment event filters accurate and evidence collection smoother.

- **Bug Fixes**
  - Access revocation: keep completion even if sync fails (wrap sync in try/catch) and log failures.
  - Evidence export: prefix checklist filenames with attachment ID to avoid ZIP collisions.
  - People: block opening non-expandable checklist rows; date presets start at beginning of day; hide pending invitations when any date filter is set; ToDo Overview switches to Offboarding via a controlled tab when data loads.
  - Settings: on save error, revalidate from the server instead of restoring stale state.
  - Tests: add `findFirst` mock and fix `AccessRevocationService` instantiation for `undoVendorRevocation`.

<sup>Written for commit e4c8388d7dd83d34902f1dca0d4eba2276e75529. Summary will update on new commits. <a href="https://cubic.dev/pr/trycompai/comp/pull/2892?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

