### PR TITLE
fix(people): address sixth round of cubic review findings

### DIFF
--- a/apps/api/src/offboarding-checklist/access-revocation.service.ts
+++ b/apps/api/src/offboarding-checklist/access-revocation.service.ts
@@ -4,7 +4,7 @@ import {
   Logger,
   NotFoundException,
 } from '@nestjs/common';
-import { AttachmentEntityType, db } from '@db';
+import { AttachmentEntityType, Prisma, db } from '@db';
 import { AttachmentsService } from '../attachments/attachments.service';
 
 @Injectable()
@@ -30,17 +30,42 @@ export class AccessRevocationService {
       revocations.map((r) => [r.vendorId, r]),
     );
 
+    const revocationIds = revocations.map((r) => r.id);
+    const allAttachments =
+      revocationIds.length > 0
+        ? await db.attachment.findMany({
+            where: {
+              organizationId,
+              entityId: { in: revocationIds },
+              entityType: AttachmentEntityType.offboarding_checklist,
+            },
+            orderBy: { createdAt: 'asc' },
+          })
+        : [];
+
+    const attachmentsByRevocation = new Map<string, typeof allAttachments>();
+    for (const attachment of allAttachments) {
+      const existing = attachmentsByRevocation.get(attachment.entityId) ?? [];
+      existing.push(attachment);
+      attachmentsByRevocation.set(attachment.entityId, existing);
+    }
+
     const vendorList = await Promise.all(
       vendors.map(async (vendor) => {
         const revocation = revocationMap.get(vendor.id);
         const domain = vendor.website?.replace(/^https?:\/\//, '').replace(/\/.*$/, '') ?? null;
-        const evidence = revocation
-          ? await this.attachmentsService.getAttachments(
-              organizationId,
-              revocation.id,
-              AttachmentEntityType.offboarding_checklist,
-            )
+        const rawAttachments = revocation
+          ? (attachmentsByRevocation.get(revocation.id) ?? [])
           : [];
+        const evidence = await Promise.all(
+          rawAttachments.map(async (attachment) => ({
+            id: attachment.id,
+            name: attachment.name,
+            type: attachment.type,
+            downloadUrl: await this.attachmentsService.getPresignedDownloadUrl(attachment.url),
+            createdAt: attachment.createdAt,
+          })),
+        );
         return {
           vendorId: vendor.id,
           vendorName: vendor.name,
@@ -102,18 +127,26 @@ export class AccessRevocationService {
       );
     }
 
-    const revocation = await db.offboardingAccessRevocation.create({
-      data: {
-        organizationId,
-        memberId,
-        vendorId,
-        revokedById,
-        notes,
-      },
-      include: {
-        revokedBy: { select: { id: true, name: true, email: true } },
-      },
-    });
+    let revocation: Awaited<ReturnType<typeof db.offboardingAccessRevocation.create>>;
+    try {
+      revocation = await db.offboardingAccessRevocation.create({
+        data: {
+          organizationId,
+          memberId,
+          vendorId,
+          revokedById,
+          notes,
+        },
+        include: {
+          revokedBy: { select: { id: true, name: true, email: true } },
+        },
+      });
+    } catch (err) {
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
+        throw new BadRequestException('Vendor access has already been revoked for this member');
+      }
+      throw err;
+    }
 
     if (evidence) {
       try {

--- a/apps/api/src/offboarding-checklist/offboarding-export.service.ts
+++ b/apps/api/src/offboarding-checklist/offboarding-export.service.ts
@@ -31,7 +31,12 @@ export class OffboardingExportService {
     output: NodeJS.WritableStream;
   }) {
     const archive = archiver('zip', { zlib: { level: 9 } });
-    archive.on('error', () => { archive.abort(); });
+    archive.on('error', (err) => {
+      archive.abort();
+      if ('destroy' in output && typeof (output as { destroy?: unknown }).destroy === 'function') {
+        (output as { destroy: (err: Error) => void }).destroy(err);
+      }
+    });
     archive.pipe(output);
 
     const checklist =
@@ -153,7 +158,12 @@ export class OffboardingExportService {
     output: NodeJS.WritableStream;
   }) {
     const archive = archiver('zip', { zlib: { level: 9 } });
-    archive.on('error', () => { archive.abort(); });
+    archive.on('error', (err) => {
+      archive.abort();
+      if ('destroy' in output && typeof (output as { destroy?: unknown }).destroy === 'function') {
+        (output as { destroy: (err: Error) => void }).destroy(err);
+      }
+    });
     archive.pipe(output);
 
     const BATCH_SIZE = 50;

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/OffboardingChecklistItem.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/OffboardingChecklistItem.tsx
@@ -190,6 +190,7 @@ export function OffboardingChecklistItem({
 
   const handleFileDrop = async (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
+    if (isProcessing) return;
     const file = e.dataTransfer.files[0];
     if (!file) return;
     await handleFileUpload(file);
@@ -373,8 +374,8 @@ function EvidenceContent({
         <div
           onDrop={onFileDrop}
           onDragOver={(e) => e.preventDefault()}
-          onClick={() => dropzoneInputRef.current?.click()}
-          className="flex cursor-pointer flex-col items-center gap-2 rounded-md border-2 border-dashed border-muted-foreground/25 px-4 py-6 text-center transition hover:border-muted-foreground/50 hover:bg-muted/25"
+          onClick={() => !isProcessing && dropzoneInputRef.current?.click()}
+          className={`flex cursor-pointer flex-col items-center gap-2 rounded-md border-2 border-dashed border-muted-foreground/25 px-4 py-6 text-center transition hover:border-muted-foreground/50 hover:bg-muted/25${isProcessing ? ' pointer-events-none opacity-50' : ''}`}
         >
           <Upload size={20} className="text-muted-foreground" />
           <div>

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/OffboardingSummaryCard.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/OffboardingSummaryCard.tsx
@@ -19,7 +19,7 @@ export function OffboardingSummaryCard({
   completedItems,
   hasEvidence,
 }: OffboardingSummaryCardProps) {
-  const daysSince = differenceInDays(new Date(), new Date(offboardDate));
+  const daysSince = Math.max(0, differenceInDays(new Date(), new Date(offboardDate)));
   const progressPercent =
     totalItems > 0 ? Math.round((completedItems / totalItems) * 100) : 0;
 


### PR DESCRIPTION
## Summary
Fixes 5 valid Cubic findings, replied won't-fix on 2 others:

**Fixed:**
- Propagate archiver errors to output stream (prevents truncated ZIP as apparent success)
- Clamp "Days since" to 0 for future offboard dates (negative value UX bug)
- Disable evidence dropzone while upload is processing (prevents silent ignore)
- Batch vendor attachment queries in `getAccessRevocations` (N+1 → 1 query)
- Catch P2002 unique constraint race on revocation create (500 → 400)

**Won't fix (replied on PR):**
- DTO all-or-none evidence validation — already enforced in controller (PR #2891)
- CSV sanitization order — current order is correct (escape first, then check prefix)

## Test plan
- [ ] Trigger archiver error during export — response should terminate, not return partial ZIP
- [ ] Set future offboard date — "Days since" should show 0
- [ ] Click dropzone while upload in progress — should be visually disabled
- [ ] View vendor revocations for org with many vendors — should load fast (batched)
- [ ] Send duplicate revocation request — should get 400, not 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes offboarding checklist issues to prevent truncated exports, improve evidence upload UX, harden revocation creation, and speed up vendor revocation loading. Supports Linear CS-312 by making employment event evidence collection and review more reliable.

- **Bug Fixes**
  - Propagate archive errors to the response stream to prevent partial ZIPs.
  - Clamp “Days since” to 0 for future offboard dates.
  - Disable evidence dropzone while an upload is processing.
  - Batch vendor attachment lookups in getAccessRevocations (N+1 → 1 query).
  - Catch `Prisma` P2002 on revocation create and return 400 instead of 500.

<sup>Written for commit 83b0d0549f4717b60735f81a3458bf67f43e11f1. Summary will update on new commits. <a href="https://cubic.dev/pr/trycompai/comp/pull/2894?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

