### PR TITLE
fix(cloud-tests): address release remediation review

### DIFF
--- a/apps/api/src/cloud-security/aws-command-executor.spec.ts
+++ b/apps/api/src/cloud-security/aws-command-executor.spec.ts
@@ -107,12 +107,13 @@ describe('validatePlanSteps — REQUIRED_PARAMS', () => {
     );
   });
 
-  it('does not let SecurityGroupRuleIds satisfy a property-based revoke group requirement', () => {
+  it('rejects revoke commands that mix rule IDs with rule properties', () => {
     const errors = validatePlanSteps([
       step({
         service: 'ec2',
         command: 'RevokeSecurityGroupIngressCommand',
         params: {
+          GroupId: 'sg-0123abc',
           SecurityGroupRuleIds: ['sgr-0123abc'],
           IpPermissions: [
             {
@@ -128,12 +129,12 @@ describe('validatePlanSteps — REQUIRED_PARAMS', () => {
 
     expect(errors).toEqual(
       expect.arrayContaining([
-        'Step 1 (RevokeSecurityGroupIngressCommand): One of "GroupId" or "GroupName" is required',
+        'Step 1 (RevokeSecurityGroupIngressCommand): SecurityGroupRuleIds cannot be combined with rule property params',
       ]),
     );
   });
 
-  it('allows security-group ingress commands when GroupId is present', () => {
+  it('requires a rule selector for security-group revoke commands', () => {
     const errors = validatePlanSteps([
       step({
         service: 'ec2',
@@ -142,7 +143,35 @@ describe('validatePlanSteps — REQUIRED_PARAMS', () => {
       }),
     ]);
 
-    expect(errors.some((e) => /GroupId/.test(e))).toBe(false);
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        'Step 1 (RevokeSecurityGroupIngressCommand): One of "SecurityGroupRuleIds" or rule property params is required',
+      ]),
+    );
+  });
+
+  it('allows property-based security-group revoke commands when GroupId is present', () => {
+    const errors = validatePlanSteps([
+      step({
+        service: 'ec2',
+        command: 'RevokeSecurityGroupIngressCommand',
+        params: {
+          GroupId: 'sg-0123abc',
+          IpPermissions: [
+            {
+              IpProtocol: 'tcp',
+              FromPort: 22,
+              ToPort: 22,
+              IpRanges: [{ CidrIp: '0.0.0.0/0' }],
+            },
+          ],
+        },
+      }),
+    ]);
+
+    expect(
+      errors.some((e) => /RevokeSecurityGroupIngressCommand/.test(e)),
+    ).toBe(false);
   });
 
   it('allows security-group revoke commands that use SecurityGroupRuleIds only', () => {
@@ -168,7 +197,7 @@ describe('validatePlanSteps — REQUIRED_PARAMS', () => {
 
     expect(errors).toEqual(
       expect.arrayContaining([
-        'Step 1 (RevokeSecurityGroupIngressCommand): One of "GroupId" or "GroupName" is required',
+        'Step 1 (RevokeSecurityGroupIngressCommand): One of "SecurityGroupRuleIds" or rule property params is required',
       ]),
     );
   });

--- a/apps/api/src/cloud-security/aws-command-executor.ts
+++ b/apps/api/src/cloud-security/aws-command-executor.ts
@@ -592,6 +592,18 @@ function validateRevokeSecurityGroupIngressParams(
       hasRequiredParamValue(params[key]),
     );
 
+  if (!hasRuleIds && !hasRuleProperties) {
+    return [
+      `${prefix}: One of "SecurityGroupRuleIds" or rule property params is required`,
+    ];
+  }
+
+  if (hasRuleIds && hasRuleProperties) {
+    return [
+      `${prefix}: SecurityGroupRuleIds cannot be combined with rule property params`,
+    ];
+  }
+
   if (hasRuleIds && !hasRuleProperties) return [];
   if (hasGroupIdentifier) return [];
 

--- a/apps/api/src/cloud-security/manual-remediation.spec.ts
+++ b/apps/api/src/cloud-security/manual-remediation.spec.ts
@@ -28,4 +28,13 @@ describe('manual remediation helpers', () => {
       'Cannot be auto-fixed. RDS encryption requires snapshot copy and restore.',
     ]);
   });
+
+  it('preserves info severity for manual remediation risk', () => {
+    const preview = buildManualRemediationPreview({
+      remediation: '[MANUAL] Review the passed informational check.',
+      severity: 'info',
+    });
+
+    expect(preview.risk).toBe('info');
+  });
 });

--- a/apps/api/src/cloud-security/manual-remediation.ts
+++ b/apps/api/src/cloud-security/manual-remediation.ts
@@ -1,6 +1,6 @@
 const MANUAL_PREFIX = '[MANUAL]';
 
-type ManualRemediationRisk = 'low' | 'medium' | 'high' | 'critical';
+type ManualRemediationRisk = 'info' | 'low' | 'medium' | 'high' | 'critical';
 
 export interface ManualRemediationPreview {
   currentState: Record<string, unknown>;
@@ -47,7 +47,8 @@ function normalizeRisk(severity?: string | null): ManualRemediationRisk {
     severity === 'low' ||
     severity === 'medium' ||
     severity === 'high' ||
-    severity === 'critical'
+    severity === 'critical' ||
+    severity === 'info'
   ) {
     return severity;
   }

--- a/apps/app/src/app/(app)/[orgId]/cloud-tests/actions/batch-fix.ts
+++ b/apps/app/src/app/(app)/[orgId]/cloud-tests/actions/batch-fix.ts
@@ -2,6 +2,7 @@
 
 import { serverApi } from '@/lib/api-server';
 import { classifyExecuteResult } from '@/trigger/tasks/cloud-security/execute-result';
+import { classifyRetryPreview } from '@/trigger/tasks/cloud-security/retry-preview';
 import { auth, runs, tasks } from '@trigger.dev/sdk';
 
 interface BatchFixInput {
@@ -162,8 +163,15 @@ export async function retryFinding(
     const data = preview.data as
       | { guidedOnly?: boolean; missingPermissions?: string[] }
       | undefined;
-    if (data?.missingPermissions && data.missingPermissions.length > 0) {
-      return { status: 'needs_permissions', missingPermissions: data.missingPermissions };
+    const previewDecision = classifyRetryPreview(data);
+    if (previewDecision.type === 'needs_permissions') {
+      return {
+        status: 'needs_permissions',
+        missingPermissions: previewDecision.missingPermissions,
+      };
+    }
+    if (previewDecision.type === 'manual') {
+      return { status: 'failed', error: previewDecision.error };
     }
 
     // Execute

--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/actions/batch-fix.ts
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/actions/batch-fix.ts
@@ -2,6 +2,7 @@
 
 import { serverApi } from '@/lib/api-server';
 import { classifyExecuteResult } from '@/trigger/tasks/cloud-security/execute-result';
+import { classifyRetryPreview } from '@/trigger/tasks/cloud-security/retry-preview';
 import { auth, runs, tasks } from '@trigger.dev/sdk';
 
 interface BatchFixInput {
@@ -162,8 +163,15 @@ export async function retryFinding(
     const data = preview.data as
       | { guidedOnly?: boolean; missingPermissions?: string[] }
       | undefined;
-    if (data?.missingPermissions && data.missingPermissions.length > 0) {
-      return { status: 'needs_permissions', missingPermissions: data.missingPermissions };
+    const previewDecision = classifyRetryPreview(data);
+    if (previewDecision.type === 'needs_permissions') {
+      return {
+        status: 'needs_permissions',
+        missingPermissions: previewDecision.missingPermissions,
+      };
+    }
+    if (previewDecision.type === 'manual') {
+      return { status: 'failed', error: previewDecision.error };
     }
 
     // Execute

--- a/apps/app/src/trigger/tasks/cloud-security/retry-preview.test.ts
+++ b/apps/app/src/trigger/tasks/cloud-security/retry-preview.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { classifyRetryPreview } from './retry-preview';
+
+describe('classifyRetryPreview', () => {
+  it('continues when preview has no blockers', () => {
+    expect(classifyRetryPreview(undefined)).toEqual({ type: 'continue' });
+    expect(classifyRetryPreview({})).toEqual({ type: 'continue' });
+  });
+
+  it('preserves missing permission retry flow', () => {
+    expect(
+      classifyRetryPreview({ missingPermissions: ['ec2:RevokeSecurityGroupIngress'] }),
+    ).toEqual({
+      type: 'needs_permissions',
+      missingPermissions: ['ec2:RevokeSecurityGroupIngress'],
+    });
+  });
+
+  it('stops guided-only retries before execute', () => {
+    expect(classifyRetryPreview({ guidedOnly: true })).toEqual({
+      type: 'manual',
+      error: 'This finding requires manual remediation and cannot be auto-fixed.',
+    });
+  });
+});

--- a/apps/app/src/trigger/tasks/cloud-security/retry-preview.ts
+++ b/apps/app/src/trigger/tasks/cloud-security/retry-preview.ts
@@ -1,0 +1,27 @@
+export interface RetryPreviewData {
+  guidedOnly?: boolean;
+  missingPermissions?: string[];
+}
+
+export type RetryPreviewDecision =
+  | { type: 'continue' }
+  | { type: 'needs_permissions'; missingPermissions: string[] }
+  | { type: 'manual'; error: string };
+
+export function classifyRetryPreview(data: RetryPreviewData | undefined): RetryPreviewDecision {
+  if (data?.missingPermissions && data.missingPermissions.length > 0) {
+    return {
+      type: 'needs_permissions',
+      missingPermissions: data.missingPermissions,
+    };
+  }
+
+  if (data?.guidedOnly) {
+    return {
+      type: 'manual',
+      error: 'This finding requires manual remediation and cannot be auto-fixed.',
+    };
+  }
+
+  return { type: 'continue' };
+}


### PR DESCRIPTION
## Summary
- stop retry flows from executing guided-only/manual remediation previews
- preserve info severity for manual remediation preview risk
- require a real selector for RevokeSecurityGroupIngressCommand validation while still allowing rule-ID-only revokes

## Verification
- bunx jest src/cloud-security/aws-command-executor.spec.ts src/cloud-security/manual-remediation.spec.ts --passWithNoTests
- bunx jest src/cloud-security --passWithNoTests --testPathIgnorePatterns=remediation.controller.spec.ts
- bunx vitest run src/trigger/tasks/cloud-security
- bunx eslint src/cloud-security/aws-command-executor.ts src/cloud-security/aws-command-executor.spec.ts src/cloud-security/manual-remediation.ts src/cloud-security/manual-remediation.spec.ts
- bunx eslint src/trigger/tasks/cloud-security/retry-preview.ts src/trigger/tasks/cloud-security/retry-preview.test.ts src/app/'(app)'/'[orgId]'/cloud-tests/actions/batch-fix.ts src/app/'(app)'/'[orgId]'/integrations/'[slug]'/actions/batch-fix.ts
- bunx prettier --check apps/api/src/cloud-security/aws-command-executor.ts apps/api/src/cloud-security/aws-command-executor.spec.ts apps/api/src/cloud-security/manual-remediation.ts apps/api/src/cloud-security/manual-remediation.spec.ts apps/app/src/trigger/tasks/cloud-security/retry-preview.ts apps/app/src/trigger/tasks/cloud-security/retry-preview.test.ts apps/app/src/app/'(app)'/'[orgId]'/cloud-tests/actions/batch-fix.ts apps/app/src/app/'(app)'/'[orgId]'/integrations/'[slug]'/actions/batch-fix.ts
- git diff --check

## Notes
- apps/app typecheck still fails on existing baseline issues outside this patch, including stale component test fixtures, AI SDK v2/v3 type mismatches, and better-auth duplicate package types.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents retry flows from executing guided-only/manual remediations, tightens Security Group revoke validation, and preserves `info` risk for manual remediation previews.

- **Bug Fixes**
  - Retry flow: added `classifyRetryPreview` and wired it into both batch-fix actions to stop guided-only cases and continue permission prompts when `missingPermissions` are present.
  - AWS validation: `RevokeSecurityGroupIngressCommand` now requires either `SecurityGroupRuleIds` or rule property params (not both), with clearer errors; rule-ID-only revokes remain allowed.
  - Manual remediation: accepts and returns `info` severity for preview risk.

<sup>Written for commit 1b3b84a77f810c539b3805819623ed718571999b. Summary will update on new commits. <a href="https://cubic.dev/pr/trycompai/comp/pull/2906?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

