### PR TITLE
fix(cloud-tests): preserve batch finding cancellations

### DIFF
--- a/apps/app/src/trigger/tasks/cloud-security/remediate-batch-helpers.test.ts
+++ b/apps/app/src/trigger/tasks/cloud-security/remediate-batch-helpers.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+vi.mock('@db/server', () => ({
+  db: {
+    remediationBatch: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@trigger.dev/sdk', () => ({
+  metadata: { set: vi.fn() },
+}));
+
+vi.mock('./api-response', () => ({
+  postCloudSecurityApi: vi.fn(),
+}));
+
+import { db } from '@db/server';
+import {
+  persistProgress,
+  type BatchProgress,
+  type FindingProgress,
+} from './remediate-batch-helpers';
+
+type MockRemediationBatch = {
+  findUnique: Mock;
+  update: Mock;
+};
+
+const remediationBatch = (db as unknown as { remediationBatch: MockRemediationBatch })
+  .remediationBatch;
+
+function finding(overrides: Partial<FindingProgress>): FindingProgress {
+  return {
+    id: overrides.id ?? 'check-1',
+    key: overrides.key ?? 'finding-key',
+    title: overrides.title ?? 'Finding',
+    status: overrides.status ?? 'pending',
+    error: overrides.error,
+    missingPermissions: overrides.missingPermissions,
+  };
+}
+
+function progress(findings: FindingProgress[]): BatchProgress {
+  return {
+    current: 1,
+    total: findings.length,
+    fixed: 0,
+    skipped: 0,
+    failed: 0,
+    findings,
+    phase: 'running',
+    confirmedPermissions: [],
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('persistProgress', () => {
+  it('preserves concurrent per-finding cancellations before writing progress', async () => {
+    remediationBatch.findUnique.mockResolvedValue({
+      findings: [
+        finding({ id: 'check-1', status: 'pending' }),
+        finding({
+          id: 'check-2',
+          status: 'cancelled',
+          error: 'Removed by user',
+        }),
+      ],
+    });
+    remediationBatch.update.mockResolvedValue({});
+
+    const batchProgress = progress([
+      finding({ id: 'check-1', status: 'fixed' }),
+      finding({ id: 'check-2', status: 'pending' }),
+    ]);
+
+    await persistProgress('batch-1', batchProgress, 'done');
+
+    expect(batchProgress.findings[1]).toMatchObject({
+      id: 'check-2',
+      status: 'cancelled',
+      error: 'Removed by user',
+      missingPermissions: undefined,
+    });
+    expect(batchProgress.fixed).toBe(1);
+    expect(batchProgress.skipped).toBe(1);
+    expect(batchProgress.failed).toBe(0);
+
+    expect(remediationBatch.update).toHaveBeenCalledWith({
+      where: { id: 'batch-1' },
+      data: expect.objectContaining({
+        status: 'done',
+        fixed: 1,
+        skipped: 1,
+        failed: 0,
+        findings: expect.arrayContaining([
+          expect.objectContaining({ id: 'check-2', status: 'cancelled' }),
+        ]),
+      }),
+    });
+  });
+});

--- a/apps/app/src/trigger/tasks/cloud-security/remediate-batch-helpers.test.ts
+++ b/apps/app/src/trigger/tasks/cloud-security/remediate-batch-helpers.test.ts
@@ -1,13 +1,34 @@
 import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 
-vi.mock('@db/server', () => ({
-  db: {
-    remediationBatch: {
-      findUnique: vi.fn(),
-      update: vi.fn(),
+vi.mock('@db/server', () => {
+  const remediationBatch = {
+    findUnique: vi.fn(),
+    update: vi.fn(),
+  };
+
+  class PrismaClientKnownRequestError extends Error {
+    code: string;
+
+    constructor(message: string, options: { code: string }) {
+      super(message);
+      this.code = options.code;
+    }
+  }
+
+  return {
+    Prisma: {
+      PrismaClientKnownRequestError,
+      TransactionIsolationLevel: { Serializable: 'Serializable' },
     },
-  },
-}));
+    db: {
+      remediationBatch,
+      $transaction: vi.fn(
+        (callback: (tx: { remediationBatch: typeof remediationBatch }) => unknown) =>
+          callback({ remediationBatch }),
+      ),
+    },
+  };
+});
 
 vi.mock('@trigger.dev/sdk', () => ({
   metadata: { set: vi.fn() },
@@ -17,7 +38,7 @@ vi.mock('./api-response', () => ({
   postCloudSecurityApi: vi.fn(),
 }));
 
-import { db } from '@db/server';
+import { Prisma, db } from '@db/server';
 import {
   persistProgress,
   type BatchProgress,
@@ -29,8 +50,13 @@ type MockRemediationBatch = {
   update: Mock;
 };
 
-const remediationBatch = (db as unknown as { remediationBatch: MockRemediationBatch })
-  .remediationBatch;
+type MockDb = {
+  remediationBatch: MockRemediationBatch;
+  $transaction: Mock;
+};
+
+const mockedDb = db as unknown as MockDb;
+const remediationBatch = mockedDb.remediationBatch;
 
 function finding(overrides: Partial<FindingProgress>): FindingProgress {
   return {
@@ -81,6 +107,10 @@ describe('persistProgress', () => {
 
     await persistProgress('batch-1', batchProgress, 'done');
 
+    expect(mockedDb.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+      isolationLevel: 'Serializable',
+    });
+
     expect(batchProgress.findings[1]).toMatchObject({
       id: 'check-2',
       status: 'cancelled',
@@ -101,6 +131,45 @@ describe('persistProgress', () => {
         findings: expect.arrayContaining([
           expect.objectContaining({ id: 'check-2', status: 'cancelled' }),
         ]),
+      }),
+    });
+  });
+
+  it('retries after a serializable transaction conflict and re-reads cancellations', async () => {
+    const conflict = new Prisma.PrismaClientKnownRequestError('write conflict', {
+      code: 'P2034',
+      clientVersion: 'test',
+    });
+
+    mockedDb.$transaction
+      .mockRejectedValueOnce(conflict)
+      .mockImplementationOnce(
+        (callback: (tx: { remediationBatch: MockRemediationBatch }) => unknown) =>
+          callback({ remediationBatch }),
+      );
+    remediationBatch.findUnique.mockResolvedValue({
+      findings: [finding({ id: 'check-1', status: 'cancelled', error: 'Removed during retry' })],
+    });
+    remediationBatch.update.mockResolvedValue({});
+
+    const batchProgress = progress([finding({ id: 'check-1', status: 'fixed' })]);
+
+    await persistProgress('batch-1', batchProgress, 'done');
+
+    expect(mockedDb.$transaction).toHaveBeenCalledTimes(2);
+    expect(remediationBatch.findUnique).toHaveBeenCalledTimes(1);
+    expect(batchProgress.findings[0]).toMatchObject({
+      id: 'check-1',
+      status: 'cancelled',
+      error: 'Removed during retry',
+    });
+    expect(remediationBatch.update).toHaveBeenCalledWith({
+      where: { id: 'batch-1' },
+      data: expect.objectContaining({
+        status: 'done',
+        fixed: 0,
+        skipped: 1,
+        failed: 0,
       }),
     });
   });

--- a/apps/app/src/trigger/tasks/cloud-security/remediate-batch-helpers.ts
+++ b/apps/app/src/trigger/tasks/cloud-security/remediate-batch-helpers.ts
@@ -35,6 +35,8 @@ export interface BatchProgress {
   confirmedPermissions?: string[];
 }
 
+export type BatchTerminalStatus = 'cancelled' | 'done';
+
 interface PreviewResult {
   guidedOnly?: boolean;
   missingPermissions?: string[];
@@ -128,10 +130,60 @@ export async function isFindingCancelled(batchId: string, findingId: string): Pr
   return findings.find((f) => f.id === findingId)?.status === 'cancelled';
 }
 
-export async function persistProgress(batchId: string, progress: BatchProgress) {
+function preservePersistedCancellations(params: {
+  progress: BatchProgress;
+  persistedFindings: FindingProgress[];
+}): void {
+  const cancelledById = new Map(
+    params.persistedFindings
+      .filter((finding) => finding.status === 'cancelled')
+      .map((finding) => [finding.id, finding]),
+  );
+
+  if (cancelledById.size === 0) return;
+
+  params.progress.findings = params.progress.findings.map((finding) => {
+    const cancelled = cancelledById.get(finding.id);
+    if (!cancelled) return finding;
+    return {
+      ...finding,
+      ...cancelled,
+      status: 'cancelled',
+      missingPermissions: undefined,
+    };
+  });
+}
+
+function recalculateProgressCounts(progress: BatchProgress): void {
+  progress.fixed = progress.findings.filter((finding) => finding.status === 'fixed').length;
+  progress.failed = progress.findings.filter((finding) => finding.status === 'failed').length;
+  progress.skipped = progress.findings.filter((finding) =>
+    ['cancelled', 'needs_permissions', 'skipped'].includes(finding.status),
+  ).length;
+}
+
+export async function persistProgress(
+  batchId: string,
+  progress: BatchProgress,
+  status?: BatchTerminalStatus,
+) {
+  const current = await db.remediationBatch.findUnique({
+    where: { id: batchId },
+    select: { findings: true },
+  });
+
+  if (current) {
+    preservePersistedCancellations({
+      progress,
+      persistedFindings: current.findings as unknown as FindingProgress[],
+    });
+    recalculateProgressCounts(progress);
+  }
+
   await db.remediationBatch.update({
     where: { id: batchId },
     data: {
+      ...(status && { status }),
       findings: JSON.parse(JSON.stringify(progress.findings)),
       fixed: progress.fixed,
       skipped: progress.skipped,

--- a/apps/app/src/trigger/tasks/cloud-security/remediate-batch-helpers.ts
+++ b/apps/app/src/trigger/tasks/cloud-security/remediate-batch-helpers.ts
@@ -1,4 +1,4 @@
-import { db } from '@db/server';
+import { Prisma, db } from '@db/server';
 import { metadata } from '@trigger.dev/sdk';
 import { postCloudSecurityApi } from './api-response';
 import { classifyExecuteResult } from './execute-result';
@@ -36,6 +36,8 @@ export interface BatchProgress {
 }
 
 export type BatchTerminalStatus = 'cancelled' | 'done';
+
+const MAX_PERSIST_PROGRESS_ATTEMPTS = 3;
 
 interface PreviewResult {
   guidedOnly?: boolean;
@@ -162,32 +164,52 @@ function recalculateProgressCounts(progress: BatchProgress): void {
   ).length;
 }
 
+function isSerializableTransactionConflict(error: unknown): boolean {
+  return error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2034';
+}
+
 export async function persistProgress(
   batchId: string,
   progress: BatchProgress,
   status?: BatchTerminalStatus,
 ) {
-  const current = await db.remediationBatch.findUnique({
-    where: { id: batchId },
-    select: { findings: true },
-  });
+  for (let attempt = 1; attempt <= MAX_PERSIST_PROGRESS_ATTEMPTS; attempt++) {
+    try {
+      // Per-finding skips update the same JSON field; serializable isolation turns
+      // stale read/write windows into P2034 conflicts that we can retry safely.
+      await db.$transaction(
+        async (tx) => {
+          const current = await tx.remediationBatch.findUnique({
+            where: { id: batchId },
+            select: { findings: true },
+          });
 
-  if (current) {
-    preservePersistedCancellations({
-      progress,
-      persistedFindings: current.findings as unknown as FindingProgress[],
-    });
-    recalculateProgressCounts(progress);
+          if (current) {
+            preservePersistedCancellations({
+              progress,
+              persistedFindings: current.findings as unknown as FindingProgress[],
+            });
+            recalculateProgressCounts(progress);
+          }
+
+          await tx.remediationBatch.update({
+            where: { id: batchId },
+            data: {
+              ...(status && { status }),
+              findings: JSON.parse(JSON.stringify(progress.findings)),
+              fixed: progress.fixed,
+              skipped: progress.skipped,
+              failed: progress.failed,
+            },
+          });
+        },
+        { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+      );
+      return;
+    } catch (error) {
+      if (!isSerializableTransactionConflict(error) || attempt === MAX_PERSIST_PROGRESS_ATTEMPTS) {
+        throw error;
+      }
+    }
   }
-
-  await db.remediationBatch.update({
-    where: { id: batchId },
-    data: {
-      ...(status && { status }),
-      findings: JSON.parse(JSON.stringify(progress.findings)),
-      fixed: progress.fixed,
-      skipped: progress.skipped,
-      failed: progress.failed,
-    },
-  });
 }

--- a/apps/app/src/trigger/tasks/cloud-security/remediate-batch.ts
+++ b/apps/app/src/trigger/tasks/cloud-security/remediate-batch.ts
@@ -59,6 +59,16 @@ export const remediateBatch = task({
       progress.current = i + 1;
       progress.findings[i]!.status = 'fixing';
       sync(progress);
+      await persistProgress(batchId, progress);
+      if (
+        progress.findings[i]!.status === 'cancelled' ||
+        (await isFindingCancelled(batchId, findings[i]!.id))
+      ) {
+        progress.findings[i]!.status = 'cancelled';
+        await persistProgress(batchId, progress);
+        sync(progress);
+        continue;
+      }
 
       logger.info(`[${i + 1}/${findings.length}] ${findings[i]!.title}`);
       const result = await tryFix(findings[i]!, connectionId, organizationId, userId);
@@ -209,16 +219,7 @@ export const remediateBatch = task({
     progress.phase = progress.phase === 'cancelled' ? 'cancelled' : 'done';
     sync(progress);
 
-    await db.remediationBatch.update({
-      where: { id: batchId },
-      data: {
-        status: progress.phase === 'cancelled' ? 'cancelled' : 'done',
-        findings: JSON.parse(JSON.stringify(progress.findings)),
-        fixed: progress.fixed,
-        skipped: progress.skipped,
-        failed: progress.failed,
-      },
-    });
+    await persistProgress(batchId, progress, progress.phase === 'cancelled' ? 'cancelled' : 'done');
 
     return {
       success: true,


### PR DESCRIPTION
## Summary
- preserve per-finding cancelled state when batch progress persists full finding snapshots
- persist a finding's fixing state before execution, then recheck cancellation before calling execute
- use the same cancellation-preserving persistence path for final batch completion

## Verification
- bunx vitest run src/trigger/tasks/cloud-security
- bunx eslint src/trigger/tasks/cloud-security/remediate-batch.ts src/trigger/tasks/cloud-security/remediate-batch-helpers.ts src/trigger/tasks/cloud-security/remediate-batch-helpers.test.ts
- bunx prettier --check apps/app/src/trigger/tasks/cloud-security/remediate-batch.ts apps/app/src/trigger/tasks/cloud-security/remediate-batch-helpers.ts apps/app/src/trigger/tasks/cloud-security/remediate-batch-helpers.test.ts
- git diff --check

## Notes
- bun run typecheck in apps/app still fails on existing baseline issues outside this patch, including stale component test fixtures, AI SDK v2/v3 type mismatches, and better-auth duplicate package types.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes remediation batches to preserve per-finding cancellations and stop cancelled findings from executing. Adds serializable, retryable progress persistence to keep counts and final status correct.

- **Bug Fixes**
  - Preserve cancelled findings when saving progress.
  - Persist "fixing", then re-check and skip execution if cancelled.
  - Wrap progress updates in a serializable transaction; retry on `Prisma` `P2034` conflicts and re-read cancellations on retry.
  - Recalculate fixed/failed/skipped; count cancelled as skipped.
  - Use `persistProgress` for final completion with optional terminal status. Tests added for cancellation and retry.

<sup>Written for commit 199dfc388ccb298e9b2cb74a75cc52aec30b8c41. Summary will update on new commits. <a href="https://cubic.dev/pr/trycompai/comp/pull/2907?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

