### PR TITLE
fix(cloud-tests): backfill egress security group ids

### DIFF
--- a/apps/api/src/cloud-security/plan-normalizer-aws-edge-cases.spec.ts
+++ b/apps/api/src/cloud-security/plan-normalizer-aws-edge-cases.spec.ts
@@ -97,6 +97,36 @@ describe('normalizeFixPlan — AWS remediation edge cases', () => {
     expect(result.rollbackSteps[0].params.GroupId).toBe('sg-0123abc');
   });
 
+  it('backfills GroupId on EC2 security-group egress commands from the finding resource id', () => {
+    const ipPermissions = [
+      {
+        IpProtocol: '-1',
+        IpRanges: [{ CidrIp: '0.0.0.0/0' }],
+      },
+    ];
+    const plan = makePlan({
+      fixSteps: [
+        makeStep({
+          service: 'ec2',
+          command: 'RevokeSecurityGroupEgressCommand',
+          params: { IpPermissions: ipPermissions },
+        }),
+      ],
+      rollbackSteps: [
+        makeStep({
+          service: 'ec2',
+          command: 'AuthorizeSecurityGroupEgressCommand',
+          params: { IpPermissions: ipPermissions },
+        }),
+      ],
+    });
+
+    const result = normalizeFixPlan(plan, { resourceId: 'sg-0123abc' });
+
+    expect(result.fixSteps[0].params.GroupId).toBe('sg-0123abc');
+    expect(result.rollbackSteps[0].params.GroupId).toBe('sg-0123abc');
+  });
+
   it('does not overwrite an explicit security-group GroupName', () => {
     const plan = makePlan({
       fixSteps: [

--- a/apps/api/src/cloud-security/plan-normalizer.ts
+++ b/apps/api/src/cloud-security/plan-normalizer.ts
@@ -35,6 +35,8 @@ const IAM_LIKE_SERVICES = new Set(['iam', 'sts']);
 const EC2_SECURITY_GROUP_COMMANDS = new Set([
   'AuthorizeSecurityGroupIngressCommand',
   'RevokeSecurityGroupIngressCommand',
+  'AuthorizeSecurityGroupEgressCommand',
+  'RevokeSecurityGroupEgressCommand',
 ]);
 const S3_ACL_COMMANDS = new Set(['PutBucketAclCommand']);
 const S3_ACL_PERMISSIONS = new Set(['s3:PutBucketAcl']);


### PR DESCRIPTION
## Summary
- include EC2 security-group egress authorize/revoke commands in GroupId backfill
- add regression coverage for egress fix and rollback steps

## Verification
- bunx jest src/cloud-security/plan-normalizer-aws-edge-cases.spec.ts src/cloud-security/plan-normalizer.spec.ts --passWithNoTests
- bunx eslint src/cloud-security/plan-normalizer.ts src/cloud-security/plan-normalizer-aws-edge-cases.spec.ts
- bunx prettier --check apps/api/src/cloud-security/plan-normalizer.ts apps/api/src/cloud-security/plan-normalizer-aws-edge-cases.spec.ts
- git diff --check

Notes: broader API typecheck still fails on existing unrelated baseline errors (AI SDK v3/v2 type mismatch, better-auth duplicate package type mismatch, stale specs). Broad src/cloud-security Jest run passed 24 suites, then remediation.controller.spec.ts stopped on the local non-TLS Postgres guard.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing `GroupId` backfill for EC2 security-group egress steps in `normalizeFixPlan`. Adds regression tests to cover egress authorize/revoke and rollback paths.

- **Bug Fixes**
  - Include `AuthorizeSecurityGroupEgressCommand` and `RevokeSecurityGroupEgressCommand` in the backfill set, deriving `GroupId` from the finding `resourceId`.
  - Add edge-case tests to verify `GroupId` is set on egress fix and rollback steps.

<sup>Written for commit 816ba5cdc696a987134be863dbb5c0bf2ebb487e. Summary will update on new commits. <a href="https://cubic.dev/pr/trycompai/comp/pull/2908?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

