### PR TITLE
fix(integrations): honor google sync exclusions for members

### DIFF
--- a/apps/api/src/integration-platform/controllers/sync-gws.controller.spec.ts
+++ b/apps/api/src/integration-platform/controllers/sync-gws.controller.spec.ts
@@ -6,6 +6,9 @@ import { ConnectionRepository } from '../repositories/connection.repository';
 import { CredentialVaultService } from '../services/credential-vault.service';
 import { OAuthCredentialsService } from '../services/oauth-credentials.service';
 import { IntegrationSyncLoggerService } from '../services/integration-sync-logger.service';
+import { GenericEmployeeSyncService } from '../services/generic-employee-sync.service';
+import { DynamicIntegrationRepository } from '../repositories/dynamic-integration.repository';
+import { CheckRunRepository } from '../repositories/check-run.repository';
 import { db } from '@db';
 
 jest.mock('@db', () => ({
@@ -99,6 +102,9 @@ describe('SyncController - Google Workspace employees', () => {
           provide: IntegrationSyncLoggerService,
           useValue: { logSync: jest.fn() },
         },
+        { provide: GenericEmployeeSyncService, useValue: {} },
+        { provide: DynamicIntegrationRepository, useValue: {} },
+        { provide: CheckRunRepository, useValue: {} },
       ],
     })
       .overrideGuard(HybridAuthGuard)
@@ -596,9 +602,12 @@ describe('SyncController - Google Workspace employees', () => {
   // ── Exclude filter mode ────────────────────────────────────────
 
   describe('exclude filter mode', () => {
-    it('should NOT deactivate excluded members in exclude mode', async () => {
+    it('should deactivate existing non-privileged members excluded from sync', async () => {
       setupSync({
-        gwUsers: [makeGwUser('kept@example.com')],
+        gwUsers: [
+          makeGwUser('kept@example.com'),
+          makeGwUser('excluded@example.com'),
+        ],
         variables: {
           sync_user_filter_mode: 'exclude',
           sync_excluded_emails: 'excluded@example.com',
@@ -613,7 +622,6 @@ describe('SyncController - Google Workspace employees', () => {
         makeMember('kept@example.com', { userId: 'user_kept' }),
       );
 
-      // Excluded member is in the org but not in the GWS active list
       (mockedDb.member.findMany as jest.Mock).mockResolvedValue([
         makeMember('kept@example.com'),
         makeMember('excluded@example.com'),
@@ -629,7 +637,14 @@ describe('SyncController - Google Workspace employees', () => {
       const deactivatedEmails = result.details
         .filter((d) => d.status === 'deactivated')
         .map((d) => d.email);
-      expect(deactivatedEmails).not.toContain('excluded@example.com');
+      expect(deactivatedEmails).toContain('excluded@example.com');
+      expect(result.details).toContainEqual(
+        expect.objectContaining({
+          email: 'excluded@example.com',
+          status: 'deactivated',
+          reason: 'User is excluded from Google Workspace sync',
+        }),
+      );
     });
 
     it('should exclude users from import by email match', async () => {

--- a/apps/api/src/integration-platform/controllers/sync.controller.ts
+++ b/apps/api/src/integration-platform/controllers/sync.controller.ts
@@ -444,18 +444,9 @@ export class SyncController {
       },
     });
 
-    const deactivationGwDomains =
-      effectiveSyncFilterMode === 'include'
-        ? new Set(
-            ouFilteredUsers.map((u) =>
-              u.primaryEmail.split('@')[1]?.toLowerCase(),
-            ),
-          )
-        : new Set(
-            filteredUsers.map((u) =>
-              u.primaryEmail.split('@')[1]?.toLowerCase(),
-            ),
-          );
+    const deactivationGwDomains = new Set(
+      ouFilteredUsers.map((u) => u.primaryEmail.split('@')[1]?.toLowerCase()),
+    );
     const deactivationSuspendedEmails =
       effectiveSyncFilterMode === 'include'
         ? allSuspendedEmails
@@ -486,12 +477,26 @@ export class SyncController {
         continue;
       }
 
-      // In exclude mode we keep excluded users unchanged and only stop syncing them.
-      if (
+      const isExcluded =
         effectiveSyncFilterMode === 'exclude' &&
         excludedTerms.length > 0 &&
-        matchesSyncFilterTerms(memberEmail, excludedTerms)
-      ) {
+        matchesSyncFilterTerms(memberEmail, excludedTerms);
+
+      if (isExcluded) {
+        try {
+          await db.member.update({
+            where: { id: member.id },
+            data: { deactivated: true, isActive: false },
+          });
+          results.deactivated++;
+          results.details.push({
+            email: member.user.email,
+            status: 'deactivated',
+            reason: 'User is excluded from Google Workspace sync',
+          });
+        } catch (error) {
+          this.logger.error(`Error deactivating excluded member: ${error}`);
+        }
         continue;
       }
 


### PR DESCRIPTION
## Summary
- deactivate existing non-privileged Google Workspace members when their email matches the sync exclude list
- use the unfiltered Google Workspace domain set during deactivation so excluded users in the managed domain are still considered
- update the Google Workspace sync spec and fix its missing controller dependency mocks

## Customer impact
Accounts such as shared inboxes or service accounts added to Google Workspace's "Exclude from Sync & Checks" list will disappear from the Active people list after the next sync, instead of remaining active forever if they were previously imported.

## Verification
- bunx jest src/integration-platform/controllers/sync-gws.controller.spec.ts --passWithNoTests
- bunx prettier --check apps/api/src/integration-platform/controllers/sync-gws.controller.spec.ts
- git diff --check

Notes: full-file eslint/prettier on sync.controller.ts still reports existing baseline issues in that large controller unrelated to this patch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor Google Workspace sync exclusions by deactivating previously imported, non‑privileged members that match the exclude list. This removes excluded service accounts and shared inboxes from the Active people list on the next sync.

- **Bug Fixes**
  - Deactivate excluded members in exclude mode and record a clear reason.
  - Use the unfiltered Google Workspace domain set during deactivation so excluded users in managed domains are handled.
  - Add missing controller dependency mocks and update the spec to reflect the new deactivation behavior.

<sup>Written for commit feb92ed37276ec1035706f57f04a76cabe1b157a. Summary will update on new commits. <a href="https://cubic.dev/pr/trycompai/comp/pull/2909?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

