### PR TITLE
fix(trust): keep portal branding after save

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/BrandSettings.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/BrandSettings.test.tsx
@@ -1,11 +1,19 @@
-import { render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-  setMockPermissions,
   ADMIN_PERMISSIONS,
   AUDITOR_PERMISSIONS,
   mockHasPermission,
+  setMockPermissions,
 } from '@/test-utils/mocks/permissions';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const navigationMock = vi.hoisted(() => ({
+  refresh: vi.fn(),
+}));
+
+const trustPortalSettingsMock = vi.hoisted(() => ({
+  updateToggleSettings: vi.fn(),
+}));
 
 vi.mock('@/hooks/use-permissions', () => ({
   usePermissions: () => ({
@@ -16,12 +24,16 @@ vi.mock('@/hooks/use-permissions', () => ({
 
 vi.mock('@/hooks/use-trust-portal-settings', () => ({
   useTrustPortalSettings: () => ({
-    updateToggleSettings: vi.fn(),
+    updateToggleSettings: trustPortalSettingsMock.updateToggleSettings,
   }),
 }));
 
 vi.mock('@/hooks/useDebounce', () => ({
   useDebounce: (value: string) => value,
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: navigationMock.refresh }),
 }));
 
 vi.mock('sonner', () => ({
@@ -32,21 +44,21 @@ import { BrandSettings } from './BrandSettings';
 
 describe('BrandSettings permission gating', () => {
   const defaultProps = {
-    orgId: 'org-1',
     primaryColor: '#FF0000',
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
+    trustPortalSettingsMock.updateToggleSettings.mockResolvedValue({
+      success: true,
+    });
   });
 
   it('renders title and description regardless of permissions', () => {
     setMockPermissions({});
     render(<BrandSettings {...defaultProps} />);
     expect(screen.getByText('Brand Settings')).toBeInTheDocument();
-    expect(
-      screen.getByText('Customize the appearance of your trust portal'),
-    ).toBeInTheDocument();
+    expect(screen.getByText('Customize the appearance of your trust portal')).toBeInTheDocument();
   });
 
   it('enables the color picker input when user has trust:update permission', () => {
@@ -74,5 +86,24 @@ describe('BrandSettings permission gating', () => {
     setMockPermissions({});
     render(<BrandSettings {...defaultProps} />);
     expect(screen.getByText('Brand Color')).toBeInTheDocument();
+  });
+
+  it('persists a valid brand color and refreshes settings', async () => {
+    setMockPermissions(ADMIN_PERMISSIONS);
+    const handlePrimaryColorChange = vi.fn();
+
+    render(<BrandSettings {...defaultProps} onPrimaryColorChange={handlePrimaryColorChange} />);
+
+    const textInput = screen.getByRole('textbox');
+    fireEvent.change(textInput, { target: { value: '#00ff00' } });
+
+    await waitFor(() => {
+      expect(trustPortalSettingsMock.updateToggleSettings).toHaveBeenCalledWith({
+        enabled: true,
+        primaryColor: '#00FF00',
+      });
+    });
+    expect(handlePrimaryColorChange).toHaveBeenCalledWith('#00FF00');
+    expect(navigationMock.refresh).toHaveBeenCalled();
   });
 });

--- a/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/BrandSettings.tsx
+++ b/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/BrandSettings.tsx
@@ -1,29 +1,50 @@
 'use client';
 
-import { useDebounce } from '@/hooks/useDebounce';
 import { usePermissions } from '@/hooks/use-permissions';
 import { useTrustPortalSettings } from '@/hooks/use-trust-portal-settings';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle, Input } from '@trycompai/design-system';
-import { Form, FormControl, FormField, FormItem, FormLabel } from '@trycompai/ui/form';
+import { useDebounce } from '@/hooks/useDebounce';
 import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Field,
+  FieldLabel,
+  Input,
+} from '@trycompai/design-system';
+import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { Controller, useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
 
+const DEFAULT_PRIMARY_COLOR = '#000000';
+const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
+
 const trustSettingsSchema = z.object({
-  primaryColor: z.string().optional(),
+  primaryColor: z.string().regex(HEX_COLOR_PATTERN, 'Enter a valid hex color').optional(),
 });
 
 interface BrandSettingsProps {
-  orgId: string;
+  enabled?: boolean;
   primaryColor: string | null;
+  onPrimaryColorChange?: (primaryColor: string | null) => void;
+}
+
+function normalizePrimaryColor(value: unknown): string | null {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  if (!HEX_COLOR_PATTERN.test(value)) return null;
+  return value.toUpperCase();
 }
 
 export function BrandSettings({
-  orgId,
+  enabled = true,
   primaryColor,
+  onPrimaryColorChange,
 }: BrandSettingsProps) {
+  const router = useRouter();
   const { hasPermission } = usePermissions();
   const canUpdate = hasPermission('trust', 'update');
   const { updateToggleSettings } = useTrustPortalSettings();
@@ -36,7 +57,7 @@ export function BrandSettings({
   });
 
   const lastSaved = useRef<{ [key: string]: string | null }>({
-    primaryColor: primaryColor ?? null,
+    primaryColor: normalizePrimaryColor(primaryColor),
   });
 
   const savingRef = useRef<{ [key: string]: boolean }>({
@@ -49,16 +70,25 @@ export function BrandSettings({
         return;
       }
 
-      if (lastSaved.current[field] !== value) {
+      const nextPrimaryColor = normalizePrimaryColor(value);
+      if (!nextPrimaryColor) {
+        return;
+      }
+
+      if (lastSaved.current[field] !== nextPrimaryColor) {
         savingRef.current[field] = true;
         try {
           await updateToggleSettings({
-            enabled: true,
+            enabled,
             primaryColor:
-              field === 'primaryColor' ? (value as string) : (form.getValues('primaryColor') ?? undefined),
+              field === 'primaryColor'
+                ? nextPrimaryColor
+                : (form.getValues('primaryColor') ?? undefined),
           });
           toast.success('Brand settings updated');
-          lastSaved.current[field] = value as string | null;
+          lastSaved.current[field] = nextPrimaryColor;
+          onPrimaryColorChange?.(nextPrimaryColor);
+          router.refresh();
         } catch {
           toast.error('Failed to update brand settings');
         } finally {
@@ -66,30 +96,43 @@ export function BrandSettings({
         }
       }
     },
-    [form, updateToggleSettings],
+    [enabled, form, onPrimaryColorChange, router, updateToggleSettings],
   );
 
   const [primaryColorValue, setPrimaryColorValue] = useState(form.getValues('primaryColor') || '');
   const debouncedPrimaryColor = useDebounce(primaryColorValue, 800);
 
   useEffect(() => {
+    const normalizedPrimaryColor = normalizePrimaryColor(primaryColor);
+    form.reset({ primaryColor: normalizedPrimaryColor ?? undefined });
+    setPrimaryColorValue(normalizedPrimaryColor ?? '');
+    lastSaved.current.primaryColor = normalizedPrimaryColor;
+  }, [form, primaryColor]);
+
+  useEffect(() => {
     if (
       debouncedPrimaryColor !== undefined &&
-      debouncedPrimaryColor !== lastSaved.current.primaryColor &&
+      normalizePrimaryColor(debouncedPrimaryColor) !== lastSaved.current.primaryColor &&
       !savingRef.current.primaryColor
     ) {
-      form.setValue('primaryColor', debouncedPrimaryColor || undefined);
-      void autoSave('primaryColor', debouncedPrimaryColor || null);
+      const normalizedPrimaryColor = normalizePrimaryColor(debouncedPrimaryColor);
+      if (normalizedPrimaryColor) {
+        form.setValue('primaryColor', normalizedPrimaryColor);
+        void autoSave('primaryColor', normalizedPrimaryColor);
+      }
     }
   }, [debouncedPrimaryColor, autoSave, form]);
 
   const handlePrimaryColorBlur = useCallback(
     (e: React.FocusEvent<HTMLInputElement>) => {
-      const value = e.target.value;
-      if (value) {
-        form.setValue('primaryColor', value);
+      const value = normalizePrimaryColor(e.target.value);
+      if (!value) {
+        toast.error('Enter a valid hex color');
+        return;
       }
-      void autoSave('primaryColor', value || null);
+      form.setValue('primaryColor', value);
+      setPrimaryColorValue(value);
+      void autoSave('primaryColor', value);
     },
     [form, autoSave],
   );
@@ -101,69 +144,68 @@ export function BrandSettings({
         <CardDescription>Customize the appearance of your trust portal</CardDescription>
       </CardHeader>
       <CardContent>
-        <Form {...form}>
-          <div className="space-y-4">
-            <FormField
-              control={form.control}
-              name="primaryColor"
-              render={({ field }) => (
-                <FormItem className="w-full">
-                  <FormLabel>Brand Color</FormLabel>
-                  <FormControl>
+        <div className="space-y-4">
+          <Controller
+            control={form.control}
+            name="primaryColor"
+            render={({ field }) => (
+              <Field>
+                <FieldLabel htmlFor="color-picker">Brand Color</FieldLabel>
+                <div className="relative">
+                  <div className="flex items-center gap-2">
                     <div className="relative">
-                      <div className="flex items-center gap-2">
-                        <div className="relative">
-                          <input
-                            {...field}
-                            value={primaryColorValue ?? '#000000'}
-                            onChange={(e) => {
-                              field.onChange(e);
-                              setPrimaryColorValue(e.target.value);
-                            }}
-                            onBlur={handlePrimaryColorBlur}
-                            type="color"
-                            className="sr-only"
-                            id="color-picker"
-                            disabled={!canUpdate}
-                          />
-                          <label
-                            htmlFor="color-picker"
-                            className="flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center rounded-lg border-2 border-border shadow-sm transition-all hover:scale-105 hover:shadow-md"
-                            style={{ backgroundColor: primaryColorValue || '#000000' }}
-                          >
-                            <span className="sr-only">Pick a color</span>
-                          </label>
-                        </div>
-                        <div className="flex-1">
-                          <div className="font-mono">
-                            <Input
-                              value={primaryColorValue?.toUpperCase() || '#000000'}
-                              onChange={(e) => {
-                                let value = e.target.value;
-                                if (!value.startsWith('#')) {
-                                  value = '#' + value;
-                                }
-                                field.onChange(value);
-                                setPrimaryColorValue(value);
-                              }}
-                              onBlur={handlePrimaryColorBlur}
-                              placeholder="#000000"
-                              maxLength={7}
-                              disabled={!canUpdate}
-                            />
-                          </div>
-                        </div>
+                      <input
+                        {...field}
+                        value={normalizePrimaryColor(primaryColorValue) ?? DEFAULT_PRIMARY_COLOR}
+                        onChange={(e) => {
+                          field.onChange(e);
+                          setPrimaryColorValue(e.target.value);
+                        }}
+                        onBlur={handlePrimaryColorBlur}
+                        type="color"
+                        className="sr-only"
+                        id="color-picker"
+                        disabled={!canUpdate}
+                      />
+                      <label
+                        htmlFor="color-picker"
+                        className="flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center rounded-lg border-2 border-border shadow-sm transition-all hover:scale-105 hover:shadow-md"
+                        style={{
+                          backgroundColor:
+                            normalizePrimaryColor(primaryColorValue) ?? DEFAULT_PRIMARY_COLOR,
+                        }}
+                      >
+                        <span className="sr-only">Pick a color</span>
+                      </label>
+                    </div>
+                    <div className="flex-1">
+                      <div className="font-mono">
+                        <Input
+                          value={primaryColorValue?.toUpperCase() || DEFAULT_PRIMARY_COLOR}
+                          onChange={(e) => {
+                            let value = e.target.value;
+                            if (value.length > 0 && !value.startsWith('#')) {
+                              value = '#' + value;
+                            }
+                            field.onChange(value);
+                            setPrimaryColorValue(value);
+                          }}
+                          onBlur={handlePrimaryColorBlur}
+                          placeholder="#000000"
+                          maxLength={7}
+                          disabled={!canUpdate}
+                        />
                       </div>
                     </div>
-                  </FormControl>
-                </FormItem>
-              )}
-            />
-            <p className="text-xs text-muted-foreground">
-              Used for branding across your trust portal
-            </p>
-          </div>
-        </Form>
+                  </div>
+                </div>
+              </Field>
+            )}
+          />
+          <p className="text-xs text-muted-foreground">
+            Used for branding across your trust portal
+          </p>
+        </div>
       </CardContent>
     </Card>
   );

--- a/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/TrustPortalBrandingSettings.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/TrustPortalBrandingSettings.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TrustPortalBrandingSettings } from './TrustPortalBrandingSettings';
+
+interface MockFaviconProps {
+  currentFaviconUrl: string | null;
+  onFaviconChange?: (faviconUrl: string | null) => void;
+}
+
+interface MockBrandProps {
+  primaryColor: string | null;
+  onPrimaryColorChange?: (primaryColor: string | null) => void;
+}
+
+vi.mock('./UpdateTrustFavicon', () => ({
+  UpdateTrustFavicon: ({ currentFaviconUrl, onFaviconChange }: MockFaviconProps) => (
+    <div>
+      <div data-testid="favicon-url">{currentFaviconUrl ?? 'default'}</div>
+      <button type="button" onClick={() => onFaviconChange?.('https://example.com/favicon.png')}>
+        Set favicon
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('./BrandSettings', () => ({
+  BrandSettings: ({ primaryColor, onPrimaryColorChange }: MockBrandProps) => (
+    <div>
+      <div data-testid="primary-color">{primaryColor ?? 'default'}</div>
+      <button type="button" onClick={() => onPrimaryColorChange?.('#00FF00')}>
+        Set color
+      </button>
+    </div>
+  ),
+}));
+
+describe('TrustPortalBrandingSettings', () => {
+  it('keeps saved branding values available for remounted tab content', () => {
+    render(<TrustPortalBrandingSettings enabled={true} primaryColor={null} faviconUrl={null} />);
+
+    expect(screen.getByTestId('favicon-url')).toHaveTextContent('default');
+    expect(screen.getByTestId('primary-color')).toHaveTextContent('default');
+
+    fireEvent.click(screen.getByRole('button', { name: /set favicon/i }));
+    fireEvent.click(screen.getByRole('button', { name: /set color/i }));
+
+    expect(screen.getByTestId('favicon-url')).toHaveTextContent('https://example.com/favicon.png');
+    expect(screen.getByTestId('primary-color')).toHaveTextContent('#00FF00');
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/TrustPortalBrandingSettings.tsx
+++ b/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/TrustPortalBrandingSettings.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { BrandSettings } from './BrandSettings';
+import { UpdateTrustFavicon } from './UpdateTrustFavicon';
+
+interface TrustPortalBrandingSettingsProps {
+  enabled: boolean;
+  primaryColor: string | null;
+  faviconUrl: string | null;
+}
+
+export function TrustPortalBrandingSettings({
+  enabled,
+  primaryColor,
+  faviconUrl,
+}: TrustPortalBrandingSettingsProps) {
+  const [currentPrimaryColor, setCurrentPrimaryColor] = useState(primaryColor);
+  const [currentFaviconUrl, setCurrentFaviconUrl] = useState(faviconUrl);
+
+  useEffect(() => {
+    setCurrentPrimaryColor(primaryColor);
+  }, [primaryColor]);
+
+  useEffect(() => {
+    setCurrentFaviconUrl(faviconUrl);
+  }, [faviconUrl]);
+
+  return (
+    <div className="space-y-6">
+      <UpdateTrustFavicon
+        currentFaviconUrl={currentFaviconUrl}
+        onFaviconChange={setCurrentFaviconUrl}
+      />
+      <BrandSettings
+        enabled={enabled}
+        primaryColor={currentPrimaryColor}
+        onPrimaryColorChange={setCurrentPrimaryColor}
+      />
+    </div>
+  );
+}

--- a/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/TrustPortalSwitch.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/TrustPortalSwitch.test.tsx
@@ -1,11 +1,11 @@
-import { render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-  setMockPermissions,
   ADMIN_PERMISSIONS,
   AUDITOR_PERMISSIONS,
   mockHasPermission,
+  setMockPermissions,
 } from '@/test-utils/mocks/permissions';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/hooks/use-permissions', () => ({
   usePermissions: () => ({
@@ -100,8 +100,12 @@ vi.mock('@dnd-kit/utilities', () => ({
 
 // Mock design system
 vi.mock('@trycompai/design-system', () => ({
-  Button: ({ children, onClick, disabled, iconLeft, iconRight, ...props }: any) => (
-    <button onClick={onClick} disabled={disabled} {...props}>{iconLeft}{children}{iconRight}</button>
+  Button: ({ children, onClick, disabled, iconLeft, iconRight, loading, ...props }: any) => (
+    <button onClick={onClick} disabled={disabled} {...props}>
+      {iconLeft}
+      {children}
+      {iconRight}
+    </button>
   ),
   Card: ({ children }: any) => <div>{children}</div>,
   CardContent: ({ children }: any) => <div>{children}</div>,
@@ -112,6 +116,8 @@ vi.mock('@trycompai/design-system', () => ({
   DropdownMenuContent: ({ children }: any) => <div>{children}</div>,
   DropdownMenuItem: ({ children, onClick }: any) => <button onClick={onClick}>{children}</button>,
   DropdownMenuTrigger: ({ children }: any) => <button>{children}</button>,
+  Field: ({ children }: any) => <div>{children}</div>,
+  FieldLabel: ({ children }: any) => <label>{children}</label>,
   Input: (props: any) => <input {...props} />,
   Select: ({ children, disabled }: any) => <div data-disabled={disabled}>{children}</div>,
   SelectContent: ({ children }: any) => <div>{children}</div>,
@@ -130,7 +136,11 @@ vi.mock('@trycompai/design-system', () => ({
   Tabs: ({ children }: any) => <div>{children}</div>,
   TabsContent: ({ children, value }: any) => <div data-value={value}>{children}</div>,
   TabsList: ({ children }: any) => <div role="tablist">{children}</div>,
-  TabsTrigger: ({ children, value }: any) => <button role="tab" data-value={value}>{children}</button>,
+  TabsTrigger: ({ children, value }: any) => (
+    <button role="tab" data-value={value}>
+      {children}
+    </button>
+  ),
   Textarea: (props: any) => <textarea {...props} />,
   Tooltip: ({ children }: any) => <div>{children}</div>,
   TooltipContent: ({ children }: any) => <div>{children}</div>,
@@ -139,46 +149,49 @@ vi.mock('@trycompai/design-system', () => ({
 
 vi.mock('@trycompai/design-system/icons', () => ({
   Add: () => <span />,
+  CertificateCheck: () => <span />,
   ChevronLeft: () => <span />,
   ChevronRight: () => <span />,
   Close: () => <span />,
+  Download: () => <span />,
   Edit: () => <span />,
   Link: () => <span />,
   OverflowMenuVertical: () => <span />,
   TrashCan: () => <span />,
+  Upload: () => <span />,
   View: () => <span />,
   ViewOff: () => <span />,
 }));
 
-vi.mock('lucide-react', () => ({
-  ChevronDown: () => <span />,
-  ChevronUp: () => <span />,
-  Download: () => <span />,
-  Eye: () => <span />,
-  FileCheck2: () => <span />,
-  FileText: () => <span />,
-  GripVertical: () => <span />,
-  Loader2: () => <span />,
-  Plus: () => <span />,
-  Save: () => <span />,
-  Trash2: () => <span />,
-  Upload: () => <span />,
-}));
-
 vi.mock('./logos', () => ({
+  CCPA: () => <span />,
+  CCPAInProgress: () => <span />,
   GDPR: () => <span />,
+  GDPRInProgress: () => <span />,
   HIPAA: () => <span />,
+  HIPAAInProgress: () => <span />,
   ISO27001: () => <span />,
+  ISO27001InProgress: () => <span />,
   ISO42001: () => <span />,
+  ISO42001InProgress: () => <span />,
   ISO9001: () => <span />,
+  ISO9001InProgress: () => <span />,
   NEN7510: () => <span />,
+  NEN7510InProgress: () => <span />,
   PCIDSS: () => <span />,
+  PCIDSSInProgress: () => <span />,
+  PIPEDA: () => <span />,
+  PIPEDAInProgress: () => <span />,
   SOC2Type1: () => <span />,
+  SOC2Type1InProgress: () => <span />,
   SOC2Type2: () => <span />,
+  SOC2Type2InProgress: () => <span />,
+  SOC3: () => <span />,
+  SOC3InProgress: () => <span />,
 }));
 
-vi.mock('./UpdateTrustFavicon', () => ({
-  UpdateTrustFavicon: () => <div data-testid="update-trust-favicon" />,
+vi.mock('./TrustPortalBrandingSettings', () => ({
+  TrustPortalBrandingSettings: () => <div data-testid="trust-portal-branding-settings" />,
 }));
 
 vi.mock('next/image', () => ({
@@ -218,6 +231,10 @@ describe('TrustPortalSwitch permission gating', () => {
     nen7510Status: 'started' as const,
     iso9001: false,
     iso9001Status: 'started' as const,
+    pipeda: false,
+    pipedaStatus: 'started' as const,
+    ccpa: false,
+    ccpaStatus: 'started' as const,
     faqs: [],
     additionalDocuments: [],
     overview: {

--- a/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/TrustPortalSwitch.tsx
+++ b/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/TrustPortalSwitch.tsx
@@ -24,20 +24,19 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@trycompai/design-system';
+import { CertificateCheck, Download, Upload, View } from '@trycompai/design-system/icons';
 import { Form } from '@trycompai/ui/form';
-import { Download, Eye, FileCheck2, Upload } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
-import { BrandSettings } from './BrandSettings';
 import {
+  CCPA,
+  CCPAInProgress,
   GDPR,
   GDPRInProgress,
   HIPAA,
   HIPAAInProgress,
-  CCPA,
-  CCPAInProgress,
   ISO27001,
   ISO27001InProgress,
   ISO42001,
@@ -61,11 +60,11 @@ import {
   TrustPortalAdditionalDocumentsSection,
   type TrustPortalDocument,
 } from './TrustPortalAdditionalDocumentsSection';
+import { TrustPortalBrandingSettings } from './TrustPortalBrandingSettings';
 import { TrustPortalCustomLinks } from './TrustPortalCustomLinks';
 import { TrustPortalFaqBuilder } from './TrustPortalFaqBuilder';
 import { TrustPortalOverview } from './TrustPortalOverview';
 import { TrustPortalVendors } from './TrustPortalVendors';
-import { UpdateTrustFavicon } from './UpdateTrustFavicon';
 
 // Client-side form schema (includes all fields for form state)
 const trustPortalSwitchSchema = z.object({
@@ -149,15 +148,7 @@ type TrustCustomLink = {
 };
 
 type ComplianceBadge = {
-  type:
-    | 'soc2'
-    | 'iso27001'
-    | 'iso42001'
-    | 'gdpr'
-    | 'hipaa'
-    | 'pci_dss'
-    | 'nen7510'
-    | 'iso9001';
+  type: 'soc2' | 'iso27001' | 'iso42001' | 'gdpr' | 'hipaa' | 'pci_dss' | 'nen7510' | 'iso9001';
   verified: boolean;
 };
 
@@ -1022,9 +1013,12 @@ export function TrustPortalSwitch({
 
           {/* Branding Tab */}
           <TabsContent value="branding">
-            <div className="pt-6 space-y-6">
-              <UpdateTrustFavicon currentFaviconUrl={faviconUrl ?? null} />
-              <BrandSettings orgId={orgId} primaryColor={primaryColor ?? null} />
+            <div className="pt-6">
+              <TrustPortalBrandingSettings
+                enabled={enabled}
+                primaryColor={primaryColor ?? null}
+                faviconUrl={faviconUrl ?? null}
+              />
             </div>
           </TabsContent>
 
@@ -1340,7 +1334,7 @@ function ComplianceFramework({
                 <div className="rounded-lg bg-muted/40 border border-border/50 p-4 space-y-3">
                   <div className="flex items-center gap-3 animate-in fade-in-0 slide-in-from-top-1 duration-200">
                     <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
-                      <FileCheck2 className="h-5 w-5 text-primary" />
+                      <CertificateCheck className="h-5 w-5 text-primary" />
                     </div>
                     <div className="flex-1 min-w-0">
                       <p className="text-sm font-medium text-foreground truncate">{fileName}</p>
@@ -1367,7 +1361,7 @@ function ComplianceFramework({
                             />
                           }
                         >
-                          <Eye className="h-3.5 w-3.5" />
+                          <View className="h-3.5 w-3.5" />
                           View
                         </TooltipTrigger>
                         <TooltipContent>Open certificate in new tab</TooltipContent>

--- a/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/UpdateTrustFavicon.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/UpdateTrustFavicon.test.tsx
@@ -1,11 +1,21 @@
-import { render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-  setMockPermissions,
   ADMIN_PERMISSIONS,
   AUDITOR_PERMISSIONS,
   mockHasPermission,
+  setMockPermissions,
 } from '@/test-utils/mocks/permissions';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const navigationMock = vi.hoisted(() => ({
+  refresh: vi.fn(),
+}));
+
+const trustPortalSettingsMock = vi.hoisted(() => ({
+  uploadFavicon: vi.fn(),
+  removeFavicon: vi.fn(),
+}));
 
 vi.mock('@/hooks/use-permissions', () => ({
   usePermissions: () => ({
@@ -16,9 +26,13 @@ vi.mock('@/hooks/use-permissions', () => ({
 
 vi.mock('@/hooks/use-trust-portal-settings', () => ({
   useTrustPortalSettings: () => ({
-    uploadFavicon: vi.fn(),
-    removeFavicon: vi.fn(),
+    uploadFavicon: trustPortalSettingsMock.uploadFavicon,
+    removeFavicon: trustPortalSettingsMock.removeFavicon,
   }),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: navigationMock.refresh }),
 }));
 
 vi.mock('next/image', () => ({
@@ -40,60 +54,94 @@ import { UpdateTrustFavicon } from './UpdateTrustFavicon';
 describe('UpdateTrustFavicon permission gating', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    trustPortalSettingsMock.uploadFavicon.mockResolvedValue({
+      success: true,
+      faviconUrl: 'https://example.com/new-favicon.png',
+    });
+    trustPortalSettingsMock.removeFavicon.mockResolvedValue({ success: true });
   });
 
   it('shows upload button when user has portal:update permission', () => {
     setMockPermissions(ADMIN_PERMISSIONS);
     render(<UpdateTrustFavicon currentFaviconUrl={null} />);
-    expect(
-      screen.getByRole('button', { name: /upload favicon/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /upload favicon/i })).toBeInTheDocument();
   });
 
   it('hides upload button when user lacks portal:update permission', () => {
     setMockPermissions(AUDITOR_PERMISSIONS);
     render(<UpdateTrustFavicon currentFaviconUrl={null} />);
-    expect(
-      screen.queryByRole('button', { name: /upload favicon/i }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /upload favicon/i })).not.toBeInTheDocument();
   });
 
   it('shows remove button when user has portal:update and a favicon exists', () => {
     setMockPermissions(ADMIN_PERMISSIONS);
-    render(
-      <UpdateTrustFavicon currentFaviconUrl="https://example.com/favicon.ico" />,
-    );
-    expect(
-      screen.getByRole('button', { name: /remove/i }),
-    ).toBeInTheDocument();
+    render(<UpdateTrustFavicon currentFaviconUrl="https://example.com/favicon.ico" />);
+    expect(screen.getByRole('button', { name: /remove/i })).toBeInTheDocument();
   });
 
   it('hides remove button when user lacks portal:update even if favicon exists', () => {
     setMockPermissions(AUDITOR_PERMISSIONS);
-    render(
-      <UpdateTrustFavicon currentFaviconUrl="https://example.com/favicon.ico" />,
-    );
-    expect(
-      screen.queryByRole('button', { name: /remove/i }),
-    ).not.toBeInTheDocument();
+    render(<UpdateTrustFavicon currentFaviconUrl="https://example.com/favicon.ico" />);
+    expect(screen.queryByRole('button', { name: /remove/i })).not.toBeInTheDocument();
   });
 
   it('hides both buttons when user has no permissions', () => {
     setMockPermissions({});
-    render(
-      <UpdateTrustFavicon currentFaviconUrl="https://example.com/favicon.ico" />,
-    );
-    expect(
-      screen.queryByRole('button', { name: /upload favicon/i }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', { name: /remove/i }),
-    ).not.toBeInTheDocument();
+    render(<UpdateTrustFavicon currentFaviconUrl="https://example.com/favicon.ico" />);
+    expect(screen.queryByRole('button', { name: /upload favicon/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /remove/i })).not.toBeInTheDocument();
   });
 
   it('renders title regardless of permissions', () => {
     setMockPermissions({});
     render(<UpdateTrustFavicon currentFaviconUrl={null} />);
     expect(screen.getByText('Trust Portal Favicon')).toBeInTheDocument();
+  });
+
+  it('uploads a favicon and refreshes settings', async () => {
+    setMockPermissions(ADMIN_PERMISSIONS);
+    const handleFaviconChange = vi.fn();
+    const { container } = render(
+      <UpdateTrustFavicon currentFaviconUrl={null} onFaviconChange={handleFaviconChange} />,
+    );
+
+    const fileInput = container.querySelector('input[type="file"]');
+    if (!(fileInput instanceof HTMLInputElement)) {
+      throw new Error('file input not found');
+    }
+
+    const file = new File(['favicon'], 'favicon.png', { type: 'image/png' });
+    await userEvent.upload(fileInput, file);
+
+    await waitFor(() => {
+      expect(trustPortalSettingsMock.uploadFavicon).toHaveBeenCalledWith(
+        'favicon.png',
+        'image/png',
+        expect.any(String),
+      );
+    });
+    expect(handleFaviconChange).toHaveBeenCalledWith('https://example.com/new-favicon.png');
+    expect(navigationMock.refresh).toHaveBeenCalled();
+  });
+
+  it('removes a favicon and refreshes settings', async () => {
+    setMockPermissions(ADMIN_PERMISSIONS);
+    const user = userEvent.setup();
+    const handleFaviconChange = vi.fn();
+
+    render(
+      <UpdateTrustFavicon
+        currentFaviconUrl="https://example.com/favicon.ico"
+        onFaviconChange={handleFaviconChange}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /remove/i }));
+
+    await waitFor(() => {
+      expect(trustPortalSettingsMock.removeFavicon).toHaveBeenCalled();
+    });
+    expect(handleFaviconChange).toHaveBeenCalledWith(null);
+    expect(navigationMock.refresh).toHaveBeenCalled();
   });
 });

--- a/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/UpdateTrustFavicon.tsx
+++ b/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/UpdateTrustFavicon.tsx
@@ -2,17 +2,31 @@
 
 import { usePermissions } from '@/hooks/use-permissions';
 import { useTrustPortalSettings } from '@/hooks/use-trust-portal-settings';
-import { Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@trycompai/design-system';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@trycompai/design-system';
 import { Add, TrashCan } from '@trycompai/design-system/icons';
 import Image from 'next/image';
-import { useCallback, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 interface UpdateTrustFaviconProps {
   currentFaviconUrl: string | null;
+  onFaviconChange?: (faviconUrl: string | null) => void;
 }
 
-export function UpdateTrustFavicon({ currentFaviconUrl }: UpdateTrustFaviconProps) {
+export function UpdateTrustFavicon({
+  currentFaviconUrl,
+  onFaviconChange,
+}: UpdateTrustFaviconProps) {
+  const router = useRouter();
   const { hasPermission } = usePermissions();
   const canUpdatePortal = hasPermission('trust', 'update');
   const { uploadFavicon, removeFavicon } = useTrustPortalSettings();
@@ -21,24 +35,29 @@ export function UpdateTrustFavicon({ currentFaviconUrl }: UpdateTrustFaviconProp
   const [isRemoving, setIsRemoving] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  useEffect(() => {
+    setPreviewUrl(currentFaviconUrl);
+  }, [currentFaviconUrl]);
+
   const handleUpload = useCallback(
     async (fileName: string, fileType: string, fileData: string) => {
       setIsUploading(true);
       try {
         const result = await uploadFavicon(fileName, fileType, fileData);
-        if (result && typeof result === 'object' && 'faviconUrl' in result) {
-          setPreviewUrl((result as { faviconUrl: string }).faviconUrl);
+        if (!result?.faviconUrl) {
+          throw new Error('Unexpected API response');
         }
+        setPreviewUrl(result.faviconUrl);
+        onFaviconChange?.(result.faviconUrl);
+        router.refresh();
         toast.success('Favicon updated');
       } catch (error) {
-        toast.error(
-          error instanceof Error ? error.message : 'Failed to upload favicon',
-        );
+        toast.error(error instanceof Error ? error.message : 'Failed to upload favicon');
       } finally {
         setIsUploading(false);
       }
     },
-    [uploadFavicon],
+    [onFaviconChange, router, uploadFavicon],
   );
 
   const handleRemove = useCallback(async () => {
@@ -46,13 +65,15 @@ export function UpdateTrustFavicon({ currentFaviconUrl }: UpdateTrustFaviconProp
     try {
       await removeFavicon();
       setPreviewUrl(null);
+      onFaviconChange?.(null);
+      router.refresh();
       toast.success('Favicon removed');
     } catch {
       toast.error('Failed to remove favicon');
     } finally {
       setIsRemoving(false);
     }
-  }, [removeFavicon]);
+  }, [onFaviconChange, removeFavicon, router]);
 
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -154,7 +175,8 @@ export function UpdateTrustFavicon({ currentFaviconUrl }: UpdateTrustFaviconProp
       </CardContent>
       <CardFooter>
         <div className="text-muted-foreground text-xs">
-          Recommended: Square image (16x16, 32x32, or 180x180px). Formats: .ico, .png, or .svg. Max 100KB.
+          Recommended: Square image (16x16, 32x32, or 180x180px). Formats: .ico, .png, or .svg. Max
+          100KB.
         </div>
       </CardFooter>
     </Card>


### PR DESCRIPTION
## Summary
- keep trust portal favicon and brand color state in a dedicated branding settings component so saved values do not fall back to initial server props when the tab remounts
- refresh trust portal server settings after successful favicon upload/removal or brand color save
- validate brand colors before saving, while still allowing empty brand color to persist as a reset to default branding
- preserve the current portal enabled state during brand color updates
- move trust portal certificate icons off lucide to the design-system icon set while touching the switch component

## Verification
- bunx vitest run 'src/app/(app)/[orgId]/trust/portal-settings/components' — 74 passed
- bunx vitest run 'src/app/(app)/[orgId]/trust/portal-settings/components/BrandSettings.test.tsx' 'src/app/(app)/[orgId]/trust/portal-settings/components/UpdateTrustFavicon.test.tsx' 'src/app/(app)/[orgId]/trust/portal-settings/components/TrustPortalBrandingSettings.test.tsx' 'src/app/(app)/[orgId]/trust/portal-settings/components/TrustPortalSwitch.test.tsx' — 21 passed
- git diff --check

## Note
- bunx turbo run typecheck --filter=@trycompai/app still fails on existing unrelated app errors, including cloud-tests provider test fixtures, AI SDK v2/v3 type mismatches, missing invitations route test module, and Better Auth duplicate type resolution. No remaining errors reference the trust portal branding files.