### PR TITLE
fix(cloud-tests): graceful manual-step fallback so auto-remediate never shows raw errors

### DIFF
--- a/apps/api/src/cloud-security/ai-remediation.service.spec.ts
+++ b/apps/api/src/cloud-security/ai-remediation.service.spec.ts
@@ -399,3 +399,112 @@ describe('AiRemediationService.refineStepFromError', () => {
     expect(callArgs.temperature).toBe(0);
   });
 });
+
+describe('AiRemediationService.generateManualSteps', () => {
+  const generateObjectMock = generateObject as unknown as jest.Mock;
+
+  const finding = {
+    title: 'No CloudTrail trails configured',
+    description: 'Account has no active CloudTrail trails.',
+    severity: 'high',
+    resourceType: 'AwsAccount',
+    resourceId: 'account-level',
+    remediation: 'Create a multi-region trail with log file validation.',
+    findingKey: 'cloudtrail-no-trails',
+    evidence: { awsAccountId: '123456789012', region: 'us-east-1' },
+  };
+
+  beforeEach(() => {
+    generateObjectMock.mockReset();
+  });
+
+  it('returns AI-generated guidedSteps + reason in the happy path', async () => {
+    generateObjectMock.mockResolvedValueOnce({
+      object: {
+        guidedSteps: [
+          'Open AWS Console → CloudTrail → Trails.',
+          'Click "Create trail" and name it compai-cloudtrail.',
+          'Enable multi-region and log file validation, then Save.',
+        ],
+        reason:
+          'Auto-fix could not generate valid create-trail params for this account.',
+      },
+    });
+
+    const result = await new AiRemediationService().generateManualSteps({
+      finding,
+      failureReason: 'Required param "S3BucketName" is missing or empty',
+    });
+
+    expect(result.guidedSteps).toHaveLength(3);
+    expect(result.guidedSteps[0]).toMatch(/CloudTrail/);
+    expect(result.reason).toMatch(/Auto-fix could not/);
+  });
+
+  it('falls back to the adapter remediation text when the AI call throws', async () => {
+    // Hard guarantee: even if the AI is down, the customer must see
+    // SOMETHING actionable instead of a raw error.
+    generateObjectMock.mockRejectedValueOnce(new Error('AI provider down'));
+
+    const result = await new AiRemediationService().generateManualSteps({
+      finding,
+      failureReason: 'anything',
+    });
+
+    expect(result.guidedSteps).toEqual([
+      'Create a multi-region trail with log file validation.',
+    ]);
+    expect(result.reason).toMatch(/Automatic fix is not available/i);
+  });
+
+  it('falls back to a generic step when there is no adapter remediation text either', async () => {
+    generateObjectMock.mockRejectedValueOnce(new Error('AI down'));
+
+    const result = await new AiRemediationService().generateManualSteps({
+      finding: { ...finding, remediation: null },
+      failureReason: 'x',
+    });
+
+    expect(result.guidedSteps).toHaveLength(1);
+    expect(result.guidedSteps[0]).toMatch(/AWS Console/i);
+  });
+
+  it('passes failing-step context to the model so manual steps reference the same resources', async () => {
+    generateObjectMock.mockResolvedValueOnce({
+      object: { guidedSteps: ['x'], reason: 'y' },
+    });
+
+    await new AiRemediationService().generateManualSteps({
+      finding,
+      failedPlan: {
+        canAutoFix: true,
+        risk: 'low',
+        description: 'd',
+        currentState: {},
+        proposedState: {},
+        requiredPermissions: [],
+        readSteps: [],
+        fixSteps: [
+          {
+            service: 's3',
+            command: 'CreateBucketCommand',
+            params: { Bucket: '' },
+            purpose: 'create log bucket',
+          },
+        ],
+        rollbackSteps: [],
+        rollbackSupported: false,
+        requiresAcknowledgment: false,
+      },
+      failureReason: 'Required param "Bucket" is missing or empty',
+    });
+
+    const callArgs = generateObjectMock.mock.calls[0][0];
+    // The prompt must include both the failing reason AND the original
+    // command so the model can translate it into a real manual step,
+    // not just regurgitate the finding text.
+    expect(callArgs.prompt).toContain('Required param "Bucket" is missing');
+    expect(callArgs.prompt).toContain('s3:CreateBucketCommand');
+    expect(callArgs.prompt).toContain('account-level');
+  });
+});

--- a/apps/api/src/cloud-security/ai-remediation.service.ts
+++ b/apps/api/src/cloud-security/ai-remediation.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { generateObject } from 'ai';
 import { anthropic } from '@ai-sdk/anthropic';
+import { z } from 'zod';
 import {
   type FixPlan,
   type PermissionFix,
@@ -28,9 +29,13 @@ import {
 import { normalizeFixPlan } from './plan-normalizer';
 
 const MODEL = anthropic('claude-opus-4-6');
+// Cheaper, faster model for the manual-steps fallback. The output is pure
+// natural language with no SDK-call shape to validate, so the strongest
+// model is overkill — we just need clear instructions.
+const FALLBACK_MODEL = anthropic('claude-sonnet-4-5');
 const REMEDIATION_ROLE_NAME = 'CompAI-Remediator';
 
-interface FindingContext {
+export interface FindingContext {
   title: string;
   description: string | null;
   severity: string | null;
@@ -328,6 +333,104 @@ INSTRUCTIONS:
     }
   }
 
+  /**
+   * Generate real, user-actionable manual steps when auto-fix cannot
+   * proceed for a finding. Called by the remediation service as a
+   * fallback so customers never see a raw "Fix could not be applied —
+   * <cryptic error>" — they get clear instructions instead.
+   *
+   * Inputs:
+   *  - the finding (so the AI knows what's actually broken),
+   *  - the fix plan we tried to apply (so steps reference the same
+   *    resources / commands the customer expected),
+   *  - the concrete failure reason from validation or AWS execution.
+   *
+   * Output: ordered list of steps that the customer can copy-paste
+   * into AWS Console / CLI to resolve the finding manually.
+   *
+   * Uses Sonnet for cost — this only fires on the failure path and
+   * the output is plain natural language. On AI failure, falls back
+   * to the finding's `remediation` text so the customer at least sees
+   * the adapter's pre-baked guidance instead of an error.
+   */
+  async generateManualSteps(params: {
+    finding: FindingContext;
+    failedPlan?: FixPlan;
+    failureReason: string;
+  }): Promise<{ guidedSteps: string[]; reason: string }> {
+    const fallback = (): { guidedSteps: string[]; reason: string } => ({
+      guidedSteps: params.finding.remediation
+        ? [params.finding.remediation]
+        : [
+            'Review the finding in your AWS Console and apply the recommended remediation manually.',
+          ],
+      reason:
+        'Automatic fix is not available for this finding. Follow the guided steps to resolve it manually.',
+    });
+
+    try {
+      const stepsSummary = params.failedPlan?.fixSteps
+        ? params.failedPlan.fixSteps
+            .map(
+              (s, i) =>
+                `${i + 1}. ${s.service}:${s.command} — ${s.purpose}`,
+            )
+            .join('\n')
+        : '(no fix steps were generated)';
+
+      const { object } = await generateObject({
+        model: FALLBACK_MODEL,
+        schema: z.object({
+          guidedSteps: z
+            .array(z.string())
+            .min(1)
+            .describe(
+              'Ordered list of clear, copy-pasteable manual instructions the customer can follow in AWS Console or CLI. Each step is one concrete action.',
+            ),
+          reason: z
+            .string()
+            .describe(
+              'One-sentence summary of WHY automatic fix could not proceed — phrased for the customer, not for an engineer.',
+            ),
+        }),
+        system:
+          'You are an AWS security expert writing manual remediation steps for a customer whose automatic fix failed. Be concrete: name exact services, exact resources, and exact actions. Prefer AWS Console clicks over CLI when the path is short, but include CLI commands when they are clearer. Never reference SDK class names. Never apologize. Never speculate about "if the issue persists" — just give the steps.',
+        prompt: `A finding could not be auto-remediated. Generate clear manual steps the customer can follow.
+
+FINDING:
+- title: ${params.finding.title}
+- description: ${params.finding.description ?? '(none)'}
+- severity: ${params.finding.severity ?? '(unknown)'}
+- resource type: ${params.finding.resourceType}
+- resource id: ${params.finding.resourceId}
+- adapter remediation guidance: ${params.finding.remediation ?? '(none)'}
+- evidence: ${JSON.stringify(params.finding.evidence ?? {}, null, 2)}
+
+WHAT WE TRIED TO DO AUTOMATICALLY (do not just repeat — translate into customer-facing actions):
+${stepsSummary}
+
+WHY IT FAILED:
+${params.failureReason}
+
+Produce 3-8 ordered steps. Each step is a single concrete action the customer can perform in AWS Console or CLI. Reference the EXACT resource (${params.finding.resourceType} ${params.finding.resourceId}) and the EXACT region from evidence when relevant. End with a verification step so the customer knows they fixed it.`,
+        temperature: 0.2,
+      });
+
+      this.logger.log(
+        `Manual-steps fallback for ${params.finding.findingKey}: ${object.guidedSteps.length} step(s)`,
+      );
+      return {
+        guidedSteps: object.guidedSteps,
+        reason: object.reason,
+      };
+    } catch (err) {
+      this.logger.warn(
+        `Manual-steps AI call failed for ${params.finding.findingKey}; using adapter remediation as fallback. ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return fallback();
+    }
+  }
+
   // ─── GCP Methods ──────────────────────────────────────────────────────
 
   async generateGcpFixPlan(finding: FindingContext): Promise<GcpFixPlan> {
@@ -556,6 +659,18 @@ const ACTIONABLE_PREFIXES = [
   'Enable',
   'Attach',
   'Set',
+  'Authorize',
+  'Revoke',
+  'Allow',
+  'Deny',
+  'Disable',
+  'Detach',
+  'Add',
+  'Remove',
+  'Register',
+  'Deregister',
+  'Tag',
+  'Untag',
 ] as const;
 
 /**

--- a/apps/api/src/cloud-security/aws-command-executor.ts
+++ b/apps/api/src/cloud-security/aws-command-executor.ts
@@ -428,7 +428,11 @@ export function looksLikeValidationError(message: string): boolean {
     lower.includes('must be a valid') ||
     lower.includes('is required') ||
     lower.includes('missing required') ||
-    lower.includes('must contain')
+    lower.includes('must contain') ||
+    lower.includes('missingparameter') ||
+    lower.includes('missing parameter') ||
+    lower.includes('parameter is required') ||
+    lower.includes('must specify')
   );
 }
 

--- a/apps/api/src/cloud-security/remediation.service.ts
+++ b/apps/api/src/cloud-security/remediation.service.ts
@@ -3,7 +3,10 @@ import { db, Prisma } from '@db';
 import { CredentialVaultService } from '../integration-platform/services/credential-vault.service';
 import { parseAwsPermissionError } from './remediation-error.utils';
 import { AWSSecurityService } from './providers/aws-security.service';
-import { AiRemediationService } from './ai-remediation.service';
+import {
+  AiRemediationService,
+  type FindingContext,
+} from './ai-remediation.service';
 import { GcpRemediationService } from './gcp-remediation.service';
 import { AzureRemediationService } from './azure-remediation.service';
 import {
@@ -498,11 +501,34 @@ export class RemediationService {
       },
     });
 
+    // Build the finding context once — reused by refineFixPlan, the
+    // step-repair callback, and the manual-steps fallback path.
+    const evidence = (finding.evidence ?? {}) as Record<string, unknown>;
+    const findingCtx: FindingContext = {
+      title: finding.title ?? 'Unknown',
+      description: finding.description,
+      severity: finding.severity,
+      resourceType: finding.resourceType,
+      resourceId: finding.resourceId,
+      remediation: finding.remediation,
+      findingKey: evidence.findingKey as string,
+      evidence,
+    };
+
     try {
       // Validate read steps first
       const readErrors = validatePlanSteps(plan.readSteps);
       if (readErrors.length > 0) {
-        throw new Error(`Invalid read steps: ${readErrors.join('; ')}`);
+        // Read step validation rarely fails (Get*/Describe* commands are
+        // simple), so don't attempt repair here — fall straight to
+        // manual steps using the original plan for context.
+        return await this.respondWithManualSteps({
+          actionId: action.id,
+          finding: findingCtx,
+          failedPlan: plan,
+          failureReason: `Read steps invalid: ${readErrors.join('; ')}`,
+          resourceId: finding.resourceId,
+        });
       }
 
       const remediationCreds =
@@ -523,18 +549,8 @@ export class RemediationService {
       );
 
       // Phase 2: Send real AWS state back to AI to generate EXACT fix steps
-      const evidence = (finding.evidence ?? {}) as Record<string, unknown>;
       const refinedPlan = await this.aiRemediationService.refineFixPlan({
-        finding: {
-          title: finding.title ?? 'Unknown',
-          description: finding.description,
-          severity: finding.severity,
-          resourceType: finding.resourceType,
-          resourceId: finding.resourceId,
-          remediation: finding.remediation,
-          findingKey: evidence.findingKey as string,
-          evidence,
-        },
+        finding: findingCtx,
         originalPlan: plan,
         realAwsState: previousState,
       });
@@ -561,11 +577,45 @@ export class RemediationService {
 
       // Validate refined fix steps
       if (!refinedPlan.fixSteps || refinedPlan.fixSteps.length === 0) {
-        throw new Error('AI refined plan has no fix steps. Cannot proceed.');
+        return await this.respondWithManualSteps({
+          actionId: action.id,
+          finding: findingCtx,
+          failedPlan: refinedPlan,
+          failureReason: 'AI refined plan produced no executable fix steps.',
+          resourceId: finding.resourceId,
+        });
       }
-      const fixErrors = validatePlanSteps(refinedPlan.fixSteps);
+
+      // First validation pass over the refined plan. If anything fails,
+      // attempt a single AI repair pass on the offending steps and
+      // re-validate — many "missing required param" cases the AI's
+      // first refinement misses are recoverable when given the exact
+      // error back as context. If repair still doesn't satisfy the
+      // validator, fall back to real manual steps so the customer
+      // never sees a raw "Invalid fix steps" error.
+      let plannedFix = refinedPlan;
+      let fixErrors = validatePlanSteps(plannedFix.fixSteps);
       if (fixErrors.length > 0) {
-        throw new Error(`Invalid fix steps: ${fixErrors.join('; ')}`);
+        this.logger.warn(
+          `Refined plan failed validation (${fixErrors.length} error(s)); attempting AI repair before falling back to manual.`,
+        );
+        plannedFix = await this.repairInvalidSteps({
+          plan: plannedFix,
+          validationErrors: fixErrors,
+          finding: findingCtx,
+          syntheticErrorPrefix:
+            'Pre-execution validator rejected this step:',
+        });
+        fixErrors = validatePlanSteps(plannedFix.fixSteps);
+      }
+      if (fixErrors.length > 0) {
+        return await this.respondWithManualSteps({
+          actionId: action.id,
+          finding: findingCtx,
+          failedPlan: plannedFix,
+          failureReason: `Even after AI repair the plan still has invalid steps: ${fixErrors.join('; ')}`,
+          resourceId: finding.resourceId,
+        });
       }
 
       // Phase 3: Execute the refined fix steps (now with REAL values).
@@ -575,27 +625,18 @@ export class RemediationService {
       // we give up — universal fix for "AI omitted a required param"
       // bugs that no per-command map can fully cover.
       const fixResult = await executePlanSteps({
-        steps: refinedPlan.fixSteps,
+        steps: plannedFix.fixSteps,
         credentials: remediationCreds,
         region,
-        autoRollbackSteps: refinedPlan.rollbackSteps,
+        autoRollbackSteps: plannedFix.rollbackSteps,
         repairStep: async ({ step, awsError }) =>
           this.aiRemediationService.refineStepFromError({
             step,
             awsError,
-            finding: {
-              title: finding.title ?? 'Unknown',
-              description: finding.description,
-              severity: finding.severity,
-              resourceType: finding.resourceType,
-              resourceId: finding.resourceId,
-              remediation: finding.remediation,
-              findingKey: evidence.findingKey as string,
-              evidence,
-            },
+            finding: findingCtx,
             planContext: {
-              fixSteps: refinedPlan.fixSteps,
-              readSteps: refinedPlan.readSteps,
+              fixSteps: plannedFix.fixSteps,
+              readSteps: plannedFix.readSteps,
             },
           }),
       });
@@ -607,7 +648,21 @@ export class RemediationService {
         this.logger.error(
           `Step params: ${JSON.stringify(fixResult.error.step.params).slice(0, 500)}`,
         );
-        throw new Error(fixResult.error.message);
+        // Permission errors still flow through the catch block below
+        // (parseAwsPermissionError produces the polished `fixScript`
+        // payload). For all OTHER unrecoverable execution errors fall
+        // back to manual steps so the customer sees real instructions
+        // rather than the raw AWS message.
+        if (parseAwsPermissionError(fixResult.error.message).isPermissionError) {
+          throw new Error(fixResult.error.message);
+        }
+        return await this.respondWithManualSteps({
+          actionId: action.id,
+          finding: findingCtx,
+          failedPlan: plannedFix,
+          failureReason: `Step ${fixResult.error.stepIndex + 1} (${fixResult.error.step.service}:${fixResult.error.step.command}) was rejected by AWS: ${fixResult.error.message}`,
+          resourceId: finding.resourceId,
+        });
       }
 
       const appliedState = {
@@ -615,7 +670,7 @@ export class RemediationService {
           command: `${r.step.service}:${r.step.command}`,
           output: r.output,
         })),
-        rollbackSteps: refinedPlan.rollbackSteps,
+        rollbackSteps: plannedFix.rollbackSteps,
       };
 
       await db.remediationAction.update({
@@ -1067,5 +1122,105 @@ export class RemediationService {
       .replace(':Delete', ':DeleteBucket');
     if (withBucket !== required && existing.has(withBucket)) return true;
     return false;
+  }
+
+  /**
+   * Best-effort AI repair pass over fix steps that failed validation.
+   * Parses step indices from the error strings (format
+   * "Step N (Command): ..."), then asks `refineStepFromError` to
+   * regenerate just those steps. If repair returns a new step, replace
+   * it; otherwise leave it alone for the caller to re-validate.
+   *
+   * Why this exists: `validatePlanSteps` runs BEFORE the executor, so
+   * the executor's own AI repair never gets a chance to fix
+   * empty-required-param plans. Without this pass, customers would see
+   * raw "Invalid fix steps" errors. With it, every plan gets one shot
+   * at AI repair before we fall back to manual guidance.
+   */
+  private async repairInvalidSteps(args: {
+    plan: FixPlan;
+    validationErrors: string[];
+    finding: FindingContext;
+    syntheticErrorPrefix: string;
+  }): Promise<FixPlan> {
+    const failingIndices = new Set<number>();
+    for (const err of args.validationErrors) {
+      const m = err.match(/^Step (\d+)\s*\(/);
+      if (m) failingIndices.add(Number(m[1]) - 1);
+    }
+    if (failingIndices.size === 0) return args.plan;
+
+    const newSteps = [...args.plan.fixSteps];
+    let anyRepaired = false;
+    for (const idx of failingIndices) {
+      const step = newSteps[idx];
+      if (!step) continue;
+      // Group the validator's complaints for THIS step into a synthetic
+      // "AWS error" the repair prompt can reason about.
+      const stepErrors = args.validationErrors
+        .filter((e) => e.startsWith(`Step ${idx + 1} `))
+        .join('; ');
+      const awsError = `${args.syntheticErrorPrefix} ${stepErrors}`;
+      const repaired = await this.aiRemediationService.refineStepFromError({
+        step,
+        awsError,
+        finding: args.finding,
+        planContext: {
+          fixSteps: args.plan.fixSteps,
+          readSteps: args.plan.readSteps,
+        },
+      });
+      if (repaired) {
+        newSteps[idx] = repaired;
+        anyRepaired = true;
+      }
+    }
+    return anyRepaired ? { ...args.plan, fixSteps: newSteps } : args.plan;
+  }
+
+  /**
+   * Universal "graceful fallback to manual steps" path. Called when an
+   * auto-fix attempt cannot succeed (validation rejects after repair,
+   * executor returns an unrecoverable error, plan has no usable steps).
+   *
+   * Persists the action as failed, generates real customer-facing
+   * manual instructions via the AI, and returns the same shape the
+   * frontend already renders for `canAutoFix: false` plans — so the
+   * customer sees clear steps instead of a raw error.
+   */
+  private async respondWithManualSteps(args: {
+    actionId: string;
+    finding: FindingContext;
+    failedPlan?: FixPlan;
+    failureReason: string;
+    resourceId: string;
+  }) {
+    const { guidedSteps, reason } =
+      await this.aiRemediationService.generateManualSteps({
+        finding: args.finding,
+        failedPlan: args.failedPlan,
+        failureReason: args.failureReason,
+      });
+
+    await db.remediationAction.update({
+      where: { id: args.actionId },
+      data: {
+        status: 'failed',
+        errorMessage: reason,
+      },
+    });
+
+    this.logger.warn(
+      `Manual-steps fallback for action ${args.actionId}: ${args.failureReason}`,
+    );
+
+    return {
+      actionId: args.actionId,
+      status: 'failed' as const,
+      resourceId: args.resourceId,
+      error: reason,
+      guidedSteps,
+      guidedOnly: true,
+    };
   }
 }

--- a/apps/app/src/app/(app)/[orgId]/cloud-tests/actions/batch-fix.ts
+++ b/apps/app/src/app/(app)/[orgId]/cloud-tests/actions/batch-fix.ts
@@ -195,6 +195,13 @@ export async function retryFinding(
         missingPermissions: result.permissionError.missingActions,
       };
     }
+    if (result.type === 'manual') {
+      // Batch flow doesn't surface per-finding manual steps in the UI
+      // today — mark as failed with the AI-generated reason so the
+      // user knows it needs manual attention. (Per-finding manual
+      // steps are available via the single-fix dialog.)
+      return { status: 'failed', error: result.reason };
+    }
 
     return { status: 'failed', error: result.error };
   } catch (err) {

--- a/apps/app/src/app/(app)/[orgId]/cloud-tests/components/RemediationDialog.tsx
+++ b/apps/app/src/app/(app)/[orgId]/cloud-tests/components/RemediationDialog.tsx
@@ -24,10 +24,11 @@ interface PreviewProgress {
 }
 
 interface SingleFixProgress {
-  phase: 'executing' | 'success' | 'failed' | 'needs_permissions';
+  phase: 'executing' | 'success' | 'failed' | 'needs_permissions' | 'manual';
   error?: string;
   actionId?: string;
   permissionError?: { missingActions: string[]; fixScript?: string };
+  guidedSteps?: string[];
 }
 
 interface RemediationDialogProps {
@@ -379,6 +380,26 @@ export function RemediationDialog({
         setExecuteRunId(null);
         setExecuteAccessToken(null);
       }, 4000);
+    } else if (progress.phase === 'manual') {
+      // Auto-fix gave up but the API returned real manual steps.
+      // Switch the dialog into guided rendering instead of showing a
+      // raw error — same UI the preview flow already uses for
+      // canAutoFix:false plans.
+      setIsExecuting(false);
+      setError(null);
+      const steps = progress.guidedSteps ?? [];
+      setPreview({
+        currentState: {},
+        proposedState: {},
+        description: progress.error ?? description ?? '',
+        risk: risk ?? 'medium',
+        apiCalls: [],
+        guidedOnly: true,
+        guidedSteps: steps,
+        rollbackSupported: false,
+      });
+      setExecuteRunId(null);
+      setExecuteAccessToken(null);
     } else if (progress.phase === 'failed') {
       setIsExecuting(false);
       setError(progress.error || 'Remediation failed');

--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/actions/batch-fix.ts
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/actions/batch-fix.ts
@@ -195,6 +195,9 @@ export async function retryFinding(
         missingPermissions: result.permissionError.missingActions,
       };
     }
+    if (result.type === 'manual') {
+      return { status: 'failed', error: result.reason };
+    }
 
     return { status: 'failed', error: result.error };
   } catch (err) {

--- a/apps/app/src/trigger/tasks/cloud-security/execute-result.test.ts
+++ b/apps/app/src/trigger/tasks/cloud-security/execute-result.test.ts
@@ -49,4 +49,78 @@ describe('classifyExecuteResult', () => {
       },
     });
   });
+
+  // ─── Manual-steps fallback (new in this PR) ────────────────────────
+
+  it('classifies a guidedOnly response with steps as the new manual type', () => {
+    expect(
+      classifyExecuteResult({
+        status: 'failed',
+        error: 'Plan still invalid after AI repair.',
+        guidedOnly: true,
+        guidedSteps: [
+          'Open AWS Console → CloudTrail',
+          'Create a new multi-region trail named compai-cloudtrail',
+        ],
+      }),
+    ).toEqual({
+      type: 'manual',
+      reason: 'Plan still invalid after AI repair.',
+      guidedSteps: [
+        'Open AWS Console → CloudTrail',
+        'Create a new multi-region trail named compai-cloudtrail',
+      ],
+    });
+  });
+
+  it('falls back to a generic reason when manual response omits error text', () => {
+    const result = classifyExecuteResult({
+      guidedOnly: true,
+      guidedSteps: ['Do thing X'],
+    });
+    expect(result.type).toBe('manual');
+    if (result.type !== 'manual') return;
+    expect(result.reason).toMatch(/Automatic fix could not be applied/i);
+    expect(result.guidedSteps).toEqual(['Do thing X']);
+  });
+
+  it('does NOT trigger the manual type when guidedOnly is true but steps are missing or empty', () => {
+    // Must have BOTH the flag and a non-empty list. Without real steps,
+    // the customer would see "manual mode" with nothing to do.
+    expect(
+      classifyExecuteResult({ guidedOnly: true, guidedSteps: [] }).type,
+    ).not.toBe('manual');
+    expect(
+      classifyExecuteResult({ guidedOnly: true }).type,
+    ).not.toBe('manual');
+    expect(
+      classifyExecuteResult({
+        guidedOnly: true,
+        guidedSteps: ['', '   '],
+      }).type,
+    ).not.toBe('manual');
+  });
+
+  it('strips non-string entries from guidedSteps before declaring manual', () => {
+    const result = classifyExecuteResult({
+      guidedOnly: true,
+      guidedSteps: ['valid step', 42, null, 'another step'],
+    });
+    expect(result.type).toBe('manual');
+    if (result.type !== 'manual') return;
+    expect(result.guidedSteps).toEqual(['valid step', 'another step']);
+  });
+
+  it('prefers permission-error classification over manual when both fields are present', () => {
+    // Permission errors have a polished dedicated UX (fixScript). Don't
+    // shadow them with a generic manual-steps view.
+    const result = classifyExecuteResult({
+      status: 'failed',
+      error: 'Access denied',
+      permissionError: { missingActions: ['s3:CreateBucket'] },
+      guidedOnly: true,
+      guidedSteps: ['Do something'],
+    });
+    expect(result.type).toBe('needs_permissions');
+  });
 });

--- a/apps/app/src/trigger/tasks/cloud-security/execute-result.ts
+++ b/apps/app/src/trigger/tasks/cloud-security/execute-result.ts
@@ -10,6 +10,11 @@ type ExecuteClassification =
       error: string;
       permissionError: PermissionError;
     }
+  | {
+      type: 'manual';
+      reason: string;
+      guidedSteps: string[];
+    }
   | { type: 'failed'; error: string };
 
 export function classifyExecuteResult(value: unknown): ExecuteClassification {
@@ -27,6 +32,20 @@ export function classifyExecuteResult(value: unknown): ExecuteClassification {
       type: 'needs_permissions',
       error: error ?? 'Missing permissions',
       permissionError,
+    };
+  }
+
+  // Manual-steps fallback: the API decided auto-fix can't proceed and
+  // is returning real, customer-actionable instructions. Surface them
+  // verbatim so the dialog can render them instead of a raw error.
+  const guidedSteps = parseGuidedSteps(record.guidedSteps);
+  if (record.guidedOnly === true && guidedSteps && guidedSteps.length > 0) {
+    return {
+      type: 'manual',
+      reason:
+        error ??
+        'Automatic fix could not be applied — follow the guided steps.',
+      guidedSteps,
     };
   }
 
@@ -52,6 +71,14 @@ export function classifyExecuteResult(value: unknown): ExecuteClassification {
     type: 'failed',
     error: 'API returned an invalid remediation response',
   };
+}
+
+function parseGuidedSteps(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const steps = value.filter(
+    (step): step is string => typeof step === 'string' && step.trim().length > 0,
+  );
+  return steps.length > 0 ? steps : undefined;
 }
 
 function parsePermissionError(value: unknown): PermissionError | undefined {

--- a/apps/app/src/trigger/tasks/cloud-security/remediate-batch-helpers.ts
+++ b/apps/app/src/trigger/tasks/cloud-security/remediate-batch-helpers.ts
@@ -110,6 +110,9 @@ export async function tryFix(
       missingPerms: result.permissionError.missingActions,
     };
   }
+  if (result.type === 'manual') {
+    return { status: 'failed', error: result.reason };
+  }
 
   return { status: 'failed', error: result.error };
 }

--- a/apps/app/src/trigger/tasks/cloud-security/remediate-single.ts
+++ b/apps/app/src/trigger/tasks/cloud-security/remediate-single.ts
@@ -7,10 +7,11 @@ import {
 import { classifyExecuteResult } from './execute-result';
 
 interface SingleFixProgress {
-  phase: 'executing' | 'success' | 'failed' | 'needs_permissions';
+  phase: 'executing' | 'success' | 'failed' | 'needs_permissions' | 'manual';
   error?: string;
   actionId?: string;
   permissionError?: { missingActions: string[]; fixScript?: string };
+  guidedSteps?: string[];
 }
 
 function sync(progress: SingleFixProgress) {
@@ -83,6 +84,22 @@ export const remediateSingle = task({
           success: false,
           needsPermissions: true,
           permissionError: result.permissionError,
+        };
+      }
+
+      if (result.type === 'manual') {
+        progress.phase = 'manual';
+        progress.error = result.reason;
+        progress.guidedSteps = result.guidedSteps;
+        sync(progress);
+        logger.info(
+          `Single fix fell back to manual steps: ${result.guidedSteps.length} step(s)`,
+        );
+        return {
+          success: false,
+          manual: true,
+          guidedSteps: result.guidedSteps,
+          reason: result.reason,
         };
       }
 


### PR DESCRIPTION
## Summary

Customers were seeing raw "Fix could not be applied — <cryptic AWS or validator message>" in the Auto-Remediate dialog when the AI's refined plan was rejected by our pre-execution validator or AWS rejected a step the executor couldn't auto-repair. This PR converts every such failure path inside AWS `executeRemediation` into a **graceful manual-steps fallback**: the API returns real, customer-actionable instructions (AI-generated from the failure context), the trigger task carries them through, and the dialog renders the existing guided-steps UI instead of a red error banner.

**Net effect:** every fix attempt now ends in either "fix worked" or "here's a concrete checklist you can follow in AWS Console / CLI". No raw errors.

## How it works (end-to-end)

```
┌─ executeRemediation (AWS) ─────────────────────────────────────────┐
│  read-step validation fails       →  manual-steps fallback         │
│  refined plan has no fix steps    →  manual-steps fallback         │
│  refined plan fails validation    →  try AI step-repair → revalidate
│                                   →  still invalid? manual fallback│
│  executor returns error           →  permission error? existing UX │
│                                   →  otherwise: manual fallback    │
└────────────────────────────────────────────────────────────────────┘

API returns { status: 'failed', guidedOnly: true, guidedSteps, error }
        ↓
classifyExecuteResult → { type: 'manual', reason, guidedSteps }
        ↓
remediate-single trigger task → progress.phase = 'manual' + guidedSteps
        ↓
RemediationDialog → switches preview into guidedOnly mode
        ↓
Customer sees: ordered numbered steps, NOT a raw error
```

## Changes

### `apps/api/src/cloud-security/ai-remediation.service.ts`
- New `generateManualSteps(...)` — Sonnet-powered. Inputs: finding, failed plan, failure reason. Output: `{ guidedSteps: string[], reason: string }`. Hard fallback to the adapter's `remediation` text if the AI call itself throws.
- Exports `FindingContext` for the orchestration layer.

### `apps/api/src/cloud-security/aws-command-executor.ts`
- `looksLikeValidationError` now matches `MissingParameter`, "must contain the parameter", "missing parameter", "parameter is required", "must specify". The earlier regex missed EC2-style wording and the AI step-repair never fired for those findings.

### `apps/api/src/cloud-security/remediation.service.ts`
- `repairInvalidSteps` — parses step indices from validator errors and calls `refineStepFromError` per offending step before falling back. Closes the gap where the executor's own AI step-repair never got a chance because the plan never reached execution.
- `respondWithManualSteps` — generates manual steps, persists the action as failed, returns the response shape the frontend already renders for `canAutoFix: false` plans.
- Every throw in `executeRemediation` swapped for the appropriate fallback. Permission errors still flow through the existing catch (don't shadow the polished fixScript UX).

### `apps/api/src/cloud-security/ai-remediation.service.ts` (other change)
- Broader `ACTIONABLE_PREFIXES` so security-group / IAM-style plans (Authorize/Revoke/Allow/Deny/Disable/Detach/Add/Remove/Register/Deregister/Tag/Untag) produce meaningful `willChange` diffs instead of `{}` `{}`.

### `apps/app/src/trigger/tasks/cloud-security/execute-result.ts`
- New `manual` classification + defensive parsing of `guidedSteps` (strips non-strings, requires `guidedOnly: true` AND a non-empty list).
- Permission-error classification still wins when both fields are present.

### `apps/app/src/trigger/tasks/cloud-security/remediate-single.ts`
- New `phase: 'manual'` in progress + `guidedSteps` field.

### `apps/app/src/app/(app)/[orgId]/cloud-tests/components/RemediationDialog.tsx`
- On `phase: 'manual'`, switch preview into `guidedOnly: true` rendering. Same UI the dialog already uses for `canAutoFix: false` plans.

### Batch flows
- `cloud-tests/actions/batch-fix.ts` + `integrations/[slug]/actions/batch-fix.ts` + `remediate-batch-helpers.ts` treat the `manual` classification as `failed` with the AI-generated reason. The per-finding guided steps remain available via the single-fix dialog.

## Tests

- `apps/api`: 16 tests on `ai-remediation.service.spec.ts` (+4 new for `generateManualSteps`). 267/267 cloud-security tests pass.
- `apps/app`: 10 tests on `execute-result.test.ts` (+5 new for the `manual` classification). All trigger task tests pass.

## What this PR is NOT

- **NOT a per-finding audit.** We have ~100+ finding types across AWS adapters; verifying each individually requires real-tenant testing and is weeks of work. This PR makes the safety net strong enough that the customer never sees a raw error regardless of which finding it is.
- **NOT a GCP/Azure parity change.** GCP and Azure remediation services have the same throw-on-validation patterns (`gcp-remediation.service.ts` lines 200, 205, 208, 239, 288, 315; `azure-remediation.service.ts` lines 136, 149, 252) and would benefit from the same treatment. Left for a follow-up PR per the requested scope ("for now just do only for AWS").
- **NOT a fix for every cryptic auto-remediate error.** The pattern broadening covers the common AWS error wording we've seen in customer reports; the universal AI step-repair is gated to validation-class errors. Errors AWS classifies as non-validation (e.g., `MethodNotAllowed`, `ResourceConflict`) will still bypass AI repair but now end up in the manual-steps fallback instead of as raw errors.

## Manual test plan

- [ ] Trigger an auto-fix on a finding known to hit the empty-required-param bug (CloudTrail "No trails configured" was the customer-reported case). Confirm the dialog shows manual steps instead of a red error.
- [ ] Trigger an auto-fix on a finding that succeeds today. Confirm the happy path still completes and the success animation still renders.
- [ ] Trigger an auto-fix that fails with a permission error. Confirm the permission-error UX (fixScript card) still renders — manual fallback should NOT shadow it.
- [ ] Trigger a batch fix that includes findings that fall back to manual. Confirm the batch UI shows them as failed with the AI-generated reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a graceful manual-steps fallback to AWS auto-remediation so users never see cryptic errors. When a plan is invalid or execution fails (except permission errors), the API returns guided steps and the dialog switches to the guided-only UI.

- **New Features**
  - Manual-steps fallback in `executeRemediation`: on read-step validation failure, empty fix steps, post-repair validation failure, or non-permission execution errors, return `{ guidedOnly: true, guidedSteps, error }`.
  - `generateManualSteps` builds clear, ordered instructions from the finding, failed plan, and failure reason, with a safe fallback to the adapter’s remediation text.
  - Pre-execution repair: `repairInvalidSteps` parses validator errors, repairs offending steps with `refineStepFromError`, then re-validates before falling back.
  - End-to-end surfacing: `classifyExecuteResult` emits `type: 'manual'`; `remediate-single` publishes `phase: 'manual'` with `guidedSteps`; `RemediationDialog` renders guided-only steps; batch-fix marks as failed with the generated reason. Permission errors keep the existing fix-script UX.

- **Bug Fixes**
  - Broader AWS validation-error detection (`MissingParameter`, “missing parameter”, “parameter is required”, “must specify”, etc.) so auto-repair paths trigger reliably.
  - Expanded actionable prefixes (Authorize, Revoke, Allow, Deny, Disable, Detach, Add, Remove, Register, Deregister, Tag, Untag) for more informative `willChange` diffs.

<sup>Written for commit f6c7d9443ad9f95f508455afa53112cd761e0797. Summary will update on new commits. <a href="https://cubic.dev/pr/trycompai/comp/pull/2915?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

