### PR TITLE
fix(cloud-tests): only fire GCP broad fallback when folder list was forbidden

### DIFF
--- a/apps/api/src/cloud-security/providers/gcp-security.service.spec.ts
+++ b/apps/api/src/cloud-security/providers/gcp-security.service.spec.ts
@@ -315,24 +315,31 @@ describe('GCPSecurityService — project detection', () => {
       expect(result).toEqual([]);
     });
 
-    it('falls back to broad parent.type:folder query when folder enumeration returns empty (customer Propper regression)', async () => {
-      // Verified failure mode in production: v3/folders (and v2 before
-      // it) returns `403 PERMISSION_DENIED` for some OAuth grants
-      // despite the user having org-level folder roles. Folder
-      // enumeration silently returns []. The picker would have been
-      // missing folder-nested projects.
-      //
-      // After the fallback: a broad `parent.type:folder` query (no
-      // parent.id) catches every folder-nested project the OAuth user
-      // can `projects.get`, including the ones we couldn't enumerate.
+    it('falls back to broad parent.type:folder query when v3/folders returns 403 PERMISSION_DENIED (customer Propper regression)', async () => {
+      // Exact production failure mode: v3/folders returns
+      // `403 PERMISSION_DENIED` for some OAuth grants despite the
+      // user having org-level folder roles. The fallback MUST fire
+      // ONLY for true forbiddens — cubic P2 on PR #2916 noted that
+      // an unconditional fallback on "empty folders" would leak
+      // cross-org projects for multi-org users whose selected org
+      // simply has no folders. See the next test for that case.
       const broadQueryHits: string[] = [];
       fetchMock.mockImplementation(async (url: string) => {
-        // Simulate 403 PERMISSION_DENIED → my prod code path returns
-        // the collected-so-far ([]) and logs a warning.
         if (url.includes('v3/folders')) {
-          return foldersPage({ folders: [] });
+          // Real 403 PERMISSION_DENIED body that GCP returns.
+          return {
+            ok: false,
+            status: 403,
+            text: async () =>
+              JSON.stringify({
+                error: {
+                  code: 403,
+                  message: 'The caller does not have permission',
+                  status: 'PERMISSION_DENIED',
+                },
+              }),
+          };
         }
-        // Direct arm: org children.
         if (
           url.includes('v1/projects') &&
           url.includes('parent.id%3A43356919874')
@@ -343,7 +350,6 @@ describe('GCPSecurityService — project detection', () => {
             ],
           });
         }
-        // Broad fallback query (parent.type:folder, NO parent.id).
         if (
           url.includes('v1/projects') &&
           url.includes('parent.type%3Afolder') &&
@@ -364,8 +370,66 @@ describe('GCPSecurityService — project detection', () => {
 
       const ids = result.map((p) => p.id).sort();
       expect(ids).toEqual(['direct-1', 'propperai-demo', 'propperai-prod']);
-      // The fallback fired exactly once.
       expect(broadQueryHits).toHaveLength(1);
+    });
+
+    it('does NOT fall back to the broad query when the org simply has no folders (cubic P2 fix)', async () => {
+      // The previous PR (#2916) fired the broad fallback for ANY
+      // empty enumeration result. That meant a multi-org user whose
+      // selected org legitimately had no folders would see folder-
+      // nested projects from OTHER orgs they had IAM access to —
+      // because the broad query is not org-scoped.
+      //
+      // This test locks in the cubic P2 fix: enumeration returns
+      // empty WITHOUT a 403 → no fallback → folder arm returns []
+      // and the picker shows only the org's direct children.
+      const broadQueryHits: string[] = [];
+      fetchMock.mockImplementation(async (url: string) => {
+        if (url.includes('v3/folders')) {
+          // 200 OK + empty list. NOT a 403. The org just has no
+          // folders. Common shape for small single-org tenants too.
+          return foldersPage({ folders: [] });
+        }
+        if (
+          url.includes('v1/projects') &&
+          url.includes('parent.id%3Aflat-org')
+        ) {
+          return gcpPage({
+            projects: [
+              {
+                projectId: 'only-direct',
+                name: 'Only Direct',
+                projectNumber: '900',
+              },
+            ],
+          });
+        }
+        if (
+          url.includes('v1/projects') &&
+          url.includes('parent.type%3Afolder') &&
+          !/parent\.id%3A/.test(url)
+        ) {
+          // Would return cross-org projects if the fallback ever
+          // fires. Track hits — must be zero.
+          broadQueryHits.push(url);
+          return gcpPage({
+            projects: [
+              {
+                projectId: 'should-not-appear',
+                name: 'Other Org Folder Project',
+                projectNumber: '999',
+              },
+            ],
+          });
+        }
+        throw new Error(`Unexpected URL: ${url}`);
+      });
+
+      const result = await service.detectProjectsForOrg('token', 'flat-org');
+
+      expect(result.map((p) => p.id)).toEqual(['only-direct']);
+      // The broad fallback must NOT fire. Cubic P2.
+      expect(broadQueryHits).toHaveLength(0);
     });
 
     it('does NOT fire the broad-query fallback when folder enumeration succeeds (precise scoping preserved)', async () => {

--- a/apps/api/src/cloud-security/providers/gcp-security.service.ts
+++ b/apps/api/src/cloud-security/providers/gcp-security.service.ts
@@ -885,7 +885,7 @@ export class GCPSecurityService {
     accessToken: string,
     organizationId: string,
   ): Promise<Array<{ id: string; name: string; number: string }>> {
-    const folderIds = await this.listFoldersUnderOrg(
+    const { folderIds, forbidden } = await this.listFoldersUnderOrg(
       accessToken,
       organizationId,
     );
@@ -900,18 +900,22 @@ export class GCPSecurityService {
     // Greg reported (propperai-prod, propperai-demo invisible in
     // the picker).
     //
-    // Fall back to the broader `parent.type:folder` query — it
-    // returns all folder-nested projects the OAuth user can `get`.
-    // For single-org tenants (the common case) this delivers the
-    // right set. For multi-org tenants it may include folder-nested
-    // projects from other orgs the user happens to have access to,
-    // which is acceptable because:
-    //   - the picker is selection-based (user chooses what to monitor),
-    //   - the alternative is a silently empty picker,
-    //   - the user already authorized those projects via IAM.
-    if (folderIds.length === 0) {
+    // The fallback below ONLY fires when enumeration was actually
+    // forbidden, not when an org legitimately has zero folders.
+    // (cubic P2 on PR #2916: the previous always-on fallback could
+    // leak folder-nested projects from OTHER orgs in a multi-org
+    // tenant whose selected org simply had no folders.)
+    //
+    // Forbidden case → broad `parent.type:folder` query catches
+    // every folder-nested project the OAuth user can `projects.get`.
+    // For single-org tenants this delivers the right set. For
+    // multi-org tenants whose v3/folders is forbidden the fallback
+    // may include projects from other accessible orgs — acceptable
+    // because the picker is selection-based and the alternative is a
+    // silently empty picker.
+    if (folderIds.length === 0 && forbidden) {
       this.logger.warn(
-        `GCP folder enumeration returned 0 folders for org ${organizationId}; falling back to broad parent.type:folder query`,
+        `GCP folder enumeration was forbidden for org ${organizationId}; falling back to broad parent.type:folder query`,
       );
       const fallback = await this.listProjectsPaginated(
         accessToken,
@@ -926,6 +930,13 @@ export class GCPSecurityService {
         `GCP folder fallback for org ${organizationId}: ${fallback.length} project(s) via broad parent.type:folder query`,
       );
       return fallback;
+    }
+
+    if (folderIds.length === 0) {
+      // No folders exist for this org AND no permission errors were
+      // observed — return empty so a multi-org user doesn't see
+      // folder-nested projects from unrelated orgs.
+      return [];
     }
 
     // Bound the fan-out: an unbounded `Promise.all(folderIds.map(...))`
@@ -962,20 +973,25 @@ export class GCPSecurityService {
   private async listFoldersUnderOrg(
     accessToken: string,
     organizationId: string,
-  ): Promise<string[]> {
+  ): Promise<{ folderIds: string[]; forbidden: boolean }> {
     const SAFE_MAX_FOLDERS = 500;
 
     const collected: string[] = [];
     const seenParents = new Set<string>();
     const queue: string[] = [`organizations/${organizationId}`];
+    // Tracks whether ANY page in the BFS hit a 403 PERMISSION_DENIED.
+    // Only true forbiddens trigger the broad-query fallback in the
+    // caller; "no folders exist" must NOT trigger it.
+    let forbidden = false;
 
     while (queue.length > 0 && collected.length < SAFE_MAX_FOLDERS) {
       const parent = queue.shift();
       if (!parent || seenParents.has(parent)) continue;
       seenParents.add(parent);
 
-      const children = await this.listChildFolders(accessToken, parent);
-      for (const folderId of children) {
+      const result = await this.listChildFolders(accessToken, parent);
+      if (result.forbidden) forbidden = true;
+      for (const folderId of result.folderIds) {
         if (collected.includes(folderId)) continue;
         collected.push(folderId);
         queue.push(`folders/${folderId}`);
@@ -988,7 +1004,7 @@ export class GCPSecurityService {
       }
     }
 
-    return collected;
+    return { folderIds: collected, forbidden };
   }
 
   /**
@@ -1010,10 +1026,11 @@ export class GCPSecurityService {
   private async listChildFolders(
     accessToken: string,
     parent: string,
-  ): Promise<string[]> {
+  ): Promise<{ folderIds: string[]; forbidden: boolean }> {
     const PAGE_SIZE = 100;
     const collected: string[] = [];
     let pageToken: string | undefined;
+    let forbidden = false;
 
     do {
       const params = new URLSearchParams({
@@ -1033,10 +1050,14 @@ export class GCPSecurityService {
       );
 
       if (!response.ok) {
+        // Distinguish "forbidden" (the caller should fall back to a
+        // broader query) from "transient / no folders" (the caller
+        // should NOT broaden — empty results are the correct answer).
+        if (response.status === 403) forbidden = true;
         this.logger.warn(
-          `Failed to list child folders of ${parent}: ${await response.text()}`,
+          `Failed to list child folders of ${parent} (HTTP ${response.status}): ${await response.text()}`,
         );
-        return collected;
+        return { folderIds: collected, forbidden };
       }
 
       const data = (await response.json()) as {
@@ -1052,7 +1073,7 @@ export class GCPSecurityService {
       pageToken = data.nextPageToken;
     } while (pageToken);
 
-    return collected;
+    return { folderIds: collected, forbidden };
   }
 
   /**


### PR DESCRIPTION
## Summary

Addresses cubic's P2 on the already-merged PR #2916: the broad-query fallback I added was firing any time folder enumeration returned an empty list, including the perfectly normal case where an org legitimately has no folders. For multi-org tenants that meant the picker for an empty-folder org could surface folder-nested projects from OTHER orgs the OAuth user had IAM access to (since the broad query is not org-scoped).

## What changed

Folder enumeration helpers now return `{ folderIds, forbidden }`, where `forbidden = true` only when GCP responded with HTTP 403 on the `v3/folders` call. The caller fires the broad-query fallback only when **enumeration returned zero AND `forbidden` is true** — exactly Greg's production failure mode.

| Case | Before (PR #2916) | After (this PR) |
|---|---|---|
| `v3/folders` 200 + empty list (no folders exist) | Fallback fires (wrong) | **No fallback** ✓ |
| `v3/folders` 403 PERMISSION_DENIED (Greg) | Fallback fires | Fallback fires ✓ |
| `v3/folders` returns folder ids | No fallback | No fallback ✓ |

## Impact on customers

- **Greg (Propper)** — unaffected. His failure mode is 403 PERMISSION_DENIED so the fallback still fires and surfaces `propperai-prod` / `propperai-demo`.
- **Single-org tenants with no folders** — unaffected (their picker showed all their projects from the direct arm, the folder arm correctly returns empty either way).
- **Multi-org tenants whose selected org has no folders** — fixed. They no longer see folder-nested projects from other orgs they happen to have IAM access to.
- **Multi-org tenants whose selected org's `v3/folders` is forbidden** — same tradeoff as PR #2916 acknowledged: broad fallback may include cross-org folder projects. Acceptable because picker is selection-based and the alternative is an empty picker.

## Tests

- New: "does NOT fall back to the broad query when the org simply has no folders" — locks in cubic's P2 fix.
- Updated: customer-Propper regression test now returns a real 403 response (matching production behavior) so it exercises the actual `forbidden` branch.
- 16/16 GCP detection tests pass. Full cloud-security suite: 270/270 (one pre-existing TLS env failure unrelated).

## Manual test plan

- [ ] After deploy, confirm Greg's picker still shows `propperai-prod` / `propperai-demo` (his 403 case is preserved).
- [ ] Pull `/ecs/comp-production-api` logs filtered for `GCP folder enumeration was forbidden` — should still appear for Greg's connection.
- [ ] On any single-org tenant with no folders, confirm the picker only shows their direct-org projects (no fallback firing — `GCP folder fallback for org` log should NOT appear for them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix GCP project detection so the broad `parent.type:folder` query only runs when folder enumeration is actually forbidden (HTTP 403). This prevents cross-org projects from appearing when an org simply has no folders.

- **Bug Fixes**
  - Trigger the broad fallback only when `v3/folders` returns 403; do not fall back on 200 + empty.
  - `listFoldersUnderOrg` and `listChildFolders` now return `{ folderIds, forbidden }`; caller checks `folderIds.length === 0 && forbidden`.
  - Tests updated: added “no folders” case; Propper regression test now simulates a real 403.
  - Impact: fixes the P2 regression from PR #2916 for multi‑org tenants; Greg (Propper) remains covered.

<sup>Written for commit 173b031c47ed9ababe0559fc93d31015c2c20677. Summary will update on new commits. <a href="https://cubic.dev/pr/trycompai/comp/pull/2918?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

