### PR TITLE
fix(policies): accept multipart file uploads on POST /policies/:id/pdf

### DIFF
--- a/apps/api/src/policies/policies.controller.ts
+++ b/apps/api/src/policies/policies.controller.ts
@@ -570,7 +570,7 @@ export class PoliciesController {
       fileType = file.mimetype;
     } else if (body.fileData && body.fileName && body.fileType) {
       const stripped = body.fileData.replace(/\s/g, '');
-      if (!/^[A-Za-z0-9+/]*={0,2}$/.test(stripped) || stripped.length % 4 !== 0) {
+      if (!/^[A-Za-z0-9+/\-_]*={0,2}$/.test(stripped)) {
         throw new BadRequestException('fileData must be valid base64-encoded content');
       }
       fileBuffer = Buffer.from(stripped, 'base64');

--- a/apps/api/src/policies/policies.controller.ts
+++ b/apps/api/src/policies/policies.controller.ts
@@ -14,10 +14,14 @@ import {
   Query,
   Req,
   Res,
+  UploadedFile,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
 import {
   ApiBody,
+  ApiConsumes,
   ApiHeader,
   ApiOperation,
   ApiParam,
@@ -513,20 +517,67 @@ export class PoliciesController {
 
   @Post(':id/pdf')
   @RequirePermission('policy', 'update')
+  @UseInterceptors(FileInterceptor('file'))
   @ApiOperation({ summary: 'Upload a PDF to a policy or version' })
+  @ApiConsumes('multipart/form-data', 'application/json')
   @ApiParam(POLICY_PARAMS.policyId)
+  @ApiBody({
+    schema: {
+      oneOf: [
+        {
+          description: 'Multipart file upload (recommended)',
+          type: 'object',
+          properties: {
+            file: { type: 'string', format: 'binary' },
+            versionId: { type: 'string', description: 'Target version ID (optional)' },
+          },
+          required: ['file'],
+        },
+        {
+          description: 'JSON with base64-encoded file data',
+          type: 'object',
+          properties: {
+            fileName: { type: 'string' },
+            fileType: { type: 'string' },
+            fileData: { type: 'string', description: 'Base64-encoded file content' },
+            versionId: { type: 'string' },
+          },
+          required: ['fileName', 'fileType', 'fileData'],
+        },
+      ],
+    },
+  })
   async uploadPolicyPdf(
     @Param('id') id: string,
+    @UploadedFile() file: Express.Multer.File | undefined,
     @Body()
     body: {
       versionId?: string;
-      fileName: string;
-      fileType: string;
-      fileData: string;
+      fileName?: string;
+      fileType?: string;
+      fileData?: string;
     },
     @OrganizationId() organizationId: string,
     @AuthContext() authContext: AuthContextType,
   ) {
+    let fileBuffer: Buffer;
+    let sanitizedFileName: string;
+    let fileType: string;
+
+    if (file) {
+      fileBuffer = file.buffer;
+      sanitizedFileName = file.originalname.replace(/[^a-zA-Z0-9.-]/g, '_');
+      fileType = file.mimetype;
+    } else if (body.fileData && body.fileName && body.fileType) {
+      fileBuffer = Buffer.from(body.fileData, 'base64');
+      sanitizedFileName = body.fileName.replace(/[^a-zA-Z0-9.-]/g, '_');
+      fileType = body.fileType;
+    } else {
+      throw new BadRequestException(
+        'Upload a file via multipart/form-data or provide fileName, fileType, and fileData in JSON',
+      );
+    }
+
     const { S3Client, PutObjectCommand, DeleteObjectCommand } =
       await import('@aws-sdk/client-s3');
     const bucketName = process.env.APP_AWS_BUCKET_NAME;
@@ -546,9 +597,6 @@ export class PoliciesController {
       },
     });
     if (!policy) throw new NotFoundException('Policy not found');
-
-    const sanitizedFileName = body.fileName.replace(/[^a-zA-Z0-9.-]/g, '_');
-    const fileBuffer = Buffer.from(body.fileData, 'base64');
 
     if (body.versionId) {
       const version = await db.policyVersion.findFirst({
@@ -573,7 +621,7 @@ export class PoliciesController {
           Bucket: bucketName,
           Key: s3Key,
           Body: fileBuffer,
-          ContentType: body.fileType,
+          ContentType: fileType,
         }),
       );
       const oldPdfUrl = version.pdfUrl;
@@ -602,7 +650,7 @@ export class PoliciesController {
         Bucket: bucketName,
         Key: s3Key,
         Body: fileBuffer,
-        ContentType: body.fileType,
+        ContentType: fileType,
       }),
     );
     const oldPdfUrl = policy.pdfUrl;

--- a/apps/api/src/policies/policies.controller.ts
+++ b/apps/api/src/policies/policies.controller.ts
@@ -569,7 +569,14 @@ export class PoliciesController {
       sanitizedFileName = file.originalname.replace(/[^a-zA-Z0-9.-]/g, '_');
       fileType = file.mimetype;
     } else if (body.fileData && body.fileName && body.fileType) {
-      fileBuffer = Buffer.from(body.fileData, 'base64');
+      const stripped = body.fileData.replace(/\s/g, '');
+      if (!/^[A-Za-z0-9+/]*={0,2}$/.test(stripped) || stripped.length % 4 !== 0) {
+        throw new BadRequestException('fileData must be valid base64-encoded content');
+      }
+      fileBuffer = Buffer.from(stripped, 'base64');
+      if (fileBuffer.length === 0) {
+        throw new BadRequestException('fileData must be valid base64-encoded content');
+      }
       sanitizedFileName = body.fileName.replace(/[^a-zA-Z0-9.-]/g, '_');
       fileType = body.fileType;
     } else {


### PR DESCRIPTION
The endpoint previously only accepted JSON with base64-encoded file data, causing a 500 when customers sent a raw PDF. Now supports both multipart/ form-data (direct file upload) and the existing JSON approach.

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixes #XXXX (GitHub issue number)
- Fixes COMP-XXXX (Linear issue number - should be visible at the bottom of the GitHub issue description)

## Visual Demo (For contributors especially)

A visual demonstration is strongly recommended, for both the original and new change **(video / image - any one)**.

#### Video Demo (if applicable):

- Show screen recordings of the issue or feature.
- Demonstrate how to reproduce the issue, the behavior before and after the change.

#### Image Demo (if applicable):

- Add side-by-side screenshots of the original and updated change.
- Highlight any significant change(s).

## Mandatory Tasks (DO NOT REMOVE)

- [ ] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I have updated the developer docs in /docs if this PR makes changes that would require a [documentation change](https://trycomp.ai/docs). If N/A, write N/A here and check the checkbox.
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Write details that help to start the tests -->

- Are there environment variables that should be set?
- What are the minimal test data to have?
- What is expected (happy path) to have (input and output)?
- Any other important info that could help to test that PR

## Checklist

<!-- Remove bullet points below that don't apply to you -->

- I haven't read the [contributing guide](https://github.com/trycompai/comp/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my changes generate no new warnings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept multipart PDF uploads on POST /policies/:id/pdf and tighten JSON base64 validation while allowing URL-safe and unpadded input. The endpoint supports both `multipart/form-data` and the existing JSON body.

- **Bug Fixes**
  - Accept `multipart/form-data` with `file` using `@nestjs/platform-express` `FileInterceptor`; keep JSON (`fileName`, `fileType`, `fileData`) with strict validation and clear 400 on bad input; allow `-`/`_` and missing padding.
  - Return 400 if neither input is provided; sanitize filenames; set Content-Type from upload mimetype or JSON `fileType`.
  - OpenAPI: `@ApiConsumes` and union `@ApiBody` schema (optional `versionId`) via `@nestjs/swagger`.

<sup>Written for commit ac7ea6589ed43992b11e1e280c795fa4588ee20f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/2942?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

