### PR TITLE
docs(mcp): add MCP server guide

### DIFF
--- a/packages/docs/api-reference/overview.mdx
+++ b/packages/docs/api-reference/overview.mdx
@@ -7,6 +7,8 @@ The Comp AI API lets engineering, security, and compliance teams connect their i
 
 Use it to automate evidence collection, manage policies, coordinate compliance tasks, answer security questionnaires, configure Trust Center access, track risks and vendors, and keep SOC 2, ISO 27001, HIPAA, GDPR, and custom framework programs connected to the systems where work actually happens.
 
+> **Prefer to drive Comp AI from an AI assistant?** The same endpoints documented here are also available as tools in the [Comp AI MCP server](/mcp-server) — install it once in Claude Desktop, Cursor, ChatGPT, Codex, or any MCP-compatible client and ask in plain language.
+
 ## Authentication
 
 Most organization automation uses the `X-API-Key` header. Create scoped API keys inside your Comp AI organization, keep them server-side, and grant only the permissions needed for the workflow you are building.

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -72,6 +72,7 @@
               "device-agent",
               "security-questionnaire",
               "penetration-tests",
+              "mcp-server",
               {
                 "group": "Trust",
                 "pages": ["trust-access"]

--- a/packages/docs/introduction.mdx
+++ b/packages/docs/introduction.mdx
@@ -31,6 +31,10 @@ Use these docs to configure automated evidence collection, policy workflows, clo
 ## Build With Comp AI
 
 <CardGroup cols={2}>
+  <Card title="MCP Server" icon="sparkles" href="/mcp-server">
+    Drive your compliance program from Claude Desktop, Cursor, ChatGPT, Codex, and other AI assistants using your Comp AI API key.
+  </Card>
+
   <Card title="Compliance Automation API" icon="code" href="/api-reference/overview">
     Automate evidence, policies, tasks, Trust Access, security questionnaires, and compliance workflows with the Comp AI API.
   </Card>

--- a/packages/docs/mcp-server.mdx
+++ b/packages/docs/mcp-server.mdx
@@ -1,0 +1,247 @@
+---
+title: 'MCP Server'
+description: 'Drive your Comp AI compliance program from any AI assistant — Claude Desktop, Cursor, ChatGPT, Codex, Gemini, VS Code, Windsurf — using just your Comp AI API key.'
+---
+
+The Comp AI MCP server lets you and your team operate your entire compliance program from inside any modern AI assistant. Ask in plain language; the AI uses real Comp AI tools to read evidence, manage tasks, generate questionnaire answers, connect cloud accounts, and more — all under your existing API key and permissions.
+
+> Built on the [Model Context Protocol](https://modelcontextprotocol.io/) — an open standard that lets AI clients talk to external tools. The Comp AI MCP server publishes hundreds of tools spanning evidence, policies, integrations, frameworks, cloud security, vendors, risks, people, and tasks.
+
+## Why use it
+
+Compliance work is full of repetitive, multi-step actions: gathering evidence, answering questionnaires, reviewing tasks, connecting cloud accounts. The MCP server collapses those into one-line natural-language requests. Examples your team can run today:
+
+- *"Show me my open SOC 2 controls and tell me which ones are missing evidence."*
+- *"Upload this vendor security questionnaire and generate the answers from our policies."*
+- *"Connect our production AWS account for monitoring."*
+- *"List employees who haven't completed offboarding yet."*
+- *"Mark the AWS audit task on Sarah's account as done."*
+- *"Export our SOC 2 evidence bundle for the upcoming audit."*
+
+The AI assistant figures out which tools to call. Your team types the request and reviews the result.
+
+## Get an API key
+
+1. Sign in to [Comp AI](https://app.trycomp.ai).
+2. Open **Settings → API Keys**.
+3. Click **Create new key**. Scope it to the actions the AI assistant should be allowed to take.
+4. Copy the key (it starts with `comp_…`) — you will paste it into your AI client's config once.
+
+The API key carries your existing RBAC and permissions. The AI assistant can only do what *your* role can do in the dashboard.
+
+## Install per AI client
+
+Pick the client your team uses. Every install is one configuration paste — no Comp AI hosting, no extra setup.
+
+<AccordionGroup>
+
+<Accordion title="Claude Desktop" icon="message">
+
+Open Claude Desktop → **Settings → Developer → Edit Config** and add:
+
+```json
+{
+  "mcpServers": {
+    "comp-ai": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@trycompai/mcp-server",
+        "start",
+        "--apikey",
+        "comp_…your_key_here…"
+      ]
+    }
+  }
+}
+```
+
+Fully quit and reopen Claude Desktop. The Comp AI tools will be available in any conversation.
+
+</Accordion>
+
+<Accordion title="Cursor" icon="code">
+
+Open **Cursor → Settings → Tools and Integrations → New MCP Server** and paste:
+
+```json
+{
+  "command": "npx",
+  "args": [
+    "-y",
+    "@trycompai/mcp-server",
+    "start",
+    "--apikey",
+    "comp_…your_key_here…"
+  ]
+}
+```
+
+Save and reload Cursor.
+
+</Accordion>
+
+<Accordion title="ChatGPT / Codex" icon="robot">
+
+ChatGPT and Codex consume MCP servers through their respective MCP integrations. Point them at the same `npx @trycompai/mcp-server` command with your API key.
+
+For Codex CLI:
+
+```bash
+codex mcp add comp-ai -- npx -y @trycompai/mcp-server start --apikey comp_…your_key_here…
+```
+
+For ChatGPT, follow OpenAI's MCP server registration docs and use the same `command` + `args` shape shown for Cursor above.
+
+</Accordion>
+
+<Accordion title="Claude Code (CLI)" icon="terminal">
+
+```bash
+claude mcp add CompAI -- npx -y @trycompai/mcp-server start --apikey comp_…your_key_here…
+```
+
+</Accordion>
+
+<Accordion title="Gemini" icon="sparkles">
+
+```bash
+gemini mcp add CompAI -- npx -y @trycompai/mcp-server start --apikey comp_…your_key_here…
+```
+
+</Accordion>
+
+<Accordion title="Windsurf" icon="wind">
+
+Open **Windsurf → Settings → Cascade → Manage MCPs → View raw config** and paste:
+
+```json
+{
+  "command": "npx",
+  "args": [
+    "-y",
+    "@trycompai/mcp-server",
+    "start",
+    "--apikey",
+    "comp_…your_key_here…"
+  ]
+}
+```
+
+</Accordion>
+
+<Accordion title="VS Code" icon="vscode">
+
+Open **Command Palette → MCP: Open User Configuration** and paste:
+
+```json
+{
+  "command": "npx",
+  "args": [
+    "-y",
+    "@trycompai/mcp-server",
+    "start",
+    "--apikey",
+    "comp_…your_key_here…"
+  ]
+}
+```
+
+</Accordion>
+
+</AccordionGroup>
+
+That's it. The first time you start a chat in your AI client after install, the assistant will discover the Comp AI tools and start using them.
+
+## What your AI assistant can do
+
+The MCP server publishes tools across the Comp AI surface:
+
+| Area | Examples |
+| --- | --- |
+| **Evidence and tasks** | List tasks, upload evidence, complete checklist items, export audit bundles |
+| **Policies** | List policies, generate drafts, publish versions, attach PDFs |
+| **Security questionnaires** | Upload, parse questions, generate answers, export reviewer-ready files |
+| **Frameworks and controls** | Inspect SOC 2 / ISO 27001 / HIPAA / GDPR coverage and missing evidence |
+| **Integrations and cloud security** | Connect AWS, Azure, GCP and other providers; run checks; review findings |
+| **Vendors and risks** | List vendors, manage assessments, track risk and remediation |
+| **People and devices** | Invite members, manage offboarding, inspect device compliance |
+| **Trust Center** | Review and approve Trust Access requests, manage shared documents |
+
+Some endpoints are intentionally **not** exposed to AI clients for security or compatibility reasons — for example, anything that rotates raw credentials, and a small number of long-lived streaming endpoints that don't fit the request/response shape AI clients expect. The web UI continues to support those flows directly.
+
+## Common workflows
+
+<CardGroup cols={2}>
+  <Card title="Generate questionnaire answers" icon="file-question" href="/security-questionnaire">
+    Ask your AI to upload a vendor questionnaire and produce answers grounded in your policies.
+  </Card>
+
+  <Card title="Connect a cloud account" icon="cloud" href="/cloud-tests">
+    Ask the AI to connect AWS, Azure, or GCP — you provide the auditor role ARN; the AI handles the rest.
+  </Card>
+
+  <Card title="Run integration checks" icon="circle-check" href="/integrations">
+    Trigger and inspect compliance checks across your connected providers in plain language.
+  </Card>
+
+  <Card title="Manage tasks and evidence" icon="clipboard-check" href="/automated-evidence">
+    Pull open tasks, attach evidence, and mark items complete from inside your AI assistant.
+  </Card>
+</CardGroup>
+
+## Security
+
+- **Your API key, your scope.** The MCP server runs locally on your machine and authenticates to the Comp AI API using the key you paste. It carries the same permissions you configured for that key — no escalation.
+- **Multi-tenant safety.** Every request is scoped to the organization the API key belongs to. The AI cannot read or modify data belonging to other Comp AI organizations.
+- **Secrets stay on your machine.** Your API key lives in your AI client's local config file. It is never sent to Comp AI, npm, or any third party except your own AI client's vendor.
+- **Sensitive endpoints are hidden.** Endpoints that handle raw secrets (credential rotation, vault material) are deliberately excluded from the MCP tool surface. They remain available in the Comp AI web UI for human operators only.
+- **All actions are logged.** Mutations performed through the MCP server appear in your Comp AI audit log marked with API-key authentication, so you can review who did what.
+
+## When to use the MCP server vs the API
+
+| If you want to… | Use |
+| --- | --- |
+| Operate your compliance program day-to-day with help from an AI assistant | **MCP server** |
+| Build a custom internal tool, dashboard, or one-off automation | **[Comp AI API](/api-reference/overview)** directly |
+| Pipe Comp AI data into your data warehouse on a schedule | **API** directly |
+| Onboard a new auditor or external reviewer to your Trust Center | **Comp AI web UI** |
+
+The MCP server and the public API hit the same endpoints with the same RBAC — the only difference is the consumer (an AI assistant vs your own code).
+
+## FAQ
+
+<AccordionGroup>
+
+<Accordion title="Do I need to host the MCP server?">
+No. The server runs locally on each user's machine via `npx`. Comp AI hosts nothing on your behalf, and you do not need to deploy or maintain any infrastructure.
+</Accordion>
+
+<Accordion title="Does the MCP server work offline?">
+No. The server is a thin translator between your AI client and the Comp AI API at `https://api.trycomp.ai`. An internet connection is required.
+</Accordion>
+
+<Accordion title="Can multiple teammates use it at the same time?">
+Yes. Each teammate installs the MCP server on their own machine with their own Comp AI API key. Their actions are independently authenticated and audit-logged.
+</Accordion>
+
+<Accordion title="What if my AI client doesn't support MCP yet?">
+You can still use the [Comp AI API](/api-reference/overview) directly. The MCP server is an additional way to interact with the same endpoints — it doesn't replace anything.
+</Accordion>
+
+<Accordion title="How do new features show up?">
+New tools and improvements ship with each Comp AI release. Because `npx -y` always pulls the latest published version, your AI client picks up new tools automatically the next time it starts the MCP server.
+</Accordion>
+
+<Accordion title="Where can I report an issue?">
+Open an issue at [github.com/trycompai/comp/issues](https://github.com/trycompai/comp/issues) or email [hello@trycomp.ai](mailto:hello@trycomp.ai).
+</Accordion>
+
+</AccordionGroup>
+
+## Resources
+
+- **npm package:** [`@trycompai/mcp-server`](https://www.npmjs.com/package/@trycompai/mcp-server)
+- **Source:** [github.com/trycompai/comp](https://github.com/trycompai/comp/tree/main/apps/mcp-server)
+- **Direct API reference:** [Comp AI API](/api-reference/overview)
+- **Model Context Protocol overview:** [modelcontextprotocol.io](https://modelcontextprotocol.io/)

--- a/packages/docs/mcp-server.mdx
+++ b/packages/docs/mcp-server.mdx
@@ -31,7 +31,13 @@ The API key carries your existing RBAC and permissions. The AI assistant can onl
 
 ## Install per AI client
 
-Pick the client your team uses. Every install is one configuration paste — no Comp AI hosting, no extra setup.
+You don't manually download anything. The Comp AI MCP server is distributed as a public npm package — [`@trycompai/mcp-server`](https://www.npmjs.com/package/@trycompai/mcp-server) — and every install snippet below uses `npx -y` to fetch it on demand the first time your AI client starts a session. New versions are picked up automatically on the next session.
+
+Pick the client your team uses. Every install is one configuration paste — no Comp AI hosting, no extra setup, no terminals to run.
+
+<Note>
+The `npx -y @trycompai/mcp-server` command you'll see in every snippet below is what handles the download. Your AI client runs that command in the background when you start a chat; npm fetches the latest published version from [npmjs.com](https://www.npmjs.com/package/@trycompai/mcp-server) and caches it locally. Nothing for you to install manually.
+</Note>
 
 <AccordionGroup>
 

--- a/packages/docs/mcp-server.mdx
+++ b/packages/docs/mcp-server.mdx
@@ -31,19 +31,29 @@ The API key carries your existing RBAC and permissions. The AI assistant can onl
 
 ## Install per AI client
 
-You don't manually download anything. The Comp AI MCP server is distributed as a public npm package — [`@trycompai/mcp-server`](https://www.npmjs.com/package/@trycompai/mcp-server) — and every install snippet below uses `npx -y` to fetch it on demand the first time your AI client starts a session. New versions are picked up automatically on the next session.
+You don't manually download anything. The Comp AI MCP server is distributed as a public npm package — [`@trycompai/mcp-server`](https://www.npmjs.com/package/@trycompai/mcp-server) — and every install path below uses `npx -y` (or a one-click button / drag-and-drop bundle) to fetch it on demand the first time your AI client starts a session. New versions are picked up automatically on the next session.
 
-Pick the client your team uses. Every install is one configuration paste — no Comp AI hosting, no extra setup, no terminals to run.
+Pick the tab for your client. Each tab shows the easiest install path first, with a manual JSON option below for advanced setups.
 
 <Note>
-The `npx -y @trycompai/mcp-server` command you'll see in every snippet below is what handles the download. Your AI client runs that command in the background when you start a chat; npm fetches the latest published version from [npmjs.com](https://www.npmjs.com/package/@trycompai/mcp-server) and caches it locally. Nothing for you to install manually.
+The `npx -y @trycompai/mcp-server` command you'll see throughout is what handles the download. Your AI client runs it in the background when you start a chat; npm fetches the latest published version from [npmjs.com](https://www.npmjs.com/package/@trycompai/mcp-server) and caches it locally. Nothing for you to install manually.
 </Note>
 
-<AccordionGroup>
+<Tabs>
 
-<Accordion title="Claude Desktop" icon="message">
+<Tab title="Claude Desktop">
 
-Open Claude Desktop → **Settings → Developer → Edit Config** and add:
+**Easiest path — drag-and-drop install:**
+
+1. Download the latest [`mcp-server.mcpb`](https://github.com/trycompai/comp/releases) bundle from our GitHub Releases page.
+2. Drag the `.mcpb` file directly onto the Claude Desktop window.
+3. Claude Desktop shows an install prompt — confirm, then paste your Comp AI API key in the extension settings.
+4. Restart any open chats. Comp AI tools are now available.
+
+No JSON editing required.
+
+<Accordion title="Advanced — manual JSON config">
+If you prefer to manage `claude_desktop_config.json` yourself, open **Settings → Developer → Edit Config** and merge:
 
 ```json
 {
@@ -62,12 +72,20 @@ Open Claude Desktop → **Settings → Developer → Edit Config** and add:
 }
 ```
 
-Fully quit and reopen Claude Desktop. The Comp AI tools will be available in any conversation.
-
+Fully quit and reopen Claude Desktop.
 </Accordion>
 
-<Accordion title="Cursor" icon="code">
+</Tab>
 
+<Tab title="Cursor">
+
+**Easiest path — one-click install:**
+
+[![Install in Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](cursor://anysphere.cursor-deeplink/mcp/install?name=CompAi&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyJAdHJ5Y29tcGFpL21jcC1zZXJ2ZXIiLCJzdGFydCIsIi0tYXBpa2V5IiwiIl19)
+
+Click the button above, confirm in Cursor, then paste your Comp AI API key when prompted.
+
+<Accordion title="Advanced — manual JSON config">
 Open **Cursor → Settings → Tools and Integrations → New MCP Server** and paste:
 
 ```json
@@ -84,80 +102,139 @@ Open **Cursor → Settings → Tools and Integrations → New MCP Server** and p
 ```
 
 Save and reload Cursor.
-
 </Accordion>
 
-<Accordion title="ChatGPT / Codex" icon="robot">
+</Tab>
 
-ChatGPT and Codex consume MCP servers through their respective MCP integrations. Point them at the same `npx @trycompai/mcp-server` command with your API key.
+<Tab title="VS Code">
 
-For Codex CLI:
+**Easiest path — one-click install:**
 
-```bash
-codex mcp add comp-ai -- npx -y @trycompai/mcp-server start --apikey comp_…your_key_here…
+[![Install in VS Code](https://img.shields.io/badge/VS_Code-VS_Code?style=flat-square&label=Install%20CompAi%20MCP&color=0098FF)](vscode://ms-vscode.vscode-mcp/install?name=CompAi&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyJAdHJ5Y29tcGFpL21jcC1zZXJ2ZXIiLCJzdGFydCIsIi0tYXBpa2V5IiwiIl19)
+
+Click the button above, confirm in VS Code, then paste your Comp AI API key when prompted.
+
+<Accordion title="Advanced — manual JSON config">
+Open the **Command Palette → MCP: Open User Configuration** and paste:
+
+```json
+{
+  "command": "npx",
+  "args": [
+    "-y",
+    "@trycompai/mcp-server",
+    "start",
+    "--apikey",
+    "comp_…your_key_here…"
+  ]
+}
 ```
-
-For ChatGPT, follow OpenAI's MCP server registration docs and use the same `command` + `args` shape shown for Cursor above.
-
 </Accordion>
 
-<Accordion title="Claude Code (CLI)" icon="terminal">
+</Tab>
+
+<Tab title="Claude Code (CLI)">
+
+Install with one command:
 
 ```bash
 claude mcp add CompAI -- npx -y @trycompai/mcp-server start --apikey comp_…your_key_here…
 ```
 
-</Accordion>
+Claude Code registers the server immediately — Comp AI tools become available in your next session.
 
-<Accordion title="Gemini" icon="sparkles">
+</Tab>
+
+<Tab title="Codex CLI">
+
+Install with one command:
+
+```bash
+codex mcp add comp-ai -- npx -y @trycompai/mcp-server start --apikey comp_…your_key_here…
+```
+
+Codex registers the server immediately — Comp AI tools become available in your next session.
+
+For ChatGPT desktop / web with MCP support, follow OpenAI's MCP integration docs and use the same `command` + `args` shape shown in the manual JSON sections of the other tabs.
+
+</Tab>
+
+<Tab title="Gemini CLI">
+
+Install with one command:
 
 ```bash
 gemini mcp add CompAI -- npx -y @trycompai/mcp-server start --apikey comp_…your_key_here…
 ```
 
-</Accordion>
+</Tab>
 
-<Accordion title="Windsurf" icon="wind">
+<Tab title="Windsurf">
 
 Open **Windsurf → Settings → Cascade → Manage MCPs → View raw config** and paste:
 
 ```json
 {
-  "command": "npx",
-  "args": [
-    "-y",
-    "@trycompai/mcp-server",
-    "start",
-    "--apikey",
-    "comp_…your_key_here…"
-  ]
+  "mcpServers": {
+    "comp-ai": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@trycompai/mcp-server",
+        "start",
+        "--apikey",
+        "comp_…your_key_here…"
+      ]
+    }
+  }
 }
 ```
 
+Save and reload Windsurf.
+
+</Tab>
+
+</Tabs>
+
+That's it. The first time you start a chat in your AI client after install, the assistant will discover the Comp AI tools and start using them.
+
+## Verify it worked
+
+Open a fresh chat in your AI client and ask:
+
+> *"List my open compliance tasks."*
+
+If the install succeeded, the AI will call Comp AI's `list-tasks` tool and return tasks from your organization. If you see no tool calls or an authentication error, jump to **Troubleshooting** below.
+
+## Troubleshooting
+
+<AccordionGroup>
+
+<Accordion title="The AI says it doesn't have Comp AI tools available">
+Most common causes:
+- You didn't fully quit and reopen your AI client after the install. Closing the window isn't enough — quit it from the menu / dock and reopen.
+- The JSON config has a syntax error. Mintlify can validate this if you paste it into any JSON linter.
+- For Claude Desktop: confirm `claude_desktop_config.json` was saved to the right path: `~/Library/Application Support/Claude/` on macOS, `%APPDATA%\Claude\` on Windows.
 </Accordion>
 
-<Accordion title="VS Code" icon="vscode">
+<Accordion title="401 / authentication error">
+- Confirm your API key starts with `comp_…` and you copied the full string (these keys are long).
+- Confirm the key hasn't been revoked in **Comp AI → Settings → API Keys**.
+- Confirm the key's role has permission for the action you're asking the AI to take.
+</Accordion>
 
-Open **Command Palette → MCP: Open User Configuration** and paste:
+<Accordion title="`npx` or `command not found`">
+The MCP server runs via [npm](https://npmjs.com) + [Node.js](https://nodejs.org). If your machine doesn't have Node 18+ installed, install it from [nodejs.org](https://nodejs.org/) and restart your AI client.
+</Accordion>
 
-```json
-{
-  "command": "npx",
-  "args": [
-    "-y",
-    "@trycompai/mcp-server",
-    "start",
-    "--apikey",
-    "comp_…your_key_here…"
-  ]
-}
-```
-
+<Accordion title="Tools show up but actions fail">
+Open Chrome / Safari DevTools (or your client's debug log) and inspect the network response. Common causes:
+- Your role lacks the permission for that endpoint (RBAC enforced server-side).
+- You're on a custom plan that doesn't include the feature being called.
+- The Comp AI API is briefly unavailable — try again in a moment or check status.
 </Accordion>
 
 </AccordionGroup>
-
-That's it. The first time you start a chat in your AI client after install, the assistant will discover the Comp AI tools and start using them.
 
 ## What your AI assistant can do
 


### PR DESCRIPTION
## Summary
Adds customer-facing documentation for the new `@trycompai/mcp-server` npm package shipped in #2945.

- **New page** `packages/docs/mcp-server.mdx` — overview, per-AI-client install (Claude Desktop, Cursor, ChatGPT/Codex, Claude Code CLI, Gemini, Windsurf, VS Code), example prompts, available tool surface, security model, FAQ
- **Nav** — added to *Get Started* group in `docs.json`
- **Discoverability** — linked from `introduction.mdx` ("Build With Comp AI") and cross-referenced from `api-reference/overview.mdx`

## Why
The MCP server lets customers drive their compliance program from any AI assistant using just their Comp AI API key. Without docs, no one will find or install it. This page is the single source of truth for that flow.

## Notes for reviewers
- Independent of the MCP code PR (#2945, now merged). This PR only adds docs.
- Mintlify auto-renders the new MDX on deploy; navigation order matches the existing *Get Started* pattern (between Penetration Tests and Trust).
- All install snippets reference the published package name `@trycompai/mcp-server`. First publish happens on the next main → release merge per `sdk_publish.yaml`; until then, the install command resolves once npm has the package.

## Test plan
- [ ] Mintlify preview builds without errors
- [ ] `/mcp-server` page renders with all AccordionGroup install blocks expanding cleanly
- [ ] Card on `/introduction` links to `/mcp-server`
- [ ] Cross-reference on `/api-reference/overview` links to `/mcp-server`
- [ ] Spot-check copy for tone consistency with the rest of the Comp AI docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a customer-facing guide for `@trycompai/mcp-server` so teams can use Comp AI from MCP-compatible assistants with their API key. Clarifies that install is handled by `npx` and reorganizes setup into per-client tabs with one-click and drag‑and‑drop options.

- **New Features**
  - New page `packages/docs/mcp-server.mdx` with per-client tabs (Claude Desktop drag-and-drop bundle, Cursor/VS Code one-click, Claude Code/Codex/Gemini CLI one-liners, Windsurf JSON), “Verify it worked,” and Troubleshooting; includes “`npx` installs automatically.”
  - Added to Get Started nav in `docs.json`.
  - Linked from `introduction.mdx` and cross-referenced in `api-reference/overview.mdx`.

<sup>Written for commit d558e3ac9f0fa5bf78f450d87cc95bb7f17041fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/2949?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

