### PR TITLE
fix(monorepo): unbreak Docker build (workspaces glob+negation)

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,10 +85,8 @@
     "typecheck:ci": "turbo typecheck --filter={apps/**} --filter={packages/**} --filter=!@trycompai/integrations --filter=!@trycompai/ui"
   },
   "workspaces": [
-    "apps/api",
-    "apps/app",
-    "apps/framework-editor",
-    "apps/portal",
+    "apps/*",
+    "!apps/mcp-server",
     "packages/*"
   ],
   "dependencies": {


### PR DESCRIPTION


PR #2950 (merged earlier) enumerated workspaces explicitly to exclude \`apps/mcp-server\`, but that **broke the API's Docker build** in the auto-PR to release:

\`\`\`
error: Workspace not found \"apps/app\"
error: Workspace not found \"apps/framework-editor\"
error: Workspace not found \"apps/portal\"
\`\`\`

The Dockerfile only COPYs \`apps/api\` into the build context, so when bun reads \`package.json\` and tries to find the other named apps, it fails. The original \`apps/*\` glob worked because globs only match what exists; explicit paths require the path to exist.

## Fix

Combine glob with negation:

\`\`\`json
[\"apps/*\", \"!apps/mcp-server\", \"packages/*\"]
\`\`\`

\`apps/*\` matches only what exists in any given context (whether full repo or Docker subset), while \`!apps/mcp-server\` excludes \`apps/mcp-server\` from the bun workspace.

## Verified locally

- \`bun install\` at root succeeds
- \`node_modules/@trycompai/mcp-server\` is NOT created (i.e. mcp-server stays outside the workspace)
- \`bun.lock\` has zero references to \`apps/mcp-server\` as a workspace member
- Original Docker-friendly glob behavior is preserved (globs match only existing paths in the Docker context)

This keeps the Speakeasy fix from PR #2950 (mcp-server outside the workspace → no \`workspace:*\` protocol errors in Speakeasy CI) while restoring the Docker-compatible glob.

## Test plan

- [x] Local \`bun install\` succeeds
- [x] mcp-server is excluded from the workspace
- [ ] Docker build for the API succeeds after this merges (verify in the auto-PR to release once it re-runs)
- [ ] Generate workflow for MCP succeeds (verify by manually triggering it after this merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)