### PR TITLE
fix(api): disable declaration emit to unblock staging build (TS4023)

### DIFF
--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": false
+  },
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
 }


### PR DESCRIPTION
## Why
The staging Docker build (`bunx nest build`) fails with:
```
src/auth/auth.server.ts:272:14 - error TS4023: Exported variable 'auth' has or is using name 'MCPOptions' from external module ".../better-auth/dist/plugins/mcp/index" but cannot be named.
```
`nest build` emits `.d.ts` (`declaration: true`). The better-auth `mcp` plugin's internal `MCPOptions` type leaks into the inferred type of the exported `auth`, but it isn't exported/nameable, so **declaration emit** fails. (Regular `tsc --noEmit` / the PR typecheck don't emit declarations, so they passed — only the Docker build hits it.)

## Fix
Disable declaration emit for the API build (`tsconfig.build.json`). The API is an app, not a library — it never consumes its own `.d.ts`. Type-checking (`tsc --noEmit`) is unaffected; this also future-proofs against other plugins leaking internal option types.

## Verified
`tsc -p tsconfig.build.json` (the exact path `nest build` runs) now compiles with no errors (`--showConfig` confirms `declaration: false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable declaration emit in the API build to unblock `nest build` in staging (TS4023 from the `better-auth` MCP plugin leaking an internal type). The API doesn't ship `.d.ts`, so we set `declaration: false` in `apps/api/tsconfig.build.json` and keep type-checking via `tsc --noEmit` unchanged.

<sup>Written for commit 7118c6e7db83752e82f2e28321bbbcbb1a4f510d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/2958?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

