### PR TITLE
chore: auto-sync OpenAPI source to Gram (no manual uploads)

### DIFF
--- a/.github/workflows/gram-sync.yml
+++ b/.github/workflows/gram-sync.yml
@@ -15,17 +15,20 @@ on:
 jobs:
   push:
     runs-on: ubuntu-latest
+    env:
+      # Org + project slugs are NOT secret — they appear in the Gram dashboard URL
+      # (app.getgram.ai/<org>/projects/<project>). Only the API key is a secret.
+      GRAM_ORG: comp-ai-f041
+      GRAM_PROJECT: default
+      GRAM_API_KEY: ${{ secrets.GRAM_API_KEY }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Gram CLI
-        run: |
-          curl -fsSL https://go.getgram.ai/cli.sh | bash
-          # The installer puts the binary under ~/.gram; expose it on PATH.
-          echo "$HOME/.gram/bin" >> "$GITHUB_PATH"
+        # Installs to /usr/local/bin (already on PATH on GitHub runners).
+        run: curl -fsSL https://go.getgram.ai/cli.sh | bash
 
       - name: Push OpenAPI source to Gram
-        run: gram push --api-key "$GRAM_API_KEY" --project "$GRAM_PROJECT" --config gram.json
-        env:
-          GRAM_API_KEY: ${{ secrets.GRAM_API_KEY }}
-          GRAM_PROJECT: ${{ secrets.GRAM_PROJECT }}
+        # api-key/org/project are read from the env vars above; --method defaults
+        # to "merge" (updates the existing source in place by slug).
+        run: gram push --config gram.json

--- a/.github/workflows/gram-sync.yml
+++ b/.github/workflows/gram-sync.yml
@@ -1,0 +1,31 @@
+name: Sync MCP source to Gram
+
+# Keeps the hosted MCP (Speakeasy Gram) in sync with the clean public OpenAPI
+# spec. Runs whenever the spec (or the Gram deployment config) changes on main,
+# and can be triggered manually. No manual uploads — the source is pushed
+# declaratively from gram.json via the Gram CLI.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/docs/openapi.json"
+      - "gram.json"
+  workflow_dispatch:
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Gram CLI
+        run: |
+          curl -fsSL https://go.getgram.ai/cli.sh | bash
+          # The installer puts the binary under ~/.gram; expose it on PATH.
+          echo "$HOME/.gram/bin" >> "$GITHUB_PATH"
+
+      - name: Push OpenAPI source to Gram
+        run: gram push --api-key "$GRAM_API_KEY" --project "$GRAM_PROJECT" --config gram.json
+        env:
+          GRAM_API_KEY: ${{ secrets.GRAM_API_KEY }}
+          GRAM_PROJECT: ${{ secrets.GRAM_PROJECT }}

--- a/.github/workflows/gram-sync.yml
+++ b/.github/workflows/gram-sync.yml
@@ -12,6 +12,10 @@ on:
       - "gram.json"
   workflow_dispatch:
 
+# Least privilege: this workflow only reads the repo to checkout + push the spec.
+permissions:
+  contents: read
+
 jobs:
   push:
     runs-on: ubuntu-latest

--- a/gram.json
+++ b/gram.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "1.0.0",
+  "type": "deployment",
+  "sources": [
+    {
+      "type": "openapiv3",
+      "location": "packages/docs/openapi.json",
+      "name": "Comp AI API",
+      "slug": "comp-ai-api"
+    }
+  ]
+}


### PR DESCRIPTION
## Why
Manually uploading the OpenAPI spec into Gram every time is an anti-pattern. This makes the hosted MCP's source **auto-sync** with the API.

## What
- **`gram.json`** — declarative Gram deployment pointing at the **clean** public spec (`packages/docs/openapi.json`, which has the deny-list applied — *not* the raw `/api/docs-json`).
- **`.github/workflows/gram-sync.yml`** — runs `gram push` whenever `packages/docs/openapi.json` (or `gram.json`) changes on `main`, plus manual `workflow_dispatch`. New/changed endpoints flow into the hosted MCP automatically.

## One-time setup required (then fully hands-off)
1. In Gram → **Settings → API Keys**, create a **provider-scoped** API key.
2. Add two **GitHub repo secrets**:
   - `GRAM_API_KEY` = that key
   - `GRAM_PROJECT` = your Gram project slug
3. After merge, run the workflow once via **Actions → "Sync MCP source to Gram" → Run workflow** to push the first time.

## Note
First `workflow_dispatch` run validates the CLI install/flags — if `gram` isn't found (PATH) or a flag needs adjusting, it's a one-line fix (normal CLI bring-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates syncing the hosted MCP in Gram with the clean public OpenAPI spec. Removes manual uploads by pushing updates from `packages/docs/openapi.json` via CI.

- **New Features**
  - Added `gram.json` pointing to `packages/docs/openapi.json` (clean spec).
  - Added `.github/workflows/gram-sync.yml` to run `gram push` on changes or manual dispatch; exports `GRAM_ORG` and `GRAM_PROJECT`; sets least-privilege `permissions: contents: read`.

- **Migration**
  - Create a provider-scoped API key in Gram and add the `GRAM_API_KEY` repo secret.
  - If needed, update `GRAM_ORG`/`GRAM_PROJECT` in the workflow, then run “Sync MCP source to Gram” once to seed.

<sup>Written for commit e53e2afa38253df7cf5ba7b319584bbfb25becbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/2959?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

