### PR TITLE
feat(api): declare oauth2 security scheme for MCP per-user auth

### DIFF
--- a/apps/api/src/openapi-docs.spec.ts
+++ b/apps/api/src/openapi-docs.spec.ts
@@ -201,4 +201,60 @@ describe('OpenAPI document', () => {
       );
     });
   });
+
+  describe('MCP OAuth security', () => {
+    it('declares an oauth2 authorization-code scheme pointed at the Comp AI auth server', () => {
+      const scheme = document.components?.securitySchemes?.oauth2 as
+        | {
+            type?: string;
+            flows?: {
+              authorizationCode?: {
+                authorizationUrl?: string;
+                tokenUrl?: string;
+                scopes?: Record<string, string>;
+              };
+            };
+          }
+        | undefined;
+
+      expect(scheme?.type).toBe('oauth2');
+      expect(scheme?.flows?.authorizationCode?.authorizationUrl).toBe(
+        `${PUBLIC_SERVER_URL}/api/auth/mcp/authorize`,
+      );
+      expect(scheme?.flows?.authorizationCode?.tokenUrl).toBe(
+        `${PUBLIC_SERVER_URL}/api/auth/mcp/token`,
+      );
+    });
+
+    it('offers oauth2 alongside the API key on every authenticated operation', () => {
+      const operations = Object.values(document.paths).flatMap((methods) =>
+        Object.values(methods as Record<string, { security?: unknown }>),
+      );
+
+      const hasReq = (security: unknown, scheme: string): boolean =>
+        Array.isArray(security) &&
+        security.some((req) => req && typeof req === 'object' && scheme in req);
+
+      const apiKeyOps = operations.filter((op) =>
+        hasReq(op?.security, 'apikey'),
+      );
+
+      // Sanity: the spec really does gate operations behind the API key.
+      expect(apiKeyOps.length).toBeGreaterThan(0);
+
+      // Every API-key operation must also accept oauth2 (OR semantics) so MCP
+      // callers authenticate per-user instead of via a shared key.
+      const missingOAuth = apiKeyOps.filter(
+        (op) => !hasReq(op?.security, 'oauth2'),
+      );
+      expect(missingOAuth).toHaveLength(0);
+
+      // And oauth2 is never offered on an endpoint that isn't API-key gated.
+      const oauthWithoutApiKey = operations.filter(
+        (op) =>
+          hasReq(op?.security, 'oauth2') && !hasReq(op?.security, 'apikey'),
+      );
+      expect(oauthWithoutApiKey).toHaveLength(0);
+    });
+  });
 });

--- a/apps/api/src/openapi/public-docs-metadata.ts
+++ b/apps/api/src/openapi/public-docs-metadata.ts
@@ -26,6 +26,15 @@ export const PUBLIC_OPENAPI_DESCRIPTION =
 
 export const PUBLIC_SERVER_URL = 'https://api.trycomp.ai';
 
+/**
+ * Name of the OAuth2 security scheme advertised in the public spec. MCP hosts
+ * (e.g. Speakeasy Gram) only surface "Sign in with Comp AI" + forward the
+ * caller's bearer token to the API when the spec declares an oauth2 scheme;
+ * with only the API key, every MCP user would hit the API as one shared
+ * identity, bypassing per-user RBAC.
+ */
+export const MCP_OAUTH_SECURITY_SCHEME = 'oauth2';
+
 function getVisibilityForOperation(
   operation: OpenApiOperation,
   metadata?: PublicOperationMetadata,
@@ -274,6 +283,67 @@ function applyMcpToolNames(
   }
 }
 
+/**
+ * Declare the OAuth2 (authorization code) security scheme and offer it on every
+ * operation that already accepts the API key. The scheme points at the
+ * better-auth MCP authorization server; the per-operation `security` entries use
+ * OR semantics, so an API key OR a Comp AI OAuth token satisfies the request.
+ * This is what lets MCP hosts forward each user's bearer token to the API so the
+ * existing per-user/per-org RBAC applies, rather than a single shared key.
+ */
+function applyMcpOAuthSecurity(document: OpenAPIObject): void {
+  document.components ??= {};
+  document.components.securitySchemes ??= {};
+  document.components.securitySchemes[MCP_OAUTH_SECURITY_SCHEME] = {
+    type: 'oauth2',
+    description:
+      'OAuth 2.1 authorization code flow. Sign in with your Comp AI account — tokens are issued by the Comp AI authorization server and scoped to your organization, role, and permissions.',
+    flows: {
+      authorizationCode: {
+        authorizationUrl: `${PUBLIC_SERVER_URL}/api/auth/mcp/authorize`,
+        tokenUrl: `${PUBLIC_SERVER_URL}/api/auth/mcp/token`,
+        refreshUrl: `${PUBLIC_SERVER_URL}/api/auth/mcp/token`,
+        scopes: {
+          openid: 'OpenID Connect authentication',
+          profile: 'Basic profile information',
+          email: 'Email address',
+          offline_access: 'Maintain access via refresh tokens',
+        },
+      },
+    },
+  };
+
+  for (const methods of Object.values(document.paths)) {
+    for (const operation of Object.values(
+      methods as Record<string, OpenApiOperation>,
+    )) {
+      if (!operation || typeof operation !== 'object') {
+        continue;
+      }
+
+      const security = operation.security;
+      if (!Array.isArray(security)) {
+        continue;
+      }
+
+      const requirements = security as Array<Record<string, string[]>>;
+      const hasApiKey = requirements.some(
+        (req) => req && typeof req === 'object' && 'apikey' in req,
+      );
+      const hasOAuth = requirements.some(
+        (req) =>
+          req && typeof req === 'object' && MCP_OAUTH_SECURITY_SCHEME in req,
+      );
+
+      // Mirror OAuth onto API-key operations only — endpoints that are
+      // intentionally public (empty security) must stay unauthenticated.
+      if (hasApiKey && !hasOAuth) {
+        requirements.push({ [MCP_OAUTH_SECURITY_SCHEME]: [] });
+      }
+    }
+  }
+}
+
 export function applyPublicOpenApiMetadata(document: OpenAPIObject): void {
   document.info.title = PUBLIC_OPENAPI_TITLE;
   document.info.description = PUBLIC_OPENAPI_DESCRIPTION;
@@ -328,4 +398,7 @@ export function applyPublicOpenApiMetadata(document: OpenAPIObject): void {
   addTagMetadata(document);
   removeUnusedSchemas(document);
   sanitizePublicSchemas(document);
+
+  // Add OAuth last so its security scheme isn't touched by schema pruning.
+  applyMcpOAuthSecurity(document);
 }

--- a/packages/docs/openapi.json
+++ b/packages/docs/openapi.json
@@ -122,6 +122,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get organization profile",
@@ -364,6 +367,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Update organization",
@@ -464,6 +470,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete organization",
@@ -496,6 +505,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get organization onboarding status",
@@ -631,6 +643,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Transfer organization ownership",
@@ -716,6 +731,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Update role notification settings",
@@ -747,6 +765,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get role notification settings",
@@ -780,6 +801,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List API keys",
@@ -811,6 +835,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Create API key",
@@ -844,6 +871,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List API key scopes",
@@ -943,6 +973,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get organization brand color",
@@ -975,6 +1008,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Upload organization logo",
@@ -1006,6 +1042,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Remove organization logo",
@@ -1039,6 +1078,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Revoke API key",
@@ -1111,6 +1153,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Invite workforce members",
@@ -1306,6 +1351,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List workforce members",
@@ -1439,6 +1487,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Create a new member",
@@ -1471,6 +1522,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get all employee devices with fleet compliance data",
@@ -1504,6 +1558,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get integration test statistics grouped by assignee",
@@ -1737,6 +1794,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Add multiple members to organization",
@@ -1778,6 +1838,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get members who can read a specific resource type",
@@ -1822,6 +1885,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Reactivate a deactivated member",
@@ -1942,6 +2008,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get person by ID",
@@ -2086,6 +2155,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Update workforce member",
@@ -2218,6 +2290,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete member",
@@ -2261,6 +2336,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get training video completions for a member",
@@ -2305,6 +2383,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get fleet compliance",
@@ -2430,6 +2511,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Remove host (device) from Fleet",
@@ -2473,6 +2557,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Resend portal invite email to a member",
@@ -2609,6 +2696,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Unlink device from member",
@@ -2664,6 +2754,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get employment evidence attachments",
@@ -2728,6 +2821,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Upload employment evidence",
@@ -2793,6 +2889,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete employment evidence",
@@ -2826,6 +2925,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get current user email notification preferences",
@@ -2867,6 +2969,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Update current user email notification preferences",
@@ -2950,6 +3055,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Upload an attachment to any supported entity",
@@ -3013,6 +3121,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get shared attachment download URL",
@@ -3483,6 +3594,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List organization risks",
@@ -3769,6 +3883,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Create organization risk",
@@ -3801,6 +3918,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get risk statistics grouped by assignee",
@@ -3834,6 +3954,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get risk counts grouped by department",
@@ -4108,6 +4231,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get organization risk",
@@ -4405,6 +4531,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Update organization risk",
@@ -4545,6 +4674,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete organization risk",
@@ -4587,6 +4719,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Search global vendors",
@@ -4816,6 +4951,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List vendors",
@@ -5076,6 +5214,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Create vendor",
@@ -5306,6 +5447,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get vendor details",
@@ -5577,6 +5721,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Update vendor record",
@@ -5717,6 +5864,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete vendor",
@@ -5760,6 +5910,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Trigger vendor risk assessment",
@@ -5978,6 +6131,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List organization context",
@@ -6204,6 +6360,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Create a new context entry",
@@ -6381,6 +6540,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get organization context",
@@ -6519,6 +6681,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Update organization context",
@@ -6668,6 +6833,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete context entry",
@@ -6792,6 +6960,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List managed devices",
@@ -6878,6 +7049,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get devices by member ID",
@@ -6928,6 +7102,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete device",
@@ -7083,6 +7260,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List compliance policies",
@@ -7214,6 +7394,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Create compliance policy",
@@ -7256,6 +7439,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Publish all draft policies",
@@ -7303,6 +7489,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Download all published policies",
@@ -7355,6 +7544,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get mapped and all controls for a policy",
@@ -7406,6 +7598,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Map controls to a policy",
@@ -7459,6 +7654,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get tasks that serve as evidence for a policy, grouped by control",
@@ -7512,6 +7710,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Regenerate policy with AI",
@@ -7573,6 +7774,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get a signed URL for the policy PDF",
@@ -7728,6 +7932,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Upload a PDF to a policy version (UI-only)",
@@ -7788,6 +7995,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete a policy version PDF",
@@ -7858,6 +8068,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Request a presigned URL to upload a policy PDF",
@@ -7921,6 +8134,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Confirm a policy PDF upload completed",
@@ -7981,6 +8197,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get signed URL for policy PDF (alternate path)",
@@ -8042,6 +8261,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Remove a control mapping from a policy",
@@ -8156,6 +8378,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get compliance policy",
@@ -8306,6 +8531,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Update compliance policy",
@@ -8426,6 +8654,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete compliance policy",
@@ -8534,6 +8765,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get policy versions",
@@ -8659,6 +8893,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Create policy version",
@@ -8774,6 +9011,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get policy version by ID",
@@ -8906,6 +9146,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Update version content",
@@ -9027,6 +9270,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete policy version",
@@ -9154,6 +9400,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Publish policy version",
@@ -9280,6 +9529,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Set active policy version",
@@ -9417,6 +9669,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Submit version for approval",
@@ -9469,6 +9724,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Accept pending policy changes and publish the version",
@@ -9522,6 +9780,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Deny pending policy changes",
@@ -9599,6 +9860,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Chat with AI about a policy",
@@ -9954,6 +10218,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Download macOS Device Agent",
@@ -10012,6 +10279,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Download Windows Device Agent ZIP",
@@ -10109,6 +10379,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get a presigned URL to upload a file",
@@ -10188,6 +10461,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List compliance tasks",
@@ -10311,6 +10587,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Create compliance task",
@@ -10354,6 +10633,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get task templates",
@@ -10452,6 +10734,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Update status for multiple tasks",
@@ -10524,6 +10809,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete multiple tasks",
@@ -10604,6 +10892,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Update assignee for multiple tasks",
@@ -10685,6 +10976,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Reorder tasks",
@@ -10752,6 +11046,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Bulk submit tasks for review",
@@ -10784,6 +11081,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get page options for tasks overview",
@@ -10863,6 +11163,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get task by ID",
@@ -11010,6 +11313,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Update a task",
@@ -11072,6 +11378,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete a task",
@@ -11115,6 +11424,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get policies that reference a task via shared controls",
@@ -11179,6 +11491,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get task activity",
@@ -11229,6 +11544,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Regenerate task from template",
@@ -11296,6 +11614,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Submit task for review",
@@ -11346,6 +11667,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Approve a task",
@@ -11396,6 +11720,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Reject a task review",
@@ -11492,6 +11819,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get task attachments",
@@ -11609,6 +11939,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Upload task evidence",
@@ -11714,6 +12047,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get task attachment download URL",
@@ -11821,6 +12157,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete task attachment",
@@ -11865,6 +12204,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get all automations for a task",
@@ -11981,6 +12323,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Create evidence automation",
@@ -12035,6 +12380,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get automation details",
@@ -12175,6 +12523,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Update an existing automation",
@@ -12227,6 +12578,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete an automation",
@@ -12279,6 +12633,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get all runs for a specific automation",
@@ -12388,6 +12745,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get all versions for an automation",
@@ -12437,6 +12797,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Create a published version record for an automation",
@@ -12528,6 +12891,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get all automation runs for a task",
@@ -12575,6 +12941,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get task evidence summary",
@@ -12633,6 +13002,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Export automation evidence as PDF",
@@ -12691,6 +13063,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Export task evidence as ZIP",
@@ -12740,6 +13115,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Export all organization evidence as ZIP (Auditor only)",
@@ -12810,6 +13188,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get comments for an entity",
@@ -12858,6 +13239,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Create a new comment",
@@ -12919,6 +13303,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Update a comment",
@@ -13032,6 +13419,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete a comment",
@@ -13064,6 +13454,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get Trust Center settings",
@@ -13097,6 +13490,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Upload a favicon for the trust portal",
@@ -13128,6 +13524,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Remove the trust portal favicon",
@@ -13186,6 +13585,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get domain verification status",
@@ -13239,6 +13641,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Upload compliance certificate",
@@ -13288,6 +13693,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Generate a temporary signed URL for a compliance certificate",
@@ -13341,6 +13749,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List uploaded compliance certificates for the organization",
@@ -13392,6 +13803,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Upload an additional trust portal document",
@@ -13444,6 +13858,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List additional trust portal documents for the organization",
@@ -13503,6 +13920,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Generate a temporary signed URL for a trust portal document",
@@ -13567,6 +13987,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete (deactivate) a trust portal document",
@@ -13600,6 +14023,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Enable or disable the trust portal",
@@ -13633,6 +14059,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Add or update a custom domain for the trust portal",
@@ -13666,6 +14095,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Check DNS records for a custom domain",
@@ -13699,6 +14131,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Update trust portal FAQs",
@@ -13732,6 +14167,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Update allowed domains for the trust portal",
@@ -13765,6 +14203,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Update trust portal framework settings",
@@ -13798,6 +14239,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Update Trust Center overview",
@@ -13838,6 +14282,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get trust portal overview",
@@ -13871,6 +14318,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Create a custom link for trust portal",
@@ -13911,6 +14361,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List custom links for trust portal",
@@ -13953,6 +14406,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Update a custom link",
@@ -13995,6 +14451,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete a custom link",
@@ -14028,6 +14487,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Reorder custom links",
@@ -14070,6 +14532,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Update vendor trust portal settings",
@@ -14113,6 +14578,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List vendors configured for trust portal",
@@ -14210,6 +14678,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List Trust Access requests",
@@ -14252,6 +14723,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get Trust Access request",
@@ -14304,6 +14778,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Approve Trust Access request",
@@ -14356,6 +14833,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Deny Trust Access request",
@@ -14389,6 +14869,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List Trust Access grants",
@@ -14441,6 +14924,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Revoke Trust Access grant",
@@ -14483,6 +14969,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Resend Trust Access email",
@@ -14525,6 +15014,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Resend Trust Access NDA",
@@ -14567,6 +15059,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Preview Trust Access NDA",
@@ -15018,6 +15513,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List audit findings",
@@ -15059,6 +15557,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Create audit finding",
@@ -15107,6 +15608,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List all findings for the organization",
@@ -15150,6 +15654,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get finding by ID",
@@ -15201,6 +15708,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Update a finding (status transition rules apply)",
@@ -15242,6 +15752,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete a finding (auditor or platform admin only)",
@@ -15285,6 +15798,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get activity history for a finding",
@@ -15376,6 +15892,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Create a custom role",
@@ -15464,6 +15983,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List all roles",
@@ -15527,6 +16049,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Resolve permissions for custom roles",
@@ -15591,6 +16116,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get obligations for a built-in role",
@@ -15666,6 +16194,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Update obligations for a built-in role",
@@ -15745,6 +16276,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get a role by ID",
@@ -15838,6 +16372,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Update a custom role",
@@ -15904,6 +16441,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete a custom role",
@@ -15936,6 +16476,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List security questionnaires",
@@ -15979,6 +16522,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get security questionnaire details",
@@ -16020,6 +16566,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete a security questionnaire",
@@ -16071,6 +16620,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Generate answers for a questionnaire",
@@ -16120,6 +16672,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Parse questionnaire content",
@@ -16201,6 +16756,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Answer one questionnaire question",
@@ -16261,6 +16819,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Save questionnaire answer",
@@ -16321,6 +16882,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete questionnaire answer",
@@ -16365,6 +16929,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Export a security questionnaire",
@@ -16424,6 +16991,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Start questionnaire parsing",
@@ -16507,6 +17077,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Upload and parse questionnaire file",
@@ -16585,6 +17158,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Auto-answer uploaded questionnaire",
@@ -16629,6 +17205,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Export generated questionnaire answers",
@@ -16698,6 +17277,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Upload and export generated answers",
@@ -16742,6 +17324,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Stream generated questionnaire answers",
@@ -16776,6 +17361,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List knowledge base documents",
@@ -16809,6 +17397,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List all manual answers for an organization",
@@ -16850,6 +17441,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Save reusable manual answer",
@@ -16893,6 +17487,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Upload knowledge base document",
@@ -16935,6 +17532,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get a signed download URL for a document",
@@ -16977,6 +17577,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get a signed view URL for a document",
@@ -17019,6 +17622,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete a knowledge base document",
@@ -17062,6 +17668,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Process knowledge base documents",
@@ -17104,6 +17713,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Create a public access token for a run",
@@ -17156,6 +17768,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete a manual answer",
@@ -17199,6 +17814,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete all manual answers for an organization",
@@ -17254,6 +17872,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Save a SOA answer",
@@ -17298,6 +17919,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Auto-fill ISO 27001 SOA",
@@ -17340,6 +17964,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Create a new SOA document",
@@ -17383,6 +18010,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Ensure SOA configuration and document exist",
@@ -17426,6 +18056,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Approve a SOA document",
@@ -17469,6 +18102,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Decline a SOA document",
@@ -17512,6 +18148,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Submit SOA document for approval",
@@ -17555,6 +18194,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Export ISO 27001 SOA",
@@ -17597,6 +18239,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List integration providers",
@@ -17639,6 +18284,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get an integration provider by slug",
@@ -17672,6 +18320,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List integration connections",
@@ -17713,6 +18364,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Create integration connection",
@@ -17755,6 +18409,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get an integration connection by ID",
@@ -17795,6 +18452,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete an integration connection",
@@ -17845,6 +18505,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Update an integration connection",
@@ -17887,6 +18550,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Test an integration connection",
@@ -17929,6 +18595,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Pause an integration connection",
@@ -17971,6 +18640,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Resume an integration connection",
@@ -18013,6 +18685,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Disconnect an integration",
@@ -18065,6 +18740,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Set services enabled on a connection",
@@ -18105,6 +18783,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List services enabled on a connection",
@@ -18147,6 +18828,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List check definitions for a provider",
@@ -18189,6 +18873,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List checks for a connection",
@@ -18241,6 +18928,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Run integration checks",
@@ -18291,6 +18981,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Run a single check on a connection",
@@ -18333,6 +19026,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List variable definitions for a provider",
@@ -18375,6 +19071,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List connection variables",
@@ -18425,6 +19124,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Update connection variables",
@@ -18475,6 +19177,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get options for a connection variable",
@@ -18517,6 +19222,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List checks for a task template",
@@ -18559,6 +19267,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List checks attached to a task",
@@ -18611,6 +19322,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Run a check for a task",
@@ -18663,6 +19377,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Disconnect checks from a task",
@@ -18715,6 +19432,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Reconnect checks to a task",
@@ -18765,6 +19485,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List check runs for a task",
@@ -18807,6 +19530,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Sync Google Workspace employees",
@@ -18840,6 +19566,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get Google Workspace sync status",
@@ -18882,6 +19611,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Sync Rippling employees",
@@ -18915,6 +19647,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get Rippling sync status",
@@ -18957,6 +19692,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Sync JumpCloud employees",
@@ -18990,6 +19728,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get JumpCloud sync status",
@@ -19023,6 +19764,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get the currently configured employee sync provider",
@@ -19064,6 +19808,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Set the employee sync provider",
@@ -19097,6 +19844,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List employee sync providers available to the org",
@@ -19147,6 +19897,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Sync employees for a dynamic provider",
@@ -19913,6 +20666,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get task items statistics for an entity",
@@ -20079,6 +20835,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get task items for an entity",
@@ -20127,6 +20886,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Create a new task item",
@@ -20188,6 +20950,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Update a task item",
@@ -20230,6 +20995,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete a task item",
@@ -20280,6 +21048,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Upload attachment to task item",
@@ -20324,6 +21095,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete attachment from task item",
@@ -20368,6 +21142,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get task item activity log",
@@ -20401,6 +21178,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List training completions",
@@ -20443,6 +21223,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Mark a training video as complete",
@@ -20493,6 +21276,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Send training completion email with certificate",
@@ -20539,6 +21325,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Generate training certificate",
@@ -20585,6 +21374,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Generate HIPAA training certificate PDF",
@@ -20627,6 +21419,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get the organization chart",
@@ -20668,6 +21463,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Create or update an interactive organization chart",
@@ -20709,6 +21507,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete the organization chart",
@@ -20762,6 +21563,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Upload an image as the organization chart",
@@ -20806,6 +21610,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List evidence forms",
@@ -20849,6 +21656,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get submission statuses for all forms",
@@ -20892,6 +21702,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get document relevance settings",
@@ -20943,6 +21756,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Update document relevance setting",
@@ -20994,6 +21810,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get current user submissions",
@@ -21037,6 +21856,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get pending submission count for current user",
@@ -21112,6 +21934,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get form definition and submissions",
@@ -21171,6 +21996,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get a single submission",
@@ -21228,6 +22056,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete a submission",
@@ -21279,6 +22110,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Submit evidence form",
@@ -21330,6 +22164,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Upload a file as an evidence submission",
@@ -21389,6 +22226,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Review evidence submission",
@@ -21432,6 +22272,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Upload evidence form file",
@@ -21483,6 +22326,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Export evidence submissions",
@@ -22311,6 +23157,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List audit logs",
@@ -22903,6 +23752,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "List penetration test runs",
@@ -22957,6 +23809,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Create penetration test",
@@ -23011,6 +23866,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get penetration test status",
@@ -23062,6 +23920,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get penetration test progress",
@@ -23113,6 +23974,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get penetration test issues",
@@ -23164,6 +24028,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get penetration test agent events",
@@ -23215,6 +24082,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get penetration test output",
@@ -23266,6 +24136,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get penetration test PDF",
@@ -23299,6 +24172,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get members with pending offboarding checklists",
@@ -23332,6 +24208,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get the offboarding checklist template",
@@ -23373,6 +24252,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Add an offboarding checklist template item",
@@ -23425,6 +24307,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Update an offboarding checklist template item",
@@ -23465,6 +24350,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Delete an offboarding checklist template item",
@@ -23507,6 +24395,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get a member's offboarding checklist",
@@ -23540,6 +24431,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Export all offboarding evidence as a zip file",
@@ -23583,6 +24477,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Export offboarding evidence as a zip file",
@@ -23643,6 +24540,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Complete an offboarding checklist item",
@@ -23691,6 +24591,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Reopen an offboarding checklist item",
@@ -23751,6 +24654,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Upload evidence for an offboarding checklist item",
@@ -23794,6 +24700,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Get vendor access revocation status for a member",
@@ -23837,6 +24746,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Confirm all vendor access as revoked",
@@ -23889,6 +24801,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Mark vendor access as revoked",
@@ -23939,6 +24854,9 @@
         "security": [
           {
             "apikey": []
+          },
+          {
+            "oauth2": []
           }
         ],
         "summary": "Undo vendor access revocation",
@@ -24117,6 +25035,23 @@
         "in": "header",
         "name": "X-API-Key",
         "description": "API key for authentication"
+      },
+      "oauth2": {
+        "type": "oauth2",
+        "description": "OAuth 2.1 authorization code flow. Sign in with your Comp AI account — tokens are issued by the Comp AI authorization server and scoped to your organization, role, and permissions.",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://api.trycomp.ai/api/auth/mcp/authorize",
+            "tokenUrl": "https://api.trycomp.ai/api/auth/mcp/token",
+            "refreshUrl": "https://api.trycomp.ai/api/auth/mcp/token",
+            "scopes": {
+              "openid": "OpenID Connect authentication",
+              "profile": "Basic profile information",
+              "email": "Email address",
+              "offline_access": "Maintain access via refresh tokens"
+            }
+          }
+        }
       }
     },
     "schemas": {


### PR DESCRIPTION
## Why
This unblocks **keyless, per-user** auth for the hosted MCP (Speakeasy Gram).

I traced Gram's source: it picks the credential it sends to our backend from the spec's **security scheme**. With only the `X-API-Key` scheme, Gram would call our API with **one shared key for every MCP user** — bypassing the per-user/per-org RBAC the API already enforces. Gram also only shows the customer-facing OAuth wizard when the spec advertises an oauth2 scheme (`oauth2SecurityCount > 0`); until then it offers only "Gram OAuth" (internal Gram-org members).

## What
- Adds an **`oauth2` (authorization code)** security scheme pointed at the better-auth MCP authorization server (`/api/auth/mcp/authorize` + `/token`).
- Offers it **alongside** the API key on every authenticated operation (**OR semantics** — either credential satisfies a request, so existing API-key integrations and the SDK are unaffected).
- Centralized in `applyPublicOpenApiMetadata` so all three spec-generation paths (`main.ts`, `gen-openapi.spec.ts`, `openapi-docs.spec.ts`) stay consistent.
- Regenerated the committed `openapi.json` — **verified byte-identical** to a real `GEN_OPENAPI=1` run (935 insertions, 0 deletions; 306/306 API-key ops now also offer oauth2).

## How it fits the rollout
Once merged, the existing `gram-sync` CI pushes the updated spec → `oauth2SecurityCount` flips above 0 → the External/Proxy OAuth wizard unlocks in Gram. Next steps (Gram-side): set the MCP server **Public**, run the OAuth wizard pointed at better-auth, set the staging `GRAM_OAUTH_*` env vars.

## Tests
- New `openapi-docs.spec.ts` cases: asserts the oauth2 scheme exists with the right endpoints, every API-key op also offers oauth2, and oauth2 is never on a non-API-key (public) op.
- Full `openapi-docs.spec.ts` green (5/5).

## Heads-up
Speakeasy SDK generation consumes this spec; it'll see the new oauth2 scheme (additive). The authorization-code flow is for interactive/MCP clients — existing API-key SDK usage is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables per-user OAuth for hosted MCP (Speakeasy Gram) by declaring an `oauth2` authorization-code security scheme in the public OpenAPI spec, alongside the existing API key. This unlocks Gram’s OAuth wizard and keeps current API-key integrations working.

- **New Features**
  - Added `oauth2` authorization code scheme pointing to `/api/auth/mcp/authorize` and `/api/auth/mcp/token`.
  - Offered `oauth2` on all API-key–gated operations (OR semantics: API key or OAuth token).
  - Centralized in `applyPublicOpenApiMetadata` to keep all spec-generation paths consistent.
  - Regenerated `packages/docs/openapi.json`.

<sup>Written for commit e906b6de87817f4f71d556c6c9fe3abeab9f3ef0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/2961?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

