### PR TITLE
style(trust): clearer Trust Portal setup nudge copy

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/overview/nudges/OverviewNudges.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/overview/nudges/OverviewNudges.test.tsx
@@ -1,7 +1,6 @@
-import { render, screen } from '@testing-library/react';
-import { fireEvent } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { mockHasPermission, setMockPermissions } from '@/test-utils/mocks/permissions';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/hooks/use-permissions', () => ({
   usePermissions: () => ({ permissions: {}, hasPermission: mockHasPermission }),
@@ -75,23 +74,23 @@ describe('OverviewNudges', () => {
 
   it('shows the trust nudge when enabled, not configured, and user can update', () => {
     render(<OverviewNudges orgId="org_123" server={server()} />);
-    expect(screen.getByText('Showcase your security posture')).toBeInTheDocument();
+    expect(screen.getByText('Set up your Trust Portal')).toBeInTheDocument();
   });
 
   it('hides the trust nudge when already configured', () => {
     render(<OverviewNudges orgId="org_123" server={server({ isConfigured: true })} />);
-    expect(screen.queryByText('Showcase your security posture')).not.toBeInTheDocument();
+    expect(screen.queryByText('Set up your Trust Portal')).not.toBeInTheDocument();
   });
 
   it('hides the trust nudge when the feature flag is off', () => {
     render(<OverviewNudges orgId="org_123" server={server({ isTrustNdaEnabled: false })} />);
-    expect(screen.queryByText('Showcase your security posture')).not.toBeInTheDocument();
+    expect(screen.queryByText('Set up your Trust Portal')).not.toBeInTheDocument();
   });
 
   it('hides the trust nudge without trust:update', () => {
     setMockPermissions({ trust: ['read'] });
     render(<OverviewNudges orgId="org_123" server={server()} />);
-    expect(screen.queryByText('Showcase your security posture')).not.toBeInTheDocument();
+    expect(screen.queryByText('Set up your Trust Portal')).not.toBeInTheDocument();
   });
 
   it('collapses to the top nudge with a stack control when several apply', () => {
@@ -99,7 +98,7 @@ describe('OverviewNudges', () => {
     render(<OverviewNudges orgId="org_123" server={server()} />);
     // Offboarding (priority 10) is shown; trust waits behind the stack.
     expect(screen.getByText(/offboarding completion/)).toBeInTheDocument();
-    expect(screen.queryByText('Showcase your security posture')).not.toBeInTheDocument();
+    expect(screen.queryByText('Set up your Trust Portal')).not.toBeInTheDocument();
     // The user is told more are waiting.
     expect(screen.getByText('2 notices')).toBeInTheDocument();
   });
@@ -110,26 +109,26 @@ describe('OverviewNudges', () => {
 
     fireEvent.click(screen.getByText('2 notices'));
     expect(screen.getByText(/offboarding completion/)).toBeInTheDocument();
-    expect(screen.getByText('Showcase your security posture')).toBeInTheDocument();
+    expect(screen.getByText('Set up your Trust Portal')).toBeInTheDocument();
 
     fireEvent.click(screen.getByText('Show less'));
-    expect(screen.queryByText('Showcase your security posture')).not.toBeInTheDocument();
+    expect(screen.queryByText('Set up your Trust Portal')).not.toBeInTheDocument();
     expect(screen.getByText('2 notices')).toBeInTheDocument();
   });
 
   it('shows no stack control when only one nudge applies', () => {
     render(<OverviewNudges orgId="org_123" server={server()} />);
-    expect(screen.getByText('Showcase your security posture')).toBeInTheDocument();
+    expect(screen.getByText('Set up your Trust Portal')).toBeInTheDocument();
     expect(screen.queryByText(/\d+ notices/)).not.toBeInTheDocument();
   });
 
   it('dismissing the trust nudge hides it and persists', () => {
     const { unmount } = render(<OverviewNudges orgId="org_123" server={server()} />);
     fireEvent.click(screen.getByLabelText('Dismiss'));
-    expect(screen.queryByText('Showcase your security posture')).not.toBeInTheDocument();
+    expect(screen.queryByText('Set up your Trust Portal')).not.toBeInTheDocument();
     unmount();
     render(<OverviewNudges orgId="org_123" server={server()} />);
-    expect(screen.queryByText('Showcase your security posture')).not.toBeInTheDocument();
+    expect(screen.queryByText('Set up your Trust Portal')).not.toBeInTheDocument();
   });
 
   it('dismissing offboarding hides it for the session without persisting', () => {
@@ -142,9 +141,7 @@ describe('OverviewNudges', () => {
 
     fireEvent.click(screen.getByLabelText('Dismiss'));
     expect(screen.queryByText(/offboarding completion/)).not.toBeInTheDocument();
-    expect(
-      window.localStorage.getItem('overview-nudge-dismissed:offboarding:org_123'),
-    ).toBeNull();
+    expect(window.localStorage.getItem('overview-nudge-dismissed:offboarding:org_123')).toBeNull();
 
     // Not persisted → reappears on remount.
     unmount();
@@ -176,17 +173,16 @@ describe('OverviewNudges', () => {
     // Collapsed: only offboarding (priority 10) on top; the other two wait.
     expect(screen.getByText(/offboarding completion/)).toBeInTheDocument();
     expect(screen.queryByText('framework updates available')).not.toBeInTheDocument();
-    expect(screen.queryByText('Showcase your security posture')).not.toBeInTheDocument();
+    expect(screen.queryByText('Set up your Trust Portal')).not.toBeInTheDocument();
     expect(screen.getByText('3 notices')).toBeInTheDocument();
 
     // Expanded: all three shown, framework updates rendered after the trust nudge.
     fireEvent.click(screen.getByText('3 notices'));
     expect(screen.getByText(/offboarding completion/)).toBeInTheDocument();
-    const trustEl = screen.getByText('Showcase your security posture');
+    const trustEl = screen.getByText('Set up your Trust Portal');
     const frameworkEl = screen.getByText('framework updates available');
     expect(
-      trustEl.compareDocumentPosition(frameworkEl) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
+      trustEl.compareDocumentPosition(frameworkEl) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });
 

--- a/apps/app/src/app/(app)/[orgId]/overview/nudges/TrustPortalSetupNudge.tsx
+++ b/apps/app/src/app/(app)/[orgId]/overview/nudges/TrustPortalSetupNudge.tsx
@@ -1,13 +1,7 @@
 'use client';
 
 import { usePermissions } from '@/hooks/use-permissions';
-import {
-  Alert,
-  AlertAction,
-  AlertDescription,
-  AlertTitle,
-  Button,
-} from '@trycompai/design-system';
+import { Alert, AlertAction, AlertDescription, AlertTitle, Button } from '@trycompai/design-system';
 import { ArrowRight, Close } from '@trycompai/design-system/icons';
 import Link from 'next/link';
 import type { NudgeState, ServerNudgeData } from './types';
@@ -29,29 +23,20 @@ export function useTrustPortalSetupNudge({
     persistDismissal: true,
     ready: true, // server data already resolved
     eligible: isTrustNdaEnabled && !isConfigured && canSetup,
-    render: (onDismiss) => (
-      <TrustPortalSetupNudgeView orgId={orgId} onDismiss={onDismiss} />
-    ),
+    render: (onDismiss) => <TrustPortalSetupNudgeView orgId={orgId} onDismiss={onDismiss} />,
   };
 }
 
-function TrustPortalSetupNudgeView({
-  orgId,
-  onDismiss,
-}: {
-  orgId: string;
-  onDismiss: () => void;
-}) {
+function TrustPortalSetupNudgeView({ orgId, onDismiss }: { orgId: string; onDismiss: () => void }) {
   return (
     <Alert variant="warning">
       <AlertTitle>
-        <span className="text-foreground">Showcase your security posture</span>
+        <span className="text-foreground">Set up your Trust Portal</span>
       </AlertTitle>
       <AlertDescription>
         <span className="text-foreground">
-          Show prospects and vendors your compliance progress — enable the
-          frameworks you’re working on and your published policies appear
-          automatically.
+          Customize and publish your Trust Portal so prospects and vendors can view your compliance
+          progress.
         </span>
       </AlertDescription>
       <div className="col-start-2 pt-1">


### PR DESCRIPTION
## What
Clarifies the Overview Trust Portal setup nudge copy (follow-up to the merged SALE-63 nudges).

**Before**
> Showcase your security posture
> Show prospects and vendors your compliance progress — enable the frameworks you're working on and your published policies appear automatically.

**After**
> Set up your Trust Portal
> Customize and publish your Trust Portal so prospects and vendors can view your compliance progress.

Title is now an explicit action; the body says plainly to customize + publish so prospects/vendors can view progress.

## Tests
Updated the nudge host test title assertions; 13 tests pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)