### PR TITLE
docs(auth): explain why MCP OAuth secrets/tokens aren't app-encrypted

### DIFF
--- a/apps/api/src/auth/auth.server.ts
+++ b/apps/api/src/auth/auth.server.ts
@@ -536,6 +536,19 @@ export const auth = betterAuth({
       oidcConfig: {
         loginPage: mcpLoginPage,
         allowDynamicClientRegistration: false,
+        // OAuth secrets at rest — DO NOT enable better-auth's
+        // `storeClientSecret: 'encrypted' | 'hashed'`. better-auth verifies every
+        // confidential client (including config `trustedClients`) through the same
+        // decrypt/hash path, but a trusted client's secret is the *plaintext*
+        // GRAM_OAUTH_CLIENT_SECRET from config — decrypting/hashing it would fail
+        // verification and break the Gram token exchange. There is also nothing to
+        // protect in `oauth_application`: the Gram client is config-only and DCR is
+        // disabled, so no client secrets are persisted to the DB.
+        //
+        // `accessToken`/`refreshToken` in `oauth_access_token` are generated and
+        // looked up by raw value by better-auth's oidcProvider, so they can't be
+        // hashed/encrypted at our layer without breaking validation; they rely on
+        // database encryption-at-rest and short access-token TTLs.
         ...(gramMcpClient ? { trustedClients: [gramMcpClient] } : {}),
       },
     }),


### PR DESCRIPTION
## TL;DR
My first attempt (`storeClientSecret: 'encrypted'`) **would have broken the Gram OAuth flow** — caught in review. This PR replaces it with a **warning comment only** (zero behavior change). The honest finding: **cubic's P1 has no safe app-level fix** for our setup.

## Why `storeClientSecret` breaks things
Verified in the locked **better-auth 1.4.22** source:
- `getClient()` returns a config `trustedClient` directly, with `clientSecret` = the **plaintext** `GRAM_OAUTH_CLIENT_SECRET`.
- The token endpoint calls `verifyStoredClientSecret()` for **every** confidential client — no trusted-client bypass.
- Under `'encrypted'`, that does `symmetricDecrypt(plaintext_config_secret) === presented` → fails/throws → `invalid_client`. `'hashed'` fails identically.

## Why there's nothing to encrypt anyway
- The Gram client is a **config-only `trustedClient`** (secret in env, never in the DB).
- **DCR is disabled** → `oauth_application` has no rows. No client secrets are persisted.

## The access/refresh tokens (what cubic pointed at)
`oauth_access_token.accessToken`/`refreshToken` are generated and **looked up by raw value** by better-auth, so they can't be hashed/encrypted at our layer without breaking token validation. They rely on **DB encryption-at-rest + short access-token TTLs**.

## What this PR does
Leaves a comment in `auth.server.ts` documenting all of the above, so nobody (human or bot) re-introduces the breaking `storeClientSecret` change. No code behavior changes.

**Alternative:** if a doc-only PR isn't wanted, close this — the knowledge is captured here and in the investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)