### PR TITLE
fix(app): small Linear wins

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/frameworks/[frameworkInstanceId]/components/FrameworkRequirementsGrouped.tsx
+++ b/apps/app/src/app/(app)/[orgId]/frameworks/[frameworkInstanceId]/components/FrameworkRequirementsGrouped.tsx
@@ -5,7 +5,6 @@ import type { FrameworkInstanceWithControls } from '@/lib/types/framework';
 import type { Control, FrameworkEditorRequirement, Task } from '@db';
 import {
   Button,
-  Heading,
   InputGroup,
   InputGroupAddon,
   InputGroupInput,
@@ -126,7 +125,6 @@ export function FrameworkRequirementsGrouped({
 
   return (
     <div className="space-y-4">
-      <Heading level="2">Requirements ({filteredItems.length})</Heading>
       <div className="flex items-center gap-3">
         <div className="w-full max-w-sm">
           <InputGroup>

--- a/apps/app/src/app/(app)/[orgId]/integrations/components/PlatformIntegrations.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/components/PlatformIntegrations.tsx
@@ -38,6 +38,7 @@ import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { CATEGORIES, type Integration, type IntegrationCategory } from '../data/integrations';
+import { matchesIntegrationSearch } from './integration-search';
 import { SearchInput } from './SearchInput';
 import { TaskCard, TaskCardSkeleton } from './TaskCard';
 
@@ -288,18 +289,15 @@ export function PlatformIntegrations({ className, taskTemplates }: PlatformInteg
 
     // Search filter
     if (searchQuery.trim()) {
-      const query = searchQuery.toLowerCase().trim();
-      const terms = query.split(' ').filter(Boolean);
+      const query = searchQuery.trim();
 
       filtered = filtered.filter((item) => {
-        if (item.type === 'platform') {
-          const searchText =
-            `${item.provider.name} ${item.provider.description} ${item.provider.category}`.toLowerCase();
-          return terms.every((term) => searchText.includes(term));
-        }
         const searchText =
-          `${item.integration.name} ${item.integration.description} ${item.integration.category} ${item.integration.examplePrompts.join(' ')}`.toLowerCase();
-        return terms.every((term) => searchText.includes(term));
+          item.type === 'platform'
+            ? `${item.provider.name} ${item.provider.description} ${item.provider.category}`
+            : `${item.integration.name} ${item.integration.description} ${item.integration.category} ${item.integration.examplePrompts.join(' ')}`;
+
+        return matchesIntegrationSearch(searchText, query);
       });
     }
 

--- a/apps/app/src/app/(app)/[orgId]/integrations/components/integration-search.test.ts
+++ b/apps/app/src/app/(app)/[orgId]/integrations/components/integration-search.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { matchesIntegrationSearch } from './integration-search';
+
+describe('matchesIntegrationSearch', () => {
+  it('matches SAST as its own searchable token', () => {
+    expect(matchesIntegrationSearch('SAST scanning configuration', 'sast')).toBe(true);
+  });
+
+  it('does not match SAST inside disaster', () => {
+    expect(matchesIntegrationSearch('Datto backup and disaster recovery platform', 'sast')).toBe(false);
+  });
+
+  it('keeps prefix matching for provider names', () => {
+    expect(matchesIntegrationSearch('GitHub code hosting Development', 'git')).toBe(true);
+  });
+
+  it('requires every search term to match a token prefix', () => {
+    expect(matchesIntegrationSearch('Aikido code security scanner', 'code scan')).toBe(true);
+    expect(matchesIntegrationSearch('Aikido code security scanner', 'code backup')).toBe(false);
+  });
+
+  it('handles punctuation in search queries', () => {
+    expect(matchesIntegrationSearch('SOC 2 compliance evidence', 'soc-2')).toBe(true);
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/integrations/components/integration-search.ts
+++ b/apps/app/src/app/(app)/[orgId]/integrations/components/integration-search.ts
@@ -1,0 +1,8 @@
+export function matchesIntegrationSearch(searchText: string, searchQuery: string): boolean {
+  const terms = searchQuery.toLowerCase().match(/[a-z0-9]+/g) ?? [];
+  if (terms.length === 0) return true;
+
+  const tokens = searchText.toLowerCase().match(/[a-z0-9]+/g) ?? [];
+
+  return terms.every((term) => tokens.some((token) => token.startsWith(term)));
+}

--- a/apps/app/src/instrumentation-client.ts
+++ b/apps/app/src/instrumentation-client.ts
@@ -6,17 +6,7 @@ import { initBotId } from 'botid/client/core';
 import * as Sentry from '@sentry/nextjs';
 
 initBotId({
-  protect: [
-    { path: '/api/chat', method: 'POST' },
-    {
-      path: `${process.env.NEXT_PUBLIC_ENTERPRISE_API_URL}/api/tasks-automations/chat`,
-      method: 'POST',
-    },
-    {
-      path: `${process.env.NEXT_PUBLIC_ENTERPRISE_API_URL}/api/tasks-automations/errors`,
-      method: 'POST',
-    },
-  ],
+  protect: [{ path: '/api/chat', method: 'POST' }],
 });
 
 Sentry.init({


### PR DESCRIPTION
Summary:
- Fixes CS-393 by removing the duplicate Requirements heading from the grouped framework requirements tab.
- Fixes CS-381 by changing integration search from substring matching to token-prefix matching, so SAST no longer matches Datto/disaster text.
- Fixes ENG-226 by removing dead cross-origin BotID protected routes and keeping only the same-origin chat route.

Validation:
- PASS: bunx vitest run "src/app/(app)/[orgId]/integrations/components/integration-search.test.ts"
- BASELINE FAIL: PlatformIntegrations.test.tsx has the same 3 failures on main and on this branch.
- BASELINE FAIL: bunx turbo run typecheck --filter=@trycompai/app fails on unrelated existing app type errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three small issues: removes a duplicate Requirements header, makes integration search token-prefix based to avoid false matches, and simplifies BotID route protection. Resolves CS-393, CS-381, and ENG-226.

- Bug Fixes
  - CS-393: Removed duplicate "Requirements" heading in the grouped framework requirements tab.
  - CS-381: Changed integration search from substring to token-prefix matching; prevents "sast" matching "disaster"; added unit tests.
  - ENG-226: Removed dead cross-origin protected routes; kept only same-origin `/api/chat` in `botid` protection config.

<sup>Written for commit 424d863458ccfd9059611515239e86895fee6c5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/2975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

