### PR TITLE
fix(app): resolve archived policy and compliance UI tasks

### DIFF
--- a/apps/api/src/admin-organizations/admin-policies.controller.ts
+++ b/apps/api/src/admin-organizations/admin-policies.controller.ts
@@ -44,7 +44,7 @@ export class AdminPoliciesController {
   @Get(':orgId/policies')
   @ApiOperation({ summary: 'List all policies for an organization (admin)' })
   async list(@Param('orgId') orgId: string) {
-    return this.policiesService.findAll(orgId);
+    return this.policiesService.findAll({ organizationId: orgId });
   }
 
   @Post(':orgId/policies')

--- a/apps/api/src/openapi/operation-metadata.ts
+++ b/apps/api/src/openapi/operation-metadata.ts
@@ -50,7 +50,7 @@ const CORE_OPERATION_METADATA: Record<string, PublicOperationMetadata> = {
   PoliciesController_getAllPolicies_v1: {
     summary: 'List compliance policies',
     description:
-      'Lists compliance policies for the organization. Use this to find a policy by name, look up a policy ID, browse drafts, or get an overview of all policies for SOC 2, ISO 27001, HIPAA, and GDPR workflows. Returns id, name, status, department, and other metadata for each policy. Pass excludeContent=true to skip the heavy TipTap content fields — recommended when you only need to identify a policy. To read or edit a single policy in detail, fetch it by ID via get-compliance-policy.',
+      'Lists active compliance policies by default. Use includeArchived=true to include archived rows and excludeContent=true when you only need policy metadata.',
     codeSamples: [
       {
         lang: 'bash',
@@ -63,6 +63,12 @@ const CORE_OPERATION_METADATA: Record<string, PublicOperationMetadata> = {
         label: 'List policies (lightweight, no content)',
         source:
           'curl --request GET --url "https://api.trycomp.ai/v1/policies?excludeContent=true" --header "X-API-Key: $COMP_AI_API_KEY"',
+      },
+      {
+        lang: 'bash',
+        label: 'List policies including archived',
+        source:
+          'curl --request GET --url "https://api.trycomp.ai/v1/policies?includeArchived=true" --header "X-API-Key: $COMP_AI_API_KEY"',
       },
     ],
   },

--- a/apps/api/src/policies/dto/policy-responses.dto.ts
+++ b/apps/api/src/policies/dto/policy-responses.dto.ts
@@ -96,6 +96,13 @@ export class PolicyResponseDto {
   isArchived: boolean;
 
   @ApiProperty({
+    description: 'When the policy was archived by framework sync',
+    example: '2024-02-01T00:00:00.000Z',
+    nullable: true,
+  })
+  archivedAt?: Date;
+
+  @ApiProperty({
     description: 'When the policy was created',
     example: '2024-01-01T00:00:00.000Z',
   })

--- a/apps/api/src/policies/policies.controller.spec.ts
+++ b/apps/api/src/policies/policies.controller.spec.ts
@@ -25,6 +25,7 @@ jest.mock('@db', () => ({
   db: {
     policy: {
       findFirst: jest.fn(),
+      findUnique: jest.fn(),
       update: jest.fn(),
     },
     control: {
@@ -43,6 +44,10 @@ jest.mock('@db', () => ({
       findFirst: jest.fn(),
       update: jest.fn(),
     },
+    frameworkControlPolicyLink: {
+      deleteMany: jest.fn(),
+    },
+    $transaction: jest.fn(),
   },
   Frequency: {
     monthly: 'monthly',
@@ -152,8 +157,10 @@ describe('PoliciesController', () => {
 
       const result = await controller.getAllPolicies(orgId, mockAuthContext);
 
-      expect(policiesService.findAll).toHaveBeenCalledWith(orgId, {
+      expect(policiesService.findAll).toHaveBeenCalledWith({
+        organizationId: orgId,
         excludeContent: false,
+        includeArchived: false,
       });
       expect(result).toEqual({
         data: mockPolicies,
@@ -167,8 +174,10 @@ describe('PoliciesController', () => {
 
       await controller.getAllPolicies(orgId, mockAuthContext, 'true');
 
-      expect(policiesService.findAll).toHaveBeenCalledWith(orgId, {
+      expect(policiesService.findAll).toHaveBeenCalledWith({
+        organizationId: orgId,
         excludeContent: true,
+        includeArchived: false,
       });
     });
 
@@ -177,8 +186,22 @@ describe('PoliciesController', () => {
 
       await controller.getAllPolicies(orgId, mockAuthContext, 'false');
 
-      expect(policiesService.findAll).toHaveBeenCalledWith(orgId, {
+      expect(policiesService.findAll).toHaveBeenCalledWith({
+        organizationId: orgId,
         excludeContent: false,
+        includeArchived: false,
+      });
+    });
+
+    it('should pass includeArchived=true to service when query param is "true"', async () => {
+      mockPoliciesService.findAll.mockResolvedValue([]);
+
+      await controller.getAllPolicies(orgId, mockAuthContext, undefined, 'true');
+
+      expect(policiesService.findAll).toHaveBeenCalledWith({
+        organizationId: orgId,
+        excludeContent: false,
+        includeArchived: true,
       });
     });
 
@@ -621,7 +644,19 @@ describe('PoliciesController', () => {
   describe('removePolicyControl', () => {
     it('should disconnect control from policy and return success', async () => {
       const { db } = require('@db');
+      db.policy.findUnique.mockResolvedValue({ controls: [] });
       db.policy.update.mockResolvedValue({});
+      db.$transaction.mockImplementation(async (callback: (tx: unknown) => Promise<unknown>) =>
+        callback({
+          policy: {
+            findUnique: db.policy.findUnique,
+            update: db.policy.update,
+          },
+          frameworkControlPolicyLink: {
+            deleteMany: db.frameworkControlPolicyLink.deleteMany,
+          },
+        }),
+      );
 
       const result = await controller.removePolicyControl(
         'pol_1',

--- a/apps/api/src/policies/policies.controller.ts
+++ b/apps/api/src/policies/policies.controller.ts
@@ -122,6 +122,13 @@ export class PoliciesController {
     description:
       'When true, omits `content` and `draftContent` from each policy in the response. Use this when listing policies to find one by name/ID — fetch the full content via GET /v1/policies/{id} after.',
   })
+  @ApiQuery({
+    name: 'includeArchived',
+    required: false,
+    type: Boolean,
+    description:
+      'When true, includes user-archived and framework-sync-archived policies in the response. Defaults to false.',
+  })
   @ApiExtension('x-speakeasy-mcp', { name: 'list-policies' })
   @ApiResponse(GET_ALL_POLICIES_RESPONSES[200])
   @ApiResponse(GET_ALL_POLICIES_RESPONSES[401])
@@ -129,9 +136,12 @@ export class PoliciesController {
     @OrganizationId() organizationId: string,
     @AuthContext() authContext: AuthContextType,
     @Query('excludeContent') excludeContent?: string,
+    @Query('includeArchived') includeArchived?: string,
   ) {
-    const policies = await this.policiesService.findAll(organizationId, {
+    const policies = await this.policiesService.findAll({
+      organizationId,
       excludeContent: excludeContent === 'true',
+      includeArchived: includeArchived === 'true',
     });
 
     return {

--- a/apps/api/src/policies/policies.service.spec.ts
+++ b/apps/api/src/policies/policies.service.spec.ts
@@ -140,7 +140,7 @@ describe('PoliciesService', () => {
     });
 
     it('includes content and draftContent in the select by default', async () => {
-      await service.findAll(orgId);
+      await service.findAll({ organizationId: orgId });
 
       const callArgs = db.policy.findMany.mock.calls[0][0];
       expect(callArgs.select.content).toBe(true);
@@ -148,7 +148,7 @@ describe('PoliciesService', () => {
     });
 
     it('includes content and draftContent when excludeContent is false', async () => {
-      await service.findAll(orgId, { excludeContent: false });
+      await service.findAll({ organizationId: orgId, excludeContent: false });
 
       const callArgs = db.policy.findMany.mock.calls[0][0];
       expect(callArgs.select.content).toBe(true);
@@ -156,7 +156,7 @@ describe('PoliciesService', () => {
     });
 
     it('omits content and draftContent from select when excludeContent is true', async () => {
-      await service.findAll(orgId, { excludeContent: true });
+      await service.findAll({ organizationId: orgId, excludeContent: true });
 
       const callArgs = db.policy.findMany.mock.calls[0][0];
       expect(callArgs.select.content).toBeUndefined();
@@ -169,12 +169,21 @@ describe('PoliciesService', () => {
     });
 
     it('scopes results to the organization regardless of excludeContent', async () => {
-      await service.findAll(orgId, { excludeContent: true });
+      await service.findAll({ organizationId: orgId, excludeContent: true });
 
       const callArgs = db.policy.findMany.mock.calls[0][0];
       expect(callArgs.where.organizationId).toBe(orgId);
       expect(callArgs.where.isArchived).toBe(false);
       expect(callArgs.where.archivedAt).toBeNull();
+    });
+
+    it('includes archived policies when includeArchived is true', async () => {
+      await service.findAll({ organizationId: orgId, includeArchived: true });
+
+      const callArgs = db.policy.findMany.mock.calls[0][0];
+      expect(callArgs.where).toEqual({ organizationId: orgId });
+      expect(callArgs.select.archivedAt).toBe(true);
+      expect(callArgs.select.isArchived).toBe(true);
     });
   });
 

--- a/apps/api/src/policies/policies.service.ts
+++ b/apps/api/src/policies/policies.service.ts
@@ -43,6 +43,7 @@ const POLICY_UPDATE_SELECT = {
   signedBy: true,
   reviewDate: true,
   isArchived: true,
+  archivedAt: true,
   createdAt: true,
   updatedAt: true,
   lastArchivedAt: true,
@@ -79,19 +80,26 @@ export class PoliciesService {
     private readonly timelinesService: TimelinesService,
   ) {}
 
-  async findAll(
-    organizationId: string,
-    options?: { excludeContent?: boolean },
-  ) {
+  async findAll({
+    organizationId,
+    excludeContent,
+    includeArchived,
+  }: {
+    organizationId: string;
+    excludeContent?: boolean;
+    includeArchived?: boolean;
+  }) {
     try {
       const policies = await db.policy.findMany({
-        where: { organizationId, isArchived: false, archivedAt: null },
+        where: includeArchived
+          ? { organizationId }
+          : { organizationId, isArchived: false, archivedAt: null },
         select: {
           id: true,
           name: true,
           description: true,
           status: true,
-          ...(options?.excludeContent
+          ...(excludeContent
             ? {}
             : { content: true, draftContent: true }),
           frequency: true,
@@ -100,6 +108,7 @@ export class PoliciesService {
           signedBy: true,
           reviewDate: true,
           isArchived: true,
+          archivedAt: true,
           createdAt: true,
           updatedAt: true,
           lastArchivedAt: true,
@@ -128,7 +137,8 @@ export class PoliciesService {
 
       this.logger.log(
         `Retrieved ${policies.length} policies for organization ${organizationId}` +
-          (options?.excludeContent ? ' (content excluded)' : ''),
+          (excludeContent ? ' (content excluded)' : '') +
+          (includeArchived ? ' (archived included)' : ''),
       );
       return policies;
     } catch (error) {
@@ -240,6 +250,7 @@ export class PoliciesService {
           signedBy: true,
           reviewDate: true,
           isArchived: true,
+          archivedAt: true,
           createdAt: true,
           updatedAt: true,
           lastArchivedAt: true,
@@ -338,6 +349,7 @@ export class PoliciesService {
             signedBy: true,
             reviewDate: true,
             isArchived: true,
+            archivedAt: true,
             createdAt: true,
             updatedAt: true,
             lastArchivedAt: true,

--- a/apps/api/src/policies/schemas/get-all-policies.responses.ts
+++ b/apps/api/src/policies/schemas/get-all-policies.responses.ts
@@ -65,6 +65,7 @@ export const GET_ALL_POLICIES_RESPONSES: Record<string, ApiResponseOptions> = {
               signedBy: [],
               reviewDate: '2024-12-31T00:00:00.000Z',
               isArchived: false,
+              archivedAt: null,
               createdAt: '2024-01-01T00:00:00.000Z',
               updatedAt: '2024-01-15T00:00:00.000Z',
               lastArchivedAt: null,

--- a/apps/api/src/policies/schemas/policy-operations.ts
+++ b/apps/api/src/policies/schemas/policy-operations.ts
@@ -4,7 +4,7 @@ export const POLICY_OPERATIONS: Record<string, ApiOperationOptions> = {
   getAllPolicies: {
     summary: 'Get all policies',
     description:
-      'Lists all policies. Pass excludeContent=true to skip the heavy content fields (recommended unless you need every policy fully). Fetch one policy via get-policy by ID when you need the full content to edit.',
+      'Lists active policies by default. Pass includeArchived=true to include archived rows and excludeContent=true to skip heavy content fields. Fetch one policy by ID for full content.',
   },
   getPolicyById: {
     summary: 'Get policy by ID',

--- a/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/EditableSOAFields.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/EditableSOAFields.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { EditableSOAFields } from './EditableSOAFields';
+
+vi.mock('../hooks/useSOADocument', () => ({
+  useSOADocument: () => ({
+    saveAnswer: vi.fn(),
+  }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+describe('EditableSOAFields', () => {
+  it('shows the edit action without requiring hover', () => {
+    render(
+      <EditableSOAFields
+        documentId="doc_1"
+        questionId="q_1"
+        isApplicable
+        justification={null}
+        isPendingApproval={false}
+        organizationId="org_1"
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Edit answer' })).toHaveClass('opacity-100');
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/EditableSOAFields.tsx
+++ b/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/EditableSOAFields.tsx
@@ -1,24 +1,22 @@
 'use client';
 
 import { useState, useEffect, useRef } from 'react';
-import { Button } from '@trycompai/design-system';
-import { Textarea } from '@trycompai/ui/textarea';
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@trycompai/ui/select';
-import {
+  Button,
   Dialog,
   DialogContent,
   DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from '@trycompai/ui/dialog';
-import { X, Loader2, Edit2 } from 'lucide-react';
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Textarea,
+} from '@trycompai/design-system';
+import { Close, Edit } from '@trycompai/design-system/icons';
 import { toast } from 'sonner';
 import { useSOADocument } from '../hooks/useSOADocument';
 import { ApplicableReadOnlyDisplay, ApplicableSwatchRow } from './ApplicableSwatch';
@@ -128,7 +126,11 @@ export function EditableSOAFields({
     setIsEditing(true);
   };
 
-  const handleSelectChange = (value: 'yes' | 'no' | 'null') => {
+  const handleSelectChange = (value: string | null) => {
+    if (value !== 'yes' && value !== 'no' && value !== 'null') {
+      return;
+    }
+
     const newValue = value === 'yes' ? true : value === 'no' ? false : null;
     setIsApplicable(newValue);
     setError(null);
@@ -191,10 +193,11 @@ export function EditableSOAFields({
         <button
           type="button"
           onClick={handleEditClick}
-          className="absolute right-0 h-6 w-6 flex items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 hover:bg-muted"
+          className="absolute right-0 flex h-6 w-6 items-center justify-center rounded border border-border bg-background text-muted-foreground opacity-100 shadow-sm transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           aria-label="Edit answer"
+          title="Edit answer"
         >
-          <Edit2 className="h-3 w-3" />
+          <Edit size={12} />
         </button>
       </div>
     );
@@ -203,25 +206,27 @@ export function EditableSOAFields({
   return (
     <div className="flex flex-col gap-3">
       <div className="flex items-center justify-between gap-2">
-        <Select
-          value={isApplicable === null ? 'null' : isApplicable ? 'yes' : 'no'}
-          onValueChange={handleSelectChange}
-        >
-          <SelectTrigger className="w-32" disabled={isSaving}>
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="null" disabled>
-              <ApplicableSwatchRow isApplicable={null} />
-            </SelectItem>
-            <SelectItem value="yes">
-              <ApplicableSwatchRow isApplicable />
-            </SelectItem>
-            <SelectItem value="no">
-              <ApplicableSwatchRow isApplicable={false} />
-            </SelectItem>
-          </SelectContent>
-        </Select>
+        <div className="w-32">
+          <Select
+            value={isApplicable === null ? 'null' : isApplicable ? 'yes' : 'no'}
+            onValueChange={handleSelectChange}
+          >
+            <SelectTrigger disabled={isSaving}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="null" disabled>
+                <ApplicableSwatchRow isApplicable={null} />
+              </SelectItem>
+              <SelectItem value="yes">
+                <ApplicableSwatchRow isApplicable />
+              </SelectItem>
+              <SelectItem value="no">
+                <ApplicableSwatchRow isApplicable={false} />
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
         <Button
           variant="ghost"
           size="icon"
@@ -229,7 +234,7 @@ export function EditableSOAFields({
           disabled={isSaving}
           aria-label="Close editing"
         >
-          <X className="h-3 w-3" />
+          <Close size={12} />
           <span className="sr-only">Close editing</span>
         </Button>
       </div>
@@ -250,13 +255,14 @@ export function EditableSOAFields({
               setError(null);
             }}
             placeholder="Enter justification (required)"
-            className="min-h-[120px]"
+            rows={5}
+            size="full"
             required
           />
           {error && (
             <p className="text-xs text-destructive">{error}</p>
           )}
-          <DialogFooter className="gap-2">
+          <DialogFooter>
             <Button
               variant="ghost"
               onClick={() => handleDialogOpenChange(false)}
@@ -266,16 +272,9 @@ export function EditableSOAFields({
             </Button>
             <Button
               onClick={handleJustificationSave}
-              disabled={isSaving}
+              loading={isSaving}
             >
-              {isSaving ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Saving...
-                </>
-              ) : (
-                'Save justification'
-              )}
+              {isSaving ? 'Saving...' : 'Save justification'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/app/src/app/(app)/[orgId]/frameworks/[frameworkInstanceId]/components/FrameworkControlsGrouped.tsx
+++ b/apps/app/src/app/(app)/[orgId]/frameworks/[frameworkInstanceId]/components/FrameworkControlsGrouped.tsx
@@ -23,6 +23,12 @@ import { parseAsArrayOf, parseAsString, useQueryState } from 'nuqs';
 import { useCallback, useMemo, useState } from 'react';
 import { FamilyFilterDropdown } from './FamilyFilterDropdown';
 import {
+  areAllFamiliesExpanded,
+  isFamilyExpanded,
+  toggleAllFamilyExpansion,
+  toggleFamilyExpansion,
+} from './family-expansion-state';
+import {
   buildControlItems,
   buildRequirementMap,
   getFamilyDisplayLabel,
@@ -57,7 +63,7 @@ export function FrameworkControlsGrouped({
 
   const [searchTerm, setSearchTerm] = useQueryState('q', parseAsString.withDefault('').withOptions({ shallow: true, throttleMs: 300 }));
   const [familyFilterParam, setFamilyFilterParam] = useQueryState('families', parseAsArrayOf(parseAsString, '|').withDefault([]).withOptions({ shallow: true }));
-  const [collapsedFamilies, setCollapsedFamilies] = useState<Set<string>>(new Set());
+  const [expandedFamilies, setExpandedFamilies] = useState<Set<string>>(new Set());
 
   const selectedFamilyFilter = useMemo(() => new Set(familyFilterParam), [familyFilterParam]);
 
@@ -95,36 +101,26 @@ export function FrameworkControlsGrouped({
   const familyCounts = useMemo(() => new Map(allGroups.map((g) => [g.family, g.items.length])), [allGroups]);
 
   const isSearching = searchTerm.trim().length > 0;
-  const allCollapsed = groups.length > 0 && groups.every((g) => collapsedFamilies.has(g.family));
+  const visibleFamilyNames = useMemo(() => groups.map((g) => g.family), [groups]);
+  const allExpanded = areAllFamiliesExpanded({
+    expandedFamilies,
+    familyNames: visibleFamilyNames,
+  });
 
   const handleToggleFamily = (family: string) => {
-    setCollapsedFamilies((prev) => {
-      const next = new Set(prev);
-      if (next.has(family)) {
-        next.delete(family);
-      } else {
-        next.add(family);
-      }
-      return next;
-    });
+    setExpandedFamilies((prev) =>
+      toggleFamilyExpansion({ expandedFamilies: prev, family }),
+    );
   };
 
-  const visibleFamilyNames = useMemo(() => groups.map((g) => g.family), [groups]);
-
   const handleToggleAll = () => {
-    if (allCollapsed) {
-      setCollapsedFamilies((prev) => {
-        const next = new Set(prev);
-        for (const name of visibleFamilyNames) next.delete(name);
-        return next;
-      });
-    } else {
-      setCollapsedFamilies((prev) => {
-        const next = new Set(prev);
-        for (const name of visibleFamilyNames) next.add(name);
-        return next;
-      });
-    }
+    setExpandedFamilies((prev) =>
+      toggleAllFamilyExpansion({
+        expandedFamilies: prev,
+        familyNames: visibleFamilyNames,
+        shouldExpand: !allExpanded,
+      }),
+    );
   };
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -145,7 +141,8 @@ export function FrameworkControlsGrouped({
     setFamilyFilterParam(null);
   };
 
-  const isFamilyExpanded = (family: string) => isSearching || !collapsedFamilies.has(family);
+  const getIsFamilyExpanded = (family: string) =>
+    isFamilyExpanded({ expandedFamilies, family, isSearching });
 
   return (
     <div className="space-y-4">
@@ -172,7 +169,7 @@ export function FrameworkControlsGrouped({
         />
         {!isSearching && (
           <Button variant="ghost" onClick={handleToggleAll}>
-            {allCollapsed ? 'Expand All' : 'Collapse All'}
+            {allExpanded ? 'Collapse All' : 'Expand All'}
           </Button>
         )}
       </div>
@@ -202,7 +199,7 @@ export function FrameworkControlsGrouped({
               <FamilySection
                 key={group.family}
                 group={group}
-                expanded={isFamilyExpanded(group.family)}
+                expanded={getIsFamilyExpanded(group.family)}
                 onToggle={() => handleToggleFamily(group.family)}
                 tasks={tasks}
                 evidenceSubmissions={evidenceSubmissions}

--- a/apps/app/src/app/(app)/[orgId]/frameworks/[frameworkInstanceId]/components/FrameworkRequirementsGrouped.tsx
+++ b/apps/app/src/app/(app)/[orgId]/frameworks/[frameworkInstanceId]/components/FrameworkRequirementsGrouped.tsx
@@ -22,6 +22,12 @@ import { parseAsArrayOf, parseAsString, useQueryState } from 'nuqs';
 import { useCallback, useMemo, useState } from 'react';
 import { FamilyFilterDropdown } from './FamilyFilterDropdown';
 import {
+  areAllFamiliesExpanded,
+  isFamilyExpanded,
+  toggleAllFamilyExpansion,
+  toggleFamilyExpansion,
+} from './family-expansion-state';
+import {
   buildRequirementItems,
   getFamilyDisplayLabel,
   groupRequirementsByFamily,
@@ -54,7 +60,7 @@ export function FrameworkRequirementsGrouped({
 
   const [searchTerm, setSearchTerm] = useQueryState('rq', parseAsString.withDefault('').withOptions({ shallow: true, throttleMs: 300 }));
   const [familyFilterParam, setFamilyFilterParam] = useQueryState('rfamilies', parseAsArrayOf(parseAsString, '|').withDefault([]).withOptions({ shallow: true }));
-  const [collapsedFamilies, setCollapsedFamilies] = useState<Set<string>>(new Set());
+  const [expandedFamilies, setExpandedFamilies] = useState<Set<string>>(new Set());
 
   const selectedFamilyFilter = useMemo(() => new Set(familyFilterParam), [familyFilterParam]);
 
@@ -90,20 +96,26 @@ export function FrameworkRequirementsGrouped({
   const familyCounts = useMemo(() => new Map(allGroups.map((g) => [g.family, g.items.length])), [allGroups]);
 
   const isSearching = searchTerm.trim().length > 0;
-  const allCollapsed = groups.length > 0 && groups.every((g) => collapsedFamilies.has(g.family));
+  const visibleFamilyNames = useMemo(() => groups.map((g) => g.family), [groups]);
+  const allExpanded = areAllFamiliesExpanded({
+    expandedFamilies,
+    familyNames: visibleFamilyNames,
+  });
 
   const handleToggleFamily = (family: string) => {
-    setCollapsedFamilies((prev) => {
-      const next = new Set(prev);
-      if (next.has(family)) next.delete(family);
-      else next.add(family);
-      return next;
-    });
+    setExpandedFamilies((prev) =>
+      toggleFamilyExpansion({ expandedFamilies: prev, family }),
+    );
   };
 
   const handleToggleAll = () => {
-    if (allCollapsed) setCollapsedFamilies(new Set());
-    else setCollapsedFamilies(new Set(allFamilyNames));
+    setExpandedFamilies((prev) =>
+      toggleAllFamilyExpansion({
+        expandedFamilies: prev,
+        familyNames: visibleFamilyNames,
+        shouldExpand: !allExpanded,
+      }),
+    );
   };
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -121,7 +133,8 @@ export function FrameworkRequirementsGrouped({
     setFamilyFilterParam(null);
   };
 
-  const isFamilyExpanded = (family: string) => isSearching || !collapsedFamilies.has(family);
+  const getIsFamilyExpanded = (family: string) =>
+    isFamilyExpanded({ expandedFamilies, family, isSearching });
 
   return (
     <div className="space-y-4">
@@ -147,7 +160,7 @@ export function FrameworkRequirementsGrouped({
         />
         {!isSearching && (
           <Button variant="ghost" onClick={handleToggleAll}>
-            {allCollapsed ? 'Expand All' : 'Collapse All'}
+            {allExpanded ? 'Collapse All' : 'Expand All'}
           </Button>
         )}
       </div>
@@ -179,7 +192,7 @@ export function FrameworkRequirementsGrouped({
               <RequirementFamilySection
                 key={group.family}
                 group={group}
-                expanded={isFamilyExpanded(group.family)}
+                expanded={getIsFamilyExpanded(group.family)}
                 onToggle={() => handleToggleFamily(group.family)}
                 orgId={orgId}
                 frameworkInstanceId={frameworkInstanceId}

--- a/apps/app/src/app/(app)/[orgId]/frameworks/[frameworkInstanceId]/components/family-expansion-state.test.ts
+++ b/apps/app/src/app/(app)/[orgId]/frameworks/[frameworkInstanceId]/components/family-expansion-state.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import {
+  areAllFamiliesExpanded,
+  isFamilyExpanded,
+  toggleAllFamilyExpansion,
+  toggleFamilyExpansion,
+} from './family-expansion-state';
+
+describe('family expansion state', () => {
+  it('defaults families to collapsed until expanded by the user', () => {
+    expect(
+      isFamilyExpanded({
+        expandedFamilies: new Set(),
+        family: 'Access Control',
+        isSearching: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('expands families while searching without changing saved expansion state', () => {
+    expect(
+      isFamilyExpanded({
+        expandedFamilies: new Set(),
+        family: 'Access Control',
+        isSearching: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('toggles one family at a time', () => {
+    const expanded = toggleFamilyExpansion({
+      expandedFamilies: new Set(),
+      family: 'Access Control',
+    });
+    expect(expanded.has('Access Control')).toBe(true);
+
+    const collapsed = toggleFamilyExpansion({
+      expandedFamilies: expanded,
+      family: 'Access Control',
+    });
+    expect(collapsed.has('Access Control')).toBe(false);
+  });
+
+  it('expands and collapses all visible families', () => {
+    const familyNames = ['Access Control', 'Audit'];
+    const expanded = toggleAllFamilyExpansion({
+      expandedFamilies: new Set(),
+      familyNames,
+      shouldExpand: true,
+    });
+
+    expect(
+      areAllFamiliesExpanded({
+        expandedFamilies: expanded,
+        familyNames,
+      }),
+    ).toBe(true);
+
+    const collapsed = toggleAllFamilyExpansion({
+      expandedFamilies: expanded,
+      familyNames,
+      shouldExpand: false,
+    });
+
+    expect(
+      areAllFamiliesExpanded({
+        expandedFamilies: collapsed,
+        familyNames,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/frameworks/[frameworkInstanceId]/components/family-expansion-state.ts
+++ b/apps/app/src/app/(app)/[orgId]/frameworks/[frameworkInstanceId]/components/family-expansion-state.ts
@@ -1,0 +1,68 @@
+interface FamilyExpansionParams {
+  expandedFamilies: Set<string>;
+  family: string;
+  isSearching: boolean;
+}
+
+interface ToggleAllFamilyExpansionParams {
+  expandedFamilies: Set<string>;
+  familyNames: string[];
+  shouldExpand: boolean;
+}
+
+interface FamilyExpansionListParams {
+  expandedFamilies: Set<string>;
+  familyNames: string[];
+}
+
+interface ToggleFamilyExpansionParams {
+  expandedFamilies: Set<string>;
+  family: string;
+}
+
+export function isFamilyExpanded({
+  expandedFamilies,
+  family,
+  isSearching,
+}: FamilyExpansionParams): boolean {
+  return isSearching || expandedFamilies.has(family);
+}
+
+export function areAllFamiliesExpanded({
+  expandedFamilies,
+  familyNames,
+}: FamilyExpansionListParams): boolean {
+  return (
+    familyNames.length > 0 &&
+    familyNames.every((family) => expandedFamilies.has(family))
+  );
+}
+
+export function toggleFamilyExpansion({
+  expandedFamilies,
+  family,
+}: ToggleFamilyExpansionParams): Set<string> {
+  const next = new Set(expandedFamilies);
+  if (next.has(family)) {
+    next.delete(family);
+  } else {
+    next.add(family);
+  }
+  return next;
+}
+
+export function toggleAllFamilyExpansion({
+  expandedFamilies,
+  familyNames,
+  shouldExpand,
+}: ToggleAllFamilyExpansionParams): Set<string> {
+  const next = new Set(expandedFamilies);
+  for (const family of familyNames) {
+    if (shouldExpand) {
+      next.add(family);
+    } else {
+      next.delete(family);
+    }
+  }
+  return next;
+}

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/MemberRow.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/MemberRow.tsx
@@ -149,6 +149,7 @@ export function MemberRow({
   const currentRoles = parseRoles(member.role);
 
   const isOwner = currentRoles.includes('owner');
+  const isAuditorOnly = currentRoles.length > 0 && currentRoles.every((role) => role === 'auditor');
   const isPlatformAdmin = member.user.role === 'admin';
   const canRemove = !isOwner;
   const isDeactivated = member.deactivated || !member.isActive;
@@ -190,7 +191,7 @@ export function MemberRow({
     });
   }
 
-  if (shouldShowTaskRequirements && backgroundCheckStepEnabled && !memberExempt) {
+  if (shouldShowTaskRequirements && backgroundCheckStepEnabled && !memberExempt && !isAuditorOnly) {
     taskItems.push({
       label: 'Background check',
       completed: hasCompletedBackgroundCheck ? 1 : 0,

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/MemberRowBackgroundCheck.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/MemberRowBackgroundCheck.test.tsx
@@ -46,12 +46,18 @@ const member = {
 
 const noop = vi.fn();
 
-function renderRow(backgroundCheckStatus?: 'completed' | 'completed_with_flags' | 'invited') {
+function renderRow({
+  backgroundCheckStatus,
+  role = 'employee',
+}: {
+  backgroundCheckStatus?: 'completed' | 'completed_with_flags' | 'invited';
+  role?: string;
+} = {}) {
   return render(
     <table>
       <tbody>
         <MemberRow
-          member={member}
+          member={{ ...member, role }}
           onRemove={noop}
           onRemoveDevice={noop}
           onUpdateRole={noop}
@@ -67,18 +73,23 @@ function renderRow(backgroundCheckStatus?: 'completed' | 'completed_with_flags' 
 
 describe('MemberRow background check status', () => {
   it('shows background check as incomplete in the tasks column', () => {
-    renderRow('invited');
+    renderRow({ backgroundCheckStatus: 'invited' });
     expect(screen.getByText('Background check 0/1')).toBeInTheDocument();
   });
 
   it('shows background check as complete in the tasks column', () => {
-    renderRow('completed_with_flags');
+    renderRow({ backgroundCheckStatus: 'completed_with_flags' });
     expect(screen.getByText('Background check 1/1')).toBeInTheDocument();
     expect(screen.getByLabelText('Employee has completed a background check')).toBeInTheDocument();
   });
 
   it('does not show the verified tick for incomplete checks', () => {
-    renderRow('invited');
+    renderRow({ backgroundCheckStatus: 'invited' });
     expect(screen.queryByLabelText('Employee has completed a background check')).not.toBeInTheDocument();
+  });
+
+  it('does not show background check tracking for auditor-only members', () => {
+    renderRow({ backgroundCheckStatus: 'invited', role: 'auditor' });
+    expect(screen.queryByText(/Background check/)).not.toBeInTheDocument();
   });
 });

--- a/apps/app/src/app/(app)/[orgId]/policies/(overview)/hooks/usePoliciesOverview.ts
+++ b/apps/app/src/app/(app)/[orgId]/policies/(overview)/hooks/usePoliciesOverview.ts
@@ -16,6 +16,7 @@ interface PolicyFromApi {
   id: string;
   status: string;
   isArchived: boolean;
+  archivedAt: string | null;
   assigneeId: string | null;
   assignee?: {
     id: string;
@@ -32,8 +33,8 @@ interface UsePoliciesOverviewOptions {
 
 export function usePoliciesOverview({ organizationId, initialData }: UsePoliciesOverviewOptions) {
   const { data, error, isLoading, mutate } = useSWR(
-    ['/v1/policies', organizationId],
-    async ([endpoint, orgId]) => {
+    ['/v1/policies?includeArchived=true', organizationId],
+    async ([endpoint]) => {
       const response = await apiClient.get<{ data: PolicyFromApi[] }>(endpoint);
       if (response.error) throw new Error(response.error);
       return response.data?.data ?? [];

--- a/apps/app/src/app/(app)/[orgId]/policies/(overview)/lib/compute-overview.ts
+++ b/apps/app/src/app/(app)/[orgId]/policies/(overview)/lib/compute-overview.ts
@@ -1,9 +1,11 @@
 // Shared utility - can be used by both server and client
+import { isArchivedPolicy } from '../../lib/policy-archive-state';
 
 interface PolicyForOverview {
   id: string;
   status: string;
   isArchived: boolean;
+  archivedAt?: Date | string | null;
   assigneeId: string | null;
   assignee?: {
     id: string;
@@ -45,8 +47,10 @@ export function computePoliciesOverview(policies: PolicyForOverview[]): Policies
   const policyDataByOwner = new Map<string, AssigneeData>();
 
   for (const policy of policies) {
+    const archived = isArchivedPolicy(policy);
+
     // Count by status
-    if (policy.isArchived) {
+    if (archived) {
       archivedPolicies += 1;
     } else if (policy.status === 'published') {
       publishedPolicies += 1;
@@ -74,7 +78,7 @@ export function computePoliciesOverview(policies: PolicyForOverview[]): Policies
       const assigneeData = policyDataByOwner.get(assigneeId)!;
       assigneeData.total += 1;
 
-      if (policy.isArchived) {
+      if (archived) {
         assigneeData.archived += 1;
       } else if (policy.status === 'published') {
         assigneeData.published += 1;

--- a/apps/app/src/app/(app)/[orgId]/policies/(overview)/page.tsx
+++ b/apps/app/src/app/(app)/[orgId]/policies/(overview)/page.tsx
@@ -5,6 +5,7 @@ import type { Metadata } from 'next';
 import { Suspense } from 'react';
 import { PolicyFilters } from '../all/components/PolicyFilters';
 import { PolicyPageActions } from '../all/components/PolicyPageActions';
+import { isArchivedPolicy } from '../lib/policy-archive-state';
 import { PolicyChartsClient } from './components/PolicyChartsClient';
 import { computePoliciesOverview } from './lib/compute-overview';
 import Loading from './loading';
@@ -25,7 +26,7 @@ export default async function PoliciesPage({ params }: PoliciesPageProps) {
   // policies…" status during first-run AI generation. Mirrors the pattern
   // used by the risks and vendors pages.
   const [policiesRes, onboardingRes] = await Promise.all([
-    serverApi.get<{ data: PolicyWithAssignee[] }>('/v1/policies'),
+    serverApi.get<{ data: PolicyWithAssignee[] }>('/v1/policies?includeArchived=true'),
     serverApi.get<{
       triggerJobId: string | null;
       triggerJobCompleted: boolean;
@@ -41,7 +42,7 @@ export default async function PoliciesPage({ params }: PoliciesPageProps) {
     policies.map((p) => ({
       id: p.id,
       status: p.status,
-      isArchived: p.isArchived,
+      isArchived: isArchivedPolicy(p),
       assigneeId: p.assigneeId,
       assignee: p.assignee,
     })),
@@ -52,7 +53,7 @@ export default async function PoliciesPage({ params }: PoliciesPageProps) {
       <Stack gap="md">
         <PageHeader
           title="Policies"
-          actions={<PolicyPageActions policies={policies.filter((p) => !p.isArchived)} />}
+          actions={<PolicyPageActions policies={policies.filter((p) => !isArchivedPolicy(p))} />}
         />
         <Suspense fallback={<Loading />}>
           <PolicyChartsClient organizationId={orgId} initialData={initialOverview} />

--- a/apps/app/src/app/(app)/[orgId]/policies/all/components/PoliciesTableDS.tsx
+++ b/apps/app/src/app/(app)/[orgId]/policies/all/components/PoliciesTableDS.tsx
@@ -17,6 +17,7 @@ import {
 import { ArrowDown, ArrowUp, ArrowsVertical, Launch } from '@trycompai/design-system/icons';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
+import { isArchivedPolicy } from '../../lib/policy-archive-state';
 import { usePolicyTailoringStatus, type PolicyTailoringStatus } from './policy-tailoring-context';
 
 type SortColumn = 'name' | 'status' | 'updatedAt';
@@ -223,7 +224,7 @@ function PolicyStatusCell({ policy, status, isTailoring }: PolicyStatusCellProps
     );
   }
 
-  if (policy.isArchived) {
+  if (isArchivedPolicy(policy)) {
     return <StatusIndicator status="archived" />;
   }
 

--- a/apps/app/src/app/(app)/[orgId]/policies/all/components/PolicyFilters.tsx
+++ b/apps/app/src/app/(app)/[orgId]/policies/all/components/PolicyFilters.tsx
@@ -12,11 +12,12 @@ import {
   SelectTrigger,
   SelectValue,
   Stack,
+  Spinner,
 } from '@trycompai/design-system';
 import { Search } from '@trycompai/design-system/icons';
-import { Loader2 } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { usePolicyOnboardingStatus } from '../../(overview)/hooks/use-policy-onboarding-status';
+import { isArchivedPolicy } from '../../lib/policy-archive-state';
 import { PoliciesTableDS } from './PoliciesTableDS';
 import { PolicyTailoringProvider } from './policy-tailoring-context';
 import { comparePoliciesByName } from './policy-name-sort';
@@ -70,9 +71,9 @@ export function PolicyFilters({ policies, onboardingRunId }: PolicyFiltersProps)
 
     // Status filter
     if (statusFilter === 'archived') {
-      result = result.filter((p) => p.isArchived);
+      result = result.filter((p) => isArchivedPolicy(p));
     } else {
-      result = result.filter((p) => !p.isArchived);
+      result = result.filter((p) => !isArchivedPolicy(p));
       if (statusFilter !== 'all') {
         result = result.filter((p) => p.status === statusFilter);
       }
@@ -170,7 +171,7 @@ export function PolicyFilters({ policies, onboardingRunId }: PolicyFiltersProps)
         {showTailoringBanner && progress !== null && (
           <div className="flex items-center gap-3 rounded-xl border border-primary/20 bg-linear-to-r from-primary/10 via-primary/5 to-transparent px-4 py-3">
             <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/15 text-primary">
-              <Loader2 className="h-5 w-5 animate-spin" />
+              <Spinner size={20} />
             </div>
             <div className="flex flex-col">
               <span className="text-sm font-medium text-primary">Tailoring your policies</span>

--- a/apps/app/src/app/(app)/[orgId]/policies/all/components/policies-table-columns.tsx
+++ b/apps/app/src/app/(app)/[orgId]/policies/all/components/policies-table-columns.tsx
@@ -3,12 +3,13 @@
 import { DataTableColumnHeader } from '@/components/data-table/data-table-column-header';
 import { StatusIndicator } from '@/components/status-indicator';
 import { formatDate } from '@/lib/format';
-import { Badge } from '@trycompai/ui/badge';
-import { Policy } from '@db';
+import type { Policy } from '@db';
 import { type ColumnDef, type Row } from '@tanstack/react-table';
-import { ExternalLink, Loader2 } from 'lucide-react';
+import { Badge, Spinner } from '@trycompai/design-system';
+import { Launch } from '@trycompai/design-system/icons';
 import Link from 'next/link';
 
+import { isArchivedPolicy } from '../../lib/policy-archive-state';
 import { usePolicyTailoringStatus } from './policy-tailoring-context';
 
 export type PolicyTailoringStatus = 'queued' | 'pending' | 'processing' | 'completed';
@@ -44,7 +45,7 @@ export function getPolicyColumns(orgId: string): ColumnDef<Policy>[] {
       header: ({ column }) => <DataTableColumnHeader column={column} title="Department" />,
       cell: ({ row }) => {
         return (
-          <Badge variant="marketing" className="w-fit uppercase">
+          <Badge variant="secondary">
             {row.original.department}
           </Badge>
         );
@@ -81,7 +82,9 @@ function PolicyNameCell({ row, orgId }: { row: Row<Policy>; orgId: string }) {
   if (isTailoring) {
     return (
       <div className="flex items-center gap-2 text-muted-foreground">
-        <Loader2 className="size-3 animate-spin text-primary" />
+        <span className="text-primary">
+          <Spinner size={12} />
+        </span>
         <span className="max-w-[31.25rem] truncate font-medium text-muted-foreground">
           {policyName}
         </span>
@@ -100,7 +103,7 @@ function PolicyNameCell({ row, orgId }: { row: Row<Policy>; orgId: string }) {
       <span className="max-w-[31.25rem] truncate font-medium group-hover:underline">
         {policyName}
       </span>
-      <ExternalLink className="size-4 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
+      <Launch size={16} className="shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
     </Link>
   );
 }
@@ -119,13 +122,13 @@ function PolicyStatusCell({ row }: { row: Row<Policy> }) {
           : 'Preparing';
     return (
       <div className="flex items-center gap-2 text-sm text-primary">
-        <Loader2 className="h-4 w-4 animate-spin" />
+        <Spinner size={16} />
         {label}
       </div>
     );
   }
 
-  if (row.original.isArchived) {
+  if (isArchivedPolicy(row.original)) {
     return <StatusIndicator status="archived" />;
   }
 

--- a/apps/app/src/app/(app)/[orgId]/policies/lib/policy-archive-state.test.ts
+++ b/apps/app/src/app/(app)/[orgId]/policies/lib/policy-archive-state.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { isArchivedPolicy } from './policy-archive-state';
+
+describe('isArchivedPolicy', () => {
+  it('treats user-archived policies as archived', () => {
+    expect(isArchivedPolicy({ isArchived: true, archivedAt: null })).toBe(true);
+  });
+
+  it('treats framework-sync-archived policies as archived', () => {
+    expect(isArchivedPolicy({ isArchived: false, archivedAt: '2026-05-30T12:00:00Z' })).toBe(
+      true,
+    );
+  });
+
+  it('treats active policies as not archived', () => {
+    expect(isArchivedPolicy({ isArchived: false, archivedAt: null })).toBe(false);
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/policies/lib/policy-archive-state.ts
+++ b/apps/app/src/app/(app)/[orgId]/policies/lib/policy-archive-state.ts
@@ -1,0 +1,8 @@
+interface PolicyArchiveState {
+  archivedAt?: Date | string | null;
+  isArchived?: boolean;
+}
+
+export function isArchivedPolicy(policy: PolicyArchiveState): boolean {
+  return policy.isArchived === true || policy.archivedAt != null;
+}

--- a/packages/docs/openapi.json
+++ b/packages/docs/openapi.json
@@ -7127,7 +7127,7 @@
     },
     "/v1/policies": {
       "get": {
-        "description": "Lists compliance policies for the organization. Use this to find a policy by name, look up a policy ID, browse drafts, or get an overview of all policies for SOC 2, ISO 27001, HIPAA, and GDPR workflows. Returns id, name, status, department, and other metadata for each policy. Pass excludeContent=true to skip the heavy TipTap content fields — recommended when you only need to identify a policy. To read or edit a single policy in detail, fetch it by ID via get-compliance-policy.",
+        "description": "Lists active compliance policies by default. Use includeArchived=true to include archived rows and excludeContent=true when you only need policy metadata.",
         "operationId": "PoliciesController_getAllPolicies_v1",
         "parameters": [
           {
@@ -7144,6 +7144,15 @@
             "required": false,
             "in": "query",
             "description": "When true, omits `content` and `draftContent` from each policy in the response. Use this when listing policies to find one by name/ID — fetch the full content via GET /v1/policies/{id} after.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "includeArchived",
+            "required": false,
+            "in": "query",
+            "description": "When true, includes user-archived and framework-sync-archived policies in the response. Defaults to false.",
             "schema": {
               "type": "boolean"
             }
@@ -7221,6 +7230,7 @@
                       "signedBy": [],
                       "reviewDate": "2024-12-31T00:00:00.000Z",
                       "isArchived": false,
+                      "archivedAt": null,
                       "createdAt": "2024-01-01T00:00:00.000Z",
                       "updatedAt": "2024-01-15T00:00:00.000Z",
                       "lastArchivedAt": null,
@@ -7276,9 +7286,9 @@
           "metadata": {
             "title": "List compliance policies | Comp AI API",
             "sidebarTitle": "List compliance policies",
-            "description": "Lists compliance policies for the organization. Use this to find a policy by name, look up a policy ID, browse drafts, or get an overview of all policies.",
+            "description": "Lists active compliance policies by default. Use includeArchived=true to include archived rows.",
             "og:title": "List compliance policies | Comp AI API",
-            "og:description": "Lists compliance policies for the organization. Use this to find a policy by name, look up a policy ID, browse drafts, or get an overview of all policies."
+            "og:description": "Lists active compliance policies by default. Use includeArchived=true to include archived rows."
           }
         },
         "x-codeSamples": [
@@ -7291,6 +7301,11 @@
             "lang": "bash",
             "label": "List policies (lightweight, no content)",
             "source": "curl --request GET --url \"https://api.trycomp.ai/v1/policies?excludeContent=true\" --header \"X-API-Key: $COMP_AI_API_KEY\""
+          },
+          {
+            "lang": "bash",
+            "label": "List policies including archived",
+            "source": "curl --request GET --url \"https://api.trycomp.ai/v1/policies?includeArchived=true\" --header \"X-API-Key: $COMP_AI_API_KEY\""
           }
         ]
       },
@@ -7349,6 +7364,7 @@
                   "signedBy": [],
                   "reviewDate": "2024-12-31T00:00:00.000Z",
                   "isArchived": false,
+                  "archivedAt": null,
                   "createdAt": "2024-01-01T00:00:00.000Z",
                   "updatedAt": "2024-01-15T00:00:00.000Z",
                   "organizationId": "org_abc123def456",
@@ -8470,6 +8486,7 @@
                   ],
                   "reviewDate": "2024-12-31T00:00:00.000Z",
                   "isArchived": false,
+                  "archivedAt": null,
                   "createdAt": "2024-01-01T00:00:00.000Z",
                   "updatedAt": "2024-01-15T00:00:00.000Z",
                   "organizationId": "org_abc123def456",
@@ -26937,6 +26954,13 @@
             "description": "Whether this policy is archived",
             "example": false
           },
+          "archivedAt": {
+            "format": "date-time",
+            "type": "string",
+            "description": "When the policy was archived by framework sync",
+            "example": "2024-02-01T00:00:00.000Z",
+            "nullable": true
+          },
           "createdAt": {
             "format": "date-time",
             "type": "string",
@@ -26999,6 +27023,7 @@
           "signedBy",
           "reviewDate",
           "isArchived",
+          "archivedAt",
           "createdAt",
           "updatedAt",
           "lastArchivedAt",


### PR DESCRIPTION
## Summary
- CS-461: add includeArchived policy listing support and use archivedAt/isArchived consistently in policy overview and tables.
- CS-391: make framework control and requirement family groups collapsed by default, with search still expanding matches.
- CS-463: keep the Statement of Applicability edit action visible without hover.
- CS-352: hide background-check tracking for auditor-only members.

## Known baseline failures
- bunx turbo run typecheck --filter=@trycompai/app still fails on existing cloud-tests fixture types, AI SDK v2/v3 mismatches, auth package duplication, and other unrelated files. No touched-file errors remain.
- bunx turbo run typecheck --filter=@trycompai/api still fails on existing AI SDK v2/v3 mismatches, auth package duplication, integration-platform spec arity issues, and other unrelated files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds archived policy support across API and app, and closes several compliance UI tasks: framework families default to collapsed, SOA edit is always visible, and auditor-only users no longer see background‑check tracking.

- **New Features**
  - CS-461: Policies API now supports `includeArchived=true` and returns `archivedAt`. Default listing shows active policies only; docs and samples updated. App overview fetches with `includeArchived=true` and uses a shared `isArchivedPolicy` helper across charts, filters, and tables.
  - CS-391: Framework control and requirement family groups are collapsed by default. Search auto-expands matching families. Added robust expand/collapse-all behavior with isolated state utilities and tests.

- **Bug Fixes**
  - CS-463: Statement of Applicability edit action is always visible (no hover needed) with accessible button styles.
  - CS-352: Hide background‑check tracking for auditor‑only members.
  - Added tests for SOA edit affordance, family expansion state, archived policy state, and API controller/service behavior.

<sup>Written for commit d8ce45093d87a3f7222fc14123ca88a82043f9c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/2978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

