### PR TITLE
feat(background-checks): admin cancel/delete/retry (CS-475)

### DIFF
--- a/apps/api/src/background-checks/background-check-custom.service.ts
+++ b/apps/api/src/background-checks/background-check-custom.service.ts
@@ -57,8 +57,10 @@ export class BackgroundCheckCustomService {
       throw new NotFoundException('Member not found.');
     }
 
-    const resolvedName = employeeName?.trim() || member.user.name || member.user.email;
-    const resolvedEmail = employeeEmail?.trim().toLowerCase() || member.user.email;
+    const resolvedName =
+      employeeName?.trim() || member.user.name || member.user.email;
+    const resolvedEmail =
+      employeeEmail?.trim().toLowerCase() || member.user.email;
 
     // Create/update the record without marking it completed yet
     const record = await db.backgroundCheckRequest.upsert({

--- a/apps/api/src/background-checks/background-check-identity.client.spec.ts
+++ b/apps/api/src/background-checks/background-check-identity.client.spec.ts
@@ -27,7 +27,9 @@ describe('BackgroundCheckIdentityClient idempotency key', () => {
   }
 
   function keyFrom(fetchMock: jest.Mock): string {
-    const init = fetchMock.mock.calls[0][1] as { headers: Record<string, string> };
+    const init = fetchMock.mock.calls[0][1] as {
+      headers: Record<string, string>;
+    };
     return init.headers['Idempotency-Key'];
   }
 
@@ -41,13 +43,19 @@ describe('BackgroundCheckIdentityClient idempotency key', () => {
 
   it('uses the bare key for the initial request (attempt 0)', async () => {
     const fetchMock = mockFetchOk();
-    await new BackgroundCheckIdentityClient().createBackgroundCheck({ ...params, attempt: 0 });
+    await new BackgroundCheckIdentityClient().createBackgroundCheck({
+      ...params,
+      attempt: 0,
+    });
     expect(keyFrom(fetchMock)).toBe('comp-background-check:mem_1');
   });
 
   it('suffixes the key with the attempt number for retries', async () => {
     const fetchMock = mockFetchOk();
-    await new BackgroundCheckIdentityClient().createBackgroundCheck({ ...params, attempt: 2 });
+    await new BackgroundCheckIdentityClient().createBackgroundCheck({
+      ...params,
+      attempt: 2,
+    });
     expect(keyFrom(fetchMock)).toBe('comp-background-check:mem_1:2');
   });
 });

--- a/apps/api/src/background-checks/background-check-identity.client.spec.ts
+++ b/apps/api/src/background-checks/background-check-identity.client.spec.ts
@@ -1,0 +1,53 @@
+import { BackgroundCheckIdentityClient } from './background-check-identity.client';
+
+describe('BackgroundCheckIdentityClient idempotency key', () => {
+  const originalEnv = { ...process.env };
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      BACKGROUND_CHECK_API_KEY: 'bc_test',
+      BACKGROUND_CHECK_API_BASE_URL: 'https://identity.test',
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    global.fetch = originalFetch;
+  });
+
+  function mockFetchOk() {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({ id: 'check_1', status: 'invited' }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+    return fetchMock;
+  }
+
+  function keyFrom(fetchMock: jest.Mock): string {
+    const init = fetchMock.mock.calls[0][1] as { headers: Record<string, string> };
+    return init.headers['Idempotency-Key'];
+  }
+
+  const params = {
+    organizationId: 'org_1',
+    memberId: 'mem_1',
+    employeeName: 'Ada',
+    employeeEmail: 'ada@example.com',
+    requesterEmail: 'admin@example.com',
+  };
+
+  it('uses the bare key for the initial request (attempt 0)', async () => {
+    const fetchMock = mockFetchOk();
+    await new BackgroundCheckIdentityClient().createBackgroundCheck({ ...params, attempt: 0 });
+    expect(keyFrom(fetchMock)).toBe('comp-background-check:mem_1');
+  });
+
+  it('suffixes the key with the attempt number for retries', async () => {
+    const fetchMock = mockFetchOk();
+    await new BackgroundCheckIdentityClient().createBackgroundCheck({ ...params, attempt: 2 });
+    expect(keyFrom(fetchMock)).toBe('comp-background-check:mem_1:2');
+  });
+});

--- a/apps/api/src/background-checks/background-check-identity.client.spec.ts
+++ b/apps/api/src/background-checks/background-check-identity.client.spec.ts
@@ -41,21 +41,21 @@ describe('BackgroundCheckIdentityClient idempotency key', () => {
     requesterEmail: 'admin@example.com',
   };
 
-  it('uses the bare key for the initial request (attempt 0)', async () => {
+  it('forwards the provided idempotency key as the Idempotency-Key header', async () => {
     const fetchMock = mockFetchOk();
     await new BackgroundCheckIdentityClient().createBackgroundCheck({
       ...params,
-      attempt: 0,
+      idempotencyKey: 'comp-background-check:bcr_1',
     });
-    expect(keyFrom(fetchMock)).toBe('comp-background-check:mem_1');
+    expect(keyFrom(fetchMock)).toBe('comp-background-check:bcr_1');
   });
 
-  it('suffixes the key with the attempt number for retries', async () => {
+  it('forwards a per-attempt retry idempotency key unchanged', async () => {
     const fetchMock = mockFetchOk();
     await new BackgroundCheckIdentityClient().createBackgroundCheck({
       ...params,
-      attempt: 2,
+      idempotencyKey: 'comp-background-check:bcr_1:2',
     });
-    expect(keyFrom(fetchMock)).toBe('comp-background-check:mem_1:2');
+    expect(keyFrom(fetchMock)).toBe('comp-background-check:bcr_1:2');
   });
 });

--- a/apps/api/src/background-checks/background-check-identity.client.ts
+++ b/apps/api/src/background-checks/background-check-identity.client.ts
@@ -14,6 +14,7 @@ export class BackgroundCheckIdentityClient {
     employeeName: string;
     employeeEmail: string;
     requesterEmail: string;
+    attempt: number;
   }): Promise<IdentityCreateResponse> {
     const apiKey = process.env.BACKGROUND_CHECK_API_KEY;
     if (!apiKey) {
@@ -28,7 +29,10 @@ export class BackgroundCheckIdentityClient {
       headers: {
         Authorization: `Bearer ${apiKey}`,
         'Content-Type': 'application/json',
-        'Idempotency-Key': `comp-background-check:${params.memberId}`,
+        'Idempotency-Key':
+          params.attempt > 0
+            ? `comp-background-check:${params.memberId}:${params.attempt}`
+            : `comp-background-check:${params.memberId}`,
       },
       body: JSON.stringify({
         candidate: {

--- a/apps/api/src/background-checks/background-check-identity.client.ts
+++ b/apps/api/src/background-checks/background-check-identity.client.ts
@@ -18,51 +18,60 @@ export class BackgroundCheckIdentityClient {
   }): Promise<IdentityCreateResponse> {
     const apiKey = process.env.BACKGROUND_CHECK_API_KEY;
     if (!apiKey) {
-      throw new BadRequestException('Background check service is not configured. Contact support.');
+      throw new BadRequestException(
+        'Background check service is not configured. Contact support.',
+      );
     }
 
     const baseUrl = this.baseUrl();
     const callbackUrl = this.callbackUrl();
 
-    const response = await this.fetchIdentity(`${baseUrl}/v1/background-checks`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        'Content-Type': 'application/json',
-        'Idempotency-Key':
-          params.attempt > 0
-            ? `comp-background-check:${params.memberId}:${params.attempt}`
-            : `comp-background-check:${params.memberId}`,
+    const response = await this.fetchIdentity(
+      `${baseUrl}/v1/background-checks`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+          'Idempotency-Key':
+            params.attempt > 0
+              ? `comp-background-check:${params.memberId}:${params.attempt}`
+              : `comp-background-check:${params.memberId}`,
+        },
+        body: JSON.stringify({
+          candidate: {
+            name: params.employeeName,
+            email: params.employeeEmail,
+          },
+          requester: {
+            email: params.requesterEmail,
+          },
+          employmentHistory: [],
+          references: [],
+          metadata: {
+            source: 'comp',
+            compOrganizationId: params.organizationId,
+            compMemberId: params.memberId,
+          },
+          callbackUrl,
+        }),
       },
-      body: JSON.stringify({
-        candidate: {
-          name: params.employeeName,
-          email: params.employeeEmail,
-        },
-        requester: {
-          email: params.requesterEmail,
-        },
-        employmentHistory: [],
-        references: [],
-        metadata: {
-          source: 'comp',
-          compOrganizationId: params.organizationId,
-          compMemberId: params.memberId,
-        },
-        callbackUrl,
-      }),
-    });
+    );
 
     const json = await this.readJson(response);
     if (!response.ok) {
       this.logger.error('Identity background check request failed', json);
-      throw new BadRequestException('Identity background check request failed.');
+      throw new BadRequestException(
+        'Identity background check request failed.',
+      );
     }
 
     return identityCreateResponseSchema.parse(json);
   }
 
-  async getBackgroundCheck(identityBackgroundCheckId: string): Promise<unknown> {
+  async getBackgroundCheck(
+    identityBackgroundCheckId: string,
+  ): Promise<unknown> {
     const apiKey = process.env.BACKGROUND_CHECK_API_KEY;
     if (!apiKey) return null;
 
@@ -80,19 +89,22 @@ export class BackgroundCheckIdentityClient {
 
   private baseUrl(): string {
     const baseUrl =
-      process.env.BACKGROUND_CHECK_API_BASE_URL ?? 'https://glad-sturgeon-729.convex.site';
+      process.env.BACKGROUND_CHECK_API_BASE_URL ??
+      'https://glad-sturgeon-729.convex.site';
     return baseUrl.replace(/\/+$/, '');
   }
 
   private callbackUrl(): string {
     const endpoint = process.env.BACKGROUND_WH_ENDPOINT?.trim();
-    return (endpoint || 'https://api.trycomp.ai/v1/background-checks/webhook').replace(
-      /\/+$/,
-      '',
-    );
+    return (
+      endpoint || 'https://api.trycomp.ai/v1/background-checks/webhook'
+    ).replace(/\/+$/, '');
   }
 
-  private async fetchIdentity(url: string, init: RequestInit): Promise<Response> {
+  private async fetchIdentity(
+    url: string,
+    init: RequestInit,
+  ): Promise<Response> {
     try {
       return await fetch(url, {
         ...init,

--- a/apps/api/src/background-checks/background-check-identity.client.ts
+++ b/apps/api/src/background-checks/background-check-identity.client.ts
@@ -14,7 +14,7 @@ export class BackgroundCheckIdentityClient {
     employeeName: string;
     employeeEmail: string;
     requesterEmail: string;
-    attempt: number;
+    idempotencyKey: string;
   }): Promise<IdentityCreateResponse> {
     const apiKey = process.env.BACKGROUND_CHECK_API_KEY;
     if (!apiKey) {
@@ -33,10 +33,7 @@ export class BackgroundCheckIdentityClient {
         headers: {
           Authorization: `Bearer ${apiKey}`,
           'Content-Type': 'application/json',
-          'Idempotency-Key':
-            params.attempt > 0
-              ? `comp-background-check:${params.memberId}:${params.attempt}`
-              : `comp-background-check:${params.memberId}`,
+          'Idempotency-Key': params.idempotencyKey,
         },
         body: JSON.stringify({
           candidate: {

--- a/apps/api/src/background-checks/background-check-report-snapshot.ts
+++ b/apps/api/src/background-checks/background-check-report-snapshot.ts
@@ -40,7 +40,9 @@ export async function fetchCompletedReportSnapshot({
   }
 
   try {
-    const snapshot = await identityClient.getBackgroundCheck(identityBackgroundCheckId);
+    const snapshot = await identityClient.getBackgroundCheck(
+      identityBackgroundCheckId,
+    );
     return toInputJsonValue(snapshot);
   } catch {
     return null;

--- a/apps/api/src/background-checks/background-check-retry.ts
+++ b/apps/api/src/background-checks/background-check-retry.ts
@@ -55,6 +55,27 @@ export async function cancelForMember({
   });
 }
 
+export async function deleteForMember({
+  organizationId,
+  memberId,
+  getForMember,
+}: {
+  organizationId: string;
+  memberId: string;
+  getForMember: GetForMemberFn;
+}): Promise<{ ok: true }> {
+  const existing = await getForMember({ organizationId, memberId });
+  if (!existing) {
+    throw new NotFoundException('Background check not found.');
+  }
+  // Hard delete; webhookEvents cascade via the FK. Frees the
+  // @@unique([organizationId, memberId]) constraint for a fresh request.
+  await db.backgroundCheckRequest.delete({
+    where: { organizationId_memberId: { organizationId, memberId } },
+  });
+  return { ok: true };
+}
+
 export async function retryForMember({
   organizationId,
   memberId,

--- a/apps/api/src/background-checks/background-check-retry.ts
+++ b/apps/api/src/background-checks/background-check-retry.ts
@@ -1,0 +1,118 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { BackgroundCheckStatus, db, Prisma } from '@db';
+import type { BackgroundCheckIdentityClient } from './background-check-identity.client';
+
+type GetForMemberFn = (params: {
+  organizationId: string;
+  memberId: string;
+}) => Promise<{
+  rerunCount: number;
+  employeeName: string;
+  employeeEmail: string;
+  status: BackgroundCheckStatus;
+} | null>;
+
+export function assertTransitionAllowed(
+  action: 'cancel' | 'retry',
+  status: BackgroundCheckStatus,
+): void {
+  const allowed: Record<'cancel' | 'retry', BackgroundCheckStatus[]> = {
+    cancel: [
+      BackgroundCheckStatus.invited,
+      BackgroundCheckStatus.in_progress,
+      BackgroundCheckStatus.in_review,
+    ],
+    retry: [BackgroundCheckStatus.failed, BackgroundCheckStatus.cancelled],
+  };
+  if (!allowed[action].includes(status)) {
+    throw new BadRequestException(
+      `Cannot ${action} a background check in '${status}' status.`,
+    );
+  }
+}
+
+export async function cancelForMember({
+  organizationId,
+  memberId,
+  getForMember,
+}: {
+  organizationId: string;
+  memberId: string;
+  getForMember: GetForMemberFn;
+}) {
+  const existing = await getForMember({ organizationId, memberId });
+  if (!existing) {
+    throw new NotFoundException('Background check not found.');
+  }
+  assertTransitionAllowed('cancel', existing.status);
+
+  return db.backgroundCheckRequest.update({
+    where: { organizationId_memberId: { organizationId, memberId } },
+    data: {
+      status: BackgroundCheckStatus.cancelled,
+      lastSyncedAt: new Date(),
+    },
+  });
+}
+
+export async function retryForMember({
+  organizationId,
+  memberId,
+  requesterEmail,
+  identityClient,
+  getForMember,
+}: {
+  organizationId: string;
+  memberId: string;
+  requesterEmail: string;
+  identityClient: BackgroundCheckIdentityClient;
+  getForMember: GetForMemberFn;
+}) {
+  const existing = await getForMember({ organizationId, memberId });
+  if (!existing) {
+    throw new NotFoundException('Background check not found.');
+  }
+  assertTransitionAllowed('retry', existing.status);
+
+  const attempt = existing.rerunCount + 1;
+  const where = { organizationId_memberId: { organizationId, memberId } };
+
+  // Free retry: no charge. Create a fresh Identity check first (varied
+  // idempotency key) so a late webhook from the prior check cannot match
+  // the row after we swap in the new id.
+  let identityResult;
+  try {
+    identityResult = await identityClient.createBackgroundCheck({
+      organizationId,
+      memberId,
+      employeeName: existing.employeeName,
+      employeeEmail: existing.employeeEmail,
+      requesterEmail,
+      attempt,
+    });
+  } catch (error) {
+    await db.backgroundCheckRequest.update({
+      where,
+      data: { status: BackgroundCheckStatus.failed, lastSyncedAt: new Date() },
+    });
+    throw error;
+  }
+
+  return db.backgroundCheckRequest.update({
+    where,
+    data: {
+      identityBackgroundCheckId: identityResult.id,
+      candidateUrl: identityResult.candidateUrl ?? null,
+      status: identityResult.status,
+      rerunCount: attempt,
+      identityStatus: null,
+      employmentStatus: null,
+      referenceStatus: null,
+      rightToWorkStatus: null,
+      adjudicationStatus: null,
+      reportSnapshot: Prisma.JsonNull,
+      reportSyncedAt: null,
+      lastSyncedAt: new Date(),
+    },
+  });
+}

--- a/apps/api/src/background-checks/background-check-retry.ts
+++ b/apps/api/src/background-checks/background-check-retry.ts
@@ -6,6 +6,7 @@ type GetForMemberFn = (params: {
   organizationId: string;
   memberId: string;
 }) => Promise<{
+  id: string;
   rerunCount: number;
   employeeName: string;
   employeeEmail: string;
@@ -109,12 +110,17 @@ export async function retryForMember({
       employeeName: existing.employeeName,
       employeeEmail: existing.employeeEmail,
       requesterEmail,
-      attempt,
+      // Per-record, per-attempt key so each retry creates a fresh vendor
+      // check rather than colliding with a prior attempt's idempotency key.
+      idempotencyKey: `comp-background-check:${existing.id}:${attempt}`,
     });
   } catch (error) {
+    // Restore the prior status (retry is only allowed from 'failed' or
+    // 'cancelled'). Forcing 'failed' here would strip a cancelled check of the
+    // webhook terminal-guard and let a late vendor webhook resurrect it.
     await db.backgroundCheckRequest.update({
       where,
-      data: { status: BackgroundCheckStatus.failed, lastSyncedAt: new Date() },
+      data: { status: existing.status, lastSyncedAt: new Date() },
     });
     throw error;
   }

--- a/apps/api/src/background-checks/background-check-webhook-signature.ts
+++ b/apps/api/src/background-checks/background-check-webhook-signature.ts
@@ -22,7 +22,10 @@ export function verifyBackgroundCheckWebhookSignature({
   }
 
   const timestamp = Number(timestampHeader);
-  if (!Number.isFinite(timestamp) || Math.abs(Date.now() - timestamp) > WEBHOOK_MAX_SKEW_MS) {
+  if (
+    !Number.isFinite(timestamp) ||
+    Math.abs(Date.now() - timestamp) > WEBHOOK_MAX_SKEW_MS
+  ) {
     throw new UnauthorizedException('Webhook timestamp is invalid.');
   }
 

--- a/apps/api/src/background-checks/background-check-webhook.service.spec.ts
+++ b/apps/api/src/background-checks/background-check-webhook.service.spec.ts
@@ -120,9 +120,9 @@ describe('BackgroundChecksService webhooks', () => {
       employeeName: 'Ada',
       employeeEmail: 'old@example.com',
     } as Awaited<ReturnType<typeof db.backgroundCheckRequest.findFirst>>);
-    mockAsync<Awaited<ReturnType<typeof db.backgroundCheckWebhookEvent.create>>>(
-      mockedDb.backgroundCheckWebhookEvent.create,
-    ).mockResolvedValueOnce(
+    mockAsync<
+      Awaited<ReturnType<typeof db.backgroundCheckWebhookEvent.create>>
+    >(mockedDb.backgroundCheckWebhookEvent.create).mockResolvedValueOnce(
       {} as Awaited<ReturnType<typeof db.backgroundCheckWebhookEvent.create>>,
     );
     const reportSnapshot = {
@@ -171,9 +171,9 @@ describe('BackgroundChecksService webhooks', () => {
       employeeName: 'Ada',
       employeeEmail: 'old@example.com',
     } as Awaited<ReturnType<typeof db.backgroundCheckRequest.findFirst>>);
-    mockAsync<Awaited<ReturnType<typeof db.backgroundCheckWebhookEvent.create>>>(
-      mockedDb.backgroundCheckWebhookEvent.create,
-    ).mockResolvedValueOnce(
+    mockAsync<
+      Awaited<ReturnType<typeof db.backgroundCheckWebhookEvent.create>>
+    >(mockedDb.backgroundCheckWebhookEvent.create).mockResolvedValueOnce(
       {} as Awaited<ReturnType<typeof db.backgroundCheckWebhookEvent.create>>,
     );
     const identityClient = {
@@ -214,9 +214,9 @@ describe('BackgroundChecksService webhooks', () => {
       employeeName: 'Ada',
       employeeEmail: 'old@example.com',
     } as Awaited<ReturnType<typeof db.backgroundCheckRequest.findFirst>>);
-    mockAsync<Awaited<ReturnType<typeof db.backgroundCheckWebhookEvent.create>>>(
-      mockedDb.backgroundCheckWebhookEvent.create,
-    ).mockResolvedValueOnce(
+    mockAsync<
+      Awaited<ReturnType<typeof db.backgroundCheckWebhookEvent.create>>
+    >(mockedDb.backgroundCheckWebhookEvent.create).mockResolvedValueOnce(
       {} as Awaited<ReturnType<typeof db.backgroundCheckWebhookEvent.create>>,
     );
     const identityClient = { getBackgroundCheck: jest.fn() };
@@ -253,13 +253,15 @@ describe('BackgroundChecksService webhooks', () => {
       employeeName: 'Ada',
       employeeEmail: 'ada@example.com',
     } as Awaited<ReturnType<typeof db.backgroundCheckRequest.findFirst>>);
-    mockAsync<Awaited<ReturnType<typeof db.backgroundCheckWebhookEvent.create>>>(
-      mockedDb.backgroundCheckWebhookEvent.create,
-    ).mockResolvedValueOnce(
+    mockAsync<
+      Awaited<ReturnType<typeof db.backgroundCheckWebhookEvent.create>>
+    >(mockedDb.backgroundCheckWebhookEvent.create).mockResolvedValueOnce(
       {} as Awaited<ReturnType<typeof db.backgroundCheckWebhookEvent.create>>,
     );
     const service = new BackgroundChecksService(
-      { getBackgroundCheck: jest.fn() } as unknown as BackgroundCheckIdentityClient,
+      {
+        getBackgroundCheck: jest.fn(),
+      } as unknown as BackgroundCheckIdentityClient,
       {} as unknown as BackgroundCheckPaymentService,
     );
 
@@ -287,16 +289,18 @@ describe('BackgroundChecksService webhooks', () => {
       employeeName: 'Ada',
       employeeEmail: 'old@example.com',
     } as Awaited<ReturnType<typeof db.backgroundCheckRequest.findFirst>>);
-    mockAsync<Awaited<ReturnType<typeof db.backgroundCheckWebhookEvent.create>>>(
-      mockedDb.backgroundCheckWebhookEvent.create,
-    ).mockRejectedValueOnce(
+    mockAsync<
+      Awaited<ReturnType<typeof db.backgroundCheckWebhookEvent.create>>
+    >(mockedDb.backgroundCheckWebhookEvent.create).mockRejectedValueOnce(
       new Prisma.PrismaClientKnownRequestError('duplicate', {
         code: 'P2002',
         clientVersion: 'test',
       }),
     );
     const identityClient = {
-      getBackgroundCheck: jest.fn().mockResolvedValue({ status: 'completed_with_flags' }),
+      getBackgroundCheck: jest
+        .fn()
+        .mockResolvedValue({ status: 'completed_with_flags' }),
     };
     const service = new BackgroundChecksService(
       identityClient as unknown as BackgroundCheckIdentityClient,

--- a/apps/api/src/background-checks/background-check-webhook.service.spec.ts
+++ b/apps/api/src/background-checks/background-check-webhook.service.spec.ts
@@ -17,6 +17,7 @@ jest.mock('@db', () => {
 
   return {
     Prisma: { PrismaClientKnownRequestError },
+    BackgroundCheckStatus: { cancelled: 'cancelled' },
     db: {
       backgroundCheckRequest: {
         findFirst: jest.fn(),
@@ -238,6 +239,41 @@ describe('BackgroundChecksService webhooks', () => {
         data: expect.objectContaining({ status: 'in_progress' }),
       }),
     );
+  });
+
+  it('does not change status when the local record is already cancelled', async () => {
+    const payload = webhookPayload();
+    const rawBody = JSON.stringify(payload);
+    const timestamp = String(Date.now());
+    mockAsync<Awaited<ReturnType<typeof db.backgroundCheckRequest.findFirst>>>(
+      mockedDb.backgroundCheckRequest.findFirst,
+    ).mockResolvedValueOnce({
+      id: 'bcr_1',
+      status: 'cancelled',
+      employeeName: 'Ada',
+      employeeEmail: 'ada@example.com',
+    } as Awaited<ReturnType<typeof db.backgroundCheckRequest.findFirst>>);
+    mockAsync<Awaited<ReturnType<typeof db.backgroundCheckWebhookEvent.create>>>(
+      mockedDb.backgroundCheckWebhookEvent.create,
+    ).mockResolvedValueOnce(
+      {} as Awaited<ReturnType<typeof db.backgroundCheckWebhookEvent.create>>,
+    );
+    const service = new BackgroundChecksService(
+      { getBackgroundCheck: jest.fn() } as unknown as BackgroundCheckIdentityClient,
+      {} as unknown as BackgroundCheckPaymentService,
+    );
+
+    const result = await service.handleWebhook({
+      rawBody: Buffer.from(rawBody),
+      headers: {
+        'x-background-check-timestamp': timestamp,
+        'x-background-check-signature': makeSignature(rawBody, timestamp),
+      },
+    });
+
+    expect(mockedDb.backgroundCheckWebhookEvent.create).toHaveBeenCalled();
+    expect(mockedDb.backgroundCheckRequest.update).not.toHaveBeenCalled();
+    expect(result).toEqual({ ok: true });
   });
 
   it('reconciles state even on duplicate webhook events', async () => {

--- a/apps/api/src/background-checks/background-checks.controller.spec.ts
+++ b/apps/api/src/background-checks/background-checks.controller.spec.ts
@@ -1,0 +1,86 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  PeopleBackgroundChecksController,
+} from './background-checks.controller';
+import { BackgroundChecksService } from './background-checks.service';
+import { BackgroundCheckCustomService } from './background-check-custom.service';
+import { HybridAuthGuard } from '../auth/hybrid-auth.guard';
+import { PermissionGuard } from '../auth/permission.guard';
+import type { AuthContext as AuthContextType } from '../auth/types';
+
+jest.mock('../auth/auth.server', () => ({
+  auth: { api: { getSession: jest.fn() } },
+}));
+
+jest.mock('@trycompai/auth', () => ({
+  statement: { member: ['create', 'read', 'update', 'delete'] },
+  BUILT_IN_ROLE_PERMISSIONS: {},
+}));
+
+jest.mock('@db', () => ({ db: {}, Prisma: {} }));
+
+describe('PeopleBackgroundChecksController admin actions', () => {
+  let controller: PeopleBackgroundChecksController;
+
+  const service = {
+    retryForMember: jest.fn(),
+    cancelForMember: jest.fn(),
+    deleteForMember: jest.fn(),
+  };
+
+  const mockGuard = { canActivate: jest.fn().mockReturnValue(true) };
+
+  const authContext: AuthContextType = {
+    authType: 'session',
+    userId: 'usr_1',
+    userEmail: 'user@example.com',
+    organizationId: 'org_1',
+    memberId: 'mem_admin',
+    isApiKey: false,
+    isPlatformAdmin: false,
+    userRoles: null,
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PeopleBackgroundChecksController],
+      providers: [
+        { provide: BackgroundChecksService, useValue: service },
+        { provide: BackgroundCheckCustomService, useValue: {} },
+      ],
+    })
+      .overrideGuard(HybridAuthGuard)
+      .useValue(mockGuard)
+      .overrideGuard(PermissionGuard)
+      .useValue(mockGuard)
+      .compile();
+
+    controller = module.get(PeopleBackgroundChecksController);
+    jest.clearAllMocks();
+  });
+
+  it('delegates retry with the requester email', async () => {
+    await controller.retryForMember('mem_1', 'org_1', authContext);
+    expect(service.retryForMember).toHaveBeenCalledWith({
+      organizationId: 'org_1',
+      memberId: 'mem_1',
+      requesterEmail: 'user@example.com',
+    });
+  });
+
+  it('delegates cancel', async () => {
+    await controller.cancelForMember('mem_1', 'org_1');
+    expect(service.cancelForMember).toHaveBeenCalledWith({
+      organizationId: 'org_1',
+      memberId: 'mem_1',
+    });
+  });
+
+  it('delegates delete', async () => {
+    await controller.deleteForMember('mem_1', 'org_1');
+    expect(service.deleteForMember).toHaveBeenCalledWith({
+      organizationId: 'org_1',
+      memberId: 'mem_1',
+    });
+  });
+});

--- a/apps/api/src/background-checks/background-checks.controller.spec.ts
+++ b/apps/api/src/background-checks/background-checks.controller.spec.ts
@@ -1,7 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import {
-  PeopleBackgroundChecksController,
-} from './background-checks.controller';
+import { PeopleBackgroundChecksController } from './background-checks.controller';
 import { BackgroundChecksService } from './background-checks.service';
 import { BackgroundCheckCustomService } from './background-check-custom.service';
 import { HybridAuthGuard } from '../auth/hybrid-auth.guard';

--- a/apps/api/src/background-checks/background-checks.controller.ts
+++ b/apps/api/src/background-checks/background-checks.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Headers,
   HttpCode,
@@ -96,6 +97,44 @@ export class PeopleBackgroundChecksController {
       },
       userId: authContext.userId,
     });
+  }
+
+  @Post(':id/background-check/retry')
+  @HttpCode(200)
+  @RequirePermission('member', 'update')
+  @ApiOperation({ summary: 'Retry a failed or cancelled background check (free)' })
+  async retryForMember(
+    @Param('id') memberId: string,
+    @OrganizationId() organizationId: string,
+    @AuthContext() authContext: AuthContextType,
+  ) {
+    return this.backgroundChecksService.retryForMember({
+      organizationId,
+      memberId,
+      requesterEmail: authContext.userEmail ?? 'api-key@trycomp.ai',
+    });
+  }
+
+  @Post(':id/background-check/cancel')
+  @HttpCode(200)
+  @RequirePermission('member', 'update')
+  @ApiOperation({ summary: 'Cancel an in-flight background check' })
+  async cancelForMember(
+    @Param('id') memberId: string,
+    @OrganizationId() organizationId: string,
+  ) {
+    return this.backgroundChecksService.cancelForMember({ organizationId, memberId });
+  }
+
+  @Delete(':id/background-check')
+  @HttpCode(200)
+  @RequirePermission('member', 'delete')
+  @ApiOperation({ summary: 'Delete a member background check' })
+  async deleteForMember(
+    @Param('id') memberId: string,
+    @OrganizationId() organizationId: string,
+  ) {
+    return this.backgroundChecksService.deleteForMember({ organizationId, memberId });
   }
 }
 

--- a/apps/api/src/background-checks/background-checks.controller.ts
+++ b/apps/api/src/background-checks/background-checks.controller.ts
@@ -41,7 +41,10 @@ export class PeopleBackgroundChecksController {
     @Param('id') memberId: string,
     @OrganizationId() organizationId: string,
   ) {
-    return this.backgroundChecksService.getForMember({ organizationId, memberId });
+    return this.backgroundChecksService.getForMember({
+      organizationId,
+      memberId,
+    });
   }
 
   @Post(':id/background-check')
@@ -66,12 +69,17 @@ export class PeopleBackgroundChecksController {
 
   @Get(':id/background-check/custom-attachments')
   @RequirePermission('member', 'read')
-  @ApiOperation({ summary: 'Get custom background check attachments for a member' })
+  @ApiOperation({
+    summary: 'Get custom background check attachments for a member',
+  })
   async getCustomAttachmentsForMember(
     @Param('id') memberId: string,
     @OrganizationId() organizationId: string,
   ) {
-    return this.customService.getAttachmentsForMember({ organizationId, memberId });
+    return this.customService.getAttachmentsForMember({
+      organizationId,
+      memberId,
+    });
   }
 
   @Post(':id/background-check/custom')
@@ -102,7 +110,9 @@ export class PeopleBackgroundChecksController {
   @Post(':id/background-check/retry')
   @HttpCode(200)
   @RequirePermission('member', 'update')
-  @ApiOperation({ summary: 'Retry a failed or cancelled background check (free)' })
+  @ApiOperation({
+    summary: 'Retry a failed or cancelled background check (free)',
+  })
   async retryForMember(
     @Param('id') memberId: string,
     @OrganizationId() organizationId: string,
@@ -123,7 +133,10 @@ export class PeopleBackgroundChecksController {
     @Param('id') memberId: string,
     @OrganizationId() organizationId: string,
   ) {
-    return this.backgroundChecksService.cancelForMember({ organizationId, memberId });
+    return this.backgroundChecksService.cancelForMember({
+      organizationId,
+      memberId,
+    });
   }
 
   @Delete(':id/background-check')
@@ -134,7 +147,10 @@ export class PeopleBackgroundChecksController {
     @Param('id') memberId: string,
     @OrganizationId() organizationId: string,
   ) {
-    return this.backgroundChecksService.deleteForMember({ organizationId, memberId });
+    return this.backgroundChecksService.deleteForMember({
+      organizationId,
+      memberId,
+    });
   }
 }
 
@@ -143,7 +159,9 @@ export class PeopleBackgroundChecksController {
 @UseGuards(HybridAuthGuard, PermissionGuard)
 @ApiSecurity('apikey')
 export class BackgroundChecksController {
-  constructor(private readonly backgroundChecksService: BackgroundChecksService) {}
+  constructor(
+    private readonly backgroundChecksService: BackgroundChecksService,
+  ) {}
 
   @Get(':id')
   @RequirePermission('member', 'read')

--- a/apps/api/src/background-checks/background-checks.service.spec.ts
+++ b/apps/api/src/background-checks/background-checks.service.spec.ts
@@ -17,8 +17,13 @@ jest.mock('@db', () => {
 
   return {
     BackgroundCheckStatus: {
-      failed: 'failed',
       invited: 'invited',
+      in_progress: 'in_progress',
+      in_review: 'in_review',
+      completed: 'completed',
+      completed_with_flags: 'completed_with_flags',
+      failed: 'failed',
+      cancelled: 'cancelled',
     },
     Prisma: {
       PrismaClientKnownRequestError,
@@ -31,6 +36,7 @@ jest.mock('@db', () => {
         create: jest.fn(),
         upsert: jest.fn(),
         update: jest.fn(),
+        delete: jest.fn(),
       },
       backgroundCheckWebhookEvent: {
         create: jest.fn(),
@@ -461,6 +467,64 @@ describe('background checks', () => {
         'http://localhost:3000/org_1/people/mem_1?background_check_billing=success',
       cancelUrl: 'http://localhost:3000/org_1/people/mem_1',
       customerEmail: 'billing@trycomp.ai',
+    });
+  });
+
+  describe('cancelForMember', () => {
+    function makeService() {
+      const identityClient = { createBackgroundCheck: jest.fn() };
+      const paymentService = { charge: jest.fn(), refund: jest.fn() };
+      const service = new BackgroundChecksService(
+        identityClient as unknown as BackgroundCheckIdentityClient,
+        paymentService as unknown as BackgroundCheckPaymentService,
+      );
+      return { service, identityClient, paymentService };
+    }
+
+    it('sets status to cancelled for an in_progress check', async () => {
+      mockAsync<Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>>(
+        mockedDb.backgroundCheckRequest.findUnique,
+      ).mockResolvedValueOnce({ id: 'bcr_1', status: 'in_progress' } as Awaited<
+        ReturnType<typeof db.backgroundCheckRequest.findUnique>
+      >);
+      mockAsync<Awaited<ReturnType<typeof db.backgroundCheckRequest.update>>>(
+        mockedDb.backgroundCheckRequest.update,
+      ).mockResolvedValueOnce({ id: 'bcr_1', status: 'cancelled' } as Awaited<
+        ReturnType<typeof db.backgroundCheckRequest.update>
+      >);
+
+      const { service } = makeService();
+      const result = await service.cancelForMember({ organizationId: 'org_1', memberId: 'mem_1' });
+
+      expect(mockedDb.backgroundCheckRequest.update).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ status: 'cancelled' }) }),
+      );
+      expect((result as { status: string }).status).toBe('cancelled');
+    });
+
+    it('rejects cancelling a completed check', async () => {
+      mockAsync<Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>>(
+        mockedDb.backgroundCheckRequest.findUnique,
+      ).mockResolvedValueOnce({ id: 'bcr_1', status: 'completed' } as Awaited<
+        ReturnType<typeof db.backgroundCheckRequest.findUnique>
+      >);
+      const { service } = makeService();
+      await expect(
+        service.cancelForMember({ organizationId: 'org_1', memberId: 'mem_1' }),
+      ).rejects.toThrow("Cannot cancel a background check in 'completed' status.");
+      expect(mockedDb.backgroundCheckRequest.update).not.toHaveBeenCalled();
+    });
+
+    it('throws when no check exists', async () => {
+      mockAsync<Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>>(
+        mockedDb.backgroundCheckRequest.findUnique,
+      ).mockResolvedValueOnce(null as Awaited<
+        ReturnType<typeof db.backgroundCheckRequest.findUnique>
+      >);
+      const { service } = makeService();
+      await expect(
+        service.cancelForMember({ organizationId: 'org_1', memberId: 'mem_1' }),
+      ).rejects.toThrow('Background check not found.');
     });
   });
 

--- a/apps/api/src/background-checks/background-checks.service.spec.ts
+++ b/apps/api/src/background-checks/background-checks.service.spec.ts
@@ -483,11 +483,12 @@ describe('background checks', () => {
     }
 
     it('sets status to cancelled for an in_progress check', async () => {
-      mockAsync<Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>>(
-        mockedDb.backgroundCheckRequest.findUnique,
-      ).mockResolvedValueOnce({ id: 'bcr_1', status: 'in_progress' } as Awaited<
-        ReturnType<typeof db.backgroundCheckRequest.findUnique>
-      >);
+      mockAsync<
+        Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>
+      >(mockedDb.backgroundCheckRequest.findUnique).mockResolvedValueOnce({
+        id: 'bcr_1',
+        status: 'in_progress',
+      } as Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>);
       mockAsync<Awaited<ReturnType<typeof db.backgroundCheckRequest.update>>>(
         mockedDb.backgroundCheckRequest.update,
       ).mockResolvedValueOnce({ id: 'bcr_1', status: 'cancelled' } as Awaited<
@@ -495,33 +496,43 @@ describe('background checks', () => {
       >);
 
       const { service } = makeService();
-      const result = await service.cancelForMember({ organizationId: 'org_1', memberId: 'mem_1' });
+      const result = await service.cancelForMember({
+        organizationId: 'org_1',
+        memberId: 'mem_1',
+      });
 
       expect(mockedDb.backgroundCheckRequest.update).toHaveBeenCalledWith(
-        expect.objectContaining({ data: expect.objectContaining({ status: 'cancelled' }) }),
+        expect.objectContaining({
+          data: expect.objectContaining({ status: 'cancelled' }),
+        }),
       );
       expect((result as { status: string }).status).toBe('cancelled');
     });
 
     it('rejects cancelling a completed check', async () => {
-      mockAsync<Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>>(
-        mockedDb.backgroundCheckRequest.findUnique,
-      ).mockResolvedValueOnce({ id: 'bcr_1', status: 'completed' } as Awaited<
-        ReturnType<typeof db.backgroundCheckRequest.findUnique>
-      >);
+      mockAsync<
+        Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>
+      >(mockedDb.backgroundCheckRequest.findUnique).mockResolvedValueOnce({
+        id: 'bcr_1',
+        status: 'completed',
+      } as Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>);
       const { service } = makeService();
       await expect(
         service.cancelForMember({ organizationId: 'org_1', memberId: 'mem_1' }),
-      ).rejects.toThrow("Cannot cancel a background check in 'completed' status.");
+      ).rejects.toThrow(
+        "Cannot cancel a background check in 'completed' status.",
+      );
       expect(mockedDb.backgroundCheckRequest.update).not.toHaveBeenCalled();
     });
 
     it('throws when no check exists', async () => {
-      mockAsync<Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>>(
-        mockedDb.backgroundCheckRequest.findUnique,
-      ).mockResolvedValueOnce(null as Awaited<
-        ReturnType<typeof db.backgroundCheckRequest.findUnique>
-      >);
+      mockAsync<
+        Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>
+      >(mockedDb.backgroundCheckRequest.findUnique).mockResolvedValueOnce(
+        null as Awaited<
+          ReturnType<typeof db.backgroundCheckRequest.findUnique>
+        >,
+      );
       const { service } = makeService();
       await expect(
         service.cancelForMember({ organizationId: 'org_1', memberId: 'mem_1' }),
@@ -531,9 +542,9 @@ describe('background checks', () => {
 
   describe('retryForMember', () => {
     it('resubmits a failed check for free with an incremented attempt key', async () => {
-      mockAsync<Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>>(
-        mockedDb.backgroundCheckRequest.findUnique,
-      ).mockResolvedValueOnce({
+      mockAsync<
+        Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>
+      >(mockedDb.backgroundCheckRequest.findUnique).mockResolvedValueOnce({
         id: 'bcr_1',
         status: 'failed',
         rerunCount: 1,
@@ -549,7 +560,11 @@ describe('background checks', () => {
       const identityClient = {
         createBackgroundCheck: jest
           .fn()
-          .mockResolvedValue({ id: 'check_new', status: 'invited', candidateUrl: 'https://c/x' }),
+          .mockResolvedValue({
+            id: 'check_new',
+            status: 'invited',
+            candidateUrl: 'https://c/x',
+          }),
       };
       const paymentService = { charge: jest.fn(), refund: jest.fn() };
       const service = new BackgroundChecksService(
@@ -582,26 +597,34 @@ describe('background checks', () => {
     });
 
     it('rejects retrying an in_progress check', async () => {
-      mockAsync<Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>>(
-        mockedDb.backgroundCheckRequest.findUnique,
-      ).mockResolvedValueOnce({ id: 'bcr_1', status: 'in_progress', rerunCount: 0 } as Awaited<
-        ReturnType<typeof db.backgroundCheckRequest.findUnique>
-      >);
+      mockAsync<
+        Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>
+      >(mockedDb.backgroundCheckRequest.findUnique).mockResolvedValueOnce({
+        id: 'bcr_1',
+        status: 'in_progress',
+        rerunCount: 0,
+      } as Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>);
       const identityClient = { createBackgroundCheck: jest.fn() };
       const service = new BackgroundChecksService(
         identityClient as unknown as BackgroundCheckIdentityClient,
         {} as unknown as BackgroundCheckPaymentService,
       );
       await expect(
-        service.retryForMember({ organizationId: 'org_1', memberId: 'mem_1', requesterEmail: 'a@b.c' }),
-      ).rejects.toThrow("Cannot retry a background check in 'in_progress' status.");
+        service.retryForMember({
+          organizationId: 'org_1',
+          memberId: 'mem_1',
+          requesterEmail: 'a@b.c',
+        }),
+      ).rejects.toThrow(
+        "Cannot retry a background check in 'in_progress' status.",
+      );
       expect(identityClient.createBackgroundCheck).not.toHaveBeenCalled();
     });
 
     it('marks the check failed and rethrows when Identity errors', async () => {
-      mockAsync<Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>>(
-        mockedDb.backgroundCheckRequest.findUnique,
-      ).mockResolvedValueOnce({
+      mockAsync<
+        Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>
+      >(mockedDb.backgroundCheckRequest.findUnique).mockResolvedValueOnce({
         id: 'bcr_1',
         status: 'cancelled',
         rerunCount: 0,
@@ -610,36 +633,55 @@ describe('background checks', () => {
       } as Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>);
       mockAsync<Awaited<ReturnType<typeof db.backgroundCheckRequest.update>>>(
         mockedDb.backgroundCheckRequest.update,
-      ).mockResolvedValue({} as Awaited<ReturnType<typeof db.backgroundCheckRequest.update>>);
+      ).mockResolvedValue(
+        {} as Awaited<ReturnType<typeof db.backgroundCheckRequest.update>>,
+      );
       const identityClient = {
-        createBackgroundCheck: jest.fn().mockRejectedValue(new Error('identity down')),
+        createBackgroundCheck: jest
+          .fn()
+          .mockRejectedValue(new Error('identity down')),
       };
       const service = new BackgroundChecksService(
         identityClient as unknown as BackgroundCheckIdentityClient,
-        { charge: jest.fn(), refund: jest.fn() } as unknown as BackgroundCheckPaymentService,
+        {
+          charge: jest.fn(),
+          refund: jest.fn(),
+        } as unknown as BackgroundCheckPaymentService,
       );
 
       await expect(
-        service.retryForMember({ organizationId: 'org_1', memberId: 'mem_1', requesterEmail: 'a@b.c' }),
+        service.retryForMember({
+          organizationId: 'org_1',
+          memberId: 'mem_1',
+          requesterEmail: 'a@b.c',
+        }),
       ).rejects.toThrow('identity down');
       expect(mockedDb.backgroundCheckRequest.update).toHaveBeenCalledWith(
-        expect.objectContaining({ data: expect.objectContaining({ status: 'failed' }) }),
+        expect.objectContaining({
+          data: expect.objectContaining({ status: 'failed' }),
+        }),
       );
     });
 
     it('throws when no check exists', async () => {
-      mockAsync<Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>>(
-        mockedDb.backgroundCheckRequest.findUnique,
-      ).mockResolvedValueOnce(null as Awaited<
-        ReturnType<typeof db.backgroundCheckRequest.findUnique>
-      >);
+      mockAsync<
+        Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>
+      >(mockedDb.backgroundCheckRequest.findUnique).mockResolvedValueOnce(
+        null as Awaited<
+          ReturnType<typeof db.backgroundCheckRequest.findUnique>
+        >,
+      );
       const identityClient = { createBackgroundCheck: jest.fn() };
       const service = new BackgroundChecksService(
         identityClient as unknown as BackgroundCheckIdentityClient,
         {} as unknown as BackgroundCheckPaymentService,
       );
       await expect(
-        service.retryForMember({ organizationId: 'org_1', memberId: 'mem_1', requesterEmail: 'a@b.c' }),
+        service.retryForMember({
+          organizationId: 'org_1',
+          memberId: 'mem_1',
+          requesterEmail: 'a@b.c',
+        }),
       ).rejects.toThrow('Background check not found.');
       expect(identityClient.createBackgroundCheck).not.toHaveBeenCalled();
     });
@@ -647,11 +689,12 @@ describe('background checks', () => {
 
   describe('deleteForMember', () => {
     it('hard-deletes an existing check', async () => {
-      mockAsync<Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>>(
-        mockedDb.backgroundCheckRequest.findUnique,
-      ).mockResolvedValueOnce({ id: 'bcr_1', status: 'failed' } as Awaited<
-        ReturnType<typeof db.backgroundCheckRequest.findUnique>
-      >);
+      mockAsync<
+        Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>
+      >(mockedDb.backgroundCheckRequest.findUnique).mockResolvedValueOnce({
+        id: 'bcr_1',
+        status: 'failed',
+      } as Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>);
       mockAsync<Awaited<ReturnType<typeof db.backgroundCheckRequest.delete>>>(
         mockedDb.backgroundCheckRequest.delete,
       ).mockResolvedValueOnce({ id: 'bcr_1' } as Awaited<
@@ -662,20 +705,30 @@ describe('background checks', () => {
         {} as unknown as BackgroundCheckIdentityClient,
         {} as unknown as BackgroundCheckPaymentService,
       );
-      const result = await service.deleteForMember({ organizationId: 'org_1', memberId: 'mem_1' });
+      const result = await service.deleteForMember({
+        organizationId: 'org_1',
+        memberId: 'mem_1',
+      });
 
       expect(mockedDb.backgroundCheckRequest.delete).toHaveBeenCalledWith({
-        where: { organizationId_memberId: { organizationId: 'org_1', memberId: 'mem_1' } },
+        where: {
+          organizationId_memberId: {
+            organizationId: 'org_1',
+            memberId: 'mem_1',
+          },
+        },
       });
       expect(result).toEqual({ ok: true });
     });
 
     it('throws when no check exists', async () => {
-      mockAsync<Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>>(
-        mockedDb.backgroundCheckRequest.findUnique,
-      ).mockResolvedValueOnce(null as Awaited<
-        ReturnType<typeof db.backgroundCheckRequest.findUnique>
-      >);
+      mockAsync<
+        Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>
+      >(mockedDb.backgroundCheckRequest.findUnique).mockResolvedValueOnce(
+        null as Awaited<
+          ReturnType<typeof db.backgroundCheckRequest.findUnique>
+        >,
+      );
       const service = new BackgroundChecksService(
         {} as unknown as BackgroundCheckIdentityClient,
         {} as unknown as BackgroundCheckPaymentService,

--- a/apps/api/src/background-checks/background-checks.service.spec.ts
+++ b/apps/api/src/background-checks/background-checks.service.spec.ts
@@ -105,6 +105,7 @@ describe('background checks', () => {
       employeeName: 'Ada Lovelace',
       employeeEmail: 'ada@example.com',
       requesterEmail: 'admin@example.com',
+      attempt: 0,
     });
 
     expect(fetchSpy).toHaveBeenCalledWith(
@@ -160,6 +161,7 @@ describe('background checks', () => {
       employeeName: 'Ada Lovelace',
       employeeEmail: 'ada@example.com',
       requesterEmail: 'admin@example.com',
+      attempt: 0,
     });
 
     const request = fetchSpy.mock.calls[0]?.[1];
@@ -186,6 +188,7 @@ describe('background checks', () => {
         employeeName: 'Ada Lovelace',
         employeeEmail: 'ada@example.com',
         requesterEmail: 'admin@example.com',
+        attempt: 0,
       }),
     ).rejects.toThrow('Identity background check request failed.');
   });

--- a/apps/api/src/background-checks/background-checks.service.spec.ts
+++ b/apps/api/src/background-checks/background-checks.service.spec.ts
@@ -645,6 +645,48 @@ describe('background checks', () => {
     });
   });
 
+  describe('deleteForMember', () => {
+    it('hard-deletes an existing check', async () => {
+      mockAsync<Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>>(
+        mockedDb.backgroundCheckRequest.findUnique,
+      ).mockResolvedValueOnce({ id: 'bcr_1', status: 'failed' } as Awaited<
+        ReturnType<typeof db.backgroundCheckRequest.findUnique>
+      >);
+      mockAsync<Awaited<ReturnType<typeof db.backgroundCheckRequest.delete>>>(
+        mockedDb.backgroundCheckRequest.delete,
+      ).mockResolvedValueOnce({ id: 'bcr_1' } as Awaited<
+        ReturnType<typeof db.backgroundCheckRequest.delete>
+      >);
+
+      const service = new BackgroundChecksService(
+        {} as unknown as BackgroundCheckIdentityClient,
+        {} as unknown as BackgroundCheckPaymentService,
+      );
+      const result = await service.deleteForMember({ organizationId: 'org_1', memberId: 'mem_1' });
+
+      expect(mockedDb.backgroundCheckRequest.delete).toHaveBeenCalledWith({
+        where: { organizationId_memberId: { organizationId: 'org_1', memberId: 'mem_1' } },
+      });
+      expect(result).toEqual({ ok: true });
+    });
+
+    it('throws when no check exists', async () => {
+      mockAsync<Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>>(
+        mockedDb.backgroundCheckRequest.findUnique,
+      ).mockResolvedValueOnce(null as Awaited<
+        ReturnType<typeof db.backgroundCheckRequest.findUnique>
+      >);
+      const service = new BackgroundChecksService(
+        {} as unknown as BackgroundCheckIdentityClient,
+        {} as unknown as BackgroundCheckPaymentService,
+      );
+      await expect(
+        service.deleteForMember({ organizationId: 'org_1', memberId: 'mem_1' }),
+      ).rejects.toThrow('Background check not found.');
+      expect(mockedDb.backgroundCheckRequest.delete).not.toHaveBeenCalled();
+    });
+  });
+
   it('includes background check and penetration test usage in billing status', async () => {
     const billingService = {
       getStatus: jest.fn().mockResolvedValue({

--- a/apps/api/src/background-checks/background-checks.service.spec.ts
+++ b/apps/api/src/background-checks/background-checks.service.spec.ts
@@ -3,7 +3,7 @@ import { BillingService } from '../billing/billing.service';
 import { BackgroundCheckBillingService } from './background-check-billing.service';
 import { BackgroundCheckPaymentService } from './background-check-payment.service';
 import { BackgroundChecksService } from './background-checks.service';
-import { db } from '@db';
+import { db, Prisma } from '@db';
 
 jest.mock('@db', () => {
   class PrismaClientKnownRequestError extends Error {
@@ -27,6 +27,7 @@ jest.mock('@db', () => {
     },
     Prisma: {
       PrismaClientKnownRequestError,
+      JsonNull: 'JsonNull',
     },
     db: {
       backgroundCheckRequest: {
@@ -525,6 +526,105 @@ describe('background checks', () => {
       await expect(
         service.cancelForMember({ organizationId: 'org_1', memberId: 'mem_1' }),
       ).rejects.toThrow('Background check not found.');
+    });
+  });
+
+  describe('retryForMember', () => {
+    it('resubmits a failed check for free with an incremented attempt key', async () => {
+      mockAsync<Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>>(
+        mockedDb.backgroundCheckRequest.findUnique,
+      ).mockResolvedValueOnce({
+        id: 'bcr_1',
+        status: 'failed',
+        rerunCount: 1,
+        employeeName: 'Ada Lovelace',
+        employeeEmail: 'ada@example.com',
+      } as Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>);
+      mockAsync<Awaited<ReturnType<typeof db.backgroundCheckRequest.update>>>(
+        mockedDb.backgroundCheckRequest.update,
+      ).mockResolvedValueOnce({ id: 'bcr_1', status: 'invited' } as Awaited<
+        ReturnType<typeof db.backgroundCheckRequest.update>
+      >);
+
+      const identityClient = {
+        createBackgroundCheck: jest
+          .fn()
+          .mockResolvedValue({ id: 'check_new', status: 'invited', candidateUrl: 'https://c/x' }),
+      };
+      const paymentService = { charge: jest.fn(), refund: jest.fn() };
+      const service = new BackgroundChecksService(
+        identityClient as unknown as BackgroundCheckIdentityClient,
+        paymentService as unknown as BackgroundCheckPaymentService,
+      );
+
+      await service.retryForMember({
+        organizationId: 'org_1',
+        memberId: 'mem_1',
+        requesterEmail: 'admin@example.com',
+      });
+
+      expect(paymentService.charge).not.toHaveBeenCalled();
+      expect(identityClient.createBackgroundCheck).toHaveBeenCalledWith(
+        expect.objectContaining({ memberId: 'mem_1', attempt: 2 }),
+      );
+      expect(mockedDb.backgroundCheckRequest.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            identityBackgroundCheckId: 'check_new',
+            status: 'invited',
+            rerunCount: 2,
+            identityStatus: null,
+            reportSnapshot: Prisma.JsonNull,
+            reportSyncedAt: null,
+          }),
+        }),
+      );
+    });
+
+    it('rejects retrying an in_progress check', async () => {
+      mockAsync<Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>>(
+        mockedDb.backgroundCheckRequest.findUnique,
+      ).mockResolvedValueOnce({ id: 'bcr_1', status: 'in_progress', rerunCount: 0 } as Awaited<
+        ReturnType<typeof db.backgroundCheckRequest.findUnique>
+      >);
+      const identityClient = { createBackgroundCheck: jest.fn() };
+      const service = new BackgroundChecksService(
+        identityClient as unknown as BackgroundCheckIdentityClient,
+        {} as unknown as BackgroundCheckPaymentService,
+      );
+      await expect(
+        service.retryForMember({ organizationId: 'org_1', memberId: 'mem_1', requesterEmail: 'a@b.c' }),
+      ).rejects.toThrow("Cannot retry a background check in 'in_progress' status.");
+      expect(identityClient.createBackgroundCheck).not.toHaveBeenCalled();
+    });
+
+    it('marks the check failed and rethrows when Identity errors', async () => {
+      mockAsync<Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>>(
+        mockedDb.backgroundCheckRequest.findUnique,
+      ).mockResolvedValueOnce({
+        id: 'bcr_1',
+        status: 'cancelled',
+        rerunCount: 0,
+        employeeName: 'Ada',
+        employeeEmail: 'ada@example.com',
+      } as Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>);
+      mockAsync<Awaited<ReturnType<typeof db.backgroundCheckRequest.update>>>(
+        mockedDb.backgroundCheckRequest.update,
+      ).mockResolvedValue({} as Awaited<ReturnType<typeof db.backgroundCheckRequest.update>>);
+      const identityClient = {
+        createBackgroundCheck: jest.fn().mockRejectedValue(new Error('identity down')),
+      };
+      const service = new BackgroundChecksService(
+        identityClient as unknown as BackgroundCheckIdentityClient,
+        { charge: jest.fn(), refund: jest.fn() } as unknown as BackgroundCheckPaymentService,
+      );
+
+      await expect(
+        service.retryForMember({ organizationId: 'org_1', memberId: 'mem_1', requesterEmail: 'a@b.c' }),
+      ).rejects.toThrow('identity down');
+      expect(mockedDb.backgroundCheckRequest.update).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ status: 'failed' }) }),
+      );
     });
   });
 

--- a/apps/api/src/background-checks/background-checks.service.spec.ts
+++ b/apps/api/src/background-checks/background-checks.service.spec.ts
@@ -626,6 +626,23 @@ describe('background checks', () => {
         expect.objectContaining({ data: expect.objectContaining({ status: 'failed' }) }),
       );
     });
+
+    it('throws when no check exists', async () => {
+      mockAsync<Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>>(
+        mockedDb.backgroundCheckRequest.findUnique,
+      ).mockResolvedValueOnce(null as Awaited<
+        ReturnType<typeof db.backgroundCheckRequest.findUnique>
+      >);
+      const identityClient = { createBackgroundCheck: jest.fn() };
+      const service = new BackgroundChecksService(
+        identityClient as unknown as BackgroundCheckIdentityClient,
+        {} as unknown as BackgroundCheckPaymentService,
+      );
+      await expect(
+        service.retryForMember({ organizationId: 'org_1', memberId: 'mem_1', requesterEmail: 'a@b.c' }),
+      ).rejects.toThrow('Background check not found.');
+      expect(identityClient.createBackgroundCheck).not.toHaveBeenCalled();
+    });
   });
 
   it('includes background check and penetration test usage in billing status', async () => {

--- a/apps/api/src/background-checks/background-checks.service.spec.ts
+++ b/apps/api/src/background-checks/background-checks.service.spec.ts
@@ -112,7 +112,7 @@ describe('background checks', () => {
       employeeName: 'Ada Lovelace',
       employeeEmail: 'ada@example.com',
       requesterEmail: 'admin@example.com',
-      attempt: 0,
+      idempotencyKey: 'comp-background-check:mem_1',
     });
 
     expect(fetchSpy).toHaveBeenCalledWith(
@@ -168,7 +168,7 @@ describe('background checks', () => {
       employeeName: 'Ada Lovelace',
       employeeEmail: 'ada@example.com',
       requesterEmail: 'admin@example.com',
-      attempt: 0,
+      idempotencyKey: 'comp-background-check:mem_1',
     });
 
     const request = fetchSpy.mock.calls[0]?.[1];
@@ -195,7 +195,7 @@ describe('background checks', () => {
         employeeName: 'Ada Lovelace',
         employeeEmail: 'ada@example.com',
         requesterEmail: 'admin@example.com',
-        attempt: 0,
+        idempotencyKey: 'comp-background-check:mem_1',
       }),
     ).rejects.toThrow('Identity background check request failed.');
   });
@@ -580,7 +580,10 @@ describe('background checks', () => {
 
       expect(paymentService.charge).not.toHaveBeenCalled();
       expect(identityClient.createBackgroundCheck).toHaveBeenCalledWith(
-        expect.objectContaining({ memberId: 'mem_1', attempt: 2 }),
+        expect.objectContaining({
+          memberId: 'mem_1',
+          idempotencyKey: 'comp-background-check:bcr_1:2',
+        }),
       );
       expect(mockedDb.backgroundCheckRequest.update).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -621,7 +624,7 @@ describe('background checks', () => {
       expect(identityClient.createBackgroundCheck).not.toHaveBeenCalled();
     });
 
-    it('marks the check failed and rethrows when Identity errors', async () => {
+    it('keeps a cancelled check cancelled (no resurrection) and rethrows when Identity errors', async () => {
       mockAsync<
         Awaited<ReturnType<typeof db.backgroundCheckRequest.findUnique>>
       >(mockedDb.backgroundCheckRequest.findUnique).mockResolvedValueOnce({
@@ -658,7 +661,7 @@ describe('background checks', () => {
       ).rejects.toThrow('identity down');
       expect(mockedDb.backgroundCheckRequest.update).toHaveBeenCalledWith(
         expect.objectContaining({
-          data: expect.objectContaining({ status: 'failed' }),
+          data: expect.objectContaining({ status: 'cancelled' }),
         }),
       );
     });

--- a/apps/api/src/background-checks/background-checks.service.ts
+++ b/apps/api/src/background-checks/background-checks.service.ts
@@ -10,12 +10,12 @@ import {
   headerValue,
   verifyBackgroundCheckWebhookSignature,
 } from './background-check-webhook-signature';
+import { identityWebhookPayloadSchema } from './background-checks.types';
+import { fetchCompletedReportSnapshot } from './background-check-report-snapshot';
 import {
-  identityWebhookPayloadSchema,
-} from './background-checks.types';
-import {
-  fetchCompletedReportSnapshot,
-} from './background-check-report-snapshot';
+  cancelForMember as cancelForMemberFn,
+  retryForMember as retryForMemberFn,
+} from './background-check-retry';
 
 @Injectable()
 export class BackgroundChecksService {
@@ -268,103 +268,20 @@ export class BackgroundChecksService {
     return { ok: true, ...(isDuplicate ? { duplicate: true } : {}) };
   }
 
-  async cancelForMember({
-    organizationId,
-    memberId,
-  }: {
-    organizationId: string;
-    memberId: string;
-  }) {
-    const existing = await this.getForMember({ organizationId, memberId });
-    if (!existing) {
-      throw new NotFoundException('Background check not found.');
-    }
-    this.assertTransitionAllowed('cancel', existing.status);
-
-    return db.backgroundCheckRequest.update({
-      where: { organizationId_memberId: { organizationId, memberId } },
-      data: {
-        status: BackgroundCheckStatus.cancelled,
-        lastSyncedAt: new Date(),
-      },
-    });
+  async cancelForMember(params: { organizationId: string; memberId: string }) {
+    return cancelForMemberFn({ ...params, getForMember: (p) => this.getForMember(p) });
   }
 
-  async retryForMember({
-    organizationId,
-    memberId,
-    requesterEmail,
-  }: {
+  async retryForMember(params: {
     organizationId: string;
     memberId: string;
     requesterEmail: string;
   }) {
-    const existing = await this.getForMember({ organizationId, memberId });
-    if (!existing) {
-      throw new NotFoundException('Background check not found.');
-    }
-    this.assertTransitionAllowed('retry', existing.status);
-
-    const attempt = existing.rerunCount + 1;
-    const where = { organizationId_memberId: { organizationId, memberId } };
-
-    // Free retry: no charge. Create a fresh Identity check first (varied
-    // idempotency key) so a late webhook from the prior check cannot match
-    // the row after we swap in the new id.
-    let identityResult;
-    try {
-      identityResult = await this.identityClient.createBackgroundCheck({
-        organizationId,
-        memberId,
-        employeeName: existing.employeeName,
-        employeeEmail: existing.employeeEmail,
-        requesterEmail,
-        attempt,
-      });
-    } catch (error) {
-      await db.backgroundCheckRequest.update({
-        where,
-        data: { status: BackgroundCheckStatus.failed, lastSyncedAt: new Date() },
-      });
-      throw error;
-    }
-
-    return db.backgroundCheckRequest.update({
-      where,
-      data: {
-        identityBackgroundCheckId: identityResult.id,
-        candidateUrl: identityResult.candidateUrl ?? null,
-        status: identityResult.status,
-        rerunCount: attempt,
-        identityStatus: null,
-        employmentStatus: null,
-        referenceStatus: null,
-        rightToWorkStatus: null,
-        adjudicationStatus: null,
-        reportSnapshot: Prisma.JsonNull,
-        reportSyncedAt: null,
-        lastSyncedAt: new Date(),
-      },
+    return retryForMemberFn({
+      ...params,
+      identityClient: this.identityClient,
+      getForMember: (p) => this.getForMember(p),
     });
-  }
-
-  private assertTransitionAllowed(
-    action: 'cancel' | 'retry',
-    status: BackgroundCheckStatus,
-  ): void {
-    const allowed: Record<'cancel' | 'retry', BackgroundCheckStatus[]> = {
-      cancel: [
-        BackgroundCheckStatus.invited,
-        BackgroundCheckStatus.in_progress,
-        BackgroundCheckStatus.in_review,
-      ],
-      retry: [BackgroundCheckStatus.failed, BackgroundCheckStatus.cancelled],
-    };
-    if (!allowed[action].includes(status)) {
-      throw new BadRequestException(
-        `Cannot ${action} a background check in '${status}' status.`,
-      );
-    }
   }
 
   private isUniqueConstraintError(error: unknown): boolean {

--- a/apps/api/src/background-checks/background-checks.service.ts
+++ b/apps/api/src/background-checks/background-checks.service.ts
@@ -68,8 +68,11 @@ export class BackgroundChecksService {
 
     // Step 1: Claim the record slot before charging. Catches the TOCTOU race
     // where two concurrent requests both pass the getForMember check.
+    let created: Awaited<
+      ReturnType<typeof db.backgroundCheckRequest.create>
+    >;
     try {
-      await db.backgroundCheckRequest.create({
+      created = await db.backgroundCheckRequest.create({
         data: {
           organizationId,
           memberId,
@@ -124,7 +127,10 @@ export class BackgroundChecksService {
         employeeName,
         employeeEmail,
         requesterEmail,
-        attempt: 0,
+        // Key on the record's unique id (not memberId) so a delete +
+        // re-request creates a genuinely fresh vendor check instead of
+        // colliding with the original request's idempotency key.
+        idempotencyKey: `comp-background-check:${created.id}`,
       });
     } catch (error) {
       const refundId = await this.paymentService.refund({

--- a/apps/api/src/background-checks/background-checks.service.ts
+++ b/apps/api/src/background-checks/background-checks.service.ts
@@ -290,6 +290,64 @@ export class BackgroundChecksService {
     });
   }
 
+  async retryForMember({
+    organizationId,
+    memberId,
+    requesterEmail,
+  }: {
+    organizationId: string;
+    memberId: string;
+    requesterEmail: string;
+  }) {
+    const existing = await this.getForMember({ organizationId, memberId });
+    if (!existing) {
+      throw new NotFoundException('Background check not found.');
+    }
+    this.assertTransitionAllowed('retry', existing.status);
+
+    const attempt = existing.rerunCount + 1;
+    const where = { organizationId_memberId: { organizationId, memberId } };
+
+    // Free retry: no charge. Create a fresh Identity check first (varied
+    // idempotency key) so a late webhook from the prior check cannot match
+    // the row after we swap in the new id.
+    let identityResult;
+    try {
+      identityResult = await this.identityClient.createBackgroundCheck({
+        organizationId,
+        memberId,
+        employeeName: existing.employeeName,
+        employeeEmail: existing.employeeEmail,
+        requesterEmail,
+        attempt,
+      });
+    } catch (error) {
+      await db.backgroundCheckRequest.update({
+        where,
+        data: { status: BackgroundCheckStatus.failed, lastSyncedAt: new Date() },
+      });
+      throw error;
+    }
+
+    return db.backgroundCheckRequest.update({
+      where,
+      data: {
+        identityBackgroundCheckId: identityResult.id,
+        candidateUrl: identityResult.candidateUrl ?? null,
+        status: identityResult.status,
+        rerunCount: attempt,
+        identityStatus: null,
+        employmentStatus: null,
+        referenceStatus: null,
+        rightToWorkStatus: null,
+        adjudicationStatus: null,
+        reportSnapshot: Prisma.JsonNull,
+        reportSyncedAt: null,
+        lastSyncedAt: new Date(),
+      },
+    });
+  }
+
   private assertTransitionAllowed(
     action: 'cancel' | 'retry',
     status: BackgroundCheckStatus,

--- a/apps/api/src/background-checks/background-checks.service.ts
+++ b/apps/api/src/background-checks/background-checks.service.ts
@@ -268,6 +268,47 @@ export class BackgroundChecksService {
     return { ok: true, ...(isDuplicate ? { duplicate: true } : {}) };
   }
 
+  async cancelForMember({
+    organizationId,
+    memberId,
+  }: {
+    organizationId: string;
+    memberId: string;
+  }) {
+    const existing = await this.getForMember({ organizationId, memberId });
+    if (!existing) {
+      throw new NotFoundException('Background check not found.');
+    }
+    this.assertTransitionAllowed('cancel', existing.status);
+
+    return db.backgroundCheckRequest.update({
+      where: { organizationId_memberId: { organizationId, memberId } },
+      data: {
+        status: BackgroundCheckStatus.cancelled,
+        lastSyncedAt: new Date(),
+      },
+    });
+  }
+
+  private assertTransitionAllowed(
+    action: 'cancel' | 'retry',
+    status: BackgroundCheckStatus,
+  ): void {
+    const allowed: Record<'cancel' | 'retry', BackgroundCheckStatus[]> = {
+      cancel: [
+        BackgroundCheckStatus.invited,
+        BackgroundCheckStatus.in_progress,
+        BackgroundCheckStatus.in_review,
+      ],
+      retry: [BackgroundCheckStatus.failed, BackgroundCheckStatus.cancelled],
+    };
+    if (!allowed[action].includes(status)) {
+      throw new BadRequestException(
+        `Cannot ${action} a background check in '${status}' status.`,
+      );
+    }
+  }
+
   private isUniqueConstraintError(error: unknown): boolean {
     return (
       error instanceof Prisma.PrismaClientKnownRequestError &&

--- a/apps/api/src/background-checks/background-checks.service.ts
+++ b/apps/api/src/background-checks/background-checks.service.ts
@@ -175,7 +175,10 @@ export class BackgroundChecksService {
       throw new NotFoundException('Background check not found.');
     }
 
-    if (!record.identityBackgroundCheckId || !process.env.BACKGROUND_CHECK_API_KEY) {
+    if (
+      !record.identityBackgroundCheckId ||
+      !process.env.BACKGROUND_CHECK_API_KEY
+    ) {
       return { record };
     }
 
@@ -197,8 +200,11 @@ export class BackgroundChecksService {
     }
 
     verifyBackgroundCheckWebhookSignature({ rawBody, headers });
-    const payload = identityWebhookPayloadSchema.parse(JSON.parse(rawBody.toString('utf8')));
-    const eventId = headerValue(headers, 'x-background-check-event-id') ?? payload.eventId;
+    const payload = identityWebhookPayloadSchema.parse(
+      JSON.parse(rawBody.toString('utf8')),
+    );
+    const eventId =
+      headerValue(headers, 'x-background-check-event-id') ?? payload.eventId;
     const eventType =
       headerValue(headers, 'x-background-check-event-type') ?? payload.type;
 
@@ -276,7 +282,10 @@ export class BackgroundChecksService {
   }
 
   async cancelForMember(params: { organizationId: string; memberId: string }) {
-    return cancelForMemberFn({ ...params, getForMember: (p) => this.getForMember(p) });
+    return cancelForMemberFn({
+      ...params,
+      getForMember: (p) => this.getForMember(p),
+    });
   }
 
   async retryForMember(params: {
@@ -292,7 +301,10 @@ export class BackgroundChecksService {
   }
 
   async deleteForMember(params: { organizationId: string; memberId: string }) {
-    return deleteForMemberFn({ ...params, getForMember: (p) => this.getForMember(p) });
+    return deleteForMemberFn({
+      ...params,
+      getForMember: (p) => this.getForMember(p),
+    });
   }
 
   private isUniqueConstraintError(error: unknown): boolean {

--- a/apps/api/src/background-checks/background-checks.service.ts
+++ b/apps/api/src/background-checks/background-checks.service.ts
@@ -14,6 +14,7 @@ import { identityWebhookPayloadSchema } from './background-checks.types';
 import { fetchCompletedReportSnapshot } from './background-check-report-snapshot';
 import {
   cancelForMember as cancelForMemberFn,
+  deleteForMember as deleteForMemberFn,
   retryForMember as retryForMemberFn,
 } from './background-check-retry';
 
@@ -282,6 +283,10 @@ export class BackgroundChecksService {
       identityClient: this.identityClient,
       getForMember: (p) => this.getForMember(p),
     });
+  }
+
+  async deleteForMember(params: { organizationId: string; memberId: string }) {
+    return deleteForMemberFn({ ...params, getForMember: (p) => this.getForMember(p) });
   }
 
   private isUniqueConstraintError(error: unknown): boolean {

--- a/apps/api/src/background-checks/background-checks.service.ts
+++ b/apps/api/src/background-checks/background-checks.service.ts
@@ -123,6 +123,7 @@ export class BackgroundChecksService {
         employeeName,
         employeeEmail,
         requesterEmail,
+        attempt: 0,
       });
     } catch (error) {
       const refundId = await this.paymentService.refund({

--- a/apps/api/src/background-checks/background-checks.service.ts
+++ b/apps/api/src/background-checks/background-checks.service.ts
@@ -236,6 +236,12 @@ export class BackgroundChecksService {
       }
     }
 
+    // Cancelled is terminal Comp-side: record the event for audit but never
+    // let a late Identity webhook resurrect the status.
+    if (record.status === BackgroundCheckStatus.cancelled) {
+      return { ok: true, ...(isDuplicate ? { duplicate: true } : {}) };
+    }
+
     const reportSnapshot = await fetchCompletedReportSnapshot({
       identityClient: this.identityClient,
       identityBackgroundCheckId: payload.data.id,

--- a/apps/api/src/background-checks/background-checks.types.ts
+++ b/apps/api/src/background-checks/background-checks.types.ts
@@ -45,6 +45,11 @@ export const identityWebhookPayloadSchema = z.object({
   }),
 });
 
-export type IdentityCreateResponse = z.infer<typeof identityCreateResponseSchema>;
-export type IdentityWebhookPayload = z.infer<typeof identityWebhookPayloadSchema>;
-export type BackgroundCheckStatusValue = (typeof backgroundCheckStatuses)[number];
+export type IdentityCreateResponse = z.infer<
+  typeof identityCreateResponseSchema
+>;
+export type IdentityWebhookPayload = z.infer<
+  typeof identityWebhookPayloadSchema
+>;
+export type BackgroundCheckStatusValue =
+  (typeof backgroundCheckStatuses)[number];

--- a/apps/api/src/background-checks/dto/attach-custom-background-check.dto.ts
+++ b/apps/api/src/background-checks/dto/attach-custom-background-check.dto.ts
@@ -1,4 +1,10 @@
-import { IsEmail, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+import {
+  IsEmail,
+  IsOptional,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
 import { UploadAttachmentDto } from '../../attachments/upload-attachment.dto';
 
 export class AttachCustomBackgroundCheckDto extends UploadAttachmentDto {

--- a/apps/api/src/background-checks/dto/request-background-check.dto.ts
+++ b/apps/api/src/background-checks/dto/request-background-check.dto.ts
@@ -1,4 +1,10 @@
-import { IsEmail, IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+import {
+  IsEmail,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+} from 'class-validator';
 import { Transform } from 'class-transformer';
 
 export class RequestBackgroundCheckDto {

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/BackgroundCheckAdminActions.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/BackgroundCheckAdminActions.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiClient } from '@/lib/api-client';
+import { BackgroundCheckAdminActions } from './BackgroundCheckAdminActions';
+import type { BackgroundCheckRecord, BackgroundCheckStatus } from './backgroundCheckTypes';
+
+const { mockHasPermission } = vi.hoisted(() => ({ mockHasPermission: vi.fn() }));
+
+vi.mock('@/hooks/use-permissions', () => ({
+  usePermissions: () => ({ hasPermission: mockHasPermission }),
+}));
+
+vi.mock('@/lib/api-client', () => ({
+  apiClient: { get: vi.fn(), post: vi.fn(), delete: vi.fn() },
+}));
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+function record(status: BackgroundCheckStatus): BackgroundCheckRecord {
+  return {
+    id: 'bcr_1',
+    employeeEmail: 'ada@example.com',
+    employeeName: 'Ada',
+    requesterNotes: null,
+    candidateUrl: null,
+    status,
+    identityStatus: null,
+    employmentStatus: null,
+    referenceStatus: null,
+    rightToWorkStatus: null,
+    adjudicationStatus: null,
+    lastSyncedAt: null,
+    reportSnapshot: null,
+    reportSyncedAt: null,
+  };
+}
+
+function renderActions(status: BackgroundCheckStatus, onChange = vi.fn()) {
+  render(
+    <BackgroundCheckAdminActions
+      backgroundCheck={record(status)}
+      memberId="mem_1"
+      organizationId="org_1"
+      onChange={onChange}
+    />,
+  );
+  return onChange;
+}
+
+describe('BackgroundCheckAdminActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHasPermission.mockImplementation(
+      (resource: string, action: string) =>
+        resource === 'member' && (action === 'update' || action === 'delete'),
+    );
+    vi.mocked(apiClient.post).mockResolvedValue({ data: record('invited'), status: 200 });
+    vi.mocked(apiClient.delete).mockResolvedValue({ data: { ok: true }, status: 200 });
+  });
+
+  it('shows Retry + Delete for a failed check', () => {
+    renderActions('failed');
+    expect(screen.getByRole('button', { name: /Retry/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Delete/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Cancel check/i })).not.toBeInTheDocument();
+  });
+
+  it('shows Cancel + Delete for an in_progress check', () => {
+    renderActions('in_progress');
+    expect(screen.getByRole('button', { name: /Cancel check/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Delete/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Retry/i })).not.toBeInTheDocument();
+  });
+
+  it('renders nothing without member permissions', () => {
+    mockHasPermission.mockReturnValue(false);
+    const { container } = render(
+      <BackgroundCheckAdminActions
+        backgroundCheck={record('failed')}
+        memberId="mem_1"
+        organizationId="org_1"
+        onChange={vi.fn()}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('retries via the API and notifies the parent', async () => {
+    const user = userEvent.setup();
+    const onChange = renderActions('failed');
+    await user.click(screen.getByRole('button', { name: /Retry/i }));
+    await waitFor(() => {
+      expect(apiClient.post).toHaveBeenCalledWith(
+        '/v1/people/mem_1/background-check/retry',
+        undefined,
+        'org_1',
+      );
+    });
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('requires a second confirm click before deleting', async () => {
+    const user = userEvent.setup();
+    const onChange = renderActions('failed');
+    await user.click(screen.getByRole('button', { name: /^Delete$/i }));
+    expect(apiClient.delete).not.toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: /Confirm delete/i }));
+    await waitFor(() => {
+      expect(apiClient.delete).toHaveBeenCalledWith('/v1/people/mem_1/background-check', 'org_1');
+    });
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/BackgroundCheckAdminActions.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/BackgroundCheckAdminActions.test.tsx
@@ -111,4 +111,18 @@ describe('BackgroundCheckAdminActions', () => {
     });
     expect(onChange).toHaveBeenCalledWith(null);
   });
+
+  it('clears a pending delete confirmation when Retry is clicked', async () => {
+    const user = userEvent.setup();
+    renderActions('failed');
+    await user.click(screen.getByRole('button', { name: /^Delete$/i }));
+    expect(screen.getByRole('button', { name: /Confirm delete/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /Retry/i }));
+    await waitFor(() => {
+      expect(apiClient.post).toHaveBeenCalled();
+    });
+    expect(screen.queryByRole('button', { name: /Confirm delete/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Delete$/i })).toBeInTheDocument();
+  });
 });

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/BackgroundCheckAdminActions.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/BackgroundCheckAdminActions.test.tsx
@@ -1,7 +1,7 @@
+import { apiClient } from '@/lib/api-client';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { apiClient } from '@/lib/api-client';
 import { BackgroundCheckAdminActions } from './BackgroundCheckAdminActions';
 import type { BackgroundCheckRecord, BackgroundCheckStatus } from './backgroundCheckTypes';
 

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/BackgroundCheckAdminActions.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/BackgroundCheckAdminActions.tsx
@@ -38,6 +38,7 @@ export function BackgroundCheckAdminActions({
   if (!showRetry && !showCancel && !showDelete) return null;
 
   const handleRetry = async () => {
+    setConfirmingDelete(false);
     setPending('retry');
     const response = await apiClient.post<BackgroundCheckRecord>(
       `/v1/people/${memberId}/background-check/retry`,
@@ -54,6 +55,7 @@ export function BackgroundCheckAdminActions({
   };
 
   const handleCancel = async () => {
+    setConfirmingDelete(false);
     setPending('cancel');
     const response = await apiClient.post<BackgroundCheckRecord>(
       `/v1/people/${memberId}/background-check/cancel`,

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/BackgroundCheckAdminActions.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/BackgroundCheckAdminActions.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { usePermissions } from '@/hooks/use-permissions';
+import { apiClient } from '@/lib/api-client';
+import { Button, HStack } from '@trycompai/design-system';
+import { useState } from 'react';
+import { toast } from 'sonner';
+import type { BackgroundCheckRecord, BackgroundCheckStatus } from './backgroundCheckTypes';
+
+const RETRYABLE: BackgroundCheckStatus[] = ['failed', 'cancelled'];
+const CANCELLABLE: BackgroundCheckStatus[] = ['invited', 'in_progress', 'in_review'];
+
+interface BackgroundCheckAdminActionsProps {
+  backgroundCheck: BackgroundCheckRecord;
+  memberId: string;
+  organizationId: string;
+  onChange: (next: BackgroundCheckRecord | null) => void | Promise<void>;
+}
+
+export function BackgroundCheckAdminActions({
+  backgroundCheck,
+  memberId,
+  organizationId,
+  onChange,
+}: BackgroundCheckAdminActionsProps) {
+  const { hasPermission } = usePermissions();
+  const canUpdate = hasPermission('member', 'update');
+  const canDelete = hasPermission('member', 'delete');
+
+  const [pending, setPending] = useState<'retry' | 'cancel' | 'delete' | null>(null);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+  const { status } = backgroundCheck;
+  const showRetry = canUpdate && RETRYABLE.includes(status);
+  const showCancel = canUpdate && CANCELLABLE.includes(status);
+  const showDelete = canDelete;
+
+  if (!showRetry && !showCancel && !showDelete) return null;
+
+  const handleRetry = async () => {
+    setPending('retry');
+    const response = await apiClient.post<BackgroundCheckRecord>(
+      `/v1/people/${memberId}/background-check/retry`,
+      undefined,
+      organizationId,
+    );
+    setPending(null);
+    if (response.error || !response.data) {
+      toast.error('Failed to retry background check');
+      return;
+    }
+    toast.success('Background check resubmitted');
+    await onChange(response.data);
+  };
+
+  const handleCancel = async () => {
+    setPending('cancel');
+    const response = await apiClient.post<BackgroundCheckRecord>(
+      `/v1/people/${memberId}/background-check/cancel`,
+      undefined,
+      organizationId,
+    );
+    setPending(null);
+    if (response.error || !response.data) {
+      toast.error('Failed to cancel background check');
+      return;
+    }
+    toast.success('Background check cancelled');
+    await onChange(response.data);
+  };
+
+  const handleDelete = async () => {
+    setPending('delete');
+    const response = await apiClient.delete<{ ok: true }>(
+      `/v1/people/${memberId}/background-check`,
+      organizationId,
+    );
+    setPending(null);
+    setConfirmingDelete(false);
+    if (response.error) {
+      toast.error('Failed to delete background check');
+      return;
+    }
+    toast.success('Background check deleted');
+    await onChange(null);
+  };
+
+  return (
+    <HStack gap="2">
+      {showRetry && (
+        <Button type="button" variant="outline" disabled={pending !== null} onClick={handleRetry}>
+          Retry
+        </Button>
+      )}
+      {showCancel && (
+        <Button type="button" variant="outline" disabled={pending !== null} onClick={handleCancel}>
+          Cancel check
+        </Button>
+      )}
+      {showDelete && !confirmingDelete && (
+        <Button
+          type="button"
+          variant="destructive"
+          disabled={pending !== null}
+          onClick={() => setConfirmingDelete(true)}
+        >
+          Delete
+        </Button>
+      )}
+      {showDelete && confirmingDelete && (
+        <>
+          <Button
+            type="button"
+            variant="destructive"
+            disabled={pending !== null}
+            onClick={handleDelete}
+          >
+            Confirm delete
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={pending !== null}
+            onClick={() => setConfirmingDelete(false)}
+          >
+            Keep
+          </Button>
+        </>
+      )}
+    </HStack>
+  );
+}

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/EmployeeBackgroundCheck.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/EmployeeBackgroundCheck.test.tsx
@@ -299,6 +299,56 @@ describe('EmployeeBackgroundCheck — V1 two-paths', () => {
     expect(screen.queryByRole('switch', { name: /exempt this employee/i })).not.toBeInTheDocument();
   });
 
+  it('renders BackgroundCheckAdminActions when a background check record exists', () => {
+    const backgroundCheck = {
+      id: 'bcr_1',
+      employeeName: 'Ada Lovelace',
+      employeeEmail: 'ada@example.com',
+      requesterNotes: null,
+      candidateUrl: 'https://identity.trycomp.ai/cand_1',
+      status: 'failed' as const,
+      identityStatus: null,
+      employmentStatus: null,
+      referenceStatus: null,
+      rightToWorkStatus: null,
+      adjudicationStatus: null,
+      lastSyncedAt: null,
+      reportSnapshot: null,
+      reportSyncedAt: null,
+    };
+
+    renderSection({ initialBackgroundCheck: backgroundCheck });
+
+    // Retry is shown for 'failed' status (member:update is mocked as allowed)
+    expect(screen.getByRole('button', { name: /Retry/i })).toBeInTheDocument();
+    // The V1 new-check flow must not appear
+    expect(screen.queryByText('How would you like to proceed?')).not.toBeInTheDocument();
+  });
+
+  it('renders Cancel button when background check is in progress', () => {
+    const backgroundCheck = {
+      id: 'bcr_2',
+      employeeName: 'Ada Lovelace',
+      employeeEmail: 'ada@example.com',
+      requesterNotes: null,
+      candidateUrl: 'https://identity.trycomp.ai/cand_2',
+      status: 'in_progress' as const,
+      identityStatus: null,
+      employmentStatus: null,
+      referenceStatus: null,
+      rightToWorkStatus: null,
+      adjudicationStatus: null,
+      lastSyncedAt: null,
+      reportSnapshot: null,
+      reportSyncedAt: null,
+    };
+
+    renderSection({ initialBackgroundCheck: backgroundCheck });
+
+    expect(screen.getByRole('button', { name: /Cancel check/i })).toBeInTheDocument();
+    expect(screen.queryByText('How would you like to proceed?')).not.toBeInTheDocument();
+  });
+
   it('resyncs internal exempt state when the prop flips to true', () => {
     const { rerender } = render(
       <EmployeeBackgroundCheck

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/EmployeeBackgroundCheck.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/EmployeeBackgroundCheck.tsx
@@ -14,6 +14,7 @@ import {
   BackgroundCheckNotice,
 } from './BackgroundCheckNotices';
 import type { OrderFormValues } from './BackgroundCheckOrderForm';
+import { BackgroundCheckAdminActions } from './BackgroundCheckAdminActions';
 import { BackgroundCheckStatusView } from './BackgroundCheckStatusView';
 import type { BackgroundCheckBillingStatus, BackgroundCheckRecord } from './backgroundCheckTypes';
 import {
@@ -245,6 +246,14 @@ export function EmployeeBackgroundCheck({
           canUpdate={canRequest}
           onToggle={handleToggleExempt}
         />
+        {backgroundCheck && (
+          <BackgroundCheckAdminActions
+            backgroundCheck={backgroundCheck}
+            memberId={employee.id}
+            organizationId={organizationId}
+            onChange={(next) => mutateBackgroundCheck(next, { revalidate: false })}
+          />
+        )}
         <BackgroundCheckStatusView
           backgroundCheck={backgroundCheck}
           memberId={employee.id}

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/EmployeeBackgroundCheck.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/EmployeeBackgroundCheck.tsx
@@ -6,6 +6,7 @@ import type { Member, User } from '@db';
 import { Stack } from '@trycompai/design-system';
 import { useState } from 'react';
 import { toast } from 'sonner';
+import { BackgroundCheckAdminActions } from './BackgroundCheckAdminActions';
 import type { AttachFormValues } from './BackgroundCheckAttachForm';
 import type { ExemptFormValues } from './BackgroundCheckExemptForm';
 import {
@@ -14,7 +15,6 @@ import {
   BackgroundCheckNotice,
 } from './BackgroundCheckNotices';
 import type { OrderFormValues } from './BackgroundCheckOrderForm';
-import { BackgroundCheckAdminActions } from './BackgroundCheckAdminActions';
 import { BackgroundCheckStatusView } from './BackgroundCheckStatusView';
 import type { BackgroundCheckBillingStatus, BackgroundCheckRecord } from './backgroundCheckTypes';
 import {
@@ -55,7 +55,9 @@ export function EmployeeBackgroundCheck({
     employeeEmail: '',
     requesterNotes: '',
   });
-  const [orderErrors, setOrderErrors] = useState<Partial<Record<keyof OrderFormValues, string>>>({});
+  const [orderErrors, setOrderErrors] = useState<Partial<Record<keyof OrderFormValues, string>>>(
+    {},
+  );
   const [attachValues, setAttachValues] = useState<AttachFormValues>({
     vendor: 'checkr',
     reportDate: '',
@@ -211,9 +213,7 @@ export function EmployeeBackgroundCheck({
       return;
     }
 
-    toast.success(
-      next ? 'Employee exempted from background check' : 'Employee no longer exempt',
-    );
+    toast.success(next ? 'Employee exempted from background check' : 'Employee no longer exempt');
   };
 
   if (!backgroundCheckStepEnabled) {
@@ -250,7 +250,9 @@ export function EmployeeBackgroundCheck({
           backgroundCheck={backgroundCheck}
           memberId={employee.id}
           organizationId={organizationId}
-          onChange={(next) => { mutateBackgroundCheck(next, { revalidate: false }); }}
+          onChange={(next) => {
+            mutateBackgroundCheck(next, { revalidate: false });
+          }}
         />
         <BackgroundCheckStatusView
           backgroundCheck={backgroundCheck}
@@ -287,5 +289,3 @@ export function EmployeeBackgroundCheck({
     />
   );
 }
-
-

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/EmployeeBackgroundCheck.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/EmployeeBackgroundCheck.tsx
@@ -246,14 +246,12 @@ export function EmployeeBackgroundCheck({
           canUpdate={canRequest}
           onToggle={handleToggleExempt}
         />
-        {backgroundCheck && (
-          <BackgroundCheckAdminActions
-            backgroundCheck={backgroundCheck}
-            memberId={employee.id}
-            organizationId={organizationId}
-            onChange={(next) => mutateBackgroundCheck(next, { revalidate: false })}
-          />
-        )}
+        <BackgroundCheckAdminActions
+          backgroundCheck={backgroundCheck}
+          memberId={employee.id}
+          organizationId={organizationId}
+          onChange={(next) => { mutateBackgroundCheck(next, { revalidate: false }); }}
+        />
         <BackgroundCheckStatusView
           backgroundCheck={backgroundCheck}
           memberId={employee.id}

--- a/packages/db/prisma/migrations/20260602144300_bg_check_rerun_count/migration.sql
+++ b/packages/db/prisma/migrations/20260602144300_bg_check_rerun_count/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "background_check_requests" ADD COLUMN     "rerunCount" INTEGER NOT NULL DEFAULT 0;

--- a/packages/db/prisma/schema/background-check.prisma
+++ b/packages/db/prisma/schema/background-check.prisma
@@ -13,6 +13,7 @@ model BackgroundCheckRequest {
   referenceStatus           String?
   rightToWorkStatus         String?
   adjudicationStatus        String?
+  rerunCount                Int                   @default(0)
   stripePaymentIntentId     String?
   stripePaymentStatus       String?
   stripeRefundId            String?


### PR DESCRIPTION
## CS-475 — Admin cancel / delete / retry for background checks

Relates to: https://linear.app/compai/issue/CS-475

### Problem
Customers get blocked when a background check errors. `BackgroundCheckRequest` has `@@unique([organizationId, memberId])` (one row per member), so `requestForMember()` silently returns the stuck/errored row — there's currently no way to clear, cancel, or re-run it.

### What this adds
Three admin actions on a member's background check, surfaced in the employee **Background Check** tab and gated by RBAC:

- **Retry** (`member:update`) — resubmit a `failed`/`cancelled` check. **Free** (reuses the original payment, no new charge), resets the record in place, keeps webhook history. Varies the Identity idempotency key by attempt (`comp-background-check:{memberId}:{attempt}`) so a genuinely fresh vendor check is created instead of the deduped old one.
- **Cancel** (`member:update`) — stop an `invited`/`in_progress`/`in_review` check Comp-side (writes the existing-but-unused `cancelled` status). `handleWebhook` now ignores events for cancelled rows so a late Identity webhook can't resurrect it.
- **Delete** (`member:delete`) — hard-delete the record (cascades webhook events), freeing the unique constraint so a fresh request can be made.

A state-machine guard rejects invalid transitions (e.g. retrying a `completed` check). Auditors are excluded automatically (no `update`/`delete`).

### Changes
- **DB**: `rerunCount` column + migration.
- **API**: `POST /v1/people/:id/background-check/retry`, `…/cancel`, `DELETE /v1/people/:id/background-check`; new `cancelForMember`/`retryForMember`/`deleteForMember` service methods; attempt-aware Identity client; webhook terminal-guard for cancelled rows.
- **Frontend**: `BackgroundCheckAdminActions` component (status + permission gated, two-step delete confirm) wired into the employee Background Check tab.

### Testing
- API: `jest src/background-checks` → **41/41 passing** (8 suites), incl. new controller + service tests.
- Frontend: new `BackgroundCheckAdminActions` 5/5; `EmployeeBackgroundCheck` 17/17.
- 1 pre-existing vitest failure in an *exemption* test (Radix Select / jsdom) — exists verbatim on `main`, untouched here.

### Decisions / scope
- Retry billing: **free** (reuses original payment).
- Cancel is **Comp-side only** — the Identity (Convex) vendor has no confirmed cancel/delete endpoint; confirming + wiring server-side cancellation is a follow-up.
- Data: cancel/retry reset in place & keep history; delete is the explicit hard-delete.

### Notes for reviewers
- Repo-wide `turbo typecheck` is not fully green due to **pre-existing** issues unrelated to this PR (`@trycompai/billing` `dist/` not built in fresh worktrees; errors in `risks`/`training`/`timelines`/`offboarding-checklist`/etc.). **No typecheck errors in any file changed here.**
- Design spec + implementation plan live under `docs/superpowers/` (gitignored / local only).

**Draft** until manual click-through verification of retry/cancel/delete in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds admin actions to retry, cancel, or delete a member’s background check so stuck requests can be cleared and resubmitted (CS-475). Ensures fresh vendor checks on both new requests and retries via record-scoped idempotency, and blocks late webhooks from changing cancelled checks.

- **New Features**
  - Retry (free): resubmits `failed`/`cancelled`, increments `rerunCount`, uses Identity Idempotency-Key `comp-background-check:{backgroundCheckRequestId}` (create) and `comp-background-check:{backgroundCheckRequestId}:{attempt}` (retries), resets statuses/report in place, and on retry failure restores the prior status to preserve the cancelled terminal guard.
  - Cancel: allows `invited`/`in_progress`/`in_review` → `cancelled`; webhook records the event but ignores status changes for cancelled rows.
  - Delete: hard-deletes to free the org+member unique slot for a fresh request.
  - API: `POST /v1/people/:id/background-check/retry`, `POST /v1/people/:id/background-check/cancel`, `DELETE /v1/people/:id/background-check`; retry passes requester email; state guards block invalid transitions.
  - UI: `BackgroundCheckAdminActions` in the employee Background Check tab, permission-gated with confirm-before-delete; clears a pending delete confirm on Retry/Cancel.

- **Migration**
  - Add `rerunCount` to `background_check_requests` (default 0). Run Prisma migrations.

<sup>Written for commit a149fa4d8b240ba6887e81a17fecc96d9aaa7eb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/2993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

