### PR TITLE
feat(admin): add Finding Templates management to admin panel

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/admin/components/AdminSidebar.tsx
+++ b/apps/app/src/app/(app)/[orgId]/admin/components/AdminSidebar.tsx
@@ -14,7 +14,16 @@ export function AdminSidebar({ orgId }: AdminSidebarProps) {
   const items = [
     { id: 'organizations', label: 'Organizations', path: `/${orgId}/admin/organizations` },
     { id: 'integrations', label: 'Integrations', path: `/${orgId}/admin/integrations` },
-    { id: 'timeline-templates', label: 'Timeline Templates', path: `/${orgId}/admin/timeline-templates` },
+    {
+      id: 'timeline-templates',
+      label: 'Timeline Templates',
+      path: `/${orgId}/admin/timeline-templates`,
+    },
+    {
+      id: 'finding-templates',
+      label: 'Finding Templates',
+      path: `/${orgId}/admin/finding-templates`,
+    },
   ];
 
   const isPathActive = (path: string) => pathname.startsWith(path);
@@ -23,9 +32,7 @@ export function AdminSidebar({ orgId }: AdminSidebarProps) {
     <AppShellNav>
       {items.map((item) => (
         <Link key={item.id} href={item.path}>
-          <AppShellNavItem isActive={isPathActive(item.path)}>
-            {item.label}
-          </AppShellNavItem>
+          <AppShellNavItem isActive={isPathActive(item.path)}>{item.label}</AppShellNavItem>
         </Link>
       ))}
     </AppShellNav>

--- a/apps/app/src/app/(app)/[orgId]/admin/finding-templates/components/DeleteTemplateDialog.tsx
+++ b/apps/app/src/app/(app)/[orgId]/admin/finding-templates/components/DeleteTemplateDialog.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import {
+  useAdminFindingTemplates,
+  type FindingTemplate,
+} from '@/hooks/use-admin-finding-templates';
+import { api } from '@/lib/api-client';
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Button,
+} from '@trycompai/design-system';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+interface DeleteTemplateDialogProps {
+  template: FindingTemplate | null;
+  onClose: () => void;
+}
+
+export function DeleteTemplateDialog({ template, onClose }: DeleteTemplateDialogProps) {
+  const { mutate } = useAdminFindingTemplates();
+  const [deleting, setDeleting] = useState(false);
+
+  const handleDelete = async () => {
+    if (!template) return;
+    setDeleting(true);
+    const res = await api.delete(`/v1/finding-template/${template.id}`);
+    setDeleting(false);
+
+    if (res.error) {
+      toast.error(res.error);
+      return;
+    }
+
+    toast.success('Template deleted');
+    mutate();
+    onClose();
+  };
+
+  return (
+    <AlertDialog open={Boolean(template)} onOpenChange={(o) => !o && onClose()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete template</AlertDialogTitle>
+          <AlertDialogDescription>
+            Are you sure you want to delete &ldquo;{template?.title}&rdquo;? This action cannot be
+            undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <Button variant="destructive" loading={deleting} onClick={handleDelete}>
+            Delete
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/app/src/app/(app)/[orgId]/admin/finding-templates/components/FindingTemplatesList.tsx
+++ b/apps/app/src/app/(app)/[orgId]/admin/finding-templates/components/FindingTemplatesList.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import {
+  useAdminFindingTemplates,
+  type FindingTemplate,
+} from '@/hooks/use-admin-finding-templates';
+import {
+  Badge,
+  Button,
+  Input,
+  PageHeader,
+  PageLayout,
+  Section,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Text,
+} from '@trycompai/design-system';
+import { Add, Edit } from '@trycompai/design-system/icons';
+import { useMemo, useState } from 'react';
+import { CATEGORY_LABELS, FINDING_TEMPLATE_CATEGORIES } from './constants';
+import { DeleteTemplateDialog } from './DeleteTemplateDialog';
+import { TemplateFormDialog } from './TemplateFormDialog';
+
+const PAGE_SIZE = 10;
+
+export function FindingTemplatesList() {
+  const { templates, isLoading } = useAdminFindingTemplates();
+
+  const [search, setSearch] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState<string>('all');
+  const [page, setPage] = useState(1);
+
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<FindingTemplate | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<FindingTemplate | null>(null);
+
+  const filtered = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return templates.filter((template) => {
+      if (categoryFilter !== 'all' && template.category !== categoryFilter) {
+        return false;
+      }
+      if (!query) return true;
+      return (
+        template.title.toLowerCase().includes(query) ||
+        template.content.toLowerCase().includes(query)
+      );
+    });
+  }, [templates, search, categoryFilter]);
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const currentPage = Math.min(page, totalPages);
+  const pageStart = (currentPage - 1) * PAGE_SIZE;
+  const pageItems = filtered.slice(pageStart, pageStart + PAGE_SIZE);
+
+  const openCreate = () => {
+    setEditing(null);
+    setFormOpen(true);
+  };
+
+  const openEdit = (template: FindingTemplate) => {
+    setEditing(template);
+    setFormOpen(true);
+  };
+
+  if (isLoading) {
+    return (
+      <PageLayout header={<PageHeader title="Finding Templates" />}>
+        <div className="flex items-center justify-center py-12 text-muted-foreground">
+          Loading templates...
+        </div>
+      </PageLayout>
+    );
+  }
+
+  return (
+    <PageLayout
+      header={
+        <PageHeader
+          title="Finding Templates"
+          actions={
+            <Button size="sm" iconLeft={<Add size={16} />} onClick={openCreate}>
+              Add Template
+            </Button>
+          }
+        />
+      }
+    >
+      <Section>
+        <div className="mb-4 flex flex-wrap items-center gap-2">
+          <div className="max-w-xs flex-1">
+            <Input
+              value={search}
+              onChange={(e) => {
+                setSearch(e.target.value);
+                setPage(1);
+              }}
+              placeholder="Search title or content..."
+            />
+          </div>
+          <div className="w-56">
+            <Select
+              value={categoryFilter}
+              onValueChange={(value) => {
+                setCategoryFilter(value ?? 'all');
+                setPage(1);
+              }}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="All categories" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All categories</SelectItem>
+                {FINDING_TEMPLATE_CATEGORIES.map((category) => (
+                  <SelectItem key={category.value} value={category.value}>
+                    {category.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        {filtered.length === 0 ? (
+          <div className="rounded-lg border border-dashed py-8 text-center text-sm text-muted-foreground">
+            {templates.length === 0
+              ? "No finding templates yet. Click 'Add Template' to create one."
+              : 'No templates match your filters.'}
+          </div>
+        ) : (
+          <>
+            <Table variant="bordered">
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Title</TableHead>
+                  <TableHead>Category</TableHead>
+                  <TableHead>Content</TableHead>
+                  <TableHead>Order</TableHead>
+                  <TableHead>Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {pageItems.map((template) => (
+                  <TableRow key={template.id}>
+                    <TableCell>
+                      <Text size="sm" weight="medium">
+                        {template.title}
+                      </Text>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="outline">
+                        {CATEGORY_LABELS[template.category] ?? template.category}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <div className="max-w-[320px] truncate text-sm text-muted-foreground">
+                        {template.content}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Text size="sm">{template.order}</Text>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex gap-2">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          iconLeft={<Edit size={16} />}
+                          onClick={() => openEdit(template)}
+                        >
+                          Edit
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => setDeleteTarget(template)}
+                        >
+                          Delete
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+
+            {filtered.length > PAGE_SIZE && (
+              <div className="mt-4 flex items-center justify-between">
+                <Text size="sm" variant="muted">
+                  {pageStart + 1}–{Math.min(pageStart + PAGE_SIZE, filtered.length)} of{' '}
+                  {filtered.length}
+                </Text>
+                <div className="flex items-center gap-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={currentPage <= 1}
+                    onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  >
+                    Previous
+                  </Button>
+                  <Text size="sm" variant="muted">
+                    {currentPage} / {totalPages}
+                  </Text>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={currentPage >= totalPages}
+                    onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                  >
+                    Next
+                  </Button>
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </Section>
+
+      <TemplateFormDialog open={formOpen} template={editing} onClose={() => setFormOpen(false)} />
+      <DeleteTemplateDialog template={deleteTarget} onClose={() => setDeleteTarget(null)} />
+    </PageLayout>
+  );
+}

--- a/apps/app/src/app/(app)/[orgId]/admin/finding-templates/components/TemplateFormDialog.tsx
+++ b/apps/app/src/app/(app)/[orgId]/admin/finding-templates/components/TemplateFormDialog.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import {
+  useAdminFindingTemplates,
+  type FindingTemplate,
+} from '@/hooks/use-admin-finding-templates';
+import { api } from '@/lib/api-client';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  Button,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Sheet,
+  SheetBody,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  Stack,
+  Text,
+  Textarea,
+} from '@trycompai/design-system';
+import { useEffect, useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+import { z } from 'zod';
+import { FINDING_TEMPLATE_CATEGORIES } from './constants';
+
+const templateSchema = z.object({
+  category: z.string().min(1, 'Category is required'),
+  title: z.string().min(1, 'Title is required').max(500),
+  content: z.string().min(1, 'Content is required').max(50000),
+  order: z.number().int().min(0),
+});
+
+type TemplateFormValues = z.infer<typeof templateSchema>;
+
+interface TemplateFormDialogProps {
+  open: boolean;
+  template: FindingTemplate | null;
+  onClose: () => void;
+}
+
+const emptyDefaults: TemplateFormValues = {
+  category: FINDING_TEMPLATE_CATEGORIES[0].value,
+  title: '',
+  content: '',
+  order: 0,
+};
+
+export function TemplateFormDialog({ open, template, onClose }: TemplateFormDialogProps) {
+  const { mutate } = useAdminFindingTemplates();
+  const [saving, setSaving] = useState(false);
+  const isEdit = Boolean(template);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    control,
+    formState: { errors },
+  } = useForm<TemplateFormValues>({
+    resolver: zodResolver(templateSchema),
+    defaultValues: emptyDefaults,
+  });
+
+  // Populate the form whenever it opens (create -> blank, edit -> template).
+  useEffect(() => {
+    if (!open) return;
+    reset(
+      template
+        ? {
+            category: template.category,
+            title: template.title,
+            content: template.content,
+            order: template.order,
+          }
+        : emptyDefaults,
+    );
+  }, [open, template, reset]);
+
+  const handleSave = async (values: TemplateFormValues) => {
+    setSaving(true);
+    const res = isEdit
+      ? await api.patch(`/v1/finding-template/${template!.id}`, values)
+      : await api.post('/v1/finding-template', values);
+    setSaving(false);
+
+    if (res.error) {
+      toast.error(res.error);
+      return;
+    }
+
+    toast.success(isEdit ? 'Template updated' : 'Template created');
+    mutate();
+    onClose();
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={(o) => !o && onClose()}>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>{isEdit ? 'Edit Template' : 'New Template'}</SheetTitle>
+        </SheetHeader>
+        <SheetBody>
+          <form onSubmit={handleSubmit(handleSave)}>
+            <Stack gap="md">
+              <div className="flex flex-col gap-1.5">
+                <Label>Category</Label>
+                <Controller
+                  control={control}
+                  name="category"
+                  render={({ field }) => (
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select a category" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {FINDING_TEMPLATE_CATEGORIES.map((category) => (
+                          <SelectItem key={category.value} value={category.value}>
+                            {category.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  )}
+                />
+                {errors.category && (
+                  <Text size="xs" variant="destructive">
+                    {errors.category.message}
+                  </Text>
+                )}
+              </div>
+
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="ft-title">Title</Label>
+                <Input id="ft-title" {...register('title')} placeholder="Template title" />
+                {errors.title && (
+                  <Text size="xs" variant="destructive">
+                    {errors.title.message}
+                  </Text>
+                )}
+              </div>
+
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="ft-content">Content</Label>
+                <Textarea
+                  id="ft-content"
+                  rows={6}
+                  {...register('content')}
+                  placeholder="Template content..."
+                />
+                {errors.content && (
+                  <Text size="xs" variant="destructive">
+                    {errors.content.message}
+                  </Text>
+                )}
+              </div>
+
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="ft-order">Order</Label>
+                <Input
+                  id="ft-order"
+                  type="number"
+                  min={0}
+                  {...register('order', { valueAsNumber: true })}
+                />
+                {errors.order && (
+                  <Text size="xs" variant="destructive">
+                    {errors.order.message}
+                  </Text>
+                )}
+              </div>
+
+              <Button type="submit" loading={saving}>
+                {isEdit ? 'Save Changes' : 'Create'}
+              </Button>
+            </Stack>
+          </form>
+        </SheetBody>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/app/src/app/(app)/[orgId]/admin/finding-templates/components/constants.ts
+++ b/apps/app/src/app/(app)/[orgId]/admin/finding-templates/components/constants.ts
@@ -1,0 +1,16 @@
+/**
+ * Finding template categories. The `value`s must match the strings stored in
+ * the `FindingTemplate.category` column (and previously managed by the
+ * cx-dashboard admin UI): evidence_issue, further_evidence, task_specific,
+ * na_incorrect.
+ */
+export const FINDING_TEMPLATE_CATEGORIES = [
+  { value: 'evidence_issue', label: 'Issue with uploaded evidence' },
+  { value: 'further_evidence', label: 'Further evidence needed' },
+  { value: 'task_specific', label: 'Task-specific issues' },
+  { value: 'na_incorrect', label: 'Marked N/A incorrectly' },
+] as const;
+
+export const CATEGORY_LABELS: Record<string, string> = Object.fromEntries(
+  FINDING_TEMPLATE_CATEGORIES.map((category) => [category.value, category.label]),
+);

--- a/apps/app/src/app/(app)/[orgId]/admin/finding-templates/page.tsx
+++ b/apps/app/src/app/(app)/[orgId]/admin/finding-templates/page.tsx
@@ -1,0 +1,5 @@
+import { FindingTemplatesList } from './components/FindingTemplatesList';
+
+export default function FindingTemplatesPage() {
+  return <FindingTemplatesList />;
+}

--- a/apps/app/src/hooks/use-admin-finding-templates.ts
+++ b/apps/app/src/hooks/use-admin-finding-templates.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { apiClient } from '@/lib/api-client';
+import useSWR from 'swr';
+
+interface FindingTemplate {
+  id: string;
+  category: string;
+  title: string;
+  content: string;
+  order: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export const findingTemplatesKey = () => ['/v1/finding-template'] as const;
+
+/**
+ * Loads all finding templates from the platform API.
+ *
+ * The `/v1/finding-template` GET endpoint returns a raw array (not a
+ * `{ data, count }` envelope), so we consume `response.data` directly.
+ */
+export function useAdminFindingTemplates() {
+  const { data, error, isLoading, mutate } = useSWR(
+    findingTemplatesKey(),
+    async () => {
+      const response = await apiClient.get<FindingTemplate[]>('/v1/finding-template');
+      if (response.error) throw new Error(response.error);
+      return response.data ?? [];
+    },
+    {
+      revalidateOnFocus: false,
+    },
+  );
+
+  const templates = Array.isArray(data) ? data : [];
+
+  return {
+    templates,
+    isLoading: isLoading && !data,
+    error,
+    mutate,
+  };
+}
+
+export type { FindingTemplate };


### PR DESCRIPTION
## Summary
Moves the **Finding Templates** management UI out of the deprecated `cx-dashboard` app and into the main app's **Admin** panel (next to Timeline Templates).

The backend already exists — comp ships the `/v1/finding-template` API (reads via `HybridAuthGuard`, create/update/delete via `PlatformAdminGuard`) and the `FindingTemplate` model. **This PR is frontend-only — no API, schema, or migration changes.**

## What's included
- New admin route `…/admin/finding-templates`:
  - List with search (title + content), category filter, and 10/page pagination
  - Create/edit via Sheet (react-hook-form + zod)
  - Delete confirmation (AlertDialog)
- `use-admin-finding-templates` SWR hook over `GET /v1/finding-template`
- **Finding Templates** sidebar entry under Admin
- Access auto-gated by the existing admin layout (`role === 'admin'`)

## Categories
Preserves the existing stored category values: `evidence_issue`, `further_evidence`, `task_specific`, `na_incorrect`.

## Verification
- `tsc --noEmit` clean for all new/changed files
- Prettier-formatted
- ⚠️ Not yet runtime-verified in a browser (needs the API + DB + a platform-admin session)

## Follow-up (not in this PR)
- Retire the finding-templates UI in the deprecated `cx-dashboard` once this is confirmed in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves Finding Templates management from the deprecated `cx-dashboard` into the main app’s Admin panel, using the existing `/v1/finding-template` API. Frontend-only; no backend, schema, or migration changes.

- **New Features**
  - New route `/[orgId]/admin/finding-templates` with a sidebar entry.
  - List with search (title/content), category filter, and 10/page pagination.
  - Create/edit in a sheet (`react-hook-form` + `zod`); delete confirmation dialog.
  - `use-admin-finding-templates` SWR hook over `GET /v1/finding-template`.
  - Admin-only access via existing layout; preserves categories: `evidence_issue`, `further_evidence`, `task_specific`, `na_incorrect`.

<sup>Written for commit d7e2caf6aab058b69808e0cdae883680ef39e466. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/2997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

