### PR TITLE
fix(background-checks): move admin actions into the status card footer

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/BackgroundCheckAdminActions.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/BackgroundCheckAdminActions.tsx
@@ -88,47 +88,54 @@ export function BackgroundCheckAdminActions({
   };
 
   return (
-    <HStack gap="2">
-      {showRetry && (
-        <Button type="button" variant="outline" disabled={pending !== null} onClick={handleRetry}>
-          Retry
-        </Button>
-      )}
-      {showCancel && (
-        <Button type="button" variant="outline" disabled={pending !== null} onClick={handleCancel}>
-          Cancel check
-        </Button>
-      )}
-      {showDelete && !confirmingDelete && (
-        <Button
-          type="button"
-          variant="destructive"
-          disabled={pending !== null}
-          onClick={() => setConfirmingDelete(true)}
-        >
-          Delete
-        </Button>
-      )}
-      {showDelete && confirmingDelete && (
-        <>
-          <Button
-            type="button"
-            variant="destructive"
-            disabled={pending !== null}
-            onClick={handleDelete}
-          >
-            Confirm delete
+    <div className="border-t pt-4">
+      <HStack gap="2">
+        {showRetry && (
+          <Button type="button" variant="outline" disabled={pending !== null} onClick={handleRetry}>
+            Retry
           </Button>
+        )}
+        {showCancel && (
           <Button
             type="button"
             variant="outline"
             disabled={pending !== null}
-            onClick={() => setConfirmingDelete(false)}
+            onClick={handleCancel}
           >
-            Keep
+            Cancel check
           </Button>
-        </>
-      )}
-    </HStack>
+        )}
+        {showDelete && !confirmingDelete && (
+          <Button
+            type="button"
+            variant="destructive"
+            disabled={pending !== null}
+            onClick={() => setConfirmingDelete(true)}
+          >
+            Delete
+          </Button>
+        )}
+        {showDelete && confirmingDelete && (
+          <>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={pending !== null}
+              onClick={handleDelete}
+            >
+              Confirm delete
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={pending !== null}
+              onClick={() => setConfirmingDelete(false)}
+            >
+              Keep
+            </Button>
+          </>
+        )}
+      </HStack>
+    </div>
   );
 }

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/BackgroundCheckStatusView.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/BackgroundCheckStatusView.tsx
@@ -2,6 +2,7 @@
 
 import { apiClient } from '@/lib/api-client';
 import { Badge, Button, Grid, HStack, Stack, Text } from '@trycompai/design-system';
+import type { ReactNode } from 'react';
 import { toast } from 'sonner';
 import useSWR from 'swr';
 import { BackgroundCheckReport } from './BackgroundCheckReport';
@@ -33,11 +34,13 @@ export function BackgroundCheckStatusView({
   confirmation,
   memberId,
   organizationId,
+  actions,
 }: {
   backgroundCheck: BackgroundCheckRecord;
   confirmation?: string | null;
   memberId?: string;
   organizationId?: string;
+  actions?: ReactNode;
 }) {
   const isComplete = isCompletedBackgroundCheck(backgroundCheck.status);
   const customAttachmentsKey =
@@ -107,6 +110,8 @@ export function BackgroundCheckStatusView({
           </Grid>
 
           <ComponentStatuses backgroundCheck={backgroundCheck} />
+
+          {actions}
         </Stack>
       </div>
 

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/EmployeeBackgroundCheck.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/EmployeeBackgroundCheck.tsx
@@ -246,18 +246,20 @@ export function EmployeeBackgroundCheck({
           canUpdate={canRequest}
           onToggle={handleToggleExempt}
         />
-        <BackgroundCheckAdminActions
-          backgroundCheck={backgroundCheck}
-          memberId={employee.id}
-          organizationId={organizationId}
-          onChange={(next) => {
-            mutateBackgroundCheck(next, { revalidate: false });
-          }}
-        />
         <BackgroundCheckStatusView
           backgroundCheck={backgroundCheck}
           memberId={employee.id}
           organizationId={organizationId}
+          actions={
+            <BackgroundCheckAdminActions
+              backgroundCheck={backgroundCheck}
+              memberId={employee.id}
+              organizationId={organizationId}
+              onChange={(next) => {
+                mutateBackgroundCheck(next, { revalidate: false });
+              }}
+            />
+          }
         />
       </Stack>
     );


### PR DESCRIPTION
## Move background-check admin actions into the status card

Follow-up UX tweak to CS-475 (#2993).

### Problem
The Retry / Cancel / Delete buttons rendered as a stray row floating *between* the "Exempt this employee" toggle and the Status card — they looked orphaned.

### Fix
Render the actions **inside the Status card, at the bottom** (below a divider), so they sit with the check they act on:
- Added an optional `actions?: ReactNode` slot to `BackgroundCheckStatusView`, rendered as the last item in the status card.
- `EmployeeBackgroundCheck` now passes `BackgroundCheckAdminActions` into that slot instead of rendering it standalone above the card.
- The `border-t` divider lives **inside** `BackgroundCheckAdminActions`, so it only appears when there are actually buttons to show (read-only users / no-op states render nothing — no empty divider).

### Before → After
```
Before:                          After:
[ exempt toggle ]                [ exempt toggle ]
[ Retry ] [ Delete ]   ←stray    ┌ Status ───────────────┐
┌ Status ──────────────┐         │ [Cancelled] …          │
│ [Cancelled] …         │        │ name        email      │
│ name        email     │        │ ─────────────────────  │
└───────────────────────┘        │ [ Retry ] [ Delete ]   │
                                 └────────────────────────┘
```

### Tests
- `BackgroundCheckAdminActions` 6/6 and `EmployeeBackgroundCheck` 17/17 still pass (buttons are queried by role; placement change doesn't affect them).
- `tsc` clean on the three changed files; design-system audit clean (no legacy/lucide imports; `className` only on a `<div>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move background-check admin actions into the status card footer to keep Retry/Cancel/Delete with the check they control and fix the stray row. Follow-up to Linear CS-475.

- **Bug Fixes**
  - Added optional `actions` slot to `BackgroundCheckStatusView` and render it at the end of the card.
  - `EmployeeBackgroundCheck` now passes `BackgroundCheckAdminActions` into that slot; removed the standalone row.
  - Divider lives inside `BackgroundCheckAdminActions` so it only shows when buttons render.

<sup>Written for commit da72dea1957e91c14fd9ba36b5f046338f9f5ead. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/2998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

