### PR TITLE
fix(integrations): render config dropdowns inline so they work inside the modal

### DIFF
--- a/apps/app/src/components/integrations/ConnectionVariablesForm.test.tsx
+++ b/apps/app/src/components/integrations/ConnectionVariablesForm.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+// Stub the design-system Select family so we can assert how it is configured.
+// SelectContent exposes its `portal` prop as a data attribute — this is the
+// crux of the fix: the DS Select is built on @base-ui/react and portals to
+// document.body by default, which escapes the Radix (@trycompai/ui) modal
+// Dialog it is rendered inside (ManageIntegrationDialog) and makes the dropdown
+// unclickable ("insta-closes"). Rendering inline (portal={false}) keeps the
+// popup inside the modal's pointer-events/focus scope.
+vi.mock('@trycompai/design-system', () => ({
+  Input: (props: Record<string, unknown>) => <input {...props} />,
+  Label: ({ children, htmlFor }: { children: React.ReactNode; htmlFor?: string }) => (
+    <label htmlFor={htmlFor}>{children}</label>
+  ),
+  Spinner: () => <span data-testid="spinner" />,
+  Select: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="ds-select">{children}</div>
+  ),
+  SelectTrigger: ({ children, id }: { children: React.ReactNode; id?: string }) => (
+    <div data-trigger-id={id}>{children}</div>
+  ),
+  SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
+  SelectContent: ({ children, portal }: { children: React.ReactNode; portal?: boolean }) => (
+    <div data-testid="select-content" data-portal={String(portal)}>
+      {children}
+    </div>
+  ),
+  SelectItem: ({ children, value }: { children: React.ReactNode; value: string }) => (
+    <div data-testid="select-item" data-value={value}>
+      {children}
+    </div>
+  ),
+}));
+
+// The multi-select field pulls in @trycompai/ui MultipleSelector — not relevant
+// to these select/boolean dropdown tests, so stub it out.
+vi.mock('./ConnectionVariableMultiSelect', () => ({
+  ConnectionVariableMultiSelect: () => <div data-testid="multi-select" />,
+}));
+
+import { ConnectionVariablesFields, type ConnectionVariable } from './ConnectionVariablesForm';
+
+const noop = () => {};
+
+function renderFields(variables: ConnectionVariable[]) {
+  return render(
+    <ConnectionVariablesFields
+      variables={variables}
+      variableValues={{}}
+      setVariableValues={noop}
+      dynamicOptions={{}}
+      loadingOptions={{}}
+      fetchOptions={noop}
+    />,
+  );
+}
+
+describe('ConnectionVariablesFields dropdown portal behavior', () => {
+  it('renders a select-type dropdown inline (portal={false}) so it survives inside a Radix modal', () => {
+    renderFields([
+      {
+        id: 'alert_severity_threshold',
+        label: 'Fail on open alerts at severity',
+        type: 'select',
+        required: false,
+        options: [
+          { value: 'low', label: 'Low' },
+          { value: 'critical', label: 'Critical' },
+        ],
+      },
+    ]);
+
+    const content = screen.getByTestId('select-content');
+    expect(content).toHaveAttribute('data-portal', 'false');
+    // Options still render
+    expect(screen.getByText('Low')).toBeInTheDocument();
+    expect(screen.getByText('Critical')).toBeInTheDocument();
+  });
+
+  it('renders a boolean-type dropdown inline (portal={false})', () => {
+    renderFields([
+      {
+        id: 'enabled',
+        label: 'Enabled',
+        type: 'boolean',
+        required: false,
+        default: false,
+      },
+    ]);
+
+    const content = screen.getByTestId('select-content');
+    expect(content).toHaveAttribute('data-portal', 'false');
+    expect(screen.getByText('Yes')).toBeInTheDocument();
+    expect(screen.getByText('No')).toBeInTheDocument();
+  });
+
+  it('does not portal any dropdown to document.body for mixed select + boolean fields', () => {
+    renderFields([
+      {
+        id: 'mode',
+        label: 'Mode',
+        type: 'select',
+        required: false,
+        options: [{ value: 'all', label: 'All' }],
+      },
+      { id: 'enabled', label: 'Enabled', type: 'boolean', required: false },
+    ]);
+
+    const contents = screen.getAllByTestId('select-content');
+    expect(contents).toHaveLength(2);
+    for (const content of contents) {
+      expect(content).toHaveAttribute('data-portal', 'false');
+    }
+  });
+});

--- a/apps/app/src/components/integrations/ConnectionVariablesForm.tsx
+++ b/apps/app/src/components/integrations/ConnectionVariablesForm.tsx
@@ -170,7 +170,14 @@ export function ConnectionVariablesFields({
                 <SelectTrigger id={variable.id}>
                   <SelectValue placeholder={`Select ${variable.label.toLowerCase()}`} />
                 </SelectTrigger>
-                <SelectContent>
+                {/*
+                  portal={false} renders the dropdown inline, inside whatever modal wraps this form.
+                  This component is shown inside a Radix (@trycompai/ui) Dialog (ManageIntegrationDialog).
+                  The DS Select is built on @base-ui/react and portals to document.body by default, which
+                  escapes the Radix modal's pointer-events/dismiss scope and makes the dropdown unclickable
+                  ("insta-closes"). Keeping it inline keeps it inside the modal's scope. Do not remove.
+                */}
+                <SelectContent portal={false}>
                   {isLoadingOptions ? (
                     <div className="py-2 px-3 text-sm text-muted-foreground flex items-center gap-2">
                       <Spinner />
@@ -203,7 +210,8 @@ export function ConnectionVariablesFields({
                 <SelectTrigger id={variable.id}>
                   <SelectValue />
                 </SelectTrigger>
-                <SelectContent>
+                {/* portal={false}: render inline so the dropdown stays inside the Radix modal scope (see note above). */}
+                <SelectContent portal={false}>
                   <SelectItem value="true">Yes</SelectItem>
                   <SelectItem value="false">No</SelectItem>
                 </SelectContent>


### PR DESCRIPTION
## Problem

Dropdowns in the integration **Configure** modals insta-close on click, blocking users from changing settings. Reported on the **Vercel** ("Projects to check") and **GitHub/Dependabot** ("Fail on open alerts at severity") integration checks.

## Root cause

Every `type: 'select'` / `boolean` config field for **all** integrations is rendered by one shared component, `ConnectionVariablesForm.tsx`, using the **design-system `Select`** — which is built on `@base-ui/react` and **portals its popup to `document.body` by default**.

That form is rendered inside `ManageIntegrationDialog`, which is a **Radix `@trycompai/ui` modal `Dialog`**. The portaled popup lands outside the Radix modal's pointer-events / dismiss scope, so the dropdown becomes unclickable ("insta-closes").

This is the **only** place in the app that mixes a design-system (Base UI) popup into a Radix `@trycompai/ui` modal — every other dialog is Radix+Radix or DS-Sheet+DS (homogeneous, and fine). It presents as "all integrations with a select field are buggy" precisely because they all funnel through this one component.

> Note: a *related* variant of this bug (the `MultipleSelector` list overlapping the Select below it) was already fixed on `main` in `b9d08c8a`. This PR closes the remaining cross-library portal hazard — which is why the Vercel top-field case (nothing overlapping) still reproduced.

## Fix

Pass `portal={false}` to the two DS `<SelectContent>` blocks so the popup renders **inline, inside the modal's own scope**.

- One shared component → fixes the dropdowns for **every** integration at once.
- Keeps the design-system component (no regression to the phased-out `@trycompai/ui` library).
- Safe for the second consumer too (the non-modal integration settings page).
- `SelectContent`'s `position` defaults to `'fixed'`, so it still escapes overflow clipping.

## Tests

- New `ConnectionVariablesForm.test.tsx` (3 tests) asserting `portal={false}` is wired for both the `select` and `boolean` field types.
- Typecheck: 0 new errors vs `main`.
- Existing integration tests pass (the 3 `PlatformIntegrations` failures are pre-existing on `main` — unrelated list ordering).

## ⚠️ Needs a manual check before merge

This is a focus/pointer/portal interaction that jsdom can't reproduce, so the unit test only locks in the prop wiring. Please verify on a preview/staging build:
1. The `select`/`boolean` dropdowns in a GitHub and a Vercel integration **Configure** modal open, stay open, and are selectable.
2. No visual clipping of a long options list inside the dialog's `max-h-[85vh]` scroll area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render design-system `Select` dropdowns inline in the integration Configure modal so they stay open and selectable. Fixes all select/boolean config fields across integrations (e.g., Vercel and GitHub/Dependabot).

- **Bug Fixes**
  - Set `portal={false}` on `SelectContent` for `select` and `boolean` fields in `ConnectionVariablesForm.tsx` to keep popups inside the `@trycompai/ui` `Dialog` (DS `Select` portals via `@base-ui/react` by default).
  - Added `ConnectionVariablesForm.test.tsx` to assert `portal={false}` for both field types.

<sup>Written for commit a93f4793f1bb9e658b30f8349f1cc5225965ce51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

