### PR TITLE
fix(app): hide evidence tasks not added to the org (no more "Not added")

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/IntegrationEvidenceTasks.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/IntegrationEvidenceTasks.test.tsx
@@ -1,0 +1,54 @@
+import type { IntegrationProvider } from '@/hooks/use-integration-platform';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { IntegrationEvidenceTasks } from './IntegrationEvidenceTasks';
+
+function makeProvider(
+  mappedTasks: Array<{ id: string; name: string }>,
+): IntegrationProvider {
+  // Only `mappedTasks` is read by the component; cast the minimal shape.
+  return { mappedTasks } as unknown as IntegrationProvider;
+}
+
+const MAPPED = [
+  { id: 'tmpl-encryption', name: 'Encryption at Rest' },
+  { id: 'tmpl-firewall', name: 'Production Firewall & No-Public-Access Controls' },
+];
+
+describe('IntegrationEvidenceTasks — hides evidence tasks not added to the org', () => {
+  it('shows only tasks that exist in the org, with a matching count and no "Not added"', () => {
+    render(
+      <IntegrationEvidenceTasks
+        provider={makeProvider(MAPPED)}
+        taskTemplates={[
+          {
+            id: 'tmpl-encryption',
+            taskId: 'task-1',
+            name: 'Encryption at Rest',
+            description: 'd',
+          },
+        ]}
+        orgId="org-1"
+      />,
+    );
+
+    expect(screen.getByText('Encryption at Rest')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Production Firewall & No-Public-Access Controls'),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Not added')).not.toBeInTheDocument();
+    // Count badge reflects added-only.
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+
+  it('renders nothing when none of the mapped tasks exist in the org', () => {
+    const { container } = render(
+      <IntegrationEvidenceTasks
+        provider={makeProvider(MAPPED)}
+        taskTemplates={[]}
+        orgId="org-1"
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/IntegrationEvidenceTasks.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/IntegrationEvidenceTasks.tsx
@@ -32,8 +32,11 @@ export function IntegrationEvidenceTasks({
     () => new Map(taskTemplates.map((task) => [task.id, task])),
     [taskTemplates],
   );
+  // Hide template mappings with no live task in this org — they would render as
+  // "Not added" and prompt customers to ask why. Show only tasks they have.
+  const visibleTasks = mappedTasks.filter((m) => taskByTemplateId.has(m.id));
 
-  if (mappedTasks.length === 0) {
+  if (visibleTasks.length === 0) {
     return null;
   }
 
@@ -48,13 +51,13 @@ export function IntegrationEvidenceTasks({
             </p>
           </div>
           <span className="shrink-0 rounded-full bg-muted px-2 py-1 text-xs text-muted-foreground">
-            {mappedTasks.length}
+            {visibleTasks.length}
           </span>
         </div>
       </div>
 
       <div className="divide-y">
-        {mappedTasks.map((mappedTask) => (
+        {visibleTasks.map((mappedTask) => (
           <EvidenceTaskRow
             key={mappedTask.id}
             fallbackName={mappedTask.name}

--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/services/[serviceId]/components/ServiceDetailView.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/services/[serviceId]/components/ServiceDetailView.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/hooks/use-permissions', () => ({
+  usePermissions: () => ({ hasPermission: () => true }),
+}));
+vi.mock('@/hooks/use-integration-platform', () => ({
+  useConnectionServices: () => ({
+    services: [],
+    updateServices: vi.fn(),
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+import type {
+  ConnectionListItemResponse,
+  IntegrationProviderResponse,
+} from '@trycompai/integration-platform';
+import { ServiceDetailView } from './ServiceDetailView';
+
+const FIREWALL = 'Production Firewall & No-Public-Access Controls';
+
+const baseProps = {
+  provider: {
+    id: 'aws',
+    name: 'Amazon Web Services',
+  } as unknown as IntegrationProviderResponse,
+  service: {
+    id: 's3',
+    name: 'S3 Bucket Security',
+    description: 'Public access blocks, default encryption, and versioning checks',
+    mappedTasks: [
+      { id: 'tmpl-encryption', name: 'Encryption at Rest' },
+      { id: 'tmpl-firewall', name: FIREWALL },
+    ],
+  },
+  connections: [] as ConnectionListItemResponse[],
+  connectionId: null,
+  connectionsErrored: false,
+  taskTemplates: [
+    {
+      id: 'tmpl-encryption',
+      taskId: 'task-1',
+      name: 'Encryption at Rest',
+      description: 'd',
+    },
+  ],
+  tasksErrored: false,
+  orgId: 'org-1',
+  slug: 'aws',
+};
+
+describe('ServiceDetailView — Evidence provided hides tasks not added to the org', () => {
+  it('shows only the org task and never renders "Not added"', () => {
+    render(<ServiceDetailView {...baseProps} />);
+    expect(screen.getByText('Encryption at Rest')).toBeInTheDocument();
+    expect(screen.queryByText(FIREWALL)).not.toBeInTheDocument();
+    expect(screen.queryByText('Not added')).not.toBeInTheDocument();
+  });
+
+  it('shows all mapped tasks (with a load-error notice) when the tasks fetch errored', () => {
+    render(<ServiceDetailView {...baseProps} taskTemplates={[]} tasksErrored />);
+    // On a fetch error we can't distinguish added from not-added, so show all
+    // and surface "Couldn't load" rather than a misleading "Not added".
+    expect(screen.getByText('Encryption at Rest')).toBeInTheDocument();
+    expect(screen.getByText(FIREWALL)).toBeInTheDocument();
+    expect(screen.queryByText('Not added')).not.toBeInTheDocument();
+    expect(screen.getAllByText('Couldn’t load tasks').length).toBeGreaterThan(0);
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/services/[serviceId]/components/ServiceDetailView.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/services/[serviceId]/components/ServiceDetailView.tsx
@@ -88,6 +88,13 @@ export function ServiceDetailView({
     [taskTemplates],
   );
   const mappedTasks = service.mappedTasks ?? [];
+  // Only surface evidence tasks that actually exist in this org. A template
+  // mapping with no live task would render as "Not added", which prompts
+  // customers to ask why it isn't added. On a tasks-fetch error we can't tell
+  // added from not-added, so show everything (the row renders "Couldn't load").
+  const visibleTasks = tasksErrored
+    ? mappedTasks
+    : mappedTasks.filter((m) => taskByTemplateId.has(m.id));
 
   const handleToggle = async () => {
     if (!effectiveConnectionId || toggling || !liveService || !canUpdate) return;
@@ -197,18 +204,18 @@ export function ServiceDetailView({
               </p>
             </div>
             <span className="shrink-0 rounded-full bg-muted px-2 py-1 text-xs text-muted-foreground">
-              {mappedTasks.length}
+              {visibleTasks.length}
             </span>
           </div>
         </div>
 
-        {mappedTasks.length === 0 ? (
+        {visibleTasks.length === 0 ? (
           <p className="px-4 py-6 text-center text-xs text-muted-foreground">
             This service doesn&apos;t map to any evidence task yet.
           </p>
         ) : (
           <div className="divide-y">
-            {mappedTasks.map((mapped) => (
+            {visibleTasks.map((mapped) => (
               <EvidenceTaskRow
                 key={mapped.id}
                 fallbackName={mapped.name}


### PR DESCRIPTION
## Problem
On the integration **service detail** page (e.g. Amazon Web Services → S3 Bucket Security → "Evidence provided") and the provider-level **"Evidence tasks"** list, mapped task templates that have **no live task in the org** render as **"Not added"**. Customers see that and ask *"why isn't this added?"* — which we don't want. Affects all cloud providers (shared components).

## Fix
Show only evidence tasks that actually exist in the org, and make each list's count match what's shown:
- `ServiceDetailView` + `IntegrationEvidenceTasks`: filter mapped tasks to those resolved against the org's task templates; the count badge reflects the filtered set.
- `ServiceDetailView` preserves the **tasks-fetch-error** case: on a real fetch error we can't distinguish added vs not-added, so it shows all rows (which render *"Couldn't load"*, not a misleading *"Not added"*).

## Tests
- `IntegrationEvidenceTasks.test.tsx` and `ServiceDetailView.test.tsx` (4 tests): assert not-added tasks are hidden, the count reflects added-only, no "Not added" text renders, and the error path still shows all rows with a "Couldn't load" notice. All pass.
- App typecheck: my files are clean (the pre-existing `.test`/`auth-client` errors on `main` are unrelated and not in this diff).

## Follow-up (not in this PR)
The service **card** in the grid still shows a task-count badge = total mapped tasks, so a card could read "2" while the detail shows "1". Threading the org task templates into the grid would make the card count match — happy to add if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide evidence tasks that aren’t added to the org in integration views, and make the count badges match what’s visible. On task fetch errors, show all mapped tasks with a “Couldn't load tasks” notice instead of “Not added”.

- **Bug Fixes**
  - Filter mapped tasks to only those with live org tasks in ServiceDetailView and IntegrationEvidenceTasks; badge counts match the filtered list.
  - Empty state: provider view renders nothing; service detail shows “This service doesn’t map to any evidence task yet.”
  - Preserve the error path: when the tasks fetch fails, show all mapped tasks and surface “Couldn't load tasks,” never “Not added.”
  - Added tests for visibility, count badges, empty states, and the error case.

<sup>Written for commit 4ba24473b6709e4d6fb8d6200e64287114fbe729. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

