### PR TITLE
fix(app): service card counts only added evidence tasks (matches detail)

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/ProviderDetailView.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/ProviderDetailView.tsx
@@ -397,6 +397,7 @@ export function ProviderDetailView({
                     connectionId={selectedConnection?.id ?? null}
                     orgId={orgId}
                     slug={provider.id}
+                    taskTemplates={taskTemplates}
                   />
                 )}
               </div>

--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/ServiceCard.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/ServiceCard.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/hooks/use-integration-platform', () => ({
+  useConnectionServices: () => ({ services: [], isLoading: false, error: null }),
+}));
+
+import { ServiceCard } from './ServiceCard';
+
+const service = {
+  id: 's3',
+  name: 'S3 Bucket Security',
+  description: 'Public access blocks, default encryption, and versioning checks',
+  mappedTasks: [
+    { id: 'tmpl-encryption', name: 'Encryption at Rest' },
+    { id: 'tmpl-firewall', name: 'Production Firewall' },
+  ],
+};
+
+describe('ServiceCard — evidence task count', () => {
+  it('counts only tasks added to the org when addedTemplateIds is provided', () => {
+    render(
+      <ServiceCard
+        service={service}
+        connectionId="c1"
+        orgId="org-1"
+        slug="aws"
+        addedTemplateIds={new Set<string>(['tmpl-encryption'])}
+      />,
+    );
+    expect(screen.getByText('1 evidence task')).toBeInTheDocument();
+    expect(screen.queryByText('2 evidence tasks')).not.toBeInTheDocument();
+  });
+
+  it('falls back to all mapped tasks when addedTemplateIds is absent', () => {
+    render(
+      <ServiceCard service={service} connectionId="c1" orgId="org-1" slug="aws" />,
+    );
+    expect(screen.getByText('2 evidence tasks')).toBeInTheDocument();
+  });
+
+  it('hides the count entirely when none of the mapped tasks are added', () => {
+    render(
+      <ServiceCard
+        service={service}
+        connectionId="c1"
+        orgId="org-1"
+        slug="aws"
+        addedTemplateIds={new Set<string>()}
+      />,
+    );
+    expect(screen.queryByText(/evidence task/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/ServiceCard.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/ServiceCard.tsx
@@ -92,6 +92,13 @@ interface ServiceCardProps {
   connectionId: string | null;
   orgId: string;
   slug: string;
+  /**
+   * Template ids that have a live task in this org. When provided, the evidence
+   * count shows only added tasks — matching the service detail page, which
+   * hides mappings the org hasn't added. Falls back to all mapped tasks when
+   * absent.
+   */
+  addedTemplateIds?: Set<string>;
 }
 
 /**
@@ -100,7 +107,13 @@ interface ServiceCardProps {
  * tasks it satisfies live). The row itself shows current scan status + the
  * count of evidence tasks the service maps to — it is NOT a toggle.
  */
-export function ServiceCard({ service, connectionId, orgId, slug }: ServiceCardProps) {
+export function ServiceCard({
+  service,
+  connectionId,
+  orgId,
+  slug,
+  addedTemplateIds,
+}: ServiceCardProps) {
   const { services, isLoading, error } = useConnectionServices(connectionId);
   const isImplemented = service.implemented !== false;
   const liveService = services.find((s) => s.id === service.id);
@@ -122,7 +135,10 @@ export function ServiceCard({ service, connectionId, orgId, slug }: ServiceCardP
     scanningOn = isEnabled;
     scanningLabel = isEnabled ? 'Scanning on' : 'Scanning off';
   }
-  const taskCount = service.mappedTasks?.length ?? 0;
+  const mappedTasks = service.mappedTasks ?? [];
+  const taskCount = addedTemplateIds
+    ? mappedTasks.filter((m) => addedTemplateIds.has(m.id)).length
+    : mappedTasks.length;
 
   const href =
     `/${encodeURIComponent(orgId)}/integrations/${encodeURIComponent(slug)}/services/${encodeURIComponent(service.id)}` +

--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/services-grid.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/services-grid.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/hooks/use-integration-platform', () => ({
+  useConnectionServices: () => ({ services: [], isLoading: false, error: null }),
+}));
+
+import { ServicesGrid } from './services-grid';
+
+const services = [
+  {
+    id: 's3',
+    name: 'S3 Bucket Security',
+    description: 'Public access blocks, default encryption, and versioning checks',
+    mappedTasks: [
+      { id: 'tmpl-a', name: 'Encryption at Rest' },
+      { id: 'tmpl-b', name: 'Production Firewall' },
+    ],
+  },
+];
+
+describe('ServicesGrid — evidence task counts', () => {
+  it('falls back to total mapped tasks when taskTemplates is not provided', () => {
+    render(
+      <ServicesGrid services={services} connectionId="c1" orgId="o" slug="aws" />,
+    );
+    // taskTemplates omitted → addedTemplateIds undefined → card counts all mapped.
+    expect(screen.getByText('2 evidence tasks')).toBeInTheDocument();
+  });
+
+  it('counts only added tasks when taskTemplates is provided', () => {
+    render(
+      <ServicesGrid
+        services={services}
+        connectionId="c1"
+        orgId="o"
+        slug="aws"
+        taskTemplates={[{ id: 'tmpl-a' }]}
+      />,
+    );
+    expect(screen.getByText('1 evidence task')).toBeInTheDocument();
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/services-grid.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/services-grid.tsx
@@ -11,6 +11,7 @@ export function ServicesGrid({
   connectionId,
   orgId,
   slug,
+  taskTemplates = [],
 }: {
   services: Array<{
     id: string;
@@ -23,8 +24,17 @@ export function ServicesGrid({
   connectionId: string | null;
   orgId: string;
   slug: string;
+  /** Org task templates (live tasks). Used to count only added evidence tasks. */
+  taskTemplates?: Array<{ id: string }>;
 }) {
   const [search, setSearch] = useState('');
+
+  // Template ids the org actually has a live task for — so each card counts
+  // only added evidence tasks (matching the service detail page).
+  const addedTemplateIds = useMemo(
+    () => new Set(taskTemplates.map((t) => t.id)),
+    [taskTemplates],
+  );
 
   const displayedServices = useMemo(
     () =>
@@ -62,6 +72,7 @@ export function ServicesGrid({
             connectionId={connectionId}
             orgId={orgId}
             slug={slug}
+            addedTemplateIds={addedTemplateIds}
           />
         ))}
         {displayedServices.length === 0 && search && (

--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/services-grid.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/services-grid.tsx
@@ -11,7 +11,7 @@ export function ServicesGrid({
   connectionId,
   orgId,
   slug,
-  taskTemplates = [],
+  taskTemplates,
 }: {
   services: Array<{
     id: string;
@@ -30,9 +30,12 @@ export function ServicesGrid({
   const [search, setSearch] = useState('');
 
   // Template ids the org actually has a live task for — so each card counts
-  // only added evidence tasks (matching the service detail page).
+  // only added evidence tasks (matching the service detail page). Stays
+  // undefined when taskTemplates isn't provided so ServiceCard falls back to
+  // counting all mapped tasks; an explicit empty array still means "none added"
+  // (count 0), matching the detail page for an org with no live tasks.
   const addedTemplateIds = useMemo(
-    () => new Set(taskTemplates.map((t) => t.id)),
+    () => (taskTemplates ? new Set(taskTemplates.map((t) => t.id)) : undefined),
     [taskTemplates],
   );
 


### PR DESCRIPTION
## Problem
The service card in a cloud integration's grid shows an evidence-task count = **total mapped templates**, while the service detail page (PR #3006) shows only tasks **added to the org**. So a card can read **"2 evidence tasks"** while the detail shows **"1"** — a mismatch that confuses users.

## Fix
Thread the org's task templates through `ProviderDetailView → ServicesGrid → ServiceCard` and count only mapped tasks that have a live task in the org, so the card matches the detail.
- The count badge **hides entirely** when none are added (existing `taskCount > 0` guard).
- Falls back to total mapped tasks if no templates are provided (defensive; the grid always passes them).

## Tests
`ServiceCard.test.tsx` (3 tests): added-only count (`1 evidence task` not `2`), fallback to total when `addedTemplateIds` absent, and the hidden-count case when none are added. All pass.

App typecheck: my files are clean (pre-existing `.test`/`auth-client` errors on `main` are unrelated, not in this diff).

## Related
- #3006 — hides "Not added" rows in the evidence lists (service detail + provider). This PR makes the **card count** consistent with that.
- #3003 — backend fix so AWS evidence checks actually run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the service card evidence-task count to show only tasks added to the org, matching the service detail page. Also fixes the fallback so cards show total mapped tasks when templates aren’t provided.

- Bug Fixes
  - Counts only mapped tasks with live org tasks via addedTemplateIds; hides the badge when zero.
  - Keeps addedTemplateIds undefined when taskTemplates is omitted so fallback to total works; an explicit empty array means “none added.”
  - Tests cover ServiceCard and ServicesGrid: added-only, fallback when omitted, and hidden badge.

<sup>Written for commit e47a500b04c34b47015c6930fdb4f46766ec5b25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

