### PR TITLE
fix(integration-platform): assume AWS customer role via roleAssumer (two-hop)

### DIFF
--- a/packages/integration-platform/src/manifests/aws/checks/shared.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/shared.ts
@@ -47,11 +47,44 @@ export function resolveAwsCredentialInputs(
   return { roleArn, externalId, regions };
 }
 
+type AwsPartition = 'aws' | 'aws-us-gov';
+
+function awsPartitionForRegion(region: string): AwsPartition {
+  return region.startsWith('us-gov-') ? 'aws-us-gov' : 'aws';
+}
+
+/** Comp's dedicated roleAssumer role ARN for the partition (set per environment). */
+function awsRoleAssumerArn(partition: AwsPartition): string | undefined {
+  return partition === 'aws-us-gov'
+    ? process.env.SECURITY_HUB_GOVCLOUD_ROLE_ASSUMER_ARN
+    : process.env.SECURITY_HUB_ROLE_ASSUMER_ARN;
+}
+
+/**
+ * Base credentials for hop 1. Commercial AWS uses the task role's default
+ * provider chain (undefined); GovCloud uses explicit access keys when set.
+ */
+function awsBaseCredentials(
+  partition: AwsPartition,
+): { accessKeyId: string; secretAccessKey: string } | undefined {
+  if (partition !== 'aws-us-gov') return undefined;
+  const accessKeyId = process.env.SECURITY_HUB_GOVCLOUD_ACCESS_KEY_ID;
+  const secretAccessKey = process.env.SECURITY_HUB_GOVCLOUD_SECRET_ACCESS_KEY;
+  if (!accessKeyId || !secretAccessKey) return undefined;
+  return { accessKeyId, secretAccessKey };
+}
+
 /**
  * Assume the customer's cross-account IAM role (role ARN + external ID from the
  * connection credentials) and return temporary credentials + the selected
  * regions. Returns null when the connection isn't configured — the check
  * should then no-op (no false pass).
+ *
+ * Uses the SAME two-hop chain as Cloud Tests (independent copy): the customer's
+ * role trust policy whitelists Comp's dedicated roleAssumer role, NOT the raw
+ * task role — so we must (1) assume the roleAssumer from the task/base creds,
+ * then (2) assume the customer role with the roleAssumer creds + external ID. A
+ * single direct hop fails with "not authorized to perform sts:AssumeRole".
  */
 export async function assumeAwsSession(
   ctx: CheckContext,
@@ -62,8 +95,51 @@ export async function assumeAwsSession(
   if (!inputs) return null;
   const { roleArn, externalId, regions } = inputs;
 
-  const sts = new STSClient({ region: regions[0] });
-  const res = await sts.send(
+  // IAM is global — assume once in the first region; the creds work everywhere.
+  const region = regions[0];
+  const partition = awsPartitionForRegion(region);
+
+  const roleAssumerArn = awsRoleAssumerArn(partition);
+  if (!roleAssumerArn) {
+    const envName =
+      partition === 'aws-us-gov'
+        ? 'SECURITY_HUB_GOVCLOUD_ROLE_ASSUMER_ARN'
+        : 'SECURITY_HUB_ROLE_ASSUMER_ARN';
+    throw new Error(`Missing ${envName} (Comp roleAssumer ARN).`);
+  }
+
+  // Hop 1: task/base creds -> Comp roleAssumer.
+  const baseSts = new STSClient({
+    region,
+    credentials: awsBaseCredentials(partition),
+  });
+  const assumerResp = await baseSts.send(
+    new AssumeRoleCommand({
+      RoleArn: roleAssumerArn,
+      RoleSessionName: 'CompRoleAssumer',
+      DurationSeconds: 3600,
+    }),
+  );
+  const assumer = assumerResp.Credentials;
+  if (
+    !assumer?.AccessKeyId ||
+    !assumer.SecretAccessKey ||
+    !assumer.SessionToken
+  ) {
+    return null;
+  }
+
+  // Hop 2: roleAssumer -> customer role (trust policy whitelists the roleAssumer
+  // ARN + external ID).
+  const assumerSts = new STSClient({
+    region,
+    credentials: {
+      accessKeyId: assumer.AccessKeyId,
+      secretAccessKey: assumer.SecretAccessKey,
+      sessionToken: assumer.SessionToken,
+    },
+  });
+  const res = await assumerSts.send(
     new AssumeRoleCommand({
       RoleArn: roleArn,
       ExternalId: externalId,


### PR DESCRIPTION
## Problem
After #3003 (regions fix), the AWS evidence automations now reach the STS `AssumeRole` step but fail with **"Could not assume AWS role"** — STS reports `User: arn:aws:sts::...assumed-role/<task-role>... is not authorized`. Cloud Tests assumes the *same* customer role fine.

## Root cause
Cloud Tests (`aws-security.service.ts:510-547`) assumes customer roles through a **two-hop chain**:
1. base/task creds → assume Comp's dedicated **roleAssumer** role (`SECURITY_HUB_ROLE_ASSUMER_ARN`, session `CompRoleAssumer`)
2. roleAssumer creds → assume the **customer** role (+ external ID)

Customer role trust policies whitelist the **roleAssumer ARN**, not the raw task role. The package's `assumeAwsSession` did a **single direct hop** from the task role → always rejected.

## Fix
Replicate the two-hop chain in `assumeAwsSession` (independent copy — **does not import or touch `apps/api/src/cloud-security`**):
- detect partition from the region (commercial vs GovCloud),
- hop 1: assume `SECURITY_HUB_ROLE_ASSUMER_ARN` (GovCloud variant + explicit keys when applicable; commercial uses the default credential chain),
- hop 2: assume the customer `roleArn` + `externalId` with the roleAssumer creds.

## Deployment requirement
`SECURITY_HUB_ROLE_ASSUMER_ARN` must be in the runtime env:
- **Manual "Run"** runs in the API, which already has it + the IAM trust (Cloud Tests works there) → fixed by this PR.
- **Scheduled (trigger.dev)** runs need the same env var **and** the trigger task role permitted to assume the roleAssumer. If that's not yet configured in trigger.dev, scheduled AWS checks will emit "Could not assume AWS role (Missing SECURITY_HUB_ROLE_ASSUMER_ARN)" until it is.

## Testing
Package builds clean; 211 tests pass (incl. the #3003 `resolveAwsCredentialInputs` tests). The two-hop STS chain mirrors the verified Cloud Tests implementation; there's no STS mock harness in the package to unit-test it, so final verification is a "Run" on stage after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AWS evidence checks by assuming customer roles via a two-hop chain through our roleAssumer, removing “Could not assume AWS role” failures. Supports commercial and GovCloud partitions, matching the Cloud Tests flow.

- **Bug Fixes**
  - Implemented two-hop AssumeRole in `assumeAwsSession`: task/base → roleAssumer → customer role (with `externalId`).
  - Detects partition from region; selects the correct roleAssumer ARN and optional GovCloud access keys.
  - Assumes once in the first region; credentials work across all selected regions.

- **Migration**
  - Set `SECURITY_HUB_ROLE_ASSUMER_ARN` (and `SECURITY_HUB_GOVCLOUD_ROLE_ASSUMER_ARN` for GovCloud).
  - For GovCloud, set `SECURITY_HUB_GOVCLOUD_ACCESS_KEY_ID` and `SECURITY_HUB_GOVCLOUD_SECRET_ACCESS_KEY` if the default chain isn’t available.
  - Ensure the trigger.dev task role can assume the roleAssumer; otherwise scheduled runs will fail.

<sup>Written for commit ad04fb28643825a1f272031d4bf80a8a8b1943bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

