### PR TITLE
fix(integrations): anchor config dropdown to its field (follow-up to #3005)

### DIFF
--- a/apps/app/src/components/integrations/ConnectionVariablesForm.test.tsx
+++ b/apps/app/src/components/integrations/ConnectionVariablesForm.test.tsx
@@ -2,12 +2,13 @@ import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 // Stub the design-system Select family so we can assert how it is configured.
-// SelectContent exposes its `portal` prop as a data attribute — this is the
-// crux of the fix: the DS Select is built on @base-ui/react and portals to
-// document.body by default, which escapes the Radix (@trycompai/ui) modal
-// Dialog it is rendered inside (ManageIntegrationDialog) and makes the dropdown
-// unclickable ("insta-closes"). Rendering inline (portal={false}) keeps the
-// popup inside the modal's pointer-events/focus scope.
+// SelectContent forwards its `style` to the popup — this is the crux of the fix:
+// the DS Select is built on @base-ui/react and portals its popup to document.body.
+// Inside the Radix (@trycompai/ui) modal Dialog it is rendered in (ManageIntegrationDialog),
+// Radix sets `body { pointer-events: none }`, so the portaled popup is unclickable and
+// the open is cancelled ("insta-closes"). pointer-events:auto re-enables the popup while
+// keeping it portaled (so it stays anchored to the trigger instead of being mis-positioned
+// by the dialog's CSS transform, as rendering inline would do).
 vi.mock('@trycompai/design-system', () => ({
   Input: (props: Record<string, unknown>) => <input {...props} />,
   Label: ({ children, htmlFor }: { children: React.ReactNode; htmlFor?: string }) => (
@@ -21,8 +22,14 @@ vi.mock('@trycompai/design-system', () => ({
     <div data-trigger-id={id}>{children}</div>
   ),
   SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
-  SelectContent: ({ children, portal }: { children: React.ReactNode; portal?: boolean }) => (
-    <div data-testid="select-content" data-portal={String(portal)}>
+  SelectContent: ({
+    children,
+    style,
+  }: {
+    children: React.ReactNode;
+    style?: React.CSSProperties;
+  }) => (
+    <div data-testid="select-content" style={style}>
       {children}
     </div>
   ),
@@ -56,8 +63,8 @@ function renderFields(variables: ConnectionVariable[]) {
   );
 }
 
-describe('ConnectionVariablesFields dropdown portal behavior', () => {
-  it('renders a select-type dropdown inline (portal={false}) so it survives inside a Radix modal', () => {
+describe('ConnectionVariablesFields dropdown clickability inside a modal', () => {
+  it('renders a select-type dropdown popup with pointer-events:auto so it works inside a Radix modal', () => {
     renderFields([
       {
         id: 'alert_severity_threshold',
@@ -72,13 +79,13 @@ describe('ConnectionVariablesFields dropdown portal behavior', () => {
     ]);
 
     const content = screen.getByTestId('select-content');
-    expect(content).toHaveAttribute('data-portal', 'false');
+    expect(content).toHaveStyle({ pointerEvents: 'auto' });
     // Options still render
     expect(screen.getByText('Low')).toBeInTheDocument();
     expect(screen.getByText('Critical')).toBeInTheDocument();
   });
 
-  it('renders a boolean-type dropdown inline (portal={false})', () => {
+  it('renders a boolean-type dropdown popup with pointer-events:auto', () => {
     renderFields([
       {
         id: 'enabled',
@@ -90,12 +97,12 @@ describe('ConnectionVariablesFields dropdown portal behavior', () => {
     ]);
 
     const content = screen.getByTestId('select-content');
-    expect(content).toHaveAttribute('data-portal', 'false');
+    expect(content).toHaveStyle({ pointerEvents: 'auto' });
     expect(screen.getByText('Yes')).toBeInTheDocument();
     expect(screen.getByText('No')).toBeInTheDocument();
   });
 
-  it('does not portal any dropdown to document.body for mixed select + boolean fields', () => {
+  it('applies pointer-events:auto to every dropdown for mixed select + boolean fields', () => {
     renderFields([
       {
         id: 'mode',
@@ -110,7 +117,7 @@ describe('ConnectionVariablesFields dropdown portal behavior', () => {
     const contents = screen.getAllByTestId('select-content');
     expect(contents).toHaveLength(2);
     for (const content of contents) {
-      expect(content).toHaveAttribute('data-portal', 'false');
+      expect(content).toHaveStyle({ pointerEvents: 'auto' });
     }
   });
 });

--- a/apps/app/src/components/integrations/ConnectionVariablesForm.tsx
+++ b/apps/app/src/components/integrations/ConnectionVariablesForm.tsx
@@ -171,13 +171,16 @@ export function ConnectionVariablesFields({
                   <SelectValue placeholder={`Select ${variable.label.toLowerCase()}`} />
                 </SelectTrigger>
                 {/*
-                  portal={false} renders the dropdown inline, inside whatever modal wraps this form.
-                  This component is shown inside a Radix (@trycompai/ui) Dialog (ManageIntegrationDialog).
-                  The DS Select is built on @base-ui/react and portals to document.body by default, which
-                  escapes the Radix modal's pointer-events/dismiss scope and makes the dropdown unclickable
-                  ("insta-closes"). Keeping it inline keeps it inside the modal's scope. Do not remove.
+                  The DS Select is built on @base-ui/react and portals its popup to document.body.
+                  This form is rendered inside a Radix (@trycompai/ui) modal Dialog (ManageIntegrationDialog),
+                  and Radix's modal sets `body { pointer-events: none }`. The portaled popup inherits that,
+                  so its options are unclickable and the open is cancelled on mouseup ("insta-closes").
+                  pointer-events:auto re-enables interaction on the popup while keeping it portaled, so it
+                  stays anchored to the trigger — rendering it inline (portal={false}) instead mis-positions
+                  it because the dialog is centered with a CSS transform. Harmless in the design-system Sheet
+                  consumer (AccountSettingsSheet), which does not lock body pointer-events. Do not remove.
                 */}
-                <SelectContent portal={false}>
+                <SelectContent style={{ pointerEvents: 'auto' }}>
                   {isLoadingOptions ? (
                     <div className="py-2 px-3 text-sm text-muted-foreground flex items-center gap-2">
                       <Spinner />
@@ -210,8 +213,8 @@ export function ConnectionVariablesFields({
                 <SelectTrigger id={variable.id}>
                   <SelectValue />
                 </SelectTrigger>
-                {/* portal={false}: render inline so the dropdown stays inside the Radix modal scope (see note above). */}
-                <SelectContent portal={false}>
+                {/* pointer-events:auto so the popup is clickable inside the Radix modal's body lock (see note above). */}
+                <SelectContent style={{ pointerEvents: 'auto' }}>
                   <SelectItem value="true">Yes</SelectItem>
                   <SelectItem value="false">No</SelectItem>
                 </SelectContent>


### PR DESCRIPTION
## Why this follow-up

#3005 fixed the dropdown **insta-close** but used `portal={false}`, which introduced a new bug: the dropdown popup now renders in the **bottom-right corner of the viewport** instead of anchored to its field. This PR replaces that with the correct fix.

## What went wrong with `portal={false}`

Rendering the popup inline put its `position: fixed` **inside the Radix `DialogContent`**, which is centered via a CSS `transform` (`translate(-50%, -50%)`). A transformed ancestor becomes the containing block for `position: fixed` descendants, so the computed viewport coordinates placed the popup in the corner.

## Correct fix

Root mechanism (verified in source): Radix's `react-dismissable-layer` sets `body { pointer-events: none }` for modal dialogs (`dist/index.js:111`). The DS Select popup (Base UI) portals to `body`, inherits `none`, so its `mouseup` passes through → Base UI's `SelectTrigger` fires `cancelOpen` → "insta-closes".

So: **keep the popup portaled** (so it stays correctly anchored to the trigger — no transform issue) and set **`style={{ pointerEvents: 'auto' }}`** on it so it's clickable despite the body lock.

- Safe in the other consumer too: `ConnectionVariablesFields` also renders inside the **DS Base-UI `Sheet`** (`AccountSettingsSheet`), which uses `aria-hidden` (not a body pointer-events lock), so `pointer-events: auto` is a harmless no-op there. (A whole-component swap to the Radix Select would have broken that consumer — so this is the right minimal fix.)
- Verified Base UI `SelectPopup` forwards/merges `style`, and its positioning is applied imperatively on the positioner, so this doesn't disturb anchoring.

## Tests
- Updated `ConnectionVariablesForm.test.tsx` (3 tests) to assert `pointer-events: auto` on the popup for both `select` and `boolean` field types.
- Typecheck: 0 new errors vs `main`.

## ⚠️ Please verify on a preview build
jsdom can't reproduce a pointer/portal bug, so the unit test only locks the prop wiring. Please confirm in a GitHub and a Vercel integration **Configure** modal that the `select` dropdowns now (a) open, (b) are **anchored to the field** (not the corner), and (c) are selectable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the integration config dropdown so it opens, is clickable, and stays anchored to its field inside modals. Keeps the popup portaled and enables interaction with pointer-events:auto to avoid the bottom-right mis-positioning from portal={false}.

- **Bug Fixes**
  - Set `style={{ pointerEvents: 'auto' }}` on `SelectContent` while keeping it portaled to restore correct anchoring and clickability in modals.
  - Updated tests to assert the style for both select and boolean dropdowns.

<sup>Written for commit ffa5c917d57c01ec2f3a8e1aee3af28d8cbc8e5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

