### PR TITLE
fix(integration-platform): meaningful "View Evidence" on every check outcome (all providers)

### DIFF
--- a/packages/integration-platform/src/manifests/aws/checks/__tests__/aws-checks.test.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/__tests__/aws-checks.test.ts
@@ -356,4 +356,20 @@ describe('IAM/CloudTrail outcomes carry evidence (so the UI shows "View Evidence
     expect(out[0]!.title).toMatch(/No CloudTrail configured/);
     expect(hasEvidence(out[0]!)).toBe(true);
   });
+
+  it('pass/fail evidence carries the determining value (S3 encryption, KMS rotation)', () => {
+    const enc = evaluateS3Encryption([
+      { name: 'enc', encrypted: true, encryptionDetermined: true, publicAccessDetermined: true, bucketBpa: null },
+      { name: 'plain', encrypted: false, encryptionDetermined: true, publicAccessDetermined: true, bucketBpa: null },
+    ]);
+    expect(enc[0]!.evidence?.encrypted).toBe(true);
+    expect(enc[1]!.evidence?.encrypted).toBe(false);
+
+    const rot = evaluateKmsRotation([
+      { keyId: 'on', region: 'us-east-1', rotationEligible: true, rotationStatusKnown: true, rotationEnabled: true },
+      { keyId: 'off', region: 'us-east-1', rotationEligible: true, rotationStatusKnown: true, rotationEnabled: false },
+    ]);
+    expect(rot[0]!.evidence?.rotationEnabled).toBe(true);
+    expect(rot[1]!.evidence?.rotationEnabled).toBe(false);
+  });
 });

--- a/packages/integration-platform/src/manifests/aws/checks/__tests__/aws-checks.test.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/__tests__/aws-checks.test.ts
@@ -314,3 +314,46 @@ describe('AWS CloudTrail evaluator', () => {
     expect(out[0]!.title).toMatch(/Could not verify/);
   });
 });
+
+describe('IAM/CloudTrail outcomes carry evidence (so the UI shows "View Evidence")', () => {
+  const hasEvidence = (o: { evidence?: Record<string, unknown> }) =>
+    !!o.evidence && Object.keys(o.evidence).length > 0;
+
+  it('every password-policy outcome has evidence (none / weak / strong)', () => {
+    expect(evaluatePasswordPolicy(null).every(hasEvidence)).toBe(true);
+    expect(
+      evaluatePasswordPolicy({ MinimumPasswordLength: 8 }).every(hasEvidence),
+    ).toBe(true);
+    expect(
+      evaluatePasswordPolicy({
+        MinimumPasswordLength: 14,
+        RequireSymbols: true,
+        RequireNumbers: true,
+        RequireUppercaseCharacters: true,
+        RequireLowercaseCharacters: true,
+      }).every(hasEvidence),
+    ).toBe(true);
+  });
+
+  it('every root-account-summary outcome has evidence (both states)', () => {
+    expect(
+      evaluateAccountSummary({
+        AccountMFAEnabled: 0,
+        AccountAccessKeysPresent: 1,
+      }).every(hasEvidence),
+    ).toBe(true);
+    expect(
+      evaluateAccountSummary({
+        AccountMFAEnabled: 1,
+        AccountAccessKeysPresent: 0,
+      }).every(hasEvidence),
+    ).toBe(true);
+  });
+
+  it('the "No CloudTrail configured" outcome has evidence', () => {
+    const out = evaluateCloudTrail([]);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.title).toMatch(/No CloudTrail configured/);
+    expect(hasEvidence(out[0]!)).toBe(true);
+  });
+});

--- a/packages/integration-platform/src/manifests/aws/checks/cloudtrail.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/cloudtrail.ts
@@ -71,6 +71,7 @@ export function evaluateCloudTrail(trails: TrailInfo[]): CheckOutcome[] {
         resourceId: 'account',
         severity: 'high',
         remediation: 'Create a multi-region CloudTrail trail with log file validation enabled.',
+        evidence: { trailsFound: 0 },
       },
     ];
   }

--- a/packages/integration-platform/src/manifests/aws/checks/cloudtrail.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/cloudtrail.ts
@@ -34,7 +34,7 @@ export function evaluateCloudTrail(trails: TrailInfo[]): CheckOutcome[] {
         description: `Trail "${good.name}" is multi-region, actively logging, with log file validation enabled.`,
         resourceType: 'aws-cloudtrail',
         resourceId: good.name,
-        evidence: { trail: good.name },
+        evidence: { trail: good.name, multiRegion: good.multiRegion, logging: good.logging, logValidation: good.logValidation },
       },
     ];
   }
@@ -86,7 +86,14 @@ export function evaluateCloudTrail(trails: TrailInfo[]): CheckOutcome[] {
       severity: 'medium',
       remediation:
         'Ensure a CloudTrail trail is multi-region, logging is started, and log file validation is enabled.',
-      evidence: { trails: trails.map((t) => t.name) },
+      evidence: {
+        trails: trails.map((t) => ({
+          name: t.name,
+          multiRegion: t.multiRegion,
+          logging: t.logging,
+          logValidation: t.logValidation,
+        })),
+      },
     },
   ];
 }

--- a/packages/integration-platform/src/manifests/aws/checks/ec2.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/ec2.ts
@@ -43,7 +43,7 @@ export function evaluateSecurityGroups(sgs: SgInfo[]): CheckOutcome[] {
           resourceId: sg.groupId,
           severity: 'critical',
           remediation: 'Restrict the inbound rule to specific CIDRs and ports.',
-          evidence: { groupId: sg.groupId, region: sg.region },
+          evidence: { groupId: sg.groupId, groupName: sg.groupName, region: sg.region, ipProtocol: perm.ipProtocol, cidrs: perm.cidrs },
         });
         continue;
       }
@@ -62,7 +62,7 @@ export function evaluateSecurityGroups(sgs: SgInfo[]): CheckOutcome[] {
             resourceId: sg.groupId,
             severity,
             remediation: `Remove the 0.0.0.0/0 rule for port ${port}; restrict ${label} to a VPN, bastion, or known CIDRs.`,
-            evidence: { groupId: sg.groupId, region: sg.region, port },
+            evidence: { groupId: sg.groupId, region: sg.region, port, ipProtocol: perm.ipProtocol, cidrs: perm.cidrs },
           });
         }
       }
@@ -74,7 +74,7 @@ export function evaluateSecurityGroups(sgs: SgInfo[]): CheckOutcome[] {
         description: `Security group "${sg.groupName ?? sg.groupId}" (${sg.region}) does not expose SSH/RDP/all-ports to 0.0.0.0/0.`,
         resourceType: 'aws-security-group',
         resourceId: sg.groupId,
-        evidence: { groupId: sg.groupId, region: sg.region },
+        evidence: { groupId: sg.groupId, groupName: sg.groupName, region: sg.region, inboundRuleCount: sg.permissions.length, internetExposedSensitivePorts: false },
       });
     }
   }

--- a/packages/integration-platform/src/manifests/aws/checks/iam.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/iam.ts
@@ -37,6 +37,7 @@ export function evaluatePasswordPolicy(
       severity: 'high',
       remediation:
         'Set an IAM password policy (min length 14; require symbols, numbers, upper and lower case).',
+      evidence: { passwordPolicyConfigured: false },
     });
   } else {
     const weak: string[] = [];
@@ -86,6 +87,7 @@ export function evaluateAccountSummary(
       description: 'The root account has MFA enabled.',
       resourceType: 'aws-account',
       resourceId: id,
+      evidence: { accountMFAEnabled: true },
     });
   } else {
     out.push({
@@ -96,6 +98,7 @@ export function evaluateAccountSummary(
       resourceId: id,
       severity: 'high',
       remediation: 'Enable MFA on the root account.',
+      evidence: { accountMFAEnabled: false },
     });
   }
 
@@ -108,6 +111,9 @@ export function evaluateAccountSummary(
       resourceId: id,
       severity: 'high',
       remediation: 'Delete root account access keys; use IAM users/roles instead.',
+      evidence: {
+        accountAccessKeysPresent: summary.AccountAccessKeysPresent ?? 0,
+      },
     });
   } else {
     out.push({
@@ -116,6 +122,7 @@ export function evaluateAccountSummary(
       description: 'The root account has no access keys.',
       resourceType: 'aws-account',
       resourceId: id,
+      evidence: { accountAccessKeysPresent: 0 },
     });
   }
 

--- a/packages/integration-platform/src/manifests/aws/checks/kms.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/kms.ts
@@ -46,7 +46,7 @@ export function evaluateKmsRotation(keys: KmsKeyInfo[]): CheckOutcome[] {
           severity: 'medium',
           remediation:
             'Grant kms:GetKeyRotationStatus to the integration role so rotation can be verified, then re-run.',
-          evidence: { keyId: k.keyId, region: k.region },
+          evidence: { keyId: k.keyId, region: k.region, rotationStatusKnown: false },
         };
       }
       return k.rotationEnabled
@@ -56,7 +56,7 @@ export function evaluateKmsRotation(keys: KmsKeyInfo[]): CheckOutcome[] {
             description: `Customer-managed KMS key "${k.keyId}" (${k.region}) has automatic rotation enabled.`,
             resourceType: 'aws-kms-key',
             resourceId: k.keyId,
-            evidence: { keyId: k.keyId, region: k.region },
+            evidence: { keyId: k.keyId, region: k.region, rotationEnabled: true },
           }
         : {
             kind: 'fail',
@@ -66,7 +66,7 @@ export function evaluateKmsRotation(keys: KmsKeyInfo[]): CheckOutcome[] {
             resourceId: k.keyId,
             severity: 'medium',
             remediation: 'Enable automatic annual key rotation on the customer-managed KMS key.',
-            evidence: { keyId: k.keyId, region: k.region },
+            evidence: { keyId: k.keyId, region: k.region, rotationEnabled: false },
           };
     });
 }

--- a/packages/integration-platform/src/manifests/aws/checks/rds.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/rds.ts
@@ -44,7 +44,7 @@ export function evaluateRdsEncryption(instances: RdsInstanceInfo[]): CheckOutcom
           description: `RDS instance "${i.id}" (${i.region}) has storage encryption enabled.`,
           resourceType: 'aws-rds-instance',
           resourceId: `${i.region}/${i.id}`,
-          evidence: { instance: i.id, region: i.region },
+          evidence: { instance: i.id, region: i.region, encrypted: true },
         }
       : {
           kind: 'fail',
@@ -55,7 +55,7 @@ export function evaluateRdsEncryption(instances: RdsInstanceInfo[]): CheckOutcom
           severity: 'high',
           remediation:
             'Enable storage encryption (encryption at rest must be set at creation; restore from an encrypted snapshot to remediate).',
-          evidence: { instance: i.id, region: i.region },
+          evidence: { instance: i.id, region: i.region, encrypted: false },
         },
   );
 }
@@ -83,7 +83,7 @@ export function evaluateRdsBackups(instances: RdsInstanceInfo[]): CheckOutcome[]
           resourceId: `${i.region}/${i.id}`,
           severity: 'medium',
           remediation: 'Set a backup retention period of at least 7 days.',
-          evidence: { instance: i.id },
+          evidence: { instance: i.id, region: i.region, backupRetentionDays: i.backupRetentionDays },
         },
   );
 }
@@ -97,7 +97,7 @@ export function evaluateRdsClusterEncryption(clusters: RdsClusterInfo[]): CheckO
           description: `RDS cluster "${c.id}" (${c.region}) has storage encryption enabled.`,
           resourceType: 'aws-rds-cluster',
           resourceId: `${c.region}/${c.id}`,
-          evidence: { cluster: c.id, region: c.region },
+          evidence: { cluster: c.id, region: c.region, encrypted: true },
         }
       : {
           kind: 'fail',
@@ -108,7 +108,7 @@ export function evaluateRdsClusterEncryption(clusters: RdsClusterInfo[]): CheckO
           severity: 'high',
           remediation:
             'Enable storage encryption (encryption at rest must be set at creation; restore from an encrypted snapshot to remediate).',
-          evidence: { cluster: c.id, region: c.region },
+          evidence: { cluster: c.id, region: c.region, encrypted: false },
         },
   );
 }
@@ -132,7 +132,7 @@ export function evaluateRdsClusterBackups(clusters: RdsClusterInfo[]): CheckOutc
           resourceId: `${c.region}/${c.id}`,
           severity: 'medium',
           remediation: 'Set a backup retention period of at least 7 days.',
-          evidence: { cluster: c.id },
+          evidence: { cluster: c.id, region: c.region, backupRetentionDays: c.backupRetentionDays },
         },
   );
 }

--- a/packages/integration-platform/src/manifests/aws/checks/s3.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/s3.ts
@@ -57,7 +57,7 @@ export function evaluateS3Encryption(buckets: S3BucketInfo[]): CheckOutcome[] {
         severity: 'medium',
         remediation:
           'Grant s3:GetEncryptionConfiguration to the integration role so default encryption can be verified, then re-run.',
-        evidence: { bucket: b.name },
+        evidence: { bucket: b.name, encryptionDetermined: false },
       };
     }
     return b.encrypted
@@ -67,7 +67,7 @@ export function evaluateS3Encryption(buckets: S3BucketInfo[]): CheckOutcome[] {
           description: `Bucket "${b.name}" has default encryption enabled.`,
           resourceType: 'aws-s3-bucket',
           resourceId: b.name,
-          evidence: { bucket: b.name },
+          evidence: { bucket: b.name, encrypted: true },
         }
       : {
           kind: 'fail',
@@ -77,7 +77,7 @@ export function evaluateS3Encryption(buckets: S3BucketInfo[]): CheckOutcome[] {
           resourceId: b.name,
           severity: 'high',
           remediation: 'Enable default encryption (SSE-S3 or SSE-KMS) on the bucket.',
-          evidence: { bucket: b.name },
+          evidence: { bucket: b.name, encrypted: false },
         };
   });
 }
@@ -97,7 +97,7 @@ export function evaluateS3PublicAccess(
         severity: 'medium',
         remediation:
           'Grant s3:GetBucketPublicAccessBlock to the integration role so public-access settings can be verified, then re-run.',
-        evidence: { bucket: b.name },
+        evidence: { bucket: b.name, publicAccessDetermined: false },
       };
     }
     return isFullyBlocked(b.bucketBpa, accountBpa)
@@ -107,7 +107,7 @@ export function evaluateS3PublicAccess(
           description: `Bucket "${b.name}" has S3 Block Public Access fully enabled (account and/or bucket level).`,
           resourceType: 'aws-s3-bucket',
           resourceId: b.name,
-          evidence: { bucket: b.name },
+          evidence: { bucket: b.name, bucketBpa: b.bucketBpa, accountBpa },
         }
       : {
           kind: 'fail',
@@ -117,7 +117,7 @@ export function evaluateS3PublicAccess(
           resourceId: b.name,
           severity: 'high',
           remediation: 'Enable all four S3 Block Public Access settings on the bucket (or account).',
-          evidence: { bucket: b.name },
+          evidence: { bucket: b.name, bucketBpa: b.bucketBpa, accountBpa },
         };
   });
 }

--- a/packages/integration-platform/src/manifests/azure/checks/entra-id.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/entra-id.ts
@@ -154,7 +154,12 @@ export const rbacLeastPrivilegeCheck: IntegrationCheck = {
         severity: 'high',
         remediation:
           'Review privileged role assignments and remove unnecessary ones; use just-in-time access via Azure PIM.',
-        evidence: { count: privileged.length },
+        evidence: {
+          privilegedCount: privileged.length,
+          threshold: 5,
+          principalIds: privileged.map((a) => a.properties.principalId),
+          principalTypes: privileged.map((a) => a.properties.principalType),
+        },
       });
     }
 
@@ -171,7 +176,10 @@ export const rbacLeastPrivilegeCheck: IntegrationCheck = {
         severity: 'medium',
         remediation:
           'Replace broad roles with scoped custom roles for service principals.',
-        evidence: { count: spPrivileged.length },
+        evidence: {
+          count: spPrivileged.length,
+          principalIds: spPrivileged.map((a) => a.properties.principalId),
+        },
       });
     }
 
@@ -196,6 +204,11 @@ export const rbacLeastPrivilegeCheck: IntegrationCheck = {
     );
     for (const role of wildcardRoles) {
       violations++;
+      const wildcardActions = role.properties.permissions.flatMap((perm) =>
+        [...(perm.actions ?? []), ...(perm.dataActions ?? [])].filter(
+          isWildcardAction,
+        ),
+      );
       ctx.fail({
         title: `Custom role with wildcard permissions: ${role.properties.roleName}`,
         description: `Custom role "${role.properties.roleName}" grants wildcard (*) permissions, which is overly permissive.`,
@@ -204,7 +217,7 @@ export const rbacLeastPrivilegeCheck: IntegrationCheck = {
         severity: 'high',
         remediation:
           'Restrict the custom role to only the specific actions required.',
-        evidence: { roleName: role.properties.roleName },
+        evidence: { roleName: role.properties.roleName, wildcardActions },
       });
     }
 
@@ -214,7 +227,13 @@ export const rbacLeastPrivilegeCheck: IntegrationCheck = {
         description: `${privileged.length} privileged assignment(s); no wildcard custom roles or privileged service principals.`,
         resourceType: 'azure-subscription',
         resourceId: sub,
-        evidence: { privilegedCount: privileged.length },
+        evidence: {
+          privilegedCount: privileged.length,
+          threshold: 5,
+          wildcardCustomRoles: wildcardRoles.length,
+          privilegedServicePrincipals: spPrivileged.length,
+          assignmentsEvaluated: assignments.length,
+        },
       });
     }
   },

--- a/packages/integration-platform/src/manifests/azure/checks/key-vault.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/key-vault.ts
@@ -78,7 +78,12 @@ export const keyVaultProtectionCheck: IntegrationCheck = {
           description: `Key Vault "${v.name}" has soft delete + purge protection and restricts public access.`,
           resourceType: 'azure-key-vault',
           resourceId: v.id,
-          evidence: { vault: v.name },
+          evidence: {
+            vault: v.name,
+            enableSoftDelete: p.enableSoftDelete,
+            enablePurgeProtection: p.enablePurgeProtection,
+            publicNetworkAccess: p.publicNetworkAccess ?? null,
+          },
         });
       }
     }
@@ -106,7 +111,7 @@ export const keyVaultRbacCheck: IntegrationCheck = {
           description: `Key Vault "${v.name}" uses Azure RBAC for access control.`,
           resourceType: 'azure-key-vault',
           resourceId: v.id,
-          evidence: { vault: v.name },
+          evidence: { vault: v.name, enableRbacAuthorization: true },
         });
       } else {
         ctx.fail({
@@ -117,7 +122,10 @@ export const keyVaultRbacCheck: IntegrationCheck = {
           severity: 'low',
           remediation:
             'Migrate to the Azure RBAC permission model for finer-grained, auditable access control.',
-          evidence: { vault: v.name },
+          evidence: {
+            vault: v.name,
+            enableRbacAuthorization: v.properties?.enableRbacAuthorization ?? false,
+          },
         });
       }
     }

--- a/packages/integration-platform/src/manifests/azure/checks/monitor.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/monitor.ts
@@ -69,7 +69,10 @@ export const monitorLoggingAlertingCheck: IntegrationCheck = {
           description: 'All recommended activity log alerts are configured.',
           resourceType: 'azure-subscription',
           resourceId: sub,
-          evidence: { recommended: RECOMMENDED_ALERTS.length },
+          evidence: {
+            recommended: RECOMMENDED_ALERTS.map((r) => r.op),
+            configuredOperations: [...ops],
+          },
         });
       }
     } else {
@@ -109,7 +112,14 @@ export const monitorLoggingAlertingCheck: IntegrationCheck = {
           description: 'Subscription activity logs are exported.',
           resourceType: 'azure-subscription',
           resourceId: sub,
-          evidence: { settings: settings.length },
+          evidence: {
+            settingsCount: settings.length,
+            exportsToLogAnalytics: settings.some((s) => !!s.properties?.workspaceId),
+            exportsToStorage: settings.some((s) => !!s.properties?.storageAccountId),
+            exportsToEventHub: settings.some(
+              (s) => !!s.properties?.eventHubAuthorizationRuleId,
+            ),
+          },
         });
       } else {
         ctx.fail({
@@ -121,7 +131,7 @@ export const monitorLoggingAlertingCheck: IntegrationCheck = {
           severity: 'medium',
           remediation:
             'Configure a diagnostic setting to export subscription activity logs.',
-          evidence: {},
+          evidence: { diagnosticSettingsFound: settings.length },
         });
       }
     } else {

--- a/packages/integration-platform/src/manifests/azure/checks/monitor.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/monitor.ts
@@ -99,12 +99,18 @@ export const monitorLoggingAlertingCheck: IntegrationCheck = {
     if (diag !== null) {
       evaluated = true;
       const settings = diag.value ?? [];
+      // A setting only exports when it targets a destination AND has at least
+      // one enabled log category. Reuse this for both the verdict and the
+      // evidence so the destination flags reflect what actually exports (a
+      // destination whose logs are disabled must not be reported as exporting).
+      const hasEnabledLogs = (s: DiagnosticSetting) =>
+        (s.properties?.logs ?? []).some((l) => l.enabled);
       const hasExport = settings.some(
         (s) =>
           (s.properties?.workspaceId ||
             s.properties?.storageAccountId ||
             s.properties?.eventHubAuthorizationRuleId) &&
-          (s.properties?.logs ?? []).some((l) => l.enabled),
+          hasEnabledLogs(s),
       );
       if (hasExport) {
         ctx.pass({
@@ -114,10 +120,14 @@ export const monitorLoggingAlertingCheck: IntegrationCheck = {
           resourceId: sub,
           evidence: {
             settingsCount: settings.length,
-            exportsToLogAnalytics: settings.some((s) => !!s.properties?.workspaceId),
-            exportsToStorage: settings.some((s) => !!s.properties?.storageAccountId),
+            exportsToLogAnalytics: settings.some(
+              (s) => !!s.properties?.workspaceId && hasEnabledLogs(s),
+            ),
+            exportsToStorage: settings.some(
+              (s) => !!s.properties?.storageAccountId && hasEnabledLogs(s),
+            ),
             exportsToEventHub: settings.some(
-              (s) => !!s.properties?.eventHubAuthorizationRuleId,
+              (s) => !!s.properties?.eventHubAuthorizationRuleId && hasEnabledLogs(s),
             ),
           },
         });

--- a/packages/integration-platform/src/manifests/azure/checks/network.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/network.ts
@@ -121,7 +121,15 @@ export const nsgNoOpenPortsCheck: IntegrationCheck = {
               severity: c.severity,
               remediation:
                 'Restrict the source to specific IP ranges, or use Azure Bastion / Private Link.',
-              evidence: { nsg: nsg.name, rule: rule.name, priority: rule.properties.priority },
+              evidence: {
+                nsg: nsg.name,
+                rule: rule.name,
+                priority: rule.properties.priority,
+                exposure: c.label,
+                sources: ruleSources(rule),
+                ports,
+                protocol: rule.properties.protocol ?? '*',
+              },
             });
           }
         }
@@ -133,7 +141,11 @@ export const nsgNoOpenPortsCheck: IntegrationCheck = {
           description: `NSG "${nsg.name}" has no overly permissive inbound rules.`,
           resourceType: 'azure-nsg',
           resourceId: nsg.id,
-          evidence: { nsg: nsg.name },
+          evidence: {
+            nsg: nsg.name,
+            inboundAllowRulesEvaluated: inbound.length,
+            totalRules: (nsg.properties.securityRules ?? []).length,
+          },
         });
       }
     }

--- a/packages/integration-platform/src/manifests/azure/checks/sql.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/sql.ts
@@ -133,7 +133,12 @@ export const sqlPublicAccessCheck: IntegrationCheck = {
           severity: violation.severity,
           remediation:
             'Disable public network access and use private endpoints; remove 0.0.0.0 firewall rules.',
-          evidence: { server: s.name, publicNetworkAccess: s.properties?.publicNetworkAccess ?? null },
+          evidence: {
+            server: s.name,
+            publicNetworkAccess: s.properties?.publicNetworkAccess ?? null,
+            reason: violation.detail,
+            firewallRuleCount: rules?.length ?? null,
+          },
         });
       } else if (rules === null) {
         // Public access not Enabled but firewall rules unreadable — can't assert a
@@ -155,7 +160,11 @@ export const sqlPublicAccessCheck: IntegrationCheck = {
           description: `SQL Server "${s.name}" restricts public network access and has no wide-open firewall rules.`,
           resourceType: 'azure-sql-server',
           resourceId: s.id,
-          evidence: { server: s.name, firewallRuleCount: rules.length },
+          evidence: {
+            server: s.name,
+            publicNetworkAccess: s.properties?.publicNetworkAccess ?? null,
+            firewallRuleCount: rules.length,
+          },
         });
       }
     }
@@ -206,7 +215,7 @@ export const sqlAuditingCheck: IntegrationCheck = {
           description: `SQL Server "${s.name}" has auditing enabled.`,
           resourceType: 'azure-sql-server',
           resourceId: s.id,
-          evidence: { server: s.name },
+          evidence: { server: s.name, state: auditing.properties?.state ?? null },
         });
       } else {
         ctx.fail({

--- a/packages/integration-platform/src/manifests/azure/checks/storage.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/storage.ts
@@ -77,7 +77,11 @@ export const storageHttpsTlsCheck: IntegrationCheck = {
           description: `Storage account "${a.name}" enforces HTTPS-only and TLS >= 1.2.`,
           resourceType: 'azure-storage-account',
           resourceId: a.id,
-          evidence: { account: a.name, minimumTlsVersion: p.minimumTlsVersion },
+          evidence: {
+            account: a.name,
+            supportsHttpsTrafficOnly: p.supportsHttpsTrafficOnly,
+            minimumTlsVersion: p.minimumTlsVersion,
+          },
         });
       }
     }
@@ -131,7 +135,12 @@ export const storagePublicAccessCheck: IntegrationCheck = {
           description: `Storage account "${a.name}" blocks anonymous blob and public network access.`,
           resourceType: 'azure-storage-account',
           resourceId: a.id,
-          evidence: { account: a.name },
+          evidence: {
+            account: a.name,
+            allowBlobPublicAccess: p.allowBlobPublicAccess,
+            publicNetworkAccess: p.publicNetworkAccess ?? null,
+            networkDefaultAction: p.networkAcls?.defaultAction ?? null,
+          },
         });
       }
     }
@@ -162,7 +171,7 @@ export const storageEncryptionCheck: IntegrationCheck = {
           description: `Storage account "${a.name}" has blob and file encryption enabled.`,
           resourceType: 'azure-storage-account',
           resourceId: a.id,
-          evidence: { account: a.name },
+          evidence: { account: a.name, blobEnabled: blobOk, fileEnabled: fileOk },
         });
       } else {
         ctx.fail({

--- a/packages/integration-platform/src/manifests/gcp/checks/cloud-sql-backups.ts
+++ b/packages/integration-platform/src/manifests/gcp/checks/cloud-sql-backups.ts
@@ -56,7 +56,7 @@ export const cloudSqlBackupsCheck: IntegrationCheck = {
               description: `Cloud SQL instance "${inst.name}" has automated backups enabled.`,
               resourceType: 'gcp-cloud-sql-instance',
               resourceId: `${projectId}/${inst.name}`,
-              evidence: { projectId, instance: inst.name },
+              evidence: { projectId, instance: inst.name, region: inst.region ?? null, backupsEnabled: true },
             });
           } else {
             ctx.fail({
@@ -67,7 +67,7 @@ export const cloudSqlBackupsCheck: IntegrationCheck = {
               severity: 'medium',
               remediation:
                 'Enable automated backups (and point-in-time recovery) in the instance backup settings.',
-              evidence: { projectId, instance: inst.name },
+              evidence: { projectId, instance: inst.name, region: inst.region ?? null, backupsEnabled: false },
             });
           }
         }

--- a/packages/integration-platform/src/manifests/gcp/checks/cloud-sql-ssl.ts
+++ b/packages/integration-platform/src/manifests/gcp/checks/cloud-sql-ssl.ts
@@ -72,7 +72,12 @@ export const cloudSqlSslCheck: IntegrationCheck = {
               severity: 'medium',
               remediation:
                 'Set the SSL mode to ENCRYPTED_ONLY (or require trusted client certificates) to enforce encrypted connections.',
-              evidence: { projectId, instance: inst.name },
+              evidence: {
+                projectId,
+                instance: inst.name,
+                sslMode: ip?.sslMode ?? null,
+                requireSsl: ip?.requireSsl ?? null,
+              },
             });
           }
         }

--- a/packages/integration-platform/src/manifests/gcp/checks/iam-primitive-roles.ts
+++ b/packages/integration-platform/src/manifests/gcp/checks/iam-primitive-roles.ts
@@ -151,7 +151,13 @@ export const iamPrimitiveRolesCheck: IntegrationCheck = {
               description: `Project "${projectId}" and its inherited folders/organization have no primitive (owner/editor) role bindings.`,
               resourceType: 'gcp-project',
               resourceId: projectId,
-              evidence: { projectId, scope: 'project+inherited', inheritedBindingsEvaluated: true },
+              evidence: {
+                projectId,
+                scope: 'project+inherited',
+                inheritedBindingsEvaluated: true,
+                scopesEvaluated: scopes.length,
+                primitiveRoleBindingsFound: 0,
+              },
             });
           } else {
             // Inherited bindings couldn't be fully read — don't satisfy the task

--- a/packages/integration-platform/src/manifests/gcp/checks/storage-public-access.ts
+++ b/packages/integration-platform/src/manifests/gcp/checks/storage-public-access.ts
@@ -150,7 +150,7 @@ async function evaluateBucket(
       severity: 'medium',
       remediation:
         'Enable uniform bucket-level access so permissions are managed exclusively through IAM.',
-      evidence: { projectId, bucket: bucket.name },
+      evidence: { projectId, bucket: bucket.name, uniformBucketLevelAccess: false, publicMembers: 0 },
     });
     return;
   }
@@ -160,6 +160,6 @@ async function evaluateBucket(
     description: `Bucket "${bucket.name}" has no allUsers/allAuthenticatedUsers IAM bindings and enforces uniform bucket-level access.`,
     resourceType: 'gcp-storage-bucket',
     resourceId,
-    evidence: { projectId, bucket: bucket.name },
+    evidence: { projectId, bucket: bucket.name, publicMembers: 0, uniformBucketLevelAccess: true },
   });
 }


### PR DESCRIPTION
## Problem
On the cloud evidence automations, check rows showed verdicts (pass/fail) with **no usable "View Evidence"** — or evidence that only named the resource, not the value that produced the verdict. For an evidence/audit feature that's the whole point: you couldn't see *why* a check passed or failed.

The frontend (`TaskIntegrationChecks.tsx`) already renders "View Evidence" for any outcome with a non-empty `evidence` object — so this is entirely a check-side data quality fix.

## What I did (comprehensive, all providers)
Audited **every outcome (pass and fail) in every check** across AWS, GCP, and Azure against the rule: evidence must show (1) the specific resource/scope **and** (2) the value that determined the verdict.

Found ~42 thin/missing outcomes and enriched them so the evidence is the actual proof:
- **AWS** — iam (password-policy / root MFA / root keys), cloudtrail (multi-region/logging/validation per trail), s3 (encrypted + the 4 BPA flags), ec2 (offending protocol/cidrs/ports), rds (encrypted, backupRetentionDays), kms (`rotationEnabled`).
- **GCP** — cloud-sql (`backupsEnabled`, `sslMode`/`requireSsl`), storage (`publicMembers`, `uniformBucketLevelAccess`), iam-primitive-roles (scopes evaluated + count).
- **Azure** — entra-id (threshold + offending principals + wildcard actions), storage (https/tls/public/encryption flags), sql (public access + reason + firewall count + auditing state), key-vault (softDelete/purge/RBAC flags), network (what's exposed, to whom, ports/protocol), monitor (configured vs recommended ops, export destinations; fixed an **empty `{}`** fail).

Now a pass like "KMS rotation enabled" carries `rotationEnabled: true`; "weak TLS" shows the actual version; "no public access" shows the flags that prove it — visible in the UI's "View Evidence".

## Tests
215 package tests pass; build clean. Added evidence-presence tests (IAM/CloudTrail) and determining-value assertions (S3 encryption, KMS rotation). GCP/Azure enrichments are build-verified (valid, in-scope data) and audit-verified for meaningfulness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)