### PR TITLE
fix(app): keep integration check dropdowns open

### DIFF
--- a/apps/app/src/components/integrations/ConnectionVariablesForm.test.tsx
+++ b/apps/app/src/components/integrations/ConnectionVariablesForm.test.tsx
@@ -1,14 +1,9 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-// Stub the design-system Select family so we can assert how it is configured.
-// SelectContent forwards its `style` to the popup — this is the crux of the fix:
-// the DS Select is built on @base-ui/react and portals its popup to document.body.
-// Inside the Radix (@trycompai/ui) modal Dialog it is rendered in (ManageIntegrationDialog),
-// Radix sets `body { pointer-events: none }`, so the portaled popup is unclickable and
-// the open is cancelled ("insta-closes"). pointer-events:auto re-enables the popup while
-// keeping it portaled (so it stays anchored to the trigger instead of being mis-positioned
-// by the dialog's CSS transform, as rendering inline would do).
+// Stub the design-system Select family so we can assert how its overlay is configured.
+// The affected modal is a legacy Radix dialog while DS Select is Base UI; rendering
+// the popup inline keeps it inside the dialog focus boundary.
 vi.mock('@trycompai/design-system', () => ({
   Input: (props: Record<string, unknown>) => <input {...props} />,
   Label: ({ children, htmlFor }: { children: React.ReactNode; htmlFor?: string }) => (
@@ -24,12 +19,23 @@ vi.mock('@trycompai/design-system', () => ({
   SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
   SelectContent: ({
     children,
+    portal,
+    alignItemWithTrigger,
     style,
   }: {
     children: React.ReactNode;
+    portal?: boolean;
+    alignItemWithTrigger?: boolean;
     style?: React.CSSProperties;
   }) => (
-    <div data-testid="select-content" style={style}>
+    <div
+      data-testid="select-content"
+      data-portal={portal === undefined ? undefined : String(portal)}
+      data-align-item-with-trigger={
+        alignItemWithTrigger === undefined ? undefined : String(alignItemWithTrigger)
+      }
+      style={style}
+    >
       {children}
     </div>
   ),
@@ -46,11 +52,18 @@ vi.mock('./ConnectionVariableMultiSelect', () => ({
   ConnectionVariableMultiSelect: () => <div data-testid="multi-select" />,
 }));
 
-import { ConnectionVariablesFields, type ConnectionVariable } from './ConnectionVariablesForm';
+import {
+  ConnectionVariablesFields,
+  type ConnectionVariable,
+  type ConnectionVariableSelectContentOptions,
+} from './ConnectionVariablesForm';
 
 const noop = () => {};
 
-function renderFields(variables: ConnectionVariable[]) {
+function renderFields(
+  variables: ConnectionVariable[],
+  selectContentOptions?: ConnectionVariableSelectContentOptions,
+) {
   return render(
     <ConnectionVariablesFields
       variables={variables}
@@ -59,50 +72,89 @@ function renderFields(variables: ConnectionVariable[]) {
       dynamicOptions={{}}
       loadingOptions={{}}
       fetchOptions={noop}
+      selectContentOptions={selectContentOptions}
     />,
   );
 }
 
 describe('ConnectionVariablesFields dropdown clickability inside a modal', () => {
-  it('renders a select-type dropdown popup with pointer-events:auto so it works inside a Radix modal', () => {
-    renderFields([
-      {
-        id: 'alert_severity_threshold',
-        label: 'Fail on open alerts at severity',
-        type: 'select',
-        required: false,
-        options: [
-          { value: 'low', label: 'Low' },
-          { value: 'critical', label: 'Critical' },
-        ],
-      },
-    ]);
+  const modalSelectContentOptions = {
+    portal: false,
+    alignItemWithTrigger: false,
+  } satisfies ConnectionVariableSelectContentOptions;
+
+  it('renders a select-type dropdown popup inline when the legacy modal opts in', () => {
+    renderFields(
+      [
+        {
+          id: 'alert_severity_threshold',
+          label: 'Fail on open alerts at severity',
+          type: 'select',
+          required: false,
+          options: [
+            { value: 'low', label: 'Low' },
+            { value: 'critical', label: 'Critical' },
+          ],
+        },
+      ],
+      modalSelectContentOptions,
+    );
 
     const content = screen.getByTestId('select-content');
+    expect(content).toHaveAttribute('data-portal', 'false');
+    expect(content).toHaveAttribute('data-align-item-with-trigger', 'false');
     expect(content).toHaveStyle({ pointerEvents: 'auto' });
-    // Options still render
     expect(screen.getByText('Low')).toBeInTheDocument();
     expect(screen.getByText('Critical')).toBeInTheDocument();
   });
 
-  it('renders a boolean-type dropdown popup with pointer-events:auto', () => {
-    renderFields([
-      {
-        id: 'enabled',
-        label: 'Enabled',
-        type: 'boolean',
-        required: false,
-        default: false,
-      },
-    ]);
+  it('renders a boolean-type dropdown popup inline when the legacy modal opts in', () => {
+    renderFields(
+      [
+        {
+          id: 'enabled',
+          label: 'Enabled',
+          type: 'boolean',
+          required: false,
+          default: false,
+        },
+      ],
+      modalSelectContentOptions,
+    );
 
     const content = screen.getByTestId('select-content');
+    expect(content).toHaveAttribute('data-portal', 'false');
+    expect(content).toHaveAttribute('data-align-item-with-trigger', 'false');
     expect(content).toHaveStyle({ pointerEvents: 'auto' });
     expect(screen.getByText('Yes')).toBeInTheDocument();
     expect(screen.getByText('No')).toBeInTheDocument();
   });
 
-  it('applies pointer-events:auto to every dropdown for mixed select + boolean fields', () => {
+  it('applies modal overlay settings to every dropdown for mixed select + boolean fields', () => {
+    renderFields(
+      [
+        {
+          id: 'mode',
+          label: 'Mode',
+          type: 'select',
+          required: false,
+          options: [{ value: 'all', label: 'All' }],
+        },
+        { id: 'enabled', label: 'Enabled', type: 'boolean', required: false },
+      ],
+      modalSelectContentOptions,
+    );
+
+    const contents = screen.getAllByTestId('select-content');
+    expect(contents).toHaveLength(2);
+    for (const content of contents) {
+      expect(content).toHaveAttribute('data-portal', 'false');
+      expect(content).toHaveAttribute('data-align-item-with-trigger', 'false');
+      expect(content).toHaveStyle({ pointerEvents: 'auto' });
+    }
+  });
+
+  it('keeps the default DS portal behavior unless a caller opts into modal-safe rendering', () => {
     renderFields([
       {
         id: 'mode',
@@ -111,13 +163,11 @@ describe('ConnectionVariablesFields dropdown clickability inside a modal', () =>
         required: false,
         options: [{ value: 'all', label: 'All' }],
       },
-      { id: 'enabled', label: 'Enabled', type: 'boolean', required: false },
     ]);
 
-    const contents = screen.getAllByTestId('select-content');
-    expect(contents).toHaveLength(2);
-    for (const content of contents) {
-      expect(content).toHaveStyle({ pointerEvents: 'auto' });
-    }
+    const content = screen.getByTestId('select-content');
+    expect(content).not.toHaveAttribute('data-portal');
+    expect(content).not.toHaveAttribute('data-align-item-with-trigger');
+    expect(content).toHaveStyle({ pointerEvents: 'auto' });
   });
 });

--- a/apps/app/src/components/integrations/ConnectionVariablesForm.tsx
+++ b/apps/app/src/components/integrations/ConnectionVariablesForm.tsx
@@ -10,7 +10,7 @@ import {
   SelectValue,
   Spinner,
 } from '@trycompai/design-system';
-import type { Dispatch, SetStateAction } from 'react';
+import type { ComponentProps, Dispatch, SetStateAction } from 'react';
 import { ConnectionVariableMultiSelect } from './ConnectionVariableMultiSelect';
 
 export interface ConnectionVariable {
@@ -28,6 +28,11 @@ export interface ConnectionVariable {
 
 export type VariableValue = string | number | boolean | string[];
 
+export type ConnectionVariableSelectContentOptions = Pick<
+  ComponentProps<typeof SelectContent>,
+  'portal' | 'alignItemWithTrigger'
+>;
+
 interface ConnectionVariablesFieldsProps {
   variables: ConnectionVariable[];
   variableValues: Record<string, VariableValue>;
@@ -35,6 +40,7 @@ interface ConnectionVariablesFieldsProps {
   dynamicOptions: Record<string, { value: string; label: string }[]>;
   loadingOptions: Record<string, boolean>;
   fetchOptions: (variableId: string) => void;
+  selectContentOptions?: ConnectionVariableSelectContentOptions;
 }
 
 export const normalizeVariableValue = (
@@ -87,6 +93,7 @@ export function ConnectionVariablesFields({
   dynamicOptions,
   loadingOptions,
   fetchOptions,
+  selectContentOptions,
 }: ConnectionVariablesFieldsProps) {
   const syncModeVariable = variables.find((variable) => variable.id === 'sync_user_filter_mode');
   const hasSyncModeVariable = Boolean(syncModeVariable);
@@ -175,12 +182,12 @@ export function ConnectionVariablesFields({
                   This form is rendered inside a Radix (@trycompai/ui) modal Dialog (ManageIntegrationDialog),
                   and Radix's modal sets `body { pointer-events: none }`. The portaled popup inherits that,
                   so its options are unclickable and the open is cancelled on mouseup ("insta-closes").
-                  pointer-events:auto re-enables interaction on the popup while keeping it portaled, so it
-                  stays anchored to the trigger — rendering it inline (portal={false}) instead mis-positions
-                  it because the dialog is centered with a CSS transform. Harmless in the design-system Sheet
-                  consumer (AccountSettingsSheet), which does not lock body pointer-events. Do not remove.
+                  ManageIntegrationDialog passes portal={false} plus alignItemWithTrigger={false} so the
+                  popup stays inside the dialog focus boundary and uses normal absolute anchored positioning.
+                  pointer-events:auto keeps the popup interactive if a modal body lock is active. Harmless in
+                  the design-system Sheet consumer (AccountSettingsSheet), which does not lock body events.
                 */}
-                <SelectContent style={{ pointerEvents: 'auto' }}>
+                <SelectContent {...selectContentOptions} style={{ pointerEvents: 'auto' }}>
                   {isLoadingOptions ? (
                     <div className="py-2 px-3 text-sm text-muted-foreground flex items-center gap-2">
                       <Spinner />
@@ -214,7 +221,7 @@ export function ConnectionVariablesFields({
                   <SelectValue />
                 </SelectTrigger>
                 {/* pointer-events:auto so the popup is clickable inside the Radix modal's body lock (see note above). */}
-                <SelectContent style={{ pointerEvents: 'auto' }}>
+                <SelectContent {...selectContentOptions} style={{ pointerEvents: 'auto' }}>
                   <SelectItem value="true">Yes</SelectItem>
                   <SelectItem value="false">No</SelectItem>
                 </SelectContent>

--- a/apps/app/src/components/integrations/ManageIntegrationDialog.tsx
+++ b/apps/app/src/components/integrations/ManageIntegrationDialog.tsx
@@ -5,6 +5,7 @@ import {
   normalizeVariableValue,
   validateTargetRepos,
   type ConnectionVariable,
+  type ConnectionVariableSelectContentOptions,
 } from '@/components/integrations/ConnectionVariablesForm';
 import {
   useIntegrationConnections,
@@ -91,6 +92,11 @@ interface ManageIntegrationDialogProps {
   onDeleted?: () => void;
   onSaved?: () => void;
 }
+
+const LEGACY_MODAL_SELECT_CONTENT_OPTIONS = {
+  portal: false,
+  alignItemWithTrigger: false,
+} satisfies ConnectionVariableSelectContentOptions;
 
 export function ManageIntegrationDialog({
   open,
@@ -471,6 +477,7 @@ function ConfigurationContent({
         dynamicOptions={dynamicOptions}
         loadingOptions={loadingDynamicOptions}
         fetchOptions={fetchDynamicOptions}
+        selectContentOptions={LEGACY_MODAL_SELECT_CONTENT_OPTIONS}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- Render connection variable select popups inline for the legacy integration modal so Radix outside-interaction handling does not close them immediately.
- Keep default design-system select portal behavior for non-modal callers.
- Add focused coverage for modal-specific select overlay configuration.

## Verification
- bunx vitest run src/components/integrations/ConnectionVariablesForm.test.tsx
- bunx prettier --check apps/app/src/components/integrations/ConnectionVariablesForm.tsx apps/app/src/components/integrations/ManageIntegrationDialog.tsx apps/app/src/components/integrations/ConnectionVariablesForm.test.tsx
- git diff --check
- bunx turbo run typecheck --filter=@trycompai/app (fails on existing unrelated type errors in cloud-tests tests, AI SDK version types, missing @aws-sdk/client-s3-control, and other pre-existing areas)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes integration check dropdowns closing instantly in the legacy Radix modal by rendering `SelectContent` inline and keeping it clickable. Default portal behavior remains unchanged outside the modal.

- **Bug Fixes**
  - Added `selectContentOptions` to `ConnectionVariablesFields` and set `{ portal: false, alignItemWithTrigger: false }` in `ManageIntegrationDialog` to keep dropdowns open inside the modal.
  - Kept default `@trycompai/design-system` `SelectContent` portal behavior for non-modal callers.
  - Added focused tests to verify modal-safe overlay settings and default behavior.

<sup>Written for commit 0d7c7fe601bfb2b69af7998f4600d6ca0213685b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

