### PR TITLE
fix(api): revert oauth2 spec scheme to restore the MCP generator

### DIFF
--- a/apps/api/src/openapi-docs.spec.ts
+++ b/apps/api/src/openapi-docs.spec.ts
@@ -202,59 +202,49 @@ describe('OpenAPI document', () => {
     });
   });
 
-  describe('MCP OAuth security', () => {
-    it('declares an oauth2 authorization-code scheme pointed at the Comp AI auth server', () => {
-      const scheme = document.components?.securitySchemes?.oauth2 as
-        | {
-            type?: string;
-            flows?: {
-              authorizationCode?: {
-                authorizationUrl?: string;
-                tokenUrl?: string;
-                scopes?: Record<string, string>;
-              };
-            };
-          }
-        | undefined;
+  // Guardrail against the regression in PR #2961: the Speakeasy mcp-typescript
+  // generator DROPS a tool whenever an operation declares more than one security
+  // scheme (it can no longer supply the credential from the server's global
+  // config). Adding a second auth method (oauth2) to every endpoint silently
+  // gutted ~300 of ~335 MCP tools. Rule: keep exactly ONE auth method in the
+  // base spec; handle any extra auth (e.g. OAuth) at the hosting layer, never here.
+  describe('MCP generator safety', () => {
+    it('never declares more than one security scheme on any operation', () => {
+      const offenders: string[] = [];
 
-      expect(scheme?.type).toBe('oauth2');
-      expect(scheme?.flows?.authorizationCode?.authorizationUrl).toBe(
-        `${PUBLIC_SERVER_URL}/api/auth/mcp/authorize`,
-      );
-      expect(scheme?.flows?.authorizationCode?.tokenUrl).toBe(
-        `${PUBLIC_SERVER_URL}/api/auth/mcp/token`,
-      );
+      for (const [routePath, methods] of Object.entries(document.paths)) {
+        for (const [method, operation] of Object.entries(
+          methods as Record<string, { security?: unknown }>,
+        )) {
+          const security = operation?.security;
+          if (Array.isArray(security) && security.length > 1) {
+            offenders.push(
+              `${method.toUpperCase()} ${routePath} (${security.length} schemes)`,
+            );
+          }
+        }
+      }
+
+      // If this fails: an operation has 2+ security schemes, which breaks the
+      // Speakeasy MCP generator (it drops the tool). Move the extra auth to the
+      // hosting layer instead of the base OpenAPI spec.
+      expect(offenders).toEqual([]);
     });
 
-    it('offers oauth2 alongside the API key on every authenticated operation', () => {
-      const operations = Object.values(document.paths).flatMap((methods) =>
-        Object.values(methods as Record<string, { security?: unknown }>),
-      );
+    it('still gates protected operations with the API key', () => {
+      const apiKeyOps = Object.values(document.paths)
+        .flatMap((methods) =>
+          Object.values(methods as Record<string, { security?: unknown }>),
+        )
+        .filter(
+          (op) =>
+            Array.isArray(op?.security) &&
+            op.security.some(
+              (req) => req && typeof req === 'object' && 'apikey' in req,
+            ),
+        );
 
-      const hasReq = (security: unknown, scheme: string): boolean =>
-        Array.isArray(security) &&
-        security.some((req) => req && typeof req === 'object' && scheme in req);
-
-      const apiKeyOps = operations.filter((op) =>
-        hasReq(op?.security, 'apikey'),
-      );
-
-      // Sanity: the spec really does gate operations behind the API key.
       expect(apiKeyOps.length).toBeGreaterThan(0);
-
-      // Every API-key operation must also accept oauth2 (OR semantics) so MCP
-      // callers authenticate per-user instead of via a shared key.
-      const missingOAuth = apiKeyOps.filter(
-        (op) => !hasReq(op?.security, 'oauth2'),
-      );
-      expect(missingOAuth).toHaveLength(0);
-
-      // And oauth2 is never offered on an endpoint that isn't API-key gated.
-      const oauthWithoutApiKey = operations.filter(
-        (op) =>
-          hasReq(op?.security, 'oauth2') && !hasReq(op?.security, 'apikey'),
-      );
-      expect(oauthWithoutApiKey).toHaveLength(0);
     });
   });
 });

--- a/apps/api/src/openapi/public-docs-metadata.ts
+++ b/apps/api/src/openapi/public-docs-metadata.ts
@@ -26,15 +26,6 @@ export const PUBLIC_OPENAPI_DESCRIPTION =
 
 export const PUBLIC_SERVER_URL = 'https://api.trycomp.ai';
 
-/**
- * Name of the OAuth2 security scheme advertised in the public spec. MCP hosts
- * (e.g. Speakeasy Gram) only surface "Sign in with Comp AI" + forward the
- * caller's bearer token to the API when the spec declares an oauth2 scheme;
- * with only the API key, every MCP user would hit the API as one shared
- * identity, bypassing per-user RBAC.
- */
-export const MCP_OAUTH_SECURITY_SCHEME = 'oauth2';
-
 function getVisibilityForOperation(
   operation: OpenApiOperation,
   metadata?: PublicOperationMetadata,
@@ -283,67 +274,6 @@ function applyMcpToolNames(
   }
 }
 
-/**
- * Declare the OAuth2 (authorization code) security scheme and offer it on every
- * operation that already accepts the API key. The scheme points at the
- * better-auth MCP authorization server; the per-operation `security` entries use
- * OR semantics, so an API key OR a Comp AI OAuth token satisfies the request.
- * This is what lets MCP hosts forward each user's bearer token to the API so the
- * existing per-user/per-org RBAC applies, rather than a single shared key.
- */
-function applyMcpOAuthSecurity(document: OpenAPIObject): void {
-  document.components ??= {};
-  document.components.securitySchemes ??= {};
-  document.components.securitySchemes[MCP_OAUTH_SECURITY_SCHEME] = {
-    type: 'oauth2',
-    description:
-      'OAuth 2.1 authorization code flow. Sign in with your Comp AI account — tokens are issued by the Comp AI authorization server and scoped to your organization, role, and permissions.',
-    flows: {
-      authorizationCode: {
-        authorizationUrl: `${PUBLIC_SERVER_URL}/api/auth/mcp/authorize`,
-        tokenUrl: `${PUBLIC_SERVER_URL}/api/auth/mcp/token`,
-        refreshUrl: `${PUBLIC_SERVER_URL}/api/auth/mcp/token`,
-        scopes: {
-          openid: 'OpenID Connect authentication',
-          profile: 'Basic profile information',
-          email: 'Email address',
-          offline_access: 'Maintain access via refresh tokens',
-        },
-      },
-    },
-  };
-
-  for (const methods of Object.values(document.paths)) {
-    for (const operation of Object.values(
-      methods as Record<string, OpenApiOperation>,
-    )) {
-      if (!operation || typeof operation !== 'object') {
-        continue;
-      }
-
-      const security = operation.security;
-      if (!Array.isArray(security)) {
-        continue;
-      }
-
-      const requirements = security as Array<Record<string, string[]>>;
-      const hasApiKey = requirements.some(
-        (req) => req && typeof req === 'object' && 'apikey' in req,
-      );
-      const hasOAuth = requirements.some(
-        (req) =>
-          req && typeof req === 'object' && MCP_OAUTH_SECURITY_SCHEME in req,
-      );
-
-      // Mirror OAuth onto API-key operations only — endpoints that are
-      // intentionally public (empty security) must stay unauthenticated.
-      if (hasApiKey && !hasOAuth) {
-        requirements.push({ [MCP_OAUTH_SECURITY_SCHEME]: [] });
-      }
-    }
-  }
-}
-
 export function applyPublicOpenApiMetadata(document: OpenAPIObject): void {
   document.info.title = PUBLIC_OPENAPI_TITLE;
   document.info.description = PUBLIC_OPENAPI_DESCRIPTION;
@@ -398,7 +328,4 @@ export function applyPublicOpenApiMetadata(document: OpenAPIObject): void {
   addTagMetadata(document);
   removeUnusedSchemas(document);
   sanitizePublicSchemas(document);
-
-  // Add OAuth last so its security scheme isn't touched by schema pruning.
-  applyMcpOAuthSecurity(document);
 }

--- a/packages/docs/openapi.json
+++ b/packages/docs/openapi.json
@@ -122,9 +122,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get organization profile",
@@ -367,9 +364,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Update organization",
@@ -470,9 +464,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete organization",
@@ -505,9 +496,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get organization onboarding status",
@@ -643,9 +631,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Transfer organization ownership",
@@ -731,9 +716,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Update role notification settings",
@@ -765,9 +747,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get role notification settings",
@@ -801,9 +780,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List API keys",
@@ -835,9 +811,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Create API key",
@@ -871,9 +844,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List API key scopes",
@@ -973,9 +943,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get organization brand color",
@@ -1008,9 +975,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Upload organization logo",
@@ -1042,9 +1006,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Remove organization logo",
@@ -1078,9 +1039,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Revoke API key",
@@ -1153,9 +1111,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Invite workforce members",
@@ -1351,9 +1306,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List workforce members",
@@ -1487,9 +1439,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Create a new member",
@@ -1522,9 +1471,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get all employee devices with fleet compliance data",
@@ -1558,9 +1504,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get integration test statistics grouped by assignee",
@@ -1794,9 +1737,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Add multiple members to organization",
@@ -1838,9 +1778,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get members who can read a specific resource type",
@@ -1885,9 +1822,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Reactivate a deactivated member",
@@ -2008,9 +1942,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get person by ID",
@@ -2155,9 +2086,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Update workforce member",
@@ -2290,9 +2218,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete member",
@@ -2336,9 +2261,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get training video completions for a member",
@@ -2383,9 +2305,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get fleet compliance",
@@ -2511,9 +2430,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Remove host (device) from Fleet",
@@ -2557,9 +2473,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Resend portal invite email to a member",
@@ -2696,9 +2609,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Unlink device from member",
@@ -2754,9 +2664,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get employment evidence attachments",
@@ -2821,9 +2728,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Upload employment evidence",
@@ -2889,9 +2793,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete employment evidence",
@@ -2925,9 +2826,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get current user email notification preferences",
@@ -2969,9 +2867,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Update current user email notification preferences",
@@ -3055,9 +2950,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Upload an attachment to any supported entity",
@@ -3121,9 +3013,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get shared attachment download URL",
@@ -3594,9 +3483,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List organization risks",
@@ -3883,9 +3769,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Create organization risk",
@@ -3918,9 +3801,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get risk statistics grouped by assignee",
@@ -3954,9 +3834,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get risk counts grouped by department",
@@ -4231,9 +4108,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get organization risk",
@@ -4531,9 +4405,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Update organization risk",
@@ -4674,9 +4545,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete organization risk",
@@ -4719,9 +4587,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Search global vendors",
@@ -4951,9 +4816,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List vendors",
@@ -5214,9 +5076,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Create vendor",
@@ -5447,9 +5306,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get vendor details",
@@ -5721,9 +5577,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Update vendor record",
@@ -5864,9 +5717,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete vendor",
@@ -5910,9 +5760,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Trigger vendor risk assessment",
@@ -6131,9 +5978,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List organization context",
@@ -6360,9 +6204,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Create a new context entry",
@@ -6540,9 +6381,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get organization context",
@@ -6681,9 +6519,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Update organization context",
@@ -6833,9 +6668,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete context entry",
@@ -6960,9 +6792,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List managed devices",
@@ -7049,9 +6878,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get devices by member ID",
@@ -7102,9 +6928,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete device",
@@ -7270,9 +7093,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List compliance policies",
@@ -7410,9 +7230,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Create compliance policy",
@@ -7455,9 +7272,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Publish all draft policies",
@@ -7505,9 +7319,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Download all published policies",
@@ -7560,9 +7371,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get mapped and all controls for a policy",
@@ -7614,9 +7422,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Map controls to a policy",
@@ -7670,9 +7475,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get tasks that serve as evidence for a policy, grouped by control",
@@ -7726,9 +7528,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Regenerate policy with AI",
@@ -7790,9 +7589,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get a signed URL for the policy PDF",
@@ -7948,9 +7744,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Upload a PDF to a policy version (UI-only)",
@@ -8011,9 +7804,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete a policy version PDF",
@@ -8084,9 +7874,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Request a presigned URL to upload a policy PDF",
@@ -8150,9 +7937,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Confirm a policy PDF upload completed",
@@ -8213,9 +7997,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get signed URL for policy PDF (alternate path)",
@@ -8277,9 +8058,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Remove a control mapping from a policy",
@@ -8394,9 +8172,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get compliance policy",
@@ -8548,9 +8323,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Update compliance policy",
@@ -8671,9 +8443,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete compliance policy",
@@ -8782,9 +8551,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get policy versions",
@@ -8910,9 +8676,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Create policy version",
@@ -9028,9 +8791,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get policy version by ID",
@@ -9163,9 +8923,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Update version content",
@@ -9287,9 +9044,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete policy version",
@@ -9417,9 +9171,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Publish policy version",
@@ -9546,9 +9297,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Set active policy version",
@@ -9686,9 +9434,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Submit version for approval",
@@ -9741,9 +9486,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Accept pending policy changes and publish the version",
@@ -9797,9 +9539,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Deny pending policy changes",
@@ -9877,9 +9616,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Chat with AI about a policy",
@@ -10235,9 +9971,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Download macOS Device Agent",
@@ -10296,9 +10029,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Download Windows Device Agent ZIP",
@@ -10396,9 +10126,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get a presigned URL to upload a file",
@@ -10478,9 +10205,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List compliance tasks",
@@ -10604,9 +10328,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Create compliance task",
@@ -10650,9 +10371,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get task templates",
@@ -10751,9 +10469,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Update status for multiple tasks",
@@ -10826,9 +10541,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete multiple tasks",
@@ -10909,9 +10621,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Update assignee for multiple tasks",
@@ -10993,9 +10702,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Reorder tasks",
@@ -11063,9 +10769,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Bulk submit tasks for review",
@@ -11098,9 +10801,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get page options for tasks overview",
@@ -11180,9 +10880,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get task by ID",
@@ -11330,9 +11027,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Update a task",
@@ -11395,9 +11089,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete a task",
@@ -11441,9 +11132,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get policies that reference a task via shared controls",
@@ -11508,9 +11196,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get task activity",
@@ -11561,9 +11246,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Regenerate task from template",
@@ -11631,9 +11313,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Submit task for review",
@@ -11684,9 +11363,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Approve a task",
@@ -11737,9 +11413,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Reject a task review",
@@ -11836,9 +11509,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get task attachments",
@@ -11956,9 +11626,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Upload task evidence",
@@ -12064,9 +11731,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get task attachment download URL",
@@ -12174,9 +11838,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete task attachment",
@@ -12221,9 +11882,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get all automations for a task",
@@ -12340,9 +11998,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Create evidence automation",
@@ -12397,9 +12052,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get automation details",
@@ -12540,9 +12192,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Update an existing automation",
@@ -12595,9 +12244,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete an automation",
@@ -12650,9 +12296,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get all runs for a specific automation",
@@ -12762,9 +12405,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get all versions for an automation",
@@ -12814,9 +12454,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Create a published version record for an automation",
@@ -12908,9 +12545,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get all automation runs for a task",
@@ -12958,9 +12592,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get task evidence summary",
@@ -13019,9 +12650,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Export automation evidence as PDF",
@@ -13080,9 +12708,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Export task evidence as ZIP",
@@ -13132,9 +12757,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Export all organization evidence as ZIP (Auditor only)",
@@ -13205,9 +12827,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get comments for an entity",
@@ -13256,9 +12875,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Create a new comment",
@@ -13320,9 +12936,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Update a comment",
@@ -13436,9 +13049,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete a comment",
@@ -13471,9 +13081,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get Trust Center settings",
@@ -13507,9 +13114,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Upload a favicon for the trust portal",
@@ -13541,9 +13145,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Remove the trust portal favicon",
@@ -13602,9 +13203,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get domain verification status",
@@ -13658,9 +13256,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Upload compliance certificate",
@@ -13710,9 +13305,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Generate a temporary signed URL for a compliance certificate",
@@ -13766,9 +13358,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List uploaded compliance certificates for the organization",
@@ -13820,9 +13409,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Upload an additional trust portal document",
@@ -13875,9 +13461,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List additional trust portal documents for the organization",
@@ -13937,9 +13520,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Generate a temporary signed URL for a trust portal document",
@@ -14004,9 +13584,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete (deactivate) a trust portal document",
@@ -14040,9 +13617,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Enable or disable the trust portal",
@@ -14076,9 +13650,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Add or update a custom domain for the trust portal",
@@ -14112,9 +13683,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Check DNS records for a custom domain",
@@ -14148,9 +13716,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Update trust portal FAQs",
@@ -14184,9 +13749,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Update allowed domains for the trust portal",
@@ -14220,9 +13782,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Update trust portal framework settings",
@@ -14256,9 +13815,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Update Trust Center overview",
@@ -14299,9 +13855,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get trust portal overview",
@@ -14335,9 +13888,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Create a custom link for trust portal",
@@ -14378,9 +13928,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List custom links for trust portal",
@@ -14423,9 +13970,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Update a custom link",
@@ -14468,9 +14012,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete a custom link",
@@ -14504,9 +14045,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Reorder custom links",
@@ -14549,9 +14087,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Update vendor trust portal settings",
@@ -14595,9 +14130,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List vendors configured for trust portal",
@@ -14695,9 +14227,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List Trust Access requests",
@@ -14740,9 +14269,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get Trust Access request",
@@ -14795,9 +14321,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Approve Trust Access request",
@@ -14850,9 +14373,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Deny Trust Access request",
@@ -14886,9 +14406,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List Trust Access grants",
@@ -14941,9 +14458,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Revoke Trust Access grant",
@@ -14986,9 +14500,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Resend Trust Access email",
@@ -15031,9 +14542,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Resend Trust Access NDA",
@@ -15076,9 +14584,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Preview Trust Access NDA",
@@ -15530,9 +15035,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List audit findings",
@@ -15574,9 +15076,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Create audit finding",
@@ -15625,9 +15124,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List all findings for the organization",
@@ -15671,9 +15167,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get finding by ID",
@@ -15725,9 +15218,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Update a finding (status transition rules apply)",
@@ -15769,9 +15259,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete a finding (auditor or platform admin only)",
@@ -15815,9 +15302,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get activity history for a finding",
@@ -15909,9 +15393,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Create a custom role",
@@ -16000,9 +15481,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List all roles",
@@ -16066,9 +15544,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Resolve permissions for custom roles",
@@ -16133,9 +15608,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get obligations for a built-in role",
@@ -16211,9 +15683,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Update obligations for a built-in role",
@@ -16293,9 +15762,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get a role by ID",
@@ -16389,9 +15855,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Update a custom role",
@@ -16458,9 +15921,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete a custom role",
@@ -16493,9 +15953,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List security questionnaires",
@@ -16539,9 +15996,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get security questionnaire details",
@@ -16583,9 +16037,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete a security questionnaire",
@@ -16637,9 +16088,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Generate answers for a questionnaire",
@@ -16689,9 +16137,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Parse questionnaire content",
@@ -16773,9 +16218,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Answer one questionnaire question",
@@ -16836,9 +16278,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Save questionnaire answer",
@@ -16899,9 +16338,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete questionnaire answer",
@@ -16946,9 +16382,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Export a security questionnaire",
@@ -17008,9 +16441,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Start questionnaire parsing",
@@ -17094,9 +16524,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Upload and parse questionnaire file",
@@ -17175,9 +16602,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Auto-answer uploaded questionnaire",
@@ -17222,9 +16646,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Export generated questionnaire answers",
@@ -17294,9 +16715,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Upload and export generated answers",
@@ -17341,9 +16759,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Stream generated questionnaire answers",
@@ -17378,9 +16793,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List knowledge base documents",
@@ -17414,9 +16826,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List all manual answers for an organization",
@@ -17458,9 +16867,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Save reusable manual answer",
@@ -17504,9 +16910,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Upload knowledge base document",
@@ -17549,9 +16952,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get a signed download URL for a document",
@@ -17594,9 +16994,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get a signed view URL for a document",
@@ -17639,9 +17036,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete a knowledge base document",
@@ -17685,9 +17079,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Process knowledge base documents",
@@ -17730,9 +17121,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Create a public access token for a run",
@@ -17785,9 +17173,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete a manual answer",
@@ -17831,9 +17216,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete all manual answers for an organization",
@@ -17889,9 +17271,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Save a SOA answer",
@@ -17936,9 +17315,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Auto-fill ISO 27001 SOA",
@@ -17981,9 +17357,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Create a new SOA document",
@@ -18027,9 +17400,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Ensure SOA configuration and document exist",
@@ -18073,9 +17443,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Approve a SOA document",
@@ -18119,9 +17486,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Decline a SOA document",
@@ -18165,9 +17529,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Submit SOA document for approval",
@@ -18211,9 +17572,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Export ISO 27001 SOA",
@@ -18256,9 +17614,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List integration providers",
@@ -18301,9 +17656,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get an integration provider by slug",
@@ -18337,9 +17689,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List integration connections",
@@ -18381,9 +17730,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Create integration connection",
@@ -18426,9 +17772,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get an integration connection by ID",
@@ -18469,9 +17812,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete an integration connection",
@@ -18522,9 +17862,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Update an integration connection",
@@ -18567,9 +17904,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Test an integration connection",
@@ -18612,9 +17946,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Pause an integration connection",
@@ -18657,9 +17988,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Resume an integration connection",
@@ -18702,9 +18030,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Disconnect an integration",
@@ -18757,9 +18082,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Set services enabled on a connection",
@@ -18800,9 +18122,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List services enabled on a connection",
@@ -18845,9 +18164,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List check definitions for a provider",
@@ -18890,9 +18206,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List checks for a connection",
@@ -18945,9 +18258,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Run integration checks",
@@ -18998,9 +18308,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Run a single check on a connection",
@@ -19043,9 +18350,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List variable definitions for a provider",
@@ -19088,9 +18392,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List connection variables",
@@ -19141,9 +18442,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Update connection variables",
@@ -19194,9 +18492,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get options for a connection variable",
@@ -19239,9 +18534,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List checks for a task template",
@@ -19284,9 +18576,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List checks attached to a task",
@@ -19339,9 +18628,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Run a check for a task",
@@ -19394,9 +18680,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Disconnect checks from a task",
@@ -19449,9 +18732,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Reconnect checks to a task",
@@ -19502,9 +18782,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List check runs for a task",
@@ -19547,9 +18824,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Sync Google Workspace employees",
@@ -19583,9 +18857,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get Google Workspace sync status",
@@ -19628,9 +18899,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Sync Rippling employees",
@@ -19664,9 +18932,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get Rippling sync status",
@@ -19709,9 +18974,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Sync JumpCloud employees",
@@ -19745,9 +19007,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get JumpCloud sync status",
@@ -19781,9 +19040,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get the currently configured employee sync provider",
@@ -19825,9 +19081,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Set the employee sync provider",
@@ -19861,9 +19114,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List employee sync providers available to the org",
@@ -19914,9 +19164,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Sync employees for a dynamic provider",
@@ -20683,9 +19930,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get task items statistics for an entity",
@@ -20852,9 +20096,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get task items for an entity",
@@ -20903,9 +20144,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Create a new task item",
@@ -20967,9 +20205,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Update a task item",
@@ -21012,9 +20247,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete a task item",
@@ -21065,9 +20297,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Upload attachment to task item",
@@ -21112,9 +20341,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete attachment from task item",
@@ -21159,9 +20385,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get task item activity log",
@@ -21195,9 +20418,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List training completions",
@@ -21240,9 +20460,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Mark a training video as complete",
@@ -21293,9 +20510,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Send training completion email with certificate",
@@ -21342,9 +20556,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Generate training certificate",
@@ -21391,9 +20602,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Generate HIPAA training certificate PDF",
@@ -21436,9 +20644,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get the organization chart",
@@ -21480,9 +20685,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Create or update an interactive organization chart",
@@ -21524,9 +20726,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete the organization chart",
@@ -21580,9 +20779,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Upload an image as the organization chart",
@@ -21627,9 +20823,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List evidence forms",
@@ -21673,9 +20866,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get submission statuses for all forms",
@@ -21719,9 +20909,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get document relevance settings",
@@ -21773,9 +20960,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Update document relevance setting",
@@ -21827,9 +21011,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get current user submissions",
@@ -21873,9 +21054,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get pending submission count for current user",
@@ -21951,9 +21129,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get form definition and submissions",
@@ -22013,9 +21188,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get a single submission",
@@ -22073,9 +21245,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete a submission",
@@ -22127,9 +21296,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Submit evidence form",
@@ -22181,9 +21347,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Upload a file as an evidence submission",
@@ -22243,9 +21406,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Review evidence submission",
@@ -22289,9 +21449,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Upload evidence form file",
@@ -22343,9 +21500,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Export evidence submissions",
@@ -23174,9 +22328,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List audit logs",
@@ -23769,9 +22920,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "List penetration test runs",
@@ -23826,9 +22974,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Create penetration test",
@@ -23883,9 +23028,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get penetration test status",
@@ -23937,9 +23079,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get penetration test progress",
@@ -23991,9 +23130,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get penetration test issues",
@@ -24045,9 +23181,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get penetration test agent events",
@@ -24099,9 +23232,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get penetration test output",
@@ -24153,9 +23283,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get penetration test PDF",
@@ -24189,9 +23316,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get members with pending offboarding checklists",
@@ -24225,9 +23349,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get the offboarding checklist template",
@@ -24269,9 +23390,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Add an offboarding checklist template item",
@@ -24324,9 +23442,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Update an offboarding checklist template item",
@@ -24367,9 +23482,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Delete an offboarding checklist template item",
@@ -24412,9 +23524,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get a member's offboarding checklist",
@@ -24448,9 +23557,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Export all offboarding evidence as a zip file",
@@ -24494,9 +23600,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Export offboarding evidence as a zip file",
@@ -24557,9 +23660,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Complete an offboarding checklist item",
@@ -24608,9 +23708,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Reopen an offboarding checklist item",
@@ -24671,9 +23768,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Upload evidence for an offboarding checklist item",
@@ -24717,9 +23811,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Get vendor access revocation status for a member",
@@ -24763,9 +23854,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Confirm all vendor access as revoked",
@@ -24818,9 +23906,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Mark vendor access as revoked",
@@ -24871,9 +23956,6 @@
         "security": [
           {
             "apikey": []
-          },
-          {
-            "oauth2": []
           }
         ],
         "summary": "Undo vendor access revocation",
@@ -25052,23 +24134,6 @@
         "in": "header",
         "name": "X-API-Key",
         "description": "API key for authentication"
-      },
-      "oauth2": {
-        "type": "oauth2",
-        "description": "OAuth 2.1 authorization code flow. Sign in with your Comp AI account — tokens are issued by the Comp AI authorization server and scoped to your organization, role, and permissions.",
-        "flows": {
-          "authorizationCode": {
-            "authorizationUrl": "https://api.trycomp.ai/api/auth/mcp/authorize",
-            "tokenUrl": "https://api.trycomp.ai/api/auth/mcp/token",
-            "refreshUrl": "https://api.trycomp.ai/api/auth/mcp/token",
-            "scopes": {
-              "openid": "OpenID Connect authentication",
-              "profile": "Basic profile information",
-              "email": "Email address",
-              "offline_access": "Maintain access via refresh tokens"
-            }
-          }
-        }
       }
     },
     "schemas": {


### PR DESCRIPTION
## Problem
Our nightly Speakeasy MCP generation has been broken since #2961. That PR added an `oauth2` security scheme to the **public OpenAPI spec**, putting **two auth methods on every endpoint** (`apikey` + `oauth2`). Speakeasy's `mcp-typescript` generator **drops a tool whenever an operation has more than one security scheme** — so every nightly run produced an "Update SDK" PR that would **delete ~300 of ~335 MCP tools** if merged. We've been closing those PRs by hand.

## Fix
**Surgically revert the oauth2 scheme from the spec** — nothing else.

- `public-docs-metadata.ts` — restored **byte-for-byte** to its pre-#2961 state (removed the `applyMcpOAuthSecurity` function, its const, and the call).
- `packages/docs/openapi.json` — removed **only** the `oauth2` scheme + the per-op `{oauth2: []}` entries. Diff is the **pure inverse of #2961** (936 deletions, no other endpoint touched). Verified: `securitySchemes` is back to `[apikey]` only, **0 operations** have >1 scheme.
- `openapi-docs.spec.ts` — removed the now-irrelevant oauth2 assertions and added a **guardrail test**.

## Nothing of value is lost
All the actual OAuth work — the better-auth provider, guards, `McpOrgBinding`, the org picker (from #2955) — is **untouched**. Only the spec's advertisement of oauth2 was removed. When we wire up keyless OAuth for real (self-host or Speakeasy Enterprise), it lives at the **hosting layer**, not the base spec.

## Guardrail (so it can't silently recur)
New test fails the suite if **any operation ever declares more than one security scheme** again — with a message pointing to keep extra auth at the hosting layer.

## Result
Once merged, the nightly generator goes back to producing the **normal 335 tools**, and normal API changes (bug fixes, new endpoints) regenerate cleanly again.

## Verification
- Regenerated the spec from the reverted code and confirmed it's clean; then applied the change surgically so the diff is purely the oauth2 removal.
- `typecheck` clean for both changed source files.
- `openapi-docs.spec.ts`: the 2 new guardrail tests pass.

## Note (pre-existing, not from this PR)
One existing test (`curates high-value API pages…`, expecting "SOC 2" in the `/v1/policies` description) fails on `main` too — that description changed and the SEO assertion is stale. Left untouched to keep this revert surgical; worth a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverted the `oauth2` security scheme from the public OpenAPI spec to stop the Speakeasy `mcp-typescript` generator from dropping tools. All endpoints now advertise only `apikey`, restoring the full ~335 MCP tools in nightly builds.

- **Bug Fixes**
  - Removed `oauth2` scheme and per-operation entries from `packages/docs/openapi.json`; spec now lists only `apikey`.
  - Reverted `public-docs-metadata.ts` to pre-#2961 (removed OAuth helper and call).
  - Updated tests: removed OAuth assertions and added a guardrail test that fails if any operation declares more than one security scheme.
  - No runtime OAuth behavior changed; only the spec’s OAuth advertisement was removed.

<sup>Written for commit 64978f542adcfb4747fe204dabf5de7d5b1e5ae3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

