### PR TITLE
feat(cloud-security): add Vertex AI as a GCP Cloud Tests service

### DIFF
--- a/apps/api/src/cloud-security/providers/gcp-security.service.spec.ts
+++ b/apps/api/src/cloud-security/providers/gcp-security.service.spec.ts
@@ -4,7 +4,10 @@
 // importing the service.
 jest.mock('@db', () => ({ db: {} }));
 
-import { GCPSecurityService } from './gcp-security.service';
+import {
+  GCPSecurityService,
+  resolveGcpServiceId,
+} from './gcp-security.service';
 
 /**
  * Helper: build a Response-like object for a single page of the GCP
@@ -637,5 +640,61 @@ describe('GCPSecurityService — project detection', () => {
       const result = await service.detectProjectsForOrg('token', '777');
       expect(result.map((p) => p.id)).toEqual(['good-proj']);
     });
+  });
+});
+
+describe('resolveGcpServiceId — Vertex AI grouping', () => {
+  it('maps an aiplatform resource type to vertex-ai (regardless of category)', () => {
+    expect(
+      resolveGcpServiceId(
+        'SOME_UNMAPPED_AI_CATEGORY',
+        'aiplatform.googleapis.com/Dataset',
+        '//aiplatform.googleapis.com/projects/p/locations/l/datasets/123',
+      ),
+    ).toBe('vertex-ai');
+  });
+
+  it('maps a Workbench (notebooks) resource type to vertex-ai', () => {
+    expect(
+      resolveGcpServiceId(
+        'NOTEBOOK_PUBLIC_IP',
+        'notebooks.googleapis.com/Instance',
+        undefined,
+      ),
+    ).toBe('vertex-ai');
+  });
+
+  it('matches on resourceName when resource type is absent', () => {
+    expect(
+      resolveGcpServiceId(
+        'X',
+        undefined,
+        '//aiplatform.googleapis.com/projects/p/locations/l/models/m',
+      ),
+    ).toBe('vertex-ai');
+  });
+
+  it('resource type takes precedence over a category mapping', () => {
+    // PUBLIC_BUCKET_ACL maps to cloud-storage, but an aiplatform resource
+    // must still group under vertex-ai (resource type is authoritative).
+    expect(
+      resolveGcpServiceId(
+        'PUBLIC_BUCKET_ACL',
+        'aiplatform.googleapis.com/Endpoint',
+        undefined,
+      ),
+    ).toBe('vertex-ai');
+  });
+
+  it('falls back to the category mapping for non-AI findings', () => {
+    expect(
+      resolveGcpServiceId('PUBLIC_BUCKET_ACL', 'storage.googleapis.com/Bucket', undefined),
+    ).toBe('cloud-storage');
+  });
+
+  it('falls back to security-command-center for unmapped, non-AI findings', () => {
+    expect(resolveGcpServiceId('TOTALLY_UNKNOWN', 'compute.googleapis.com/Foo', undefined)).toBe(
+      'security-command-center',
+    );
   });
 });

--- a/apps/api/src/cloud-security/providers/gcp-security.service.ts
+++ b/apps/api/src/cloud-security/providers/gcp-security.service.ts
@@ -130,6 +130,7 @@ const SERVICE_NAMES: Record<string, string> = {
   bigquery: 'BigQuery',
   pubsub: 'Pub/Sub',
   'cloud-armor': 'Cloud Armor',
+  'vertex-ai': 'Vertex AI',
   'security-command-center': 'Security Command Center',
 };
 
@@ -151,7 +152,39 @@ const GCP_API_TO_SERVICE: Record<string, string[]> = {
   'networksecurity.googleapis.com': ['cloud-armor'],
   'iam.googleapis.com': ['iam'],
   'iamcredentials.googleapis.com': ['iam'],
+  'aiplatform.googleapis.com': ['vertex-ai'],
+  'notebooks.googleapis.com': ['vertex-ai'],
 };
+
+/**
+ * GCP resource-type hosts that map to a Cloud Tests service, checked BEFORE the
+ * finding category. SCC names AI detector categories inconsistently across
+ * resources (Dataset/Model/Endpoint/Workbench, CMEK/access/policy, etc.), so
+ * grouping by the authoritative resource type is far more robust than trying to
+ * enumerate every category string. Any finding on an `aiplatform`/`notebooks`
+ * resource is grouped under "Vertex AI".
+ */
+const RESOURCE_TYPE_HOST_TO_SERVICE: Array<[string, string]> = [
+  ['aiplatform.googleapis.com', 'vertex-ai'],
+  ['notebooks.googleapis.com', 'vertex-ai'],
+];
+
+/**
+ * Resolve the Cloud Tests service ID for an SCC finding. Prefer the resource
+ * type (authoritative) over the category, then fall back to the generic
+ * Security Command Center bucket so nothing is ever dropped.
+ */
+export function resolveGcpServiceId(
+  category: string,
+  resourceType: string | undefined,
+  resourceName: string | undefined,
+): string {
+  const haystack = `${resourceType ?? ''} ${resourceName ?? ''}`;
+  for (const [host, service] of RESOURCE_TYPE_HOST_TO_SERVICE) {
+    if (haystack.includes(host)) return service;
+  }
+  return CATEGORY_TO_SERVICE[category] ?? 'security-command-center';
+}
 
 export type GcpSetupStepId =
   | 'enable_security_command_center_api'
@@ -1359,8 +1392,11 @@ export class GCPSecurityService {
             if (seenIds.has(f.name)) continue;
             seenIds.add(f.name);
 
-            const serviceId =
-              CATEGORY_TO_SERVICE[f.category] ?? 'security-command-center';
+            const serviceId = resolveGcpServiceId(
+              f.category,
+              result.resource?.type,
+              f.resourceName,
+            );
             if (enabledServiceSet && !enabledServiceSet.has(serviceId)) {
               continue;
             }

--- a/apps/app/src/app/(app)/[orgId]/cloud-tests/components/ServiceCard.tsx
+++ b/apps/app/src/app/(app)/[orgId]/cloud-tests/components/ServiceCard.tsx
@@ -14,6 +14,7 @@ import {
   ScanSearch,
   Server,
   Shield,
+  Sparkles,
   Terminal,
   Workflow,
 } from 'lucide-react';
@@ -78,6 +79,7 @@ const SERVICE_ICONS: Record<string, React.ElementType> = {
   'bigquery': Database,
   'pubsub': Workflow,
   'cloud-armor': Shield,
+  'vertex-ai': Sparkles,
   'security-command-center': Shield,
 };
 

--- a/packages/integration-platform/src/manifests/gcp/index.ts
+++ b/packages/integration-platform/src/manifests/gcp/index.ts
@@ -89,6 +89,7 @@ This is industry standard - all GCP security monitoring tools use the same scope
     { id: 'bigquery', name: 'BigQuery', description: 'Dataset encryption and public access checks', enabledByDefault: false, implemented: true },
     { id: 'pubsub', name: 'Pub/Sub', description: 'Topic encryption configuration checks', enabledByDefault: false, implemented: true },
     { id: 'cloud-armor', name: 'Cloud Armor', description: 'SSL policy strength and WAF configuration checks', enabledByDefault: false, implemented: true },
+    { id: 'vertex-ai', name: 'Vertex AI', description: 'Vertex AI and Workbench checks — encryption (CMEK), public access, and notebook exposure. Requires SCC Premium or Enterprise.', enabledByDefault: false, implemented: true },
   ],
 
   // Integration-level variables (used by cloud security scanning)


### PR DESCRIPTION
## Summary

Adds **Vertex AI** as a first-class service in GCP Cloud Tests. Today, GCP Cloud Tests only surface findings from Google's Security Command Center (SCC), and any finding we don't explicitly map falls into a generic **"Security Command Center"** bucket. This PR groups GCP **Vertex AI / Workbench** findings under a dedicated **"Vertex AI"** service.

Requested by a customer ("heavy Gemini users") who asked whether Vertex AI is covered.

## What changed
- **`gcp-security.service.ts`**
  - `SERVICE_NAMES`: add `vertex-ai → "Vertex AI"`.
  - `GCP_API_TO_SERVICE`: detect `vertex-ai` from `aiplatform.googleapis.com` / `notebooks.googleapis.com` — required so its findings pass the enabled-services filter (the scan drops findings whose service isn't in the enabled set).
  - `resolveGcpServiceId(category, resourceType, resourceName)`: group by the **resource-type host** (e.g. `aiplatform.googleapis.com/*`) **before** the SCC category. Google names AI detector categories inconsistently across resources (Dataset/Model/Endpoint/Workbench; CMEK/access/policy), so resource type is the robust, authoritative signal. Falls back to the category map, then the SCC bucket — nothing is ever dropped.
- **integration-platform GCP manifest**: add the Vertex AI entry to the Services-tab catalog, with a description that states it **requires SCC Premium / Enterprise**.
- **`ServiceCard.tsx`**: Vertex AI icon.
- **Tests**: `resolveGcpServiceId` resource-type precedence + fallbacks.

## Behavior / caveats (honest)
- **Detection-gated:** orgs that don't use Vertex AI never see it (the `aiplatform` API isn't enabled → not detected).
- **SCC tier matters:** Vertex AI is only scanned by SCC on **Premium / Enterprise**. A Vertex-AI org on the free **Standard** tier will see the service with **no findings** — the card description states the tier requirement so it isn't mysterious.
- **Gemini API / AI Studio** (`generativelanguage`) is a separate product **not covered by SCC on any tier** — out of scope.
- **Not yet verified against a live Vertex AI finding** (no test org / expired token). The mapping is built on the stable SCC `resource.type` field rather than guessed category strings, so it's defensive — but a real finding is the final proof.

## Tests
- `gcp-security.service.spec.ts`: 6 new cases for `resolveGcpServiceId` (incl. resource-type precedence over category, and fallbacks). Full GCP spec green; changed files typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Vertex AI as a first-class GCP Cloud Tests service so Vertex AI and Workbench findings are grouped under “Vertex AI” instead of the generic Security Command Center bucket.

- **New Features**
  - Added `vertex-ai` service; detect `aiplatform.googleapis.com` and `notebooks.googleapis.com`.
  - Implemented and exported `resolveGcpServiceId` to prefer resource-type host over SCC category; falls back to category, then Security Command Center. Also matches on `resourceName` if `resource.type` is missing.
  - Added catalog entry noting it requires SCC Premium or Enterprise, and a Vertex AI icon in `ServiceCard.tsx`.
  - Added tests for resource-type precedence, `resourceName` fallback, and non-AI fallbacks.
  - Behavior: only visible if Vertex AI APIs are enabled; SCC Standard may show the service with no findings.

<sup>Written for commit 84fdac52581b5f2213c902dd4921c1ae14c04675. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

