### PR TITLE
fix(cloud-security): scope Cloud Tests findings to the selected account

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/cloud-tests/components/CloudTestsSection.tsx
+++ b/apps/app/src/app/(app)/[orgId]/cloud-tests/components/CloudTestsSection.tsx
@@ -47,6 +47,7 @@ import type { Finding } from '../types';
 import { CheckDefinitionPanel } from './CheckDefinitionPanel';
 import { CheckGroupBlock } from './CheckGroupBlock';
 import { buildCheckGroups } from './check-groups';
+import { filterFindingsByConnection } from './finding-filters';
 import { EvidenceJsonViewer } from './EvidenceJsonViewer';
 import { MarkExceptionModal } from './MarkExceptionModal';
 import { RemediationSection } from './RemediationSection';
@@ -285,28 +286,26 @@ export function CloudTestsSection({
   );
 
   const findings = useMemo(() => {
-    return allFindings
-      .filter((f) => f.providerSlug === providerSlug || f.connectionId === connectionId)
+    // Scope to the selected connection (= the selected cloud account) so
+    // picking a different account narrows the list to that account's findings.
+    return filterFindingsByConnection(allFindings, connectionId)
       .filter((f) => !projectFilter || f.projectDisplayName === projectFilter)
       .sort(
         (a, b) =>
           (SEVERITY_ORDER[a.severity ?? 'info'] ?? 5) - (SEVERITY_ORDER[b.severity ?? 'info'] ?? 5),
       );
-  }, [allFindings, providerSlug, connectionId, projectFilter]);
+  }, [allFindings, connectionId, projectFilter]);
 
-  // Unique project names across all findings (for filter pills)
+  // Unique project names for the selected connection (for filter pills)
   const projectNames = useMemo(() => {
     const names = new Set<string>();
-    for (const f of allFindings) {
-      if (
-        (f.providerSlug === providerSlug || f.connectionId === connectionId) &&
-        f.projectDisplayName
-      ) {
+    for (const f of filterFindingsByConnection(allFindings, connectionId)) {
+      if (f.projectDisplayName) {
         names.add(f.projectDisplayName);
       }
     }
     return [...names].sort((a, b) => a.localeCompare(b));
-  }, [allFindings, providerSlug, connectionId]);
+  }, [allFindings, connectionId]);
 
   const failedFindings = findings.filter((f) => f.status === 'failed' || f.status === 'FAILED');
   const passedFindings = findings.filter((f) => f.status === 'passed' || f.status === 'success');

--- a/apps/app/src/app/(app)/[orgId]/cloud-tests/components/ProviderTabs.tsx
+++ b/apps/app/src/app/(app)/[orgId]/cloud-tests/components/ProviderTabs.tsx
@@ -279,6 +279,15 @@ export function ProviderTabs({
       {providerTypes.map((providerType) => {
         const connections = providerGroups[providerType] || [];
         const activeConnId = activeConnectionTabs[providerType] || connections[0]?.id;
+        // The connection selector also filters the findings list, so label it
+        // with the provider's term for a connection (AWS account, Azure
+        // subscription, etc.) to make that clear.
+        const connectionNoun =
+          providerType === 'aws'
+            ? 'Account'
+            : providerType === 'azure'
+              ? 'Subscription'
+              : 'Connection';
 
         if (connections.length === 0) {
           return <TabsContent key={providerType} value={providerType} />;
@@ -292,27 +301,32 @@ export function ProviderTabs({
                 onValueChange={(value) => onConnectionTabChange(providerType, value)}
               >
                 <div className="mb-3 flex items-center justify-between">
-                  <Select
-                    value={activeConnId}
-                    onValueChange={(value) => {
-                      if (value) onConnectionTabChange(providerType, value);
-                    }}
-                  >
-                    <div className="w-[240px]">
-                      <SelectTrigger size="sm">
-                        {connections.find((c) => c.id === activeConnId)?.displayName
-                          || connections.find((c) => c.id === activeConnId)?.name
-                          || 'Select connection'}
-                      </SelectTrigger>
-                    </div>
-                    <SelectContent>
-                      {connections.map((connection) => (
-                        <SelectItem key={connection.id} value={connection.id}>
-                          {connection.displayName || connection.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <div className="flex items-center gap-2">
+                    <span className="shrink-0 text-xs font-medium text-muted-foreground">
+                      {connectionNoun}:
+                    </span>
+                    <Select
+                      value={activeConnId}
+                      onValueChange={(value) => {
+                        if (value) onConnectionTabChange(providerType, value);
+                      }}
+                    >
+                      <div className="w-[240px]">
+                        <SelectTrigger size="sm">
+                          {connections.find((c) => c.id === activeConnId)?.displayName
+                            || connections.find((c) => c.id === activeConnId)?.name
+                            || `Select ${connectionNoun.toLowerCase()}`}
+                        </SelectTrigger>
+                      </div>
+                      <SelectContent>
+                        {connections.map((connection) => (
+                          <SelectItem key={connection.id} value={connection.id}>
+                            {connection.displayName || connection.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
                   {/* Only show "Add connection" button for providers that support multiple connections */}
                   {canAddConnection !== false && connections.some((c) => c.supportsMultipleConnections) && (
                     <Button

--- a/apps/app/src/app/(app)/[orgId]/cloud-tests/components/finding-filters.test.ts
+++ b/apps/app/src/app/(app)/[orgId]/cloud-tests/components/finding-filters.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { filterFindingsByConnection } from './finding-filters';
+
+type TestFinding = {
+  connectionId: string;
+  providerSlug: string;
+  title: string;
+};
+
+const findings: TestFinding[] = [
+  { connectionId: 'aws-acct-a', providerSlug: 'aws', title: 'a-1' },
+  { connectionId: 'aws-acct-a', providerSlug: 'aws', title: 'a-2' },
+  { connectionId: 'aws-acct-b', providerSlug: 'aws', title: 'b-1' },
+  { connectionId: 'gcp-conn-1', providerSlug: 'gcp', title: 'g-1' },
+];
+
+describe('filterFindingsByConnection', () => {
+  it('returns only the selected connection (account) findings', () => {
+    const result = filterFindingsByConnection(findings, 'aws-acct-a');
+    expect(result.map((f) => f.title)).toEqual(['a-1', 'a-2']);
+  });
+
+  it('does NOT leak findings from another account of the same provider (the bug)', () => {
+    // Regression guard: the old `providerSlug === providerSlug || ...` filter
+    // returned every AWS finding regardless of the selected account.
+    const result = filterFindingsByConnection(findings, 'aws-acct-b');
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe('b-1');
+    expect(result.some((f) => f.connectionId === 'aws-acct-a')).toBe(false);
+  });
+
+  it('scopes to a single connection across providers', () => {
+    expect(filterFindingsByConnection(findings, 'gcp-conn-1').map((f) => f.title)).toEqual([
+      'g-1',
+    ]);
+  });
+
+  it('returns an empty array when no finding matches the connection', () => {
+    expect(filterFindingsByConnection(findings, 'does-not-exist')).toEqual([]);
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/cloud-tests/components/finding-filters.ts
+++ b/apps/app/src/app/(app)/[orgId]/cloud-tests/components/finding-filters.ts
@@ -1,0 +1,22 @@
+/**
+ * Scope a flat list of findings to a single connection (= one cloud account).
+ *
+ * Cloud Tests fetches findings for every connected account in one call, and
+ * each provider section renders only the *selected* account's findings. The
+ * scoping was previously written as
+ *   `f.providerSlug === providerSlug || f.connectionId === connectionId`
+ * — an OR whose first clause matches EVERY finding of the provider, so the
+ * second clause never narrowed anything. With multiple AWS accounts, picking a
+ * different account in the connection selector therefore did nothing: the list
+ * always showed all accounts' findings merged together.
+ *
+ * Scoping strictly by `connectionId` is correct because every finding carries a
+ * required `connectionId` (see `types.ts`) and each section is rendered with the
+ * selected connection's id (see `ProviderTabs`).
+ */
+export function filterFindingsByConnection<T extends { connectionId: string }>(
+  findings: T[],
+  connectionId: string,
+): T[] {
+  return findings.filter((finding) => finding.connectionId === connectionId);
+}


### PR DESCRIPTION
## Summary

Customers with **multiple AWS accounts** reported they can't filter the Cloud Tests findings list down to a single account — *"we still can't filter the list down by account… would be good if the list filtered to the problems with that account when we select it."*

It wasn't by design — it's a multi-account filtering bug.

## Root cause
`CloudTestsSection.tsx` scoped findings with:
```js
.filter((f) => f.providerSlug === providerSlug || f.connectionId === connectionId)
```
That's an **OR**, and the first clause (`f.providerSlug === providerSlug`) matches **every** finding of the provider — so the connection (account) clause never narrowed anything. The account selector switched the active `connectionId`, but the filter ignored it, so the list always showed all accounts' findings merged. (Looks like the filter predates multi-account support.)

## Fix
- Extract `filterFindingsByConnection(findings, connectionId)` and use it for both the findings list and the project-name pills, scoping strictly to the selected connection (= selected account).
- Safe because every `Finding` carries a required `connectionId` (`types.ts`) and each section is rendered with the selected connection's id (`ProviderTabs.tsx:163`) — so nothing is hidden; the list (and the Passed/Failed/Total stats derived from it) now reflect the selected account.

## Effect for the customer
Selecting an account in the connection selector now narrows the findings, stats, and "Looking good"/empty states to that account — exactly the per-account focus they asked for.

## Tests
- `finding-filters.test.ts`: scopes to one account, and a regression guard that it does **not** leak another account of the same provider. 4 passing; changed files typecheck clean.

## Note
This sharpens scoping to one account at a time (matching the existing selector UX). If we later want an explicit "All accounts" aggregate view, that's a follow-up — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes Cloud Tests findings, stats, and project pills to the selected account. Adds a clear label to the connection selector so it’s obvious it filters by account.

- **Bug Fixes**
  - Extracted and used `filterFindingsByConnection(findings, connectionId)` for findings and project-name pills; replaced the `providerSlug || connectionId` logic with strict `connectionId` scoping.
  - Added tests to prevent cross-account leakage and verify empty results.

- **New Features**
  - Labeled the connection selector in `ProviderTabs` with provider-aware terms (“Account” for AWS, “Subscription” for Azure, “Connection” for GCP) and matching placeholder.

<sup>Written for commit 2d1404ed5abfcc0fa28a95ada5680365ee55535b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

