### PR TITLE
fix(integration-platform): correctly attribute AWS evidence assume-role failures

### DIFF
--- a/packages/integration-platform/src/manifests/aws/checks/__tests__/aws-checks.test.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/__tests__/aws-checks.test.ts
@@ -14,7 +14,11 @@ import {
   evaluateRdsEncryption,
 } from '../rds';
 import { evaluateS3Encryption, evaluateS3PublicAccess } from '../s3';
-import { resolveAwsCredentialInputs } from '../shared';
+import {
+  AwsAssumeError,
+  describeAssumeFailure,
+  resolveAwsCredentialInputs,
+} from '../shared';
 
 const kinds = (os: { kind: string }[]) => os.map((o) => o.kind);
 
@@ -371,5 +375,45 @@ describe('IAM/CloudTrail outcomes carry evidence (so the UI shows "View Evidence
     ]);
     expect(rot[0]!.evidence?.rotationEnabled).toBe(true);
     expect(rot[1]!.evidence?.rotationEnabled).toBe(false);
+  });
+});
+
+describe('AWS assume-role failure classification (describeAssumeFailure)', () => {
+  it('treats a customer-role (hop 2) failure as customer-side with actionable IAM guidance', () => {
+    const c = describeAssumeFailure(
+      new AwsAssumeError('AccessDenied: not authorized', 'customer-role'),
+    );
+    expect(c.isInternal).toBe(false);
+    expect(c.hop).toBe('customer-role');
+    expect(c.remediation).toContain('Verify the role ARN and external ID');
+    expect(c.description).toContain('AccessDenied: not authorized');
+  });
+
+  it('treats a roleAssumer (hop 1) failure as internal and does NOT blame the customer', () => {
+    const c = describeAssumeFailure(
+      new AwsAssumeError('not authorized to assume roleAssumer', 'role-assumer'),
+    );
+    expect(c.isInternal).toBe(true);
+    expect(c.hop).toBe('role-assumer');
+    expect(c.remediation).toContain('No action is needed on your side');
+    expect(c.remediation).not.toContain('Verify the role ARN');
+    expect(c.description).toContain("Comp's side");
+    expect(c.description).toContain('not authorized to assume roleAssumer');
+  });
+
+  it('treats a missing-config failure as internal', () => {
+    const c = describeAssumeFailure(
+      new AwsAssumeError('Missing SECURITY_HUB_ROLE_ASSUMER_ARN', 'config'),
+    );
+    expect(c.isInternal).toBe(true);
+    expect(c.hop).toBe('config');
+    expect(c.remediation).toContain('No action is needed on your side');
+  });
+
+  it('defaults a non-tagged error to customer-role and surfaces the real message', () => {
+    const c = describeAssumeFailure(new Error('boom'));
+    expect(c.hop).toBe('customer-role');
+    expect(c.error).toBe('boom');
+    expect(c.description).toContain('boom');
   });
 });

--- a/packages/integration-platform/src/manifests/aws/checks/shared.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/shared.ts
@@ -17,6 +17,70 @@ export interface AwsCredentialInputs {
 }
 
 /**
+ * Which hop of the role-assumption chain failed:
+ *  - `config`        — Comp-side config (missing roleAssumer ARN env var)
+ *  - `role-assumer`  — Comp-side (could not assume our own roleAssumer role)
+ *  - `customer-role` — customer-side (their role's trust policy / external ID)
+ *
+ * `config` and `role-assumer` are internal failures — the customer's AWS setup
+ * is fine and they should NOT be told to change their IAM.
+ */
+export type AssumeHop = 'config' | 'role-assumer' | 'customer-role';
+
+/** Error raised while assuming the customer's role, tagged with the failed hop. */
+export class AwsAssumeError extends Error {
+  constructor(
+    message: string,
+    readonly hop: AssumeHop,
+    readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = 'AwsAssumeError';
+  }
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export interface AssumeFailureClassification {
+  hop: AssumeHop;
+  /** true when the failure is on Comp's side, not the customer's AWS config. */
+  isInternal: boolean;
+  error: string;
+  description: string;
+  remediation: string;
+}
+
+/**
+ * Turn an assume-role failure into accurate, customer-facing copy. The key
+ * point: only a `customer-role` (hop 2) failure means the customer needs to
+ * check their role ARN / external ID / trust policy. A `config` or
+ * `role-assumer` failure is on us — telling the customer to "verify your role
+ * ARN" there is wrong and is exactly what confused this customer. The real
+ * underlying error is always included so the failure is diagnosable.
+ */
+export function describeAssumeFailure(
+  err: unknown,
+): AssumeFailureClassification {
+  const hop: AssumeHop =
+    err instanceof AwsAssumeError ? err.hop : 'customer-role';
+  const error = errorMessage(err);
+  const isInternal = hop === 'config' || hop === 'role-assumer';
+  return {
+    hop,
+    isInternal,
+    error,
+    description: isInternal
+      ? `This check could not run due to an internal issue on Comp's side, not your AWS configuration (${error}). Our team has been notified.`
+      : `The cross-account IAM role could not be assumed, so this check could not be verified (${error}).`,
+    remediation: isInternal
+      ? 'No action is needed on your side — Comp will resolve this and the check will pass on the next run.'
+      : "Verify the role ARN and external ID are correct and the role's trust policy allows Comp's roleAssumer to assume it with that external ID, then re-run the check.",
+  };
+}
+
+/**
  * Resolve role ARN, external ID, and regions from raw connection credentials.
  * Returns null when any is missing (treated as "connection not configured").
  *
@@ -105,32 +169,49 @@ export async function assumeAwsSession(
       partition === 'aws-us-gov'
         ? 'SECURITY_HUB_GOVCLOUD_ROLE_ASSUMER_ARN'
         : 'SECURITY_HUB_ROLE_ASSUMER_ARN';
-    throw new Error(`Missing ${envName} (Comp roleAssumer ARN).`);
+    throw new AwsAssumeError(
+      `Missing ${envName} (Comp roleAssumer ARN).`,
+      'config',
+    );
   }
 
-  // Hop 1: task/base creds -> Comp roleAssumer.
+  // Hop 1: task/base creds -> Comp roleAssumer. A failure here is on Comp's
+  // side (our runtime can't assume our own roleAssumer), not the customer's.
   const baseSts = new STSClient({
     region,
     credentials: awsBaseCredentials(partition),
   });
-  const assumerResp = await baseSts.send(
-    new AssumeRoleCommand({
-      RoleArn: roleAssumerArn,
-      RoleSessionName: 'CompRoleAssumer',
-      DurationSeconds: 3600,
-    }),
-  );
+  let assumerResp;
+  try {
+    assumerResp = await baseSts.send(
+      new AssumeRoleCommand({
+        RoleArn: roleAssumerArn,
+        RoleSessionName: 'CompRoleAssumer',
+        DurationSeconds: 3600,
+      }),
+    );
+  } catch (err) {
+    throw new AwsAssumeError(
+      `Failed to assume Comp roleAssumer: ${errorMessage(err)}`,
+      'role-assumer',
+      err,
+    );
+  }
   const assumer = assumerResp.Credentials;
   if (
     !assumer?.AccessKeyId ||
     !assumer.SecretAccessKey ||
     !assumer.SessionToken
   ) {
-    return null;
+    throw new AwsAssumeError(
+      'Comp roleAssumer returned no credentials.',
+      'role-assumer',
+    );
   }
 
   // Hop 2: roleAssumer -> customer role (trust policy whitelists the roleAssumer
-  // ARN + external ID).
+  // ARN + external ID). A failure here points at the customer's trust policy /
+  // external ID.
   const assumerSts = new STSClient({
     region,
     credentials: {
@@ -139,16 +220,30 @@ export async function assumeAwsSession(
       sessionToken: assumer.SessionToken,
     },
   });
-  const res = await assumerSts.send(
-    new AssumeRoleCommand({
-      RoleArn: roleArn,
-      ExternalId: externalId,
-      RoleSessionName: 'CompEvidenceCheck',
-      DurationSeconds: 3600,
-    }),
-  );
+  let res;
+  try {
+    res = await assumerSts.send(
+      new AssumeRoleCommand({
+        RoleArn: roleArn,
+        ExternalId: externalId,
+        RoleSessionName: 'CompEvidenceCheck',
+        DurationSeconds: 3600,
+      }),
+    );
+  } catch (err) {
+    throw new AwsAssumeError(
+      `Failed to assume the customer role: ${errorMessage(err)}`,
+      'customer-role',
+      err,
+    );
+  }
   const c = res.Credentials;
-  if (!c?.AccessKeyId || !c.SecretAccessKey || !c.SessionToken) return null;
+  if (!c?.AccessKeyId || !c.SecretAccessKey || !c.SessionToken) {
+    throw new AwsAssumeError(
+      'The customer role returned no credentials.',
+      'customer-role',
+    );
+  }
 
   return {
     credentials: {
@@ -174,16 +269,15 @@ export async function resolveAwsSessionOrFail(
   try {
     return await assumeAwsSession(ctx);
   } catch (err) {
+    const classified = describeAssumeFailure(err);
     ctx.fail({
       title: 'Could not assume AWS role',
-      description:
-        'The cross-account IAM role could not be assumed, so this check could not be verified.',
+      description: classified.description,
       resourceType: 'aws-account',
       resourceId: 'account',
       severity: 'medium',
-      remediation:
-        'Verify the role ARN and external ID are correct and the role trust policy allows Comp to assume it, then re-run the check.',
-      evidence: { error: err instanceof Error ? err.message : String(err) },
+      remediation: classified.remediation,
+      evidence: { hop: classified.hop, error: classified.error },
     });
     return null;
   }


### PR DESCRIPTION
## Summary

A customer's AWS **evidence task automations** (S3/RDS/KMS "App Automations") were failing with **"Could not assume AWS role"**, and they asked whether it was something on their end. It isn't — their connection and trust policy are correct, and the assume code already does the proper two-hop (task → Comp `roleAssumer` → customer role), the same as Cloud Tests.

The real problem is the **error handling** in `manifests/aws/checks/shared.ts`:
- **Every** failure — including Comp-side ones — was reported to the customer as *"Verify the role ARN and external ID are correct…"*, telling them to fix IAM that's actually fine.
- The **real** underlying STS error was buried in `evidence` only, so the failure wasn't diagnosable at a glance.

## What changed
- **Tag failures by hop** in `assumeAwsSession`:
  - `config` — missing `SECURITY_HUB_ROLE_ASSUMER_ARN` env var → **Comp-side**
  - `role-assumer` — couldn't assume our own roleAssumer (hop 1) → **Comp-side**
  - `customer-role` — couldn't assume the customer role (hop 2) → **customer-side** (trust policy / external ID)
  Both STS calls are wrapped so the failing hop is known, and the "no credentials returned" cases now **throw** (surfaced) instead of silently no-op'ing.
- **`describeAssumeFailure()`** — a pure classifier that produces accurate copy:
  - Internal failures → *"internal issue on Comp's side, not your AWS configuration… no action needed on your side"* (with the real error).
  - Customer-side failures → keep the actionable role-ARN / external-ID guidance.
  - The real STS error is included in **both** the description and `evidence` so it's diagnosable.
- `resolveAwsSessionOrFail()` uses the classifier.
- Tests: hop classification (customer-side vs internal) + non-tagged-error default.

## Honest scope
This **corrects attribution and diagnosability** — customers are no longer wrongly told to fix correct IAM, and the real failure is now visible. It does **not** change whether the assume itself succeeds: if the check-runner runtime genuinely can't assume the roleAssumer (e.g. the env var isn't set there, or its identity isn't allowed to assume our roleAssumer — the most likely cause, since Cloud Tests works but the trigger-run evidence checks don't), the check will still fail — but now **correctly labeled Comp-side with the real STS error surfaced**, which is exactly what's needed to apply the final runtime/IAM fix. After deploy, re-run a failed check and the now-visible error pinpoints the remaining infra fix.

## Tests
`aws-checks.test.ts`: 36 passing (4 new classification cases). Package builds; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect attribution of AWS assume-role failures in evidence checks by tagging the failing hop and surfacing the real STS error. Customers no longer get blamed for Comp-side issues, and failures are now diagnosable.

- Bug Fixes
  - Tag assume-role failures by hop: `config`, `role-assumer`, `customer-role`; throw on missing/no credentials.
  - Add `AwsAssumeError` and `describeAssumeFailure()` to classify errors and generate accurate messages.
  - Update `resolveAwsSessionOrFail()` to show correct description/remediation and include `hop` and `error` in evidence.
  - Add tests covering classification and default behavior.

<sup>Written for commit 0733f34332f256118b929339e1e6397c3fccd7c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

