### PR TITLE
fix(cloud-security): make CloudWatch metric-filter auto-fix reliable

### DIFF
--- a/apps/api/src/cloud-security/ai-remediation.prompt.ts
+++ b/apps/api/src/cloud-security/ai-remediation.prompt.ts
@@ -171,6 +171,12 @@ A human will ALWAYS review your plan before execution. Be precise and correct.
 - To make a recorder record ALL supported resource types, first read the existing recorder with DescribeConfigurationRecordersCommand (service "config-service", in readSteps) to get its exact name and roleARN, then call PutConfigurationRecorderCommand with ConfigurationRecorder = { name, roleARN, recordingGroup: { allSupported: true, includeGlobalResourceTypes: true } }.
 - NEVER set allSupported:true together with recordingStrategy, exclusionByResourceTypes, or resourceTypes — they are mutually exclusive and AWS rejects the request with a ValidationException. Omit those fields entirely (this also overwrites an existing exclusion-based strategy so global IAM resources are recorded).
 
+## CLOUDWATCH METRIC FILTERS (IMPORTANT)
+- For logs:PutMetricFilterCommand (service "cloudwatch-logs"), ALL of these are required: logGroupName, filterName, filterPattern, and metricTransformations.
+- metricTransformations MUST be an ARRAY of objects (never a single object), and each object MUST set metricName, metricNamespace, and metricValue. Example: "metricTransformations": [{ "metricName": "compai-cis-metric", "metricNamespace": "CloudTrailMetrics", "metricValue": "1" }].
+- metricValue MUST be a STRING ("1"), not the number 1 — AWS rejects a numeric metricValue.
+- logGroupName must be the REAL CloudTrail CloudWatch Logs group name from the read step — never a placeholder.
+
 ## IDEMPOTENCY (CRITICAL)
 - All fix steps MUST be safe to run even if the resource already exists
 - For Create operations: our executor automatically handles "already exists" errors — they are treated as success, not failure

--- a/apps/api/src/cloud-security/aws-command-executor.spec.ts
+++ b/apps/api/src/cloud-security/aws-command-executor.spec.ts
@@ -3,6 +3,7 @@ import {
   REQUIRED_PARAMS,
   looksLikeValidationError,
   normalizeConfigRecordingGroup,
+  normalizeMetricFilterTransformations,
   validatePlanSteps,
 } from './aws-command-executor';
 
@@ -399,5 +400,93 @@ describe('normalizeConfigRecordingGroup', () => {
     };
     normalizeConfigRecordingGroup(input2);
     expect(input2).toEqual({ ConfigurationRecorder: { name: 'default' } });
+  });
+});
+
+/**
+ * CloudWatch metric filters: `metricTransformations` is a required, non-empty
+ * array whose entries' `metricValue` must be a string. The model often emits a
+ * single object or a numeric metricValue, which AWS rejects ("metric
+ * transformations were not properly provided…") and sends the auto-fix to
+ * manual steps. normalizeMetricFilterTransformations coerces the valid shape;
+ * REQUIRED_PARAMS catches a truly-missing field before execution.
+ */
+describe('PutMetricFilterCommand required params + normalization', () => {
+  it('enforces the required PutMetricFilter params', () => {
+    const errors = validatePlanSteps([
+      step({
+        service: 'cloudwatch-logs',
+        command: 'PutMetricFilterCommand',
+        params: { logGroupName: 'lg', filterName: 'fn' }, // missing pattern + transforms
+      }),
+    ]);
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/Required param "filterPattern" is missing/),
+        expect.stringMatching(/Required param "metricTransformations" is missing/),
+      ]),
+    );
+  });
+
+  it('does not error when all PutMetricFilter params are present', () => {
+    const errors = validatePlanSteps([
+      step({
+        service: 'cloudwatch-logs',
+        command: 'PutMetricFilterCommand',
+        params: {
+          logGroupName: 'lg',
+          filterName: 'fn',
+          filterPattern: '{ $.eventName = "X" }',
+          metricTransformations: [
+            { metricName: 'm', metricNamespace: 'CloudTrailMetrics', metricValue: '1' },
+          ],
+        },
+      }),
+    ]);
+    expect(
+      errors.filter((e) => e.includes('PutMetricFilterCommand')),
+    ).toHaveLength(0);
+  });
+
+  it('wraps a single metricTransformations object in an array', () => {
+    const input: Record<string, unknown> = {
+      logGroupName: 'lg',
+      metricTransformations: {
+        metricName: 'm',
+        metricNamespace: 'CloudTrailMetrics',
+        metricValue: '1',
+      },
+    };
+    normalizeMetricFilterTransformations(input);
+    expect(input.metricTransformations).toEqual([
+      { metricName: 'm', metricNamespace: 'CloudTrailMetrics', metricValue: '1' },
+    ]);
+  });
+
+  it('coerces a numeric metricValue to a string', () => {
+    const input: Record<string, unknown> = {
+      metricTransformations: [
+        { metricName: 'm', metricNamespace: 'CloudTrailMetrics', metricValue: 1 },
+      ],
+    };
+    normalizeMetricFilterTransformations(input);
+    expect(input.metricTransformations).toEqual([
+      { metricName: 'm', metricNamespace: 'CloudTrailMetrics', metricValue: '1' },
+    ]);
+  });
+
+  it('leaves a well-formed metricTransformations array untouched', () => {
+    const good = [
+      { metricName: 'm', metricNamespace: 'CloudTrailMetrics', metricValue: '1' },
+    ];
+    const input: Record<string, unknown> = { metricTransformations: good };
+    normalizeMetricFilterTransformations(input);
+    expect(input.metricTransformations).toEqual(good);
+  });
+
+  it('is a no-op when metricTransformations is absent', () => {
+    const input: Record<string, unknown> = { logGroupName: 'lg' };
+    expect(() => normalizeMetricFilterTransformations(input)).not.toThrow();
+    expect(input).toEqual({ logGroupName: 'lg' });
   });
 });

--- a/apps/api/src/cloud-security/aws-command-executor.ts
+++ b/apps/api/src/cloud-security/aws-command-executor.ts
@@ -165,6 +165,12 @@ export const REQUIRED_PARAMS: Record<string, readonly string[]> = {
   StartConfigurationRecorderCommand: ['ConfigurationRecorderName'],
   PutBucketPolicyCommand: ['Bucket', 'Policy'],
   CreateTrailCommand: ['Name', 'S3BucketName'],
+  PutMetricFilterCommand: [
+    'logGroupName',
+    'filterName',
+    'filterPattern',
+    'metricTransformations',
+  ],
 };
 
 const REQUIRED_PARAM_ONE_OF: Record<string, readonly (readonly string[])[]> = {
@@ -276,6 +282,50 @@ function normaliseInputParams(
   if (command === 'PutConfigurationRecorderCommand') {
     normalizeConfigRecordingGroup(input);
   }
+
+  // Rule 5: CloudWatch Logs metric filters — `metricTransformations` is a
+  // required, NON-EMPTY ARRAY of { metricName, metricNamespace, metricValue }
+  // where `metricValue` must be a STRING. The model frequently emits it as a
+  // single object instead of an array, or as a number `1` instead of `"1"`,
+  // which AWS rejects (the customer-visible "metric transformations were not
+  // properly provided to the CloudWatch Logs API" failure that sends the
+  // auto-fix to manual steps). Coerce to the one valid shape.
+  if (command === 'PutMetricFilterCommand') {
+    normalizeMetricFilterTransformations(input);
+  }
+}
+
+export function normalizeMetricFilterTransformations(
+  input: Record<string, unknown>,
+): void {
+  let transformations = input.metricTransformations;
+
+  // A single transformation object → wrap in an array (AWS expects a list).
+  if (
+    transformations &&
+    typeof transformations === 'object' &&
+    !Array.isArray(transformations)
+  ) {
+    transformations = [transformations];
+    input.metricTransformations = transformations;
+  }
+
+  if (!Array.isArray(transformations)) return;
+
+  input.metricTransformations = transformations.map((entry) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      return entry;
+    }
+    const transform = entry as Record<string, unknown>;
+    // metricValue must be a string (e.g. "1"); the model often emits a number.
+    if (
+      transform.metricValue != null &&
+      typeof transform.metricValue !== 'string'
+    ) {
+      return { ...transform, metricValue: String(transform.metricValue) };
+    }
+    return transform;
+  });
 }
 
 export function normalizeConfigRecordingGroup(


### PR DESCRIPTION
## Summary

Customer (aymenrc) reported AWS auto-fix falling back to **manual steps** with *"required parameters were not properly provided… metric transformations were not properly provided to the CloudWatch Logs API"* on the CIS **CloudWatch metric-filter** checks (e.g. "CloudTrail config changes — metric filter missing").

That finding **is** meant to be auto-fixable — the fix is three standard API calls (`logs:PutMetricFilter` + `sns:CreateTopic` + `cloudwatch:PutMetricAlarm`, `cloudwatch.adapter.ts:155`), not `[MANUAL]`. So this is a **bug**, not an inherently-manual finding.

## Root cause
`PutMetricFilterCommand` was **not** in the executor's `REQUIRED_PARAMS`, so a step with a missing or mis-shaped `metricTransformations` wasn't caught before execution — it went to AWS, got rejected, and the system fell back to manual steps. The model commonly emits `metricTransformations` as a **single object** instead of an array, or `metricValue` as the number `1` instead of `"1"` — both of which AWS rejects.

## Fix
- **`aws-command-executor.ts`**
  - Add `PutMetricFilterCommand` to `REQUIRED_PARAMS` (`logGroupName`, `filterName`, `filterPattern`, `metricTransformations`) → a missing field now fails fast and triggers the existing AI repair pass instead of dumping to manual steps.
  - Add `normalizeMetricFilterTransformations` (Rule 5 in `normaliseInputParams`): wrap a single transformation object in an array, and coerce `metricValue` to a string. Deterministic guardrail before the SDK call (mirrors the Config-recorder guardrail).
- **`ai-remediation.prompt.ts`**: explicit `PutMetricFilter` shape guidance — `metricTransformations` as an array, string `metricValue`, real `logGroupName` from the read step.
- **Tests**: `REQUIRED_PARAMS` enforcement + normalizer cases (object→array, number→string, well-formed untouched, absent no-op).

## Notes / caveats
- It's auto-fixable in principle; this makes it **reliable** instead of an intermittent coin-flip.
- **Not yet verified against a live failing finding** (no server-side failed-plan for the customer's org) — this addresses the whole failure class, which covers the reported symptom. The exact malformation would be confirmable from his remediation logs.
- Edge case worth knowing: if a trail has **no CloudWatch Logs group** at all, there's nothing to attach a metric filter to — that's a genuine setup prerequisite, separate from this bug.

Full cloud-security suite green (310 passing); changed files typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unreliable auto-fix for CloudWatch Logs metric filters by validating required params and normalizing `metricTransformations`, preventing fallbacks to manual steps on CIS checks.

- **Bug Fixes**
  - Add `PutMetricFilterCommand` to `REQUIRED_PARAMS` (`logGroupName`, `filterName`, `filterPattern`, `metricTransformations`) to fail early and trigger the repair pass.
  - Add `normalizeMetricFilterTransformations` to wrap a single object into an array and coerce `metricValue` to a string.
  - Update `ai-remediation.prompt.ts` with explicit `PutMetricFilter` shape guidance and using the real `logGroupName` from the read step.
  - Add tests for required params and normalization (object→array, number→string, pass-through, absent no-op).

<sup>Written for commit 837ecde24df60453cdd331e672385a69e9842c7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

