### PR TITLE
fix(cloud-security): allow empty filterPattern for PutMetricFilter validation

### DIFF
--- a/apps/api/src/cloud-security/aws-command-executor.spec.ts
+++ b/apps/api/src/cloud-security/aws-command-executor.spec.ts
@@ -422,10 +422,30 @@ describe('PutMetricFilterCommand required params + normalization', () => {
     ]);
     expect(errors).toEqual(
       expect.arrayContaining([
-        expect.stringMatching(/Required param "filterPattern" is missing/),
+        // filterPattern must be PRESENT (but may be empty), so a missing one is
+        // reported via the present-check, not the non-empty REQUIRED_PARAMS one.
+        expect.stringMatching(/Required param "filterPattern" must be provided/),
         expect.stringMatching(/Required param "metricTransformations" is missing/),
       ]),
     );
+  });
+
+  it('allows an empty filterPattern (AWS accepts "" — it matches all events)', () => {
+    const errors = validatePlanSteps([
+      step({
+        service: 'cloudwatch-logs',
+        command: 'PutMetricFilterCommand',
+        params: {
+          logGroupName: 'lg',
+          filterName: 'fn',
+          filterPattern: '',
+          metricTransformations: [
+            { metricName: 'm', metricNamespace: 'CloudTrailMetrics', metricValue: '1' },
+          ],
+        },
+      }),
+    ]);
+    expect(errors.filter((e) => /filterPattern/.test(e))).toHaveLength(0);
   });
 
   it('does not error when all PutMetricFilter params are present', () => {

--- a/apps/api/src/cloud-security/aws-command-executor.ts
+++ b/apps/api/src/cloud-security/aws-command-executor.ts
@@ -165,12 +165,18 @@ export const REQUIRED_PARAMS: Record<string, readonly string[]> = {
   StartConfigurationRecorderCommand: ['ConfigurationRecorderName'],
   PutBucketPolicyCommand: ['Bucket', 'Policy'],
   CreateTrailCommand: ['Name', 'S3BucketName'],
-  PutMetricFilterCommand: [
-    'logGroupName',
-    'filterName',
-    'filterPattern',
-    'metricTransformations',
-  ],
+  PutMetricFilterCommand: ['logGroupName', 'filterName', 'metricTransformations'],
+};
+
+/**
+ * Params that must be PRESENT in the request but may legitimately be an empty
+ * string — unlike REQUIRED_PARAMS, which also rejects "". For example, AWS
+ * CloudWatch Logs PutMetricFilter requires `filterPattern` to be supplied but
+ * accepts an empty pattern (an empty filterPattern matches all log events), so
+ * we must reject only a missing/null value, not "".
+ */
+const REQUIRED_PRESENT_PARAMS: Record<string, readonly string[]> = {
+  PutMetricFilterCommand: ['filterPattern'],
 };
 
 const REQUIRED_PARAM_ONE_OF: Record<string, readonly (readonly string[])[]> = {
@@ -645,6 +651,18 @@ export function validatePlanSteps(steps: AwsCommandStep[]): string[] {
         const value = step.params?.[key];
         if (!hasRequiredParamValue(value)) {
           errors.push(`${prefix}: Required param "${key}" is missing or empty`);
+        }
+      }
+    }
+
+    const requiredPresent = REQUIRED_PRESENT_PARAMS[step.command];
+    if (requiredPresent) {
+      for (const key of requiredPresent) {
+        const value = step.params?.[key];
+        // Must be supplied, but an empty string is valid (e.g. an empty
+        // CloudWatch filterPattern matches all log events).
+        if (value === undefined || value === null) {
+          errors.push(`${prefix}: Required param "${key}" must be provided`);
         }
       }
     }


### PR DESCRIPTION
## Summary

Follow-up to a **cubic review** on #3050. #3050 added `PutMetricFilterCommand` to the executor's `REQUIRED_PARAMS` with `filterPattern` included — but that list rejects empty strings (via `hasRequiredParamValue`), while **AWS allows an empty `filterPattern`** (min length 0; an empty pattern matches all log events). The parameter must be *present*, but its value may be `""`.

## Verification
[AWS PutMetricFilter API docs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutMetricFilter.html) — `filterPattern` minimum length is **0**, so `""` is valid; the field is required to be supplied.

## Fix
- Move `filterPattern` out of `REQUIRED_PARAMS` (which rejects `""`) into a new **`REQUIRED_PRESENT_PARAMS`** check that only rejects a **missing/null** value — so `""` is accepted, while a truly-omitted pattern is still caught before execution.
- `logGroupName` / `filterName` / `metricTransformations` stay non-empty-required.
- Tests: empty `filterPattern` is accepted; a missing one is reported via the present-check.

## Impact
Low practical impact — our CIS metric-filter remediations always emit a non-empty pattern (an empty "match-all" pattern would be wrong for a CIS alarm), so this never blocked a plan we generate. It aligns the validator with AWS semantics and clears the reviewer finding.

Executor spec green (43 tests); typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow empty `filterPattern` for CloudWatch Logs `PutMetricFilterCommand` validation to match AWS behavior and avoid false errors. Adds a presence-only check while keeping other params strict.

- **Bug Fixes**
  - Introduced `REQUIRED_PRESENT_PARAMS` and moved `filterPattern` there for `PutMetricFilterCommand`; accepts "" but rejects missing/null.
  - Kept `logGroupName`, `filterName`, and `metricTransformations` as non-empty in `REQUIRED_PARAMS`.
  - Added tests to ensure empty `filterPattern` passes and a missing one fails.

<sup>Written for commit f8f2908f64080d9510d2473690934f75052d0fb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

