### PR TITLE
fix(cloud-security): reconcile conflicting logGroupName guidance in fix prompt

### DIFF
--- a/apps/api/src/cloud-security/ai-remediation.prompt.ts
+++ b/apps/api/src/cloud-security/ai-remediation.prompt.ts
@@ -290,7 +290,7 @@ NEVER omit AWSServiceName, leave it as null, or use a placeholder string.
 - NEVER use placeholder values like "{{variable}}", "<PLACEHOLDER>", or template syntax
 - ALWAYS use concrete values in fix step params
 - If a value depends on the account (like a log group name), put the discovery in readSteps and use a reasonable default or convention in fixSteps:
-  - CloudTrail log group: use "CloudTrail/DefaultLogGroup" (the system will resolve the real one from readSteps)
+  - CloudTrail log group: discover the trail's CloudWatch Logs log group in a read step (e.g. from the trail's CloudWatchLogsLogGroupArn) and use that exact, real log group name in fixSteps — do not invent a name
   - SNS topic: use "CompAI-CIS-Alerts" (will be created if it doesn't exist)
   - KMS keys: use "alias/aws/service-name" for AWS-managed keys
 - The finding evidence contains REAL data from the AWS account scan — use those values


### PR DESCRIPTION
## Summary

Cubic follow-up to the metric-filter work (#3050). The fix-plan prompt gave the model **two conflicting instructions** for the CloudWatch `logGroupName`:
- The new **CLOUDWATCH METRIC FILTERS** section: *"logGroupName must be the REAL CloudTrail CloudWatch Logs group name from the read step — never a placeholder."*
- The older **NO PLACEHOLDERS** section: *"CloudTrail log group: use \"CloudTrail/DefaultLogGroup\" (the system will resolve the real one from readSteps)."*

That inconsistency can produce varying `PutMetricFilter` plans.

## Why "use the real name" is correct
Nothing in code resolves the literal `"CloudTrail/DefaultLogGroup"` string (`grep` confirms it's prompt-only); real values are filled by the **refine pass** from read-step output. A metric filter must attach to the **actual** log group, so a made-up name is wrong.

## Fix
Align the older guidance with the metric-filter section: *"discover the trail's CloudWatch Logs log group in a read step (e.g. from the trail's CloudWatchLogsLogGroupArn) and use that exact, real log group name in fixSteps — do not invent a name."*

**Prompt-only, one-line change.** Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align the CloudWatch `logGroupName` guidance in the remediation prompt to always use the real log group from a read step. Removes the old "CloudTrail/DefaultLogGroup" placeholder to prevent inconsistent `PutMetricFilter` plans.

<sup>Written for commit e7af1ec0e4edc473cabffb5e9336e8fae87a47e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

