### PR TITLE
fix(cloud-security): resolve AWS check-path session in ECS, not Trigger.dev

### DIFF
--- a/apps/api/src/auth/service-token-only.guard.spec.ts
+++ b/apps/api/src/auth/service-token-only.guard.spec.ts
@@ -1,0 +1,45 @@
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { ServiceTokenOnlyGuard } from './service-token-only.guard';
+import type { AuthenticatedRequest } from './types';
+
+function contextFor(
+  request: Partial<AuthenticatedRequest>,
+): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => request as AuthenticatedRequest,
+    }),
+  } as unknown as ExecutionContext;
+}
+
+describe('ServiceTokenOnlyGuard', () => {
+  const guard = new ServiceTokenOnlyGuard();
+
+  it('allows internal service-token requests', () => {
+    expect(
+      guard.canActivate(contextFor({ isServiceToken: true })),
+    ).toBe(true);
+  });
+
+  it('rejects session requests', () => {
+    expect(() =>
+      guard.canActivate(
+        contextFor({ authType: 'session', isApiKey: false, isServiceToken: false }),
+      ),
+    ).toThrow(ForbiddenException);
+  });
+
+  it('rejects API-key requests', () => {
+    expect(() =>
+      guard.canActivate(
+        contextFor({ authType: 'api-key', isApiKey: true, isServiceToken: false }),
+      ),
+    ).toThrow(ForbiddenException);
+  });
+
+  it('rejects requests with no service-token flag set', () => {
+    expect(() => guard.canActivate(contextFor({}))).toThrow(
+      ForbiddenException,
+    );
+  });
+});

--- a/apps/api/src/auth/service-token-only.guard.ts
+++ b/apps/api/src/auth/service-token-only.guard.ts
@@ -1,0 +1,30 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { AuthenticatedRequest } from './types';
+
+/**
+ * Guard that rejects everything except internal service-token auth.
+ * Use on internal-only endpoints that return sensitive data not meant for
+ * customers (e.g., minting temporary AWS credentials for background workers).
+ *
+ * Place between HybridAuthGuard and PermissionGuard:
+ * @UseGuards(HybridAuthGuard, ServiceTokenOnlyGuard, PermissionGuard)
+ */
+@Injectable()
+export class ServiceTokenOnlyGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+
+    if (!request.isServiceToken) {
+      throw new ForbiddenException(
+        'This endpoint is only available for internal service-token requests.',
+      );
+    }
+
+    return true;
+  }
+}

--- a/apps/api/src/cloud-security/cloud-security.controller.spec.ts
+++ b/apps/api/src/cloud-security/cloud-security.controller.spec.ts
@@ -16,7 +16,10 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { HttpException, HttpStatus } from '@nestjs/common';
 
 import { CloudSecurityController } from './cloud-security.controller';
-import { CloudSecurityService } from './cloud-security.service';
+import {
+  CloudSecurityService,
+  ConnectionNotFoundError,
+} from './cloud-security.service';
 import { CloudSecurityQueryService } from './cloud-security-query.service';
 import { CloudSecurityLegacyService } from './cloud-security-legacy.service';
 import { CloudSecurityActivityService } from './cloud-security-activity.service';
@@ -29,6 +32,7 @@ import { CloudAwsScanModeService } from './aws-scan-mode.service';
 import { ActingUserResolver } from '../auth/acting-user.service';
 import { HybridAuthGuard } from '../auth/hybrid-auth.guard';
 import { PermissionGuard } from '../auth/permission.guard';
+import { ServiceTokenOnlyGuard } from '../auth/service-token-only.guard';
 import type { AuthenticatedRequest } from '../auth/types';
 
 /**
@@ -86,6 +90,8 @@ describe('CloudSecurityController — API-key mutation support', () => {
       .overrideGuard(HybridAuthGuard)
       .useValue(mockGuard)
       .overrideGuard(PermissionGuard)
+      .useValue(mockGuard)
+      .overrideGuard(ServiceTokenOnlyGuard)
       .useValue(mockGuard)
       .compile();
 
@@ -307,5 +313,90 @@ describe('CloudSecurityController — API-key mutation support', () => {
       expect((error as HttpException).getStatus()).toBe(HttpStatus.BAD_REQUEST);
       expect(exceptionService.revokeException).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('CloudSecurityController — resolveSession (internal)', () => {
+  let controller: CloudSecurityController;
+  let cloudSecurityService: { resolveAwsSession: jest.Mock };
+  const mockGuard = { canActivate: jest.fn().mockReturnValue(true) };
+
+  beforeEach(async () => {
+    cloudSecurityService = { resolveAwsSession: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CloudSecurityController],
+      providers: [
+        { provide: CloudSecurityService, useValue: cloudSecurityService },
+        { provide: CloudSecurityQueryService, useValue: {} },
+        { provide: CloudSecurityLegacyService, useValue: {} },
+        { provide: CloudSecurityActivityService, useValue: {} },
+        { provide: GCPSecurityService, useValue: {} },
+        { provide: AzureSecurityService, useValue: {} },
+        { provide: CheckDefinitionService, useValue: {} },
+        { provide: CloudExceptionService, useValue: {} },
+        { provide: CloudHistoryService, useValue: {} },
+        { provide: CloudAwsScanModeService, useValue: {} },
+        { provide: ActingUserResolver, useValue: {} },
+      ],
+    })
+      .overrideGuard(HybridAuthGuard)
+      .useValue(mockGuard)
+      .overrideGuard(PermissionGuard)
+      .useValue(mockGuard)
+      .overrideGuard(ServiceTokenOnlyGuard)
+      .useValue(mockGuard)
+      .compile();
+
+    controller = module.get(CloudSecurityController);
+    jest.clearAllMocks();
+  });
+
+  it('returns the resolved session from the service', async () => {
+    const session = {
+      ok: true,
+      session: {
+        accessKeyId: 'AKIA_TEMP',
+        secretAccessKey: 'secret',
+        sessionToken: 'token',
+      },
+    };
+    cloudSecurityService.resolveAwsSession.mockResolvedValueOnce(session);
+
+    const result = await controller.resolveSession('conn_1', 'org_1');
+
+    expect(cloudSecurityService.resolveAwsSession).toHaveBeenCalledWith(
+      'conn_1',
+      'org_1',
+    );
+    expect(result).toEqual(session);
+  });
+
+  it('passes through not_configured / assume_failed results', async () => {
+    cloudSecurityService.resolveAwsSession.mockResolvedValueOnce({
+      ok: false,
+      reason: 'assume_failed',
+      error: 'denied',
+    });
+
+    const result = await controller.resolveSession('conn_1', 'org_1');
+    expect(result).toEqual({
+      ok: false,
+      reason: 'assume_failed',
+      error: 'denied',
+    });
+  });
+
+  it('maps ConnectionNotFoundError to a 404', async () => {
+    cloudSecurityService.resolveAwsSession.mockRejectedValueOnce(
+      new ConnectionNotFoundError(),
+    );
+
+    const error = await controller
+      .resolveSession('conn_missing', 'org_1')
+      .catch((e) => e);
+
+    expect(error).toBeInstanceOf(HttpException);
+    expect((error as HttpException).getStatus()).toBe(HttpStatus.NOT_FOUND);
   });
 });

--- a/apps/api/src/cloud-security/cloud-security.controller.ts
+++ b/apps/api/src/cloud-security/cloud-security.controller.ts
@@ -17,6 +17,7 @@ import { ApiOperation } from '@nestjs/swagger';
 import { SkipThrottle } from '@nestjs/throttler';
 import { HybridAuthGuard } from '../auth/hybrid-auth.guard';
 import { PermissionGuard } from '../auth/permission.guard';
+import { ServiceTokenOnlyGuard } from '../auth/service-token-only.guard';
 import { RequirePermission } from '../auth/require-permission.decorator';
 import { OrganizationId } from '../auth/auth-context.decorator';
 import {
@@ -252,6 +253,31 @@ export class CloudSecurityController {
       organizationId,
     );
     return { data: definition };
+  }
+
+  @Post('resolve-session/:connectionId')
+  @SkipThrottle()
+  @UseGuards(HybridAuthGuard, ServiceTokenOnlyGuard, PermissionGuard)
+  @RequirePermission('integration', 'update')
+  @ApiOperation({
+    summary:
+      'Resolve short-lived AWS credentials for a connection (internal only)',
+  })
+  async resolveSession(
+    @Param('connectionId') connectionId: string,
+    @OrganizationId() organizationId: string,
+  ) {
+    try {
+      return await this.cloudSecurityService.resolveAwsSession(
+        connectionId,
+        organizationId,
+      );
+    } catch (error) {
+      if (error instanceof ConnectionNotFoundError) {
+        throw new HttpException('Connection not found', HttpStatus.NOT_FOUND);
+      }
+      throw error;
+    }
   }
 
   @Post('scan/:connectionId')

--- a/apps/api/src/cloud-security/cloud-security.service.resolve-session.spec.ts
+++ b/apps/api/src/cloud-security/cloud-security.service.resolve-session.spec.ts
@@ -1,0 +1,125 @@
+jest.mock('@db', () => ({
+  db: { integrationConnection: { findFirst: jest.fn() } },
+  Prisma: {},
+}));
+
+import { db } from '@db';
+import {
+  CloudSecurityService,
+  ConnectionNotFoundError,
+} from './cloud-security.service';
+
+type Ctor = ConstructorParameters<typeof CloudSecurityService>;
+
+const findFirst = (db as unknown as {
+  integrationConnection: { findFirst: jest.Mock };
+}).integrationConnection.findFirst;
+
+describe('CloudSecurityService.resolveAwsSession', () => {
+  let credentialVault: { getDecryptedCredentials: jest.Mock };
+  let awsService: { resolveRoleSession: jest.Mock };
+  let service: CloudSecurityService;
+
+  beforeEach(() => {
+    credentialVault = { getDecryptedCredentials: jest.fn() };
+    awsService = { resolveRoleSession: jest.fn() };
+    service = new CloudSecurityService(
+      credentialVault as unknown as Ctor[0],
+      {} as unknown as Ctor[1],
+      {} as unknown as Ctor[2],
+      awsService as unknown as Ctor[3],
+      {} as unknown as Ctor[4],
+      {} as unknown as Ctor[5],
+    );
+    jest.clearAllMocks();
+  });
+
+  it('scopes the connection lookup by organizationId (tenant isolation)', async () => {
+    findFirst.mockResolvedValueOnce(null);
+
+    await expect(
+      service.resolveAwsSession('conn_1', 'org_1'),
+    ).rejects.toBeInstanceOf(ConnectionNotFoundError);
+
+    expect(findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'conn_1', organizationId: 'org_1', status: 'active' },
+      }),
+    );
+  });
+
+  it('returns not_configured for a non-AWS provider (never assumes)', async () => {
+    findFirst.mockResolvedValueOnce({ provider: { slug: 'gcp' } });
+
+    const result = await service.resolveAwsSession('conn_1', 'org_1');
+
+    expect(result).toEqual({ ok: false, reason: 'not_configured' });
+    expect(awsService.resolveRoleSession).not.toHaveBeenCalled();
+  });
+
+  it('returns not_configured when roleArn/externalId are missing', async () => {
+    findFirst.mockResolvedValueOnce({
+      provider: { slug: 'aws' },
+      variables: {},
+    });
+    credentialVault.getDecryptedCredentials.mockResolvedValueOnce({
+      externalId: 'eid', // roleArn missing
+    });
+
+    const result = await service.resolveAwsSession('conn_1', 'org_1');
+
+    expect(result).toEqual({ ok: false, reason: 'not_configured' });
+    expect(awsService.resolveRoleSession).not.toHaveBeenCalled();
+  });
+
+  it('returns the resolved session on success', async () => {
+    findFirst.mockResolvedValueOnce({
+      provider: { slug: 'aws' },
+      variables: { regions: ['us-east-1'] },
+    });
+    credentialVault.getDecryptedCredentials.mockResolvedValueOnce({
+      roleArn: 'arn:aws:iam::123456789012:role/x',
+      externalId: 'eid',
+      regions: ['us-east-1'],
+    });
+    awsService.resolveRoleSession.mockResolvedValueOnce({
+      accessKeyId: 'AKIA_TEMP',
+      secretAccessKey: 'secret',
+      sessionToken: 'token',
+    });
+
+    const result = await service.resolveAwsSession('conn_1', 'org_1');
+
+    expect(result).toEqual({
+      ok: true,
+      session: {
+        accessKeyId: 'AKIA_TEMP',
+        secretAccessKey: 'secret',
+        sessionToken: 'token',
+      },
+    });
+  });
+
+  it('returns assume_failed with the real reason when the assume throws', async () => {
+    findFirst.mockResolvedValueOnce({
+      provider: { slug: 'aws' },
+      variables: {},
+    });
+    credentialVault.getDecryptedCredentials.mockResolvedValueOnce({
+      roleArn: 'arn:aws:iam::123456789012:role/x',
+      externalId: 'eid',
+      regions: ['us-east-1'],
+    });
+    awsService.resolveRoleSession.mockRejectedValueOnce(
+      new Error('not authorized to perform sts:AssumeRole'),
+    );
+
+    const result = await service.resolveAwsSession('conn_1', 'org_1');
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'assume_failed',
+      error: 'not authorized to perform sts:AssumeRole',
+    });
+  });
+});

--- a/apps/api/src/cloud-security/cloud-security.service.ts
+++ b/apps/api/src/cloud-security/cloud-security.service.ts
@@ -32,6 +32,23 @@ export interface ScanResult {
   error?: string;
 }
 
+/**
+ * Outcome of resolving short-lived AWS session credentials for a connection.
+ * `not_configured` = nothing to do (check should no-op); `assume_failed` = the
+ * assume genuinely failed and the check should surface a finding.
+ */
+export type ResolveAwsSessionResult =
+  | {
+      ok: true;
+      session: {
+        accessKeyId: string;
+        secretAccessKey: string;
+        sessionToken: string;
+      };
+    }
+  | { ok: false; reason: 'not_configured' }
+  | { ok: false; reason: 'assume_failed'; error: string };
+
 export class ConnectionNotFoundError extends Error {
   constructor() {
     super('Connection not found');
@@ -388,6 +405,59 @@ export class CloudSecurityService {
         findings: [],
         scannedAt: new Date().toISOString(),
         error: errorMessage,
+      };
+    }
+  }
+
+  /**
+   * Resolve short-lived, customer-scoped AWS credentials for a connection's
+   * IAM role — performed here in ECS, which holds the roleAssumer task role and
+   * the SECURITY_HUB_ROLE_ASSUMER_ARN env.
+   *
+   * The Cloud Tests CHECK path runs in the Trigger.dev runtime, which has no
+   * base AWS credentials or roleAssumer ARN, so it cannot assume the
+   * cross-account role itself. It calls this (via the internal `resolve-session`
+   * endpoint) and injects the returned temp creds into the check credentials,
+   * so the cross-tenant master credential never leaves ECS.
+   *
+   * Org-scoped: a service-token caller cannot resolve another org's connection.
+   */
+  async resolveAwsSession(
+    connectionId: string,
+    organizationId: string,
+  ): Promise<ResolveAwsSessionResult> {
+    const connection = await db.integrationConnection.findFirst({
+      where: { id: connectionId, organizationId, status: 'active' },
+      include: { provider: true },
+    });
+
+    if (!connection) {
+      throw new ConnectionNotFoundError();
+    }
+
+    if (connection.provider.slug !== 'aws') {
+      return { ok: false, reason: 'not_configured' };
+    }
+
+    const decrypted =
+      await this.credentialVaultService.getDecryptedCredentials(connectionId);
+    if (!decrypted || !(decrypted.roleArn && decrypted.externalId)) {
+      return { ok: false, reason: 'not_configured' };
+    }
+
+    const variables = (connection.variables as Record<string, unknown>) || {};
+
+    try {
+      const session = await this.awsService.resolveRoleSession(
+        decrypted,
+        variables,
+      );
+      return { ok: true, session };
+    } catch (error) {
+      return {
+        ok: false,
+        reason: 'assume_failed',
+        error: error instanceof Error ? error.message : String(error),
       };
     }
   }

--- a/apps/api/src/cloud-security/providers/aws-security.service.ts
+++ b/apps/api/src/cloud-security/providers/aws-security.service.ts
@@ -253,6 +253,60 @@ export class AWSSecurityService {
   }
 
   /**
+   * Resolve short-lived, customer-scoped AWS credentials for a role-auth
+   * connection, using the SAME partition/region normalization and two-hop
+   * assume as a scan. Returns ONLY the temporary session credentials.
+   *
+   * This exists so the Cloud Tests CHECK path can perform the cross-account
+   * assume in ECS (which holds the roleAssumer task role + env), instead of in
+   * the Trigger.dev runtime where no base AWS credentials or roleAssumer ARN
+   * are available. Throws when the connection is not role-auth or the assume
+   * fails — the caller maps those to "not_configured" / "assume_failed".
+   */
+  async resolveRoleSession(
+    credentials: Record<string, unknown>,
+    variables: Record<string, unknown>,
+  ): Promise<{
+    accessKeyId: string;
+    secretAccessKey: string;
+    sessionToken: string;
+  }> {
+    const isRoleAuth = Boolean(credentials.roleArn && credentials.externalId);
+    if (!isRoleAuth) {
+      throw new Error(
+        'AWS connection is not configured for IAM role access (roleArn/externalId missing).',
+      );
+    }
+
+    const partition = normalizeAwsPartition(
+      credentials.awsType ?? variables.awsType,
+    );
+    const configuredRegions = this.getConfiguredRegions(
+      credentials,
+      variables,
+      partition,
+    );
+
+    const session = await this.resolveRoleCredentials({
+      roleArn: credentials.roleArn as string,
+      externalId: credentials.externalId as string,
+      partition,
+      regions: configuredRegions,
+      primaryRegion: configuredRegions[0],
+    });
+
+    if (!session.sessionToken) {
+      throw new Error('Assumed role returned no session token.');
+    }
+
+    return {
+      accessKeyId: session.accessKeyId,
+      secretAccessKey: session.secretAccessKey,
+      sessionToken: session.sessionToken,
+    };
+  }
+
+  /**
    * Today's default scan engine. Runs each registered service adapter
    * (global once, regional per region) and aggregates the findings.
    * Behavior is byte-for-byte identical to the pre-mode implementation —

--- a/apps/api/src/trigger/integration-platform/checks-aws-session.ts
+++ b/apps/api/src/trigger/integration-platform/checks-aws-session.ts
@@ -1,0 +1,125 @@
+import { logger } from '@trigger.dev/sdk';
+import type { IntegrationCredentialValues } from './ensure-valid-credentials';
+
+const RESOLVE_SESSION_TIMEOUT_MS = 30_000;
+
+type ResolveSessionResponse =
+  | {
+      ok: true;
+      session: {
+        accessKeyId: string;
+        secretAccessKey: string;
+        sessionToken: string;
+      };
+    }
+  | { ok: false; reason: 'not_configured' }
+  | { ok: false; reason: 'assume_failed'; error?: string };
+
+/**
+ * Credential keys injected by {@link injectAwsResolvedSession} and consumed by
+ * the AWS manifest checks (`assumeAwsSession` in the integration-platform
+ * package). Underscore-prefixed so they never collide with real AWS connection
+ * credential fields (roleArn, externalId, regions, awsType, remediationRoleArn).
+ */
+export const RESOLVED_AWS_SESSION_KEYS = {
+  accessKeyId: '__resolvedAccessKeyId',
+  secretAccessKey: '__resolvedSecretAccessKey',
+  sessionToken: '__resolvedSessionToken',
+  error: '__resolvedSessionError',
+} as const;
+
+/**
+ * For AWS connections, resolve the cross-account session in ECS (which holds the
+ * roleAssumer task role + `SECURITY_HUB_ROLE_ASSUMER_ARN`) and inject the
+ * resulting short-lived, customer-scoped credentials into `credentials`.
+ *
+ * Why: the Cloud Tests CHECK path runs inside the Trigger.dev runtime, which has
+ * no base AWS credentials or roleAssumer ARN, so it cannot perform the two-hop
+ * assume itself. Resolving in ECS keeps the cross-tenant master credential out
+ * of Trigger.dev; the check just consumes the temp creds.
+ *
+ * On a genuine assume failure (or any transport error) an error marker is
+ * injected so the AWS check surfaces a real "Could not assume AWS role" finding
+ * with the true reason, rather than silently failing or falsely passing.
+ * Non-AWS providers and not-configured connections are left untouched.
+ *
+ * Mutates and returns the same credentials object.
+ */
+export async function injectAwsResolvedSession(params: {
+  credentials: IntegrationCredentialValues;
+  apiUrl: string;
+  connectionId: string;
+  organizationId: string;
+  providerSlug: string;
+}): Promise<IntegrationCredentialValues> {
+  const { credentials, apiUrl, connectionId, organizationId, providerSlug } =
+    params;
+
+  if (providerSlug !== 'aws') return credentials;
+
+  const serviceToken = process.env.SERVICE_TOKEN_TRIGGER;
+  if (!serviceToken) {
+    credentials[RESOLVED_AWS_SESSION_KEYS.error] =
+      'SERVICE_TOKEN_TRIGGER is not configured';
+    return credentials;
+  }
+
+  const abortController = new AbortController();
+  const timeoutId = setTimeout(
+    () => abortController.abort(),
+    RESOLVE_SESSION_TIMEOUT_MS,
+  );
+
+  try {
+    const response = await fetch(
+      `${apiUrl}/v1/cloud-security/resolve-session/${connectionId}`,
+      {
+        method: 'POST',
+        signal: abortController.signal,
+        headers: {
+          'Content-Type': 'application/json',
+          'x-service-token': serviceToken,
+          'x-organization-id': organizationId,
+        },
+      },
+    );
+
+    if (!response.ok) {
+      credentials[RESOLVED_AWS_SESSION_KEYS.error] =
+        `Could not resolve AWS session (status ${response.status}).`;
+      return credentials;
+    }
+
+    const result = (await response.json()) as ResolveSessionResponse;
+
+    if (result.ok) {
+      credentials[RESOLVED_AWS_SESSION_KEYS.accessKeyId] =
+        result.session.accessKeyId;
+      credentials[RESOLVED_AWS_SESSION_KEYS.secretAccessKey] =
+        result.session.secretAccessKey;
+      credentials[RESOLVED_AWS_SESSION_KEYS.sessionToken] =
+        result.session.sessionToken;
+      logger.info('Resolved AWS session via ECS for connection', {
+        connectionId,
+      });
+      return credentials;
+    }
+
+    if (result.reason === 'assume_failed') {
+      credentials[RESOLVED_AWS_SESSION_KEYS.error] =
+        result.error || 'The cross-account IAM role could not be assumed.';
+    }
+    // not_configured -> inject nothing; the check no-ops naturally.
+    return credentials;
+  } catch (error) {
+    credentials[RESOLVED_AWS_SESSION_KEYS.error] = abortController.signal
+      .aborted
+      ? `Timed out resolving AWS session after ${RESOLVE_SESSION_TIMEOUT_MS}ms.`
+      : error instanceof Error
+        ? error.message
+        : String(error);
+    return credentials;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/apps/api/src/trigger/integration-platform/run-connection-checks.ts
+++ b/apps/api/src/trigger/integration-platform/run-connection-checks.ts
@@ -6,6 +6,7 @@ import {
   requestValidCredentials,
   type IntegrationCredentialValues,
 } from './ensure-valid-credentials';
+import { injectAwsResolvedSession } from './checks-aws-session';
 
 /**
  * Trigger task that runs all checks for a connection.
@@ -146,6 +147,17 @@ export const runConnectionChecks = task({
       );
       return { success: false, error: 'No credentials found' };
     }
+
+    // For AWS, resolve the cross-account session in ECS and inject the temp
+    // creds — the checks run in the Trigger.dev runtime, which cannot assume the
+    // role itself (no base creds / roleAssumer ARN there).
+    credentials = await injectAwsResolvedSession({
+      credentials,
+      apiUrl,
+      connectionId,
+      organizationId,
+      providerSlug,
+    });
 
     const variables =
       (connection.variables as Record<

--- a/apps/api/src/trigger/integration-platform/run-task-integration-checks.ts
+++ b/apps/api/src/trigger/integration-platform/run-task-integration-checks.ts
@@ -10,6 +10,7 @@ import {
   requestValidCredentials,
   type IntegrationCredentialValues,
 } from './ensure-valid-credentials';
+import { injectAwsResolvedSession } from './checks-aws-session';
 
 /**
  * Send email notifications for task status change
@@ -291,6 +292,17 @@ export const runTaskIntegrationChecks = task({
         error: 'No credentials found for custom integration',
       };
     }
+
+    // For AWS, resolve the cross-account session in ECS and inject the temp
+    // creds — the checks run in the Trigger.dev runtime, which cannot assume the
+    // role itself (no base creds / roleAssumer ARN there).
+    credentials = await injectAwsResolvedSession({
+      credentials,
+      apiUrl,
+      connectionId,
+      organizationId,
+      providerSlug,
+    });
 
     const variables =
       (connection.variables as Record<

--- a/packages/integration-platform/src/manifests/aws/checks/__tests__/aws-checks.test.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/__tests__/aws-checks.test.ts
@@ -14,9 +14,77 @@ import {
   evaluateRdsEncryption,
 } from '../rds';
 import { evaluateS3Encryption, evaluateS3PublicAccess } from '../s3';
-import { resolveAwsCredentialInputs } from '../shared';
+import { assumeAwsSession, resolveAwsCredentialInputs } from '../shared';
 
 const kinds = (os: { kind: string }[]) => os.map((o) => o.kind);
+
+// Minimal CheckContext stub — assumeAwsSession only reads ctx.credentials.
+const ctxWith = (credentials: Record<string, unknown>) =>
+  ({ credentials }) as unknown as Parameters<typeof assumeAwsSession>[0];
+
+describe('assumeAwsSession — ECS-resolved session injection (CHECK path)', () => {
+  const base = {
+    roleArn: 'arn:aws:iam::123456789012:role/x',
+    externalId: 'eid',
+    regions: ['us-east-1', 'eu-west-1'],
+  };
+
+  it('uses injected ECS-resolved credentials directly (no STS, no env needed)', async () => {
+    const session = await assumeAwsSession(
+      ctxWith({
+        ...base,
+        __resolvedAccessKeyId: 'AKIA_TEMP',
+        __resolvedSecretAccessKey: 'secret_temp',
+        __resolvedSessionToken: 'token_temp',
+      }),
+    );
+    expect(session).toEqual({
+      credentials: {
+        accessKeyId: 'AKIA_TEMP',
+        secretAccessKey: 'secret_temp',
+        sessionToken: 'token_temp',
+      },
+      regions: ['us-east-1', 'eu-west-1'],
+    });
+  });
+
+  it('throws the injected error so the caller surfaces the real reason', async () => {
+    await expect(
+      assumeAwsSession(
+        ctxWith({
+          ...base,
+          __resolvedSessionError: 'The cross-account IAM role could not be assumed.',
+        }),
+      ),
+    ).rejects.toThrow('The cross-account IAM role could not be assumed.');
+  });
+
+  it('returns null for a not-configured connection even if creds are injected', async () => {
+    const session = await assumeAwsSession(
+      ctxWith({
+        externalId: 'eid', // roleArn missing -> not configured
+        __resolvedAccessKeyId: 'AKIA_TEMP',
+        __resolvedSecretAccessKey: 'secret_temp',
+        __resolvedSessionToken: 'token_temp',
+      }),
+    );
+    expect(session).toBeNull();
+  });
+
+  it('falls back to the in-runtime two-hop when nothing is injected (ECS/dev path)', async () => {
+    const prev = process.env.SECURITY_HUB_ROLE_ASSUMER_ARN;
+    delete process.env.SECURITY_HUB_ROLE_ASSUMER_ARN;
+    try {
+      // No injected creds + no roleAssumer env -> the fallback runs and fails
+      // fast (before any STS call), proving the original path is preserved.
+      await expect(assumeAwsSession(ctxWith(base))).rejects.toThrow(
+        /SECURITY_HUB_ROLE_ASSUMER_ARN/,
+      );
+    } finally {
+      if (prev !== undefined) process.env.SECURITY_HUB_ROLE_ASSUMER_ARN = prev;
+    }
+  });
+});
 
 describe('AWS credential resolution (regions shape)', () => {
   const base = { roleArn: 'arn:aws:iam::123456789012:role/x', externalId: 'eid' };

--- a/packages/integration-platform/src/manifests/aws/checks/shared.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/shared.ts
@@ -47,6 +47,43 @@ export function resolveAwsCredentialInputs(
   return { roleArn, externalId, regions };
 }
 
+/**
+ * Short-lived AWS session credentials (or an error) injected into the connection
+ * credentials by the Cloud Tests CHECK runner (apps/api `checks-aws-session.ts`)
+ * when the cross-account assume was performed in ECS. The underscore-prefixed
+ * keys never collide with real connection fields. When present, the check uses
+ * these directly instead of assuming the role itself — it runs in the Trigger.dev
+ * runtime, which has no base AWS credentials or roleAssumer ARN.
+ */
+function readInjectedAwsSession(
+  credentials: Record<string, unknown>,
+):
+  | {
+      credentials: {
+        accessKeyId: string;
+        secretAccessKey: string;
+        sessionToken: string;
+      };
+    }
+  | { error: string }
+  | null {
+  const error = credentials.__resolvedSessionError;
+  if (typeof error === 'string' && error.length > 0) {
+    return { error };
+  }
+  const accessKeyId = credentials.__resolvedAccessKeyId;
+  const secretAccessKey = credentials.__resolvedSecretAccessKey;
+  const sessionToken = credentials.__resolvedSessionToken;
+  if (
+    typeof accessKeyId === 'string' &&
+    typeof secretAccessKey === 'string' &&
+    typeof sessionToken === 'string'
+  ) {
+    return { credentials: { accessKeyId, secretAccessKey, sessionToken } };
+  }
+  return null;
+}
+
 type AwsPartition = 'aws' | 'aws-us-gov';
 
 function awsPartitionForRegion(region: string): AwsPartition {
@@ -94,6 +131,18 @@ export async function assumeAwsSession(
   );
   if (!inputs) return null;
   const { roleArn, externalId, regions } = inputs;
+
+  // If the CHECK runner already resolved a session in ECS (the cross-account
+  // assume cannot run in the Trigger.dev runtime, which lacks base AWS creds and
+  // the roleAssumer ARN), use it directly. An injected error surfaces the real
+  // failure reason via the caller's "Could not assume AWS role" finding.
+  const injected = readInjectedAwsSession(
+    ctx.credentials as Record<string, unknown>,
+  );
+  if (injected) {
+    if ('error' in injected) throw new Error(injected.error);
+    return { credentials: injected.credentials, regions };
+  }
 
   // IAM is global — assume once in the first region; the creds work everywhere.
   const region = regions[0];


### PR DESCRIPTION
## Problem

Customers connecting AWS see a customer-visible finding **"Could not assume AWS role"** even when their IAM role and trust policy are correct (reported by Ivan; likely affects **every** AWS connection's checks).

Root cause, verified end-to-end:

- **Scan path** (`run-cloud-security-scan.ts`) doesn't assume AWS itself — it `fetch`es back to the **ECS** API (`POST /v1/cloud-security/scan/:connectionId`). The assume runs in ECS, which has the task role + `SECURITY_HUB_ROLE_ASSUMER_ARN` (from Secrets Manager). ✅ Works.
- **Check path** (`run-connection-checks.ts`, `run-task-integration-checks.ts`) calls `runAllChecks(...)` **directly inside the Trigger.dev runtime**, where the AWS checks do the two-hop STS assume via `assumeAwsSession` (`shared.ts`). That runtime has **no** `SECURITY_HUB_ROLE_ASSUMER_ARN` and **no** base AWS credentials (only `APP_AWS_*`, which the SDK default chain ignores) → throws `Missing SECURITY_HUB_ROLE_ASSUMER_ARN` → `resolveAwsSessionOrFail` emits "Could not assume AWS role".

The AWS Secrets Manager values are correct — they just feed **ECS**, not Trigger.dev. Putting the cross-tenant master credential into Trigger.dev would work but is a credential-hygiene risk (a static key that can pivot into every customer account, living in a third-party SaaS).

## Fix

Keep the check running in Trigger.dev, but move the **credential resolution** to ECS — mirroring the proven scan-path pattern — so only short-lived, read-only, single-customer temp creds ever reach Trigger.dev.

- **New internal endpoint** `POST /v1/cloud-security/resolve-session/:connectionId`, guarded by a new `ServiceTokenOnlyGuard` (callable only by the internal Trigger worker, never customers). Org-scoped.
- **`AWSSecurityService.resolveRoleSession`** reuses the scan path's partition/region normalization (`getConfiguredRegions` + `resolveRoleCredentials`) and returns only the temp session creds — so GovCloud and region-mismatched connections are handled correctly.
- **`CloudSecurityService.resolveAwsSession`** org-scopes the connection, decrypts, and maps outcomes to `not_configured` / `assume_failed` / `ok`.
- **`injectAwsResolvedSession`** (shared by both check tasks) calls the endpoint for AWS connections and injects the temp creds (or a real error reason) into the check credentials.
- **`assumeAwsSession`** (`shared.ts`) uses the injected creds directly when present, throws the injected error otherwise, and keeps the existing in-runtime two-hop as a fallback for the **ECS controller** callers and local dev.

Result: the cross-tenant roleAssumer credential never leaves ECS, and no AWS secrets need to be added to Trigger.dev.

## Tests

- `aws-checks.test.ts` (bun): injected creds → used directly (no STS, no env); injected error → thrown; not-configured → null; fallback preserved.
- `cloud-security.service.resolve-session.spec.ts` (jest): tenant org-scoping, non-AWS → `not_configured`, missing roleArn → `not_configured`, success, assume-failure → `assume_failed`.
- `cloud-security.controller.spec.ts`: resolveSession pass-through + 404 mapping.
- `service-token-only.guard.spec.ts`: allows service token, rejects session/API-key.

All new tests pass; changed packages compile clean; full apps/api suite green except 3 pre-existing/environmental suites unrelated to this change (remote-Postgres TLS guard in a fresh worktree; a pre-existing `auth.server.ts` CORS/`domainVerified` test).

> Not live-verified against a real AWS account yet — the proof is an end-to-end run post-deploy (connect AWS → confirm the "Could not assume AWS role" finding clears with no AWS secrets in Trigger.dev).

Independent of #3055 (transient-retry); the two compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false “Could not assume AWS role” findings by resolving AWS check-path sessions in ECS instead of Trigger.dev, keeping cross-tenant credentials in ECS and clearing errors without adding secrets to `Trigger.dev`.

- **Bug Fixes**
  - Added internal `POST /v1/cloud-security/resolve-session/:connectionId` (org-scoped, behind `HybridAuthGuard` + `ServiceTokenOnlyGuard` + permissions) to mint short-lived AWS creds; returns 404 when the connection is missing.
  - Implemented `AWSSecurityService.resolveRoleSession` to reuse scan normalization and two-hop assume; returns only temp creds.
  - `CloudSecurityService.resolveAwsSession` maps outcomes to `ok` / `not_configured` / `assume_failed`.
  - Trigger check tasks call the endpoint and inject the session via `injectAwsResolvedSession`; `assumeAwsSession` uses injected creds or throws the injected error; falls back to in-runtime assume for ECS/local dev.

- **Migration**
  - Set `SERVICE_TOKEN_TRIGGER` for the Trigger worker so it can call the internal resolve-session endpoint.

<sup>Written for commit c5d103252edc4a7e0b7d86795e39d63e9bb351fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

