### PR TITLE
fix(cloud-tests): scroll connection-settings account tabs when they overflow

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/cloud-tests/components/CloudSettingsModal.tsx
+++ b/apps/app/src/app/(app)/[orgId]/cloud-tests/components/CloudSettingsModal.tsx
@@ -121,13 +121,20 @@ export function CloudSettingsModal({
         {/* Provider selector (if multiple) */}
         {connectedProviders.length > 1 && (
           <Tabs value={activeProvider} onValueChange={setActiveProvider}>
-            <TabsList variant="default">
-              {connectedProviders.map((p) => (
-                <TabsTrigger key={p.connectionId} value={p.connectionId}>
-                  {p.name}
-                </TabsTrigger>
-              ))}
-            </TabsList>
+            {/* Scroll the account strip horizontally so connections beyond the
+                modal width stay reachable. TabsList is `w-fit`, so without a
+                width-constrained scroll container it overflows the dialog and
+                the extra accounts get clipped (the modal has overflow-hidden).
+                TabsList doesn't accept className, hence the wrapper. */}
+            <div className="w-full overflow-x-auto">
+              <TabsList variant="default">
+                {connectedProviders.map((p) => (
+                  <TabsTrigger key={p.connectionId} value={p.connectionId}>
+                    {p.name}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+            </div>
           </Tabs>
         )}
 


### PR DESCRIPTION
## Problem

In the Cloud Tests **Connection Settings** modal, each connected account is a tab. With more than ~3 accounts the tab strip grows wider than the dialog and gets **clipped** (the modal is `overflow-hidden`), so the extra accounts are **unreachable** — a customer with 6 AWS accounts could only see/select the first few.

## Cause

The account strip uses the design-system `<TabsList>`, which is `inline-flex w-fit`. It already carries `overflow-x-auto`, but that never kicks in: `w-fit` sizes it to its content, so it overflows its *parent* (the dialog) instead of scrolling *within itself*. And `TabsList` doesn't accept `className`, so it can't be constrained directly.

## Fix

Wrap `<TabsList>` in a width-constrained scroll container (`<div className="w-full overflow-x-auto">`) so the strip scrolls horizontally and every account stays reachable. Purely presentational — no DS internals or imports changed.

```diff
 <Tabs value={activeProvider} onValueChange={setActiveProvider}>
-  <TabsList variant="default">
-    {connectedProviders.map((p) => (...))}
-  </TabsList>
+  <div className="w-full overflow-x-auto">
+    <TabsList variant="default">
+      {connectedProviders.map((p) => (...))}
+    </TabsList>
+  </div>
 </Tabs>
```

## Verification

- `CloudSettingsModal.tsx` typechecks clean (the only app-typecheck failures are pre-existing/unrelated: a `better-auth` nested-`node_modules` artifact + two unrelated test files).
- DS migration audit: change adds no `@trycompai/ui` / `lucide-react` imports. (The file's pre-existing `@trycompai/ui/dialog` import is left as-is — out of scope for this fix.)
- Behavior: with many accounts the tab strip now scrolls horizontally; all accounts selectable. Single/few-account layout unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Connection Settings account tabs scroll horizontally when they overflow, so all connected accounts remain selectable in the Cloud Tests modal. Fixes clipped tabs when there are many accounts.

- **Bug Fixes**
  - Wrap the tab list in a `div` with `w-full overflow-x-auto` to constrain width and enable horizontal scrolling, avoiding clipping from the dialog’s `overflow-hidden`. Presentational change only; behavior for few accounts is unchanged.

<sup>Written for commit 75f836006744adfa8aa2f7a0414dfec696c6fde0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

