### PR TITLE
fix(cloud-security): resolve the real CloudTrail log group for CloudWatch metric-filter auto-fix

### DIFF
--- a/apps/api/src/cloud-security/ai-remediation.prompt.ts
+++ b/apps/api/src/cloud-security/ai-remediation.prompt.ts
@@ -290,7 +290,7 @@ NEVER omit AWSServiceName, leave it as null, or use a placeholder string.
 - NEVER use placeholder values like "{{variable}}", "<PLACEHOLDER>", or template syntax
 - ALWAYS use concrete values in fix step params
 - If a value depends on the account (like a log group name), put the discovery in readSteps and use a reasonable default or convention in fixSteps:
-  - CloudTrail log group: discover the trail's CloudWatch Logs log group in a read step (e.g. from the trail's CloudWatchLogsLogGroupArn) and use that exact, real log group name in fixSteps — do not invent a name
+  - CloudTrail log group: the finding evidence provides the real log group as "cloudWatchLogGroupName" — use that exact value for logGroupName in fixSteps. Only if it is absent, discover it in a read step (from the trail's CloudWatchLogsLogGroupArn) and use that exact, real name. Never invent a name and never use a placeholder like "CloudTrail/DefaultLogGroup"
   - SNS topic: use "CompAI-CIS-Alerts" (will be created if it doesn't exist)
   - KMS keys: use "alias/aws/service-name" for AWS-managed keys
 - The finding evidence contains REAL data from the AWS account scan — use those values

--- a/apps/api/src/cloud-security/metric-filter-loggroup.spec.ts
+++ b/apps/api/src/cloud-security/metric-filter-loggroup.spec.ts
@@ -1,0 +1,56 @@
+import { applyResolvedMetricFilterLogGroup } from './metric-filter-loggroup';
+import type { AwsCommandStep } from './ai-remediation.prompt';
+
+const putMetricFilterStep = (params: Record<string, unknown>): AwsCommandStep => ({
+  service: 'cloudwatch-logs',
+  command: 'PutMetricFilterCommand',
+  params,
+  purpose: 'create metric filter',
+});
+
+describe('applyResolvedMetricFilterLogGroup', () => {
+  it('pins the trail log group from cloudWatchLogGroupName (missing-filter case)', () => {
+    const steps = [putMetricFilterStep({ logGroupName: '', filterName: 'f' })];
+    applyResolvedMetricFilterLogGroup(steps, {
+      cloudWatchLogGroupName: 'my-ct-logs',
+    });
+    expect(steps[0].params.logGroupName).toBe('my-ct-logs');
+  });
+
+  it('uses the existing filter log group (update case) when cloudWatchLogGroupName is absent', () => {
+    const steps = [putMetricFilterStep({ logGroupName: 'wrong', filterName: 'f' })];
+    applyResolvedMetricFilterLogGroup(steps, { logGroupName: 'existing-lg' });
+    expect(steps[0].params.logGroupName).toBe('existing-lg');
+  });
+
+  it('overwrites a wrong/placeholder value the AI produced', () => {
+    const steps = [
+      putMetricFilterStep({ logGroupName: 'CloudTrail/DefaultLogGroup' }),
+    ];
+    applyResolvedMetricFilterLogGroup(steps, {
+      cloudWatchLogGroupName: 'real-lg',
+    });
+    expect(steps[0].params.logGroupName).toBe('real-lg');
+  });
+
+  it('only touches PutMetricFilter steps', () => {
+    const other: AwsCommandStep = {
+      service: 'sns',
+      command: 'CreateTopicCommand',
+      params: { Name: 'compai-cis-alerts' },
+      purpose: 'create topic',
+    };
+    const steps = [other, putMetricFilterStep({ logGroupName: '' })];
+    applyResolvedMetricFilterLogGroup(steps, {
+      cloudWatchLogGroupName: 'my-ct-logs',
+    });
+    expect(steps[0].params).toEqual({ Name: 'compai-cis-alerts' }); // untouched
+    expect(steps[1].params.logGroupName).toBe('my-ct-logs');
+  });
+
+  it('is a no-op when no log group was resolved (e.g. DescribeTrails denied)', () => {
+    const steps = [putMetricFilterStep({ logGroupName: '' })];
+    applyResolvedMetricFilterLogGroup(steps, { keywords: ['Root'] });
+    expect(steps[0].params.logGroupName).toBe('');
+  });
+});

--- a/apps/api/src/cloud-security/metric-filter-loggroup.ts
+++ b/apps/api/src/cloud-security/metric-filter-loggroup.ts
@@ -1,0 +1,38 @@
+import type { AwsCommandStep } from './ai-remediation.prompt';
+
+/**
+ * Force the real CloudTrail log group onto every PutMetricFilter fix step.
+ *
+ * PutMetricFilter cannot work without the exact CloudWatch Logs log group, and
+ * the AI must never be the source of truth for it (it guessed and failed before,
+ * surfacing "could not determine which CloudTrail log group..."). The scan
+ * resolves the real log group deterministically and carries it in the finding
+ * evidence — `cloudWatchLogGroupName` for a missing filter, `logGroupName` for an
+ * existing-filter update — so we overwrite the step's logGroupName from evidence,
+ * guaranteeing the executed value is correct regardless of what the model
+ * produced. No-op for any non-PutMetricFilter step or when no log group was
+ * resolved (e.g. DescribeTrails was denied at scan time).
+ */
+export function applyResolvedMetricFilterLogGroup(
+  steps: AwsCommandStep[],
+  evidence: Record<string, unknown>,
+): void {
+  const fromName =
+    typeof evidence.cloudWatchLogGroupName === 'string' &&
+    evidence.cloudWatchLogGroupName.trim().length > 0
+      ? evidence.cloudWatchLogGroupName
+      : null;
+  const fromExisting =
+    typeof evidence.logGroupName === 'string' &&
+    evidence.logGroupName.trim().length > 0
+      ? evidence.logGroupName
+      : null;
+  const resolved = fromName ?? fromExisting;
+  if (!resolved) return;
+
+  for (const step of steps) {
+    if (step.command !== 'PutMetricFilterCommand') continue;
+    if (!step.params || typeof step.params !== 'object') continue;
+    (step.params as Record<string, unknown>).logGroupName = resolved;
+  }
+}

--- a/apps/api/src/cloud-security/providers/aws/cloudwatch.adapter.spec.ts
+++ b/apps/api/src/cloud-security/providers/aws/cloudwatch.adapter.spec.ts
@@ -1,0 +1,157 @@
+const mockTrailSend = jest.fn();
+const mockLogsSend = jest.fn();
+const mockCwSend = jest.fn();
+
+jest.mock('@aws-sdk/client-cloudtrail', () => ({
+  CloudTrailClient: jest.fn(() => ({ send: mockTrailSend })),
+  DescribeTrailsCommand: jest.fn((input: unknown) => ({
+    _cmd: 'DescribeTrails',
+    input,
+  })),
+}));
+jest.mock('@aws-sdk/client-cloudwatch-logs', () => ({
+  CloudWatchLogsClient: jest.fn(() => ({ send: mockLogsSend })),
+  DescribeMetricFiltersCommand: jest.fn((input: unknown) => ({
+    _cmd: 'DescribeMetricFilters',
+    input,
+  })),
+}));
+jest.mock('@aws-sdk/client-cloudwatch', () => ({
+  CloudWatchClient: jest.fn(() => ({ send: mockCwSend })),
+  DescribeAlarmsForMetricCommand: jest.fn((input: unknown) => ({
+    _cmd: 'DescribeAlarmsForMetric',
+    input,
+  })),
+}));
+
+import { CloudWatchAdapter, logGroupNameFromArn } from './cloudwatch.adapter';
+
+const CREDS = {
+  accessKeyId: 'AKIA',
+  secretAccessKey: 'secret',
+  sessionToken: 'token',
+};
+
+const scan = () =>
+  new CloudWatchAdapter().scan({ credentials: CREDS, region: 'us-east-1' });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCwSend.mockResolvedValue({ MetricAlarms: [] });
+});
+
+describe('logGroupNameFromArn', () => {
+  it('derives the bare name and strips the trailing :*', () => {
+    expect(
+      logGroupNameFromArn(
+        'arn:aws:logs:us-east-1:123456789012:log-group:aws-cloudtrail-logs-xyz:*',
+      ),
+    ).toBe('aws-cloudtrail-logs-xyz');
+  });
+
+  it('handles an ARN without a trailing :*', () => {
+    expect(
+      logGroupNameFromArn('arn:aws:logs:us-east-1:123:log-group:my-lg'),
+    ).toBe('my-lg');
+  });
+
+  it('handles the GovCloud partition', () => {
+    expect(
+      logGroupNameFromArn(
+        'arn:aws-us-gov:logs:us-gov-west-1:123:log-group:ct-logs:*',
+      ),
+    ).toBe('ct-logs');
+  });
+
+  it('returns null for a missing or malformed ARN', () => {
+    expect(logGroupNameFromArn(undefined)).toBeNull();
+    expect(logGroupNameFromArn('not-an-arn')).toBeNull();
+  });
+});
+
+describe('CloudWatchAdapter — CloudTrail log group resolution', () => {
+  it('injects the real log group name into the metric-filter-missing finding (the customer bug)', async () => {
+    mockTrailSend.mockResolvedValue({
+      trailList: [
+        {
+          Name: 'main',
+          CloudWatchLogsLogGroupArn:
+            'arn:aws:logs:us-east-1:123456789012:log-group:my-ct-logs:*',
+        },
+      ],
+    });
+    mockLogsSend.mockResolvedValue({ metricFilters: [] }); // nothing configured
+
+    const findings = await scan();
+    const missing = findings.find((f) =>
+      f.title.includes('metric filter missing'),
+    );
+
+    expect(missing).toBeDefined();
+    expect(missing!.evidence?.cloudWatchLogGroupName).toBe('my-ct-logs');
+    expect(missing!.remediation).toContain('logGroupName set to "my-ct-logs"');
+    // The old generic phrasing that forced the AI to guess must be gone.
+    expect(missing!.remediation).not.toContain(
+      'logGroupName set to the CloudTrail log group',
+    );
+  });
+
+  it('uses the existing filter\'s own log group for the no-transformation update', async () => {
+    mockTrailSend.mockResolvedValue({
+      trailList: [
+        {
+          Name: 'main',
+          CloudWatchLogsLogGroupArn:
+            'arn:aws:logs:us-east-1:123:log-group:my-ct-logs:*',
+        },
+      ],
+    });
+    // A filter matching CIS 4.3 (Root account usage) keywords, but with no
+    // metric transformation → "no metric transformation" finding.
+    mockLogsSend.mockResolvedValue({
+      metricFilters: [
+        {
+          filterName: 'root-filter',
+          filterPattern: '{ $.userIdentity.type = "Root" }',
+          logGroupName: 'existing-lg',
+          metricTransformations: [],
+        },
+      ],
+    });
+
+    const findings = await scan();
+    const noTransform = findings.find((f) =>
+      f.title.includes('no metric transformation'),
+    );
+
+    expect(noTransform).toBeDefined();
+    expect(noTransform!.evidence?.logGroupName).toBe('existing-lg');
+    expect(noTransform!.remediation).toContain('logGroupName set to "existing-lg"');
+  });
+
+  it('returns the prerequisite finding when no trail integrates with CloudWatch Logs', async () => {
+    mockTrailSend.mockResolvedValue({
+      trailList: [{ Name: 'main' }], // no CloudWatchLogsLogGroupArn
+    });
+
+    const findings = await scan();
+    expect(findings).toHaveLength(1);
+    expect(findings[0].title).toMatch(/not integrated with CloudWatch Logs/i);
+  });
+
+  it('falls back to a generic instruction when DescribeTrails is denied', async () => {
+    // DescribeTrails throws (e.g. missing cloudtrail:DescribeTrails) -> the log
+    // group stays unknown, so the finding keeps the generic text rather than a
+    // wrong name. (Not the customer's case, but must not crash or fabricate.)
+    mockTrailSend.mockRejectedValue(new Error('AccessDenied'));
+    mockLogsSend.mockResolvedValue({ metricFilters: [] });
+
+    const findings = await scan();
+    const missing = findings.find((f) =>
+      f.title.includes('metric filter missing'),
+    );
+    expect(missing).toBeDefined();
+    expect(missing!.evidence?.cloudWatchLogGroupName).toBeUndefined();
+    expect(missing!.remediation).toContain("CloudWatch Logs log group");
+  });
+});

--- a/apps/api/src/cloud-security/providers/aws/cloudwatch.adapter.ts
+++ b/apps/api/src/cloud-security/providers/aws/cloudwatch.adapter.ts
@@ -87,6 +87,24 @@ const CIS_CHECKS: CisCheck[] = [
   },
 ];
 
+/**
+ * Derive the bare CloudWatch Logs log-group NAME from a CloudWatchLogsLogGroupArn.
+ * e.g. "arn:aws:logs:us-east-1:123456789012:log-group:aws-cloudtrail-logs-xyz:*"
+ *   -> "aws-cloudtrail-logs-xyz"
+ * Log-group names cannot contain ":", so the trailing ":*" (all log streams) suffix
+ * is stripped safely. Returns null when the ARN is missing or malformed.
+ */
+export function logGroupNameFromArn(arn: string | undefined): string | null {
+  if (!arn) return null;
+  const marker = ':log-group:';
+  const idx = arn.indexOf(marker);
+  if (idx === -1) return null;
+  let name = arn.slice(idx + marker.length);
+  if (name.endsWith(':*')) name = name.slice(0, -2);
+  name = name.trim();
+  return name.length > 0 ? name : null;
+}
+
 export class CloudWatchAdapter implements AwsServiceAdapter {
   readonly serviceId = 'cloudwatch';
   readonly isGlobal = false;
@@ -103,16 +121,24 @@ export class CloudWatchAdapter implements AwsServiceAdapter {
     const cwClient = new CloudWatchClient({ credentials, region });
     const findings: SecurityFinding[] = [];
 
-    // Prerequisite: check if any CloudTrail trail has CloudWatch Logs integration
+    // Prerequisite: find a CloudTrail trail that delivers to CloudWatch Logs, and
+    // capture the exact log group so the metric-filter auto-fix can target it.
+    // PutMetricFilter requires a real logGroupName — the AI cannot guess it, so we
+    // resolve it here (zero extra AWS calls: DescribeTrails is already invoked)
+    // and surface it in each finding's remediation text + evidence.
+    let cloudWatchLogGroupName: string | null = null;
     try {
       const ctClient = new CloudTrailClient({ credentials, region });
       const trailsResp = await ctClient.send(new DescribeTrailsCommand({}));
       const trails = trailsResp.trailList ?? [];
-      const hasCloudWatchIntegration = trails.some(
+      const integratedTrail = trails.find(
         (trail) => !!trail.CloudWatchLogsLogGroupArn,
       );
+      cloudWatchLogGroupName = logGroupNameFromArn(
+        integratedTrail?.CloudWatchLogsLogGroupArn,
+      );
 
-      if (!hasCloudWatchIntegration) {
+      if (!integratedTrail) {
         return [
           this.makeFinding({
             checkId: 'cloudwatch-no-cloudtrail-integration',
@@ -146,14 +172,24 @@ export class CloudWatchAdapter implements AwsServiceAdapter {
         });
 
         if (!matchingFilter) {
+          // Give the auto-fix the concrete log group to attach the filter to. The
+          // generic phrase "the CloudTrail log group" forced the AI to guess and
+          // fail ("could not determine which CloudTrail log group ...").
+          const logGroupClause = cloudWatchLogGroupName
+            ? `logGroupName set to "${cloudWatchLogGroupName}"`
+            : `logGroupName set to your CloudTrail trail's CloudWatch Logs log group`;
           findings.push(
             this.makeFinding({
               checkId: check.id,
               title: `${check.name} — metric filter missing`,
               description: `No CloudWatch metric filter found for CIS ${check.id} (${check.name}). A metric filter matching keywords [${check.keywords.join(', ')}] is required.`,
               severity: 'medium',
-              remediation: `Step 1: Create a CloudWatch Logs metric filter using logs:PutMetricFilterCommand with logGroupName set to the CloudTrail log group, filterName set to "compai-cis-${check.id}-${check.name.toLowerCase().replace(/\s+/g, '-')}", filterPattern set to the required CIS pattern for ${check.name} matching keywords [${check.keywords.join(', ')}], and metricTransformations containing metricName, metricNamespace "CloudTrailMetrics", and metricValue "1". Step 2: Create an SNS topic using sns:CreateTopicCommand with Name "compai-cis-alerts" if one does not already exist. Step 3: Create a CloudWatch alarm using cloudwatch:PutMetricAlarmCommand with AlarmName "compai-cis-${check.id}-alarm", MetricName matching the filter metric, Namespace "CloudTrailMetrics", Statistic "Sum", Period 300, EvaluationPeriods 1, Threshold 1, ComparisonOperator "GreaterThanOrEqualToThreshold", and AlarmActions set to the SNS topic ARN. Rollback by deleting the alarm with cloudwatch:DeleteAlarmsCommand, deleting the metric filter with logs:DeleteMetricFilterCommand, and optionally deleting the SNS topic with sns:DeleteTopicCommand.`,
-              evidence: { keywords: check.keywords, filterFound: false },
+              remediation: `Step 1: Create a CloudWatch Logs metric filter using logs:PutMetricFilterCommand with ${logGroupClause}, filterName set to "compai-cis-${check.id}-${check.name.toLowerCase().replace(/\s+/g, '-')}", filterPattern set to the required CIS pattern for ${check.name} matching keywords [${check.keywords.join(', ')}], and metricTransformations containing metricName, metricNamespace "CloudTrailMetrics", and metricValue "1". Step 2: Create an SNS topic using sns:CreateTopicCommand with Name "compai-cis-alerts" if one does not already exist. Step 3: Create a CloudWatch alarm using cloudwatch:PutMetricAlarmCommand with AlarmName "compai-cis-${check.id}-alarm", MetricName matching the filter metric, Namespace "CloudTrailMetrics", Statistic "Sum", Period 300, EvaluationPeriods 1, Threshold 1, ComparisonOperator "GreaterThanOrEqualToThreshold", and AlarmActions set to the SNS topic ARN. Rollback by deleting the alarm with cloudwatch:DeleteAlarmsCommand, deleting the metric filter with logs:DeleteMetricFilterCommand, and optionally deleting the SNS topic with sns:DeleteTopicCommand.`,
+              evidence: {
+                keywords: check.keywords,
+                filterFound: false,
+                cloudWatchLogGroupName: cloudWatchLogGroupName ?? undefined,
+              },
               passed: false,
             }),
           );
@@ -165,15 +201,23 @@ export class CloudWatchAdapter implements AwsServiceAdapter {
           matchingFilter.metricTransformations?.[0]?.metricName;
 
         if (!metricName) {
+          // An existing filter is updated in place — target its own log group
+          // (fall back to the trail's resolved log group if unavailable).
+          const updateLogGroup =
+            matchingFilter.logGroupName ?? cloudWatchLogGroupName;
+          const updateLogGroupClause = updateLogGroup
+            ? `logGroupName set to "${updateLogGroup}"`
+            : `logGroupName set to the metric filter's existing log group`;
           findings.push(
             this.makeFinding({
               checkId: check.id,
               title: `${check.name} — no metric transformation`,
               description: `Metric filter for CIS ${check.id} (${check.name}) exists but has no metric transformation configured.`,
               severity: 'medium',
-              remediation: `Step 1: Update the existing metric filter using logs:PutMetricFilterCommand with logGroupName, filterName set to the existing filter name, filterPattern preserved, and metricTransformations containing metricName "compai-cis-${check.id}-metric", metricNamespace "CloudTrailMetrics", and metricValue "1". Step 2: Create an SNS topic using sns:CreateTopicCommand with Name "compai-cis-alerts" if one does not already exist. Step 3: Create a CloudWatch alarm using cloudwatch:PutMetricAlarmCommand with AlarmName "compai-cis-${check.id}-alarm", MetricName "compai-cis-${check.id}-metric", Namespace "CloudTrailMetrics", Statistic "Sum", Period 300, EvaluationPeriods 1, Threshold 1, ComparisonOperator "GreaterThanOrEqualToThreshold", and AlarmActions set to the SNS topic ARN. Rollback by deleting the alarm with cloudwatch:DeleteAlarmsCommand and removing the metric transformation by calling logs:PutMetricFilterCommand with the original filter settings.`,
+              remediation: `Step 1: Update the existing metric filter using logs:PutMetricFilterCommand with ${updateLogGroupClause}, filterName set to the existing filter name, filterPattern preserved, and metricTransformations containing metricName "compai-cis-${check.id}-metric", metricNamespace "CloudTrailMetrics", and metricValue "1". Step 2: Create an SNS topic using sns:CreateTopicCommand with Name "compai-cis-alerts" if one does not already exist. Step 3: Create a CloudWatch alarm using cloudwatch:PutMetricAlarmCommand with AlarmName "compai-cis-${check.id}-alarm", MetricName "compai-cis-${check.id}-metric", Namespace "CloudTrailMetrics", Statistic "Sum", Period 300, EvaluationPeriods 1, Threshold 1, ComparisonOperator "GreaterThanOrEqualToThreshold", and AlarmActions set to the SNS topic ARN. Rollback by deleting the alarm with cloudwatch:DeleteAlarmsCommand and removing the metric transformation by calling logs:PutMetricFilterCommand with the original filter settings.`,
               evidence: {
                 filterName: matchingFilter.filterName,
+                logGroupName: updateLogGroup ?? undefined,
                 metricTransformations: null,
               },
               passed: false,
@@ -231,12 +275,14 @@ export class CloudWatchAdapter implements AwsServiceAdapter {
     {
       filterName?: string;
       filterPattern?: string;
+      logGroupName?: string;
       metricTransformations?: { metricName?: string }[];
     }[]
   > {
     const filters: {
       filterName?: string;
       filterPattern?: string;
+      logGroupName?: string;
       metricTransformations?: { metricName?: string }[];
     }[] = [];
 
@@ -251,6 +297,7 @@ export class CloudWatchAdapter implements AwsServiceAdapter {
         filters.push({
           filterName: filter.filterName,
           filterPattern: filter.filterPattern,
+          logGroupName: filter.logGroupName,
           metricTransformations: filter.metricTransformations?.map((t) => ({
             metricName: t.metricName,
           })),

--- a/apps/api/src/cloud-security/remediation.service.ts
+++ b/apps/api/src/cloud-security/remediation.service.ts
@@ -22,6 +22,7 @@ import {
   buildManualRemediationPreview,
   isManualRemediation,
 } from './manual-remediation';
+import { applyResolvedMetricFilterLogGroup } from './metric-filter-loggroup';
 import type { FixPlan, AwsCommandStep } from './ai-remediation.prompt';
 
 const UNSUPPORTED_S3_ACL_PERMISSIONS = new Set(['s3:PutBucketAcl']);
@@ -278,6 +279,11 @@ export class RemediationService {
               requiresAcknowledgment: undefined,
             };
           }
+
+          // Pin the real CloudTrail log group on metric-filter steps so the
+          // preview matches what execution will actually apply (deterministic,
+          // not AI-dependent).
+          applyResolvedMetricFilterLogGroup(refined.fixSteps, evidence);
 
           // Build the COMPLETE permission list from ALL sources
           const aiPermissions =
@@ -645,6 +651,11 @@ export class RemediationService {
           resourceId: finding.resourceId,
         });
       }
+
+      // Deterministically pin the CloudTrail log group on any PutMetricFilter
+      // step from the finding evidence — the AI must never be the source of
+      // truth for it (this is what failed for the customer before).
+      applyResolvedMetricFilterLogGroup(plannedFix.fixSteps, findingCtx.evidence);
 
       // Phase 3: Execute the refined fix steps (now with REAL values).
       // Pass rollback steps for automatic undo on partial failure.


### PR DESCRIPTION
## Customer report (aymenrc — recurring)
Auto-fix for CloudWatch CIS metric filters keeps failing with:
> The automatic fix failed because it could not determine which CloudTrail log group to attach the metric filter to

…across **all** CloudWatch metric-filter fixes, even after the earlier fixes we shipped.

## Why the earlier PRs didn't fix it
PRs #3050/#3052/#3054 fixed the `PutMetricFilter` **param shape** (transformations, empty `filterPattern`) and the prompt's log-group **wording**. None of them addressed the actual blocker: **nothing ever told the fix *which* log group to attach the filter to.**

## Root cause (verified)
A metric filter must be created on the specific CloudWatch Logs log group that CloudTrail delivers to (`trail.CloudWatchLogsLogGroupArn`).
- `cloudwatch.adapter.ts` **already calls `DescribeTrails` and reads `CloudWatchLogsLogGroupArn`** — but only to compute a boolean; it **discarded the name**.
- So the metric-filter-missing finding's evidence was just `{ keywords, filterFound:false }` and the remediation said the generic *"logGroupName set to the CloudTrail log group"*.
- The prompt told the AI *"use placeholder, the system will resolve the real one from readSteps"* — but **there is no deterministic resolver**; the only "resolution" is a second LLM pass (`refineFixPlan`) that must extract the ARN→name from raw `DescribeTrails` JSON. When it can't, it returns `canAutoFix:false` with that reason, surfaced to the customer verbatim. (The phrase exists nowhere in the codebase — confirming it's AI-generated.)

## Fix
Resolve the log group **deterministically in the adapter** (the right layer — it already has the data, so zero new AWS calls / IAM):
- New `logGroupNameFromArn()` derives the bare name (`…:log-group:NAME:*` → `NAME`).
- The **metric-filter-missing** finding now carries the concrete name in its remediation text (`logGroupName set to "<name>"`) **and** evidence (`cloudWatchLogGroupName`).
- The **existing-filter update** case uses that filter's own `logGroupName` (now captured from `DescribeMetricFilters`).
- The AI prompt now points at `cloudWatchLogGroupName` in evidence (no placeholder).

The **"no CloudTrail→CloudWatch integration"** case is unchanged — a dedicated early-return finding already gives a clear "enable delivery first" message, so those customers never hit the vague error.

## Tests (jest)
`cloudwatch.adapter.spec.ts` (new): `logGroupNameFromArn` derivation (incl. GovCloud, no-`:*`, malformed); metric-filter-missing finding now contains the real name in evidence + remediation (and **not** the old generic phrase); existing-filter update uses the filter's own log group; no-integration → prerequisite finding preserved; `DescribeTrails` denied → graceful generic fallback (no crash, no fabricated name). **8/8 pass; full cloud-security suite 327 pass** (1 unrelated suite fails to load on the local prisma-TLS env guard); my files typecheck clean.

## Caveats
- **No customer reconnect.** Backend-only. The customer needs a **re-scan** (so findings regenerate with the log group in evidence) before retrying the auto-fix.
- **Not live-tested** against the customer's AWS — proof is an impersonated run post-deploy. But the fix is correct for both observed failure modes (AI gives up, or placeholder reaches AWS), since both stem from the missing log group which is now supplied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deterministically resolve and enforce the real CloudTrail CloudWatch Logs log group for CloudWatch metric-filter auto-fix, removing “could not determine which CloudTrail log group…” failures without extra AWS calls.

- **Bug Fixes**
  - Derive the log group from `CloudWatchLogsLogGroupArn` via `logGroupNameFromArn`.
  - Add the concrete name to findings evidence (`cloudWatchLogGroupName`) and remediation text; for updates, use the existing filter’s `logGroupName`.
  - Force this value onto every `PutMetricFilterCommand` in preview and execution using `applyResolvedMetricFilterLogGroup` (prefers `cloudWatchLogGroupName`, falls back to `logGroupName`).
  - Update the remediation prompt to reference the evidence; avoid placeholders.
  - Preserve the “no CloudTrail → CloudWatch Logs integration” prerequisite; safe fallback on `DescribeTrails` denial.

- **Migration**
  - Re-scan so findings include the log group before retrying the auto-fix.

<sup>Written for commit 2e7e6bab04e5958da27e41730c5a7dfcf2443e2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

