### PR TITLE
chore(cloud-security): upgrade remediation models to latest (Opus 4.8, Sonnet 4.6)

### DIFF
--- a/apps/api/src/cloud-security/ai-remediation.service.ts
+++ b/apps/api/src/cloud-security/ai-remediation.service.ts
@@ -28,11 +28,11 @@ import {
 } from './azure-ai-remediation.prompt';
 import { normalizeFixPlan } from './plan-normalizer';
 
-const MODEL = anthropic('claude-opus-4-6');
+const MODEL = anthropic('claude-opus-4-8');
 // Cheaper, faster model for the manual-steps fallback. The output is pure
 // natural language with no SDK-call shape to validate, so the strongest
 // model is overkill — we just need clear instructions.
-const FALLBACK_MODEL = anthropic('claude-sonnet-4-5');
+const FALLBACK_MODEL = anthropic('claude-sonnet-4-6');
 const REMEDIATION_ROLE_NAME = 'CompAI-Remediator';
 
 export interface FindingContext {


### PR DESCRIPTION
## What
Bump the two cloud-security **remediation** models that were behind the latest:

| Constant | Before | After | Used for |
|---|---|---|---|
| `MODEL` | `claude-opus-4-6` | **`claude-opus-4-8`** | Fix-plan generation, refinement, self-repair, permission analysis (AWS/GCP/Azure) |
| `FALLBACK_MODEL` | `claude-sonnet-4-5` | **`claude-sonnet-4-6`** | Manual-steps fallback (plain instructions) |

## Why
The auto-fix feature leans heavily on the LLM to emit **exact AWS SDK commands as structured output**. Newer models follow explicit instructions and schemas more reliably, which should raise auto-fix success rates **across all providers/checks**, not just one customer.

## Deliberately NOT changed
Descriptions stay on **`claude-haiku-4-5`** (`ai-description.service.ts`). It's already the current Haiku and the right tier for simple, **cached** explanatory text — moving it to Sonnet would add ~4–5× cost and noticeable first-view latency (plus a one-time cache regeneration) for no clear quality gain on a task that isn't broken. Match the model tier to the task: Opus for hard reasoning, Sonnet for fallback, Haiku for trivial text.

## Honest notes
- This did **not** cause the recent CloudWatch auto-fix bug (that was missing *data* — see #3062). This is a separate, general reliability lever.
- Typecheck confirms `@ai-sdk/anthropic` accepts the new model ids; no other code changes.
- It's a **behavior change** to every auto-fix, so before relying on it, sanity-check the output on a handful of real findings (plans still validate, pass rates don't regress). Easy rollback (revert the 2 strings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded cloud-security remediation models to `claude-opus-4-8` and the manual-steps fallback to `claude-sonnet-4-6` to improve auto-fix reliability and schema adherence across AWS/GCP/Azure. Description generation stays on `claude-haiku-4-5`.

<sup>Written for commit 87b7401a9b19a0d62e7bab6d8245aedae606e892. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

