### PR TITLE
fix(integration-platform): attribute AWS check findings to their AWS account (multi-account)

### DIFF
--- a/packages/integration-platform/src/manifests/aws/checks/__tests__/aws-checks.test.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/__tests__/aws-checks.test.ts
@@ -14,7 +14,14 @@ import {
   evaluateRdsEncryption,
 } from '../rds';
 import { evaluateS3Encryption, evaluateS3PublicAccess } from '../s3';
-import { assumeAwsSession, resolveAwsCredentialInputs } from '../shared';
+import {
+  assumeAwsSession,
+  awsAccountIdFromCtx,
+  emitOutcomes,
+  resolveAwsCredentialInputs,
+  type CheckOutcome,
+} from '../shared';
+import type { CheckContext } from '../../../../types';
 
 const kinds = (os: { kind: string }[]) => os.map((o) => o.kind);
 
@@ -439,5 +446,82 @@ describe('IAM/CloudTrail outcomes carry evidence (so the UI shows "View Evidence
     ]);
     expect(rot[0]!.evidence?.rotationEnabled).toBe(true);
     expect(rot[1]!.evidence?.rotationEnabled).toBe(false);
+  });
+});
+
+// ── AWS account attribution (multi-account findings) ───────────────────────
+
+function captureCtx(credentials: Record<string, unknown>) {
+  const passed: Array<{ description: string; evidence?: Record<string, unknown> }> = [];
+  const failed: Array<{ description: string; evidence?: Record<string, unknown> }> = [];
+  const ctx = {
+    credentials,
+    pass: (r: { description: string; evidence?: Record<string, unknown> }) =>
+      passed.push(r),
+    fail: (r: { description: string; evidence?: Record<string, unknown> }) =>
+      failed.push(r),
+  } as unknown as CheckContext;
+  return { ctx, passed, failed };
+}
+
+const PASS_OUTCOME: CheckOutcome = {
+  kind: 'pass',
+  title: 'Default encryption enabled: my-bucket',
+  description: 'Bucket "my-bucket" has default encryption enabled.',
+  resourceType: 'aws-s3-bucket',
+  resourceId: 'my-bucket',
+  evidence: { bucket: 'my-bucket', encrypted: true },
+};
+
+describe('awsAccountIdFromCtx', () => {
+  it('extracts the 12-digit account id from the role ARN', () => {
+    expect(
+      awsAccountIdFromCtx({
+        credentials: { roleArn: 'arn:aws:iam::123456789012:role/CompAIAuditor' },
+      } as unknown as CheckContext),
+    ).toBe('123456789012');
+  });
+
+  it('returns null when the role ARN is missing or malformed', () => {
+    expect(
+      awsAccountIdFromCtx({ credentials: {} } as unknown as CheckContext),
+    ).toBeNull();
+    expect(
+      awsAccountIdFromCtx({
+        credentials: { roleArn: 'not-an-arn' },
+      } as unknown as CheckContext),
+    ).toBeNull();
+  });
+});
+
+describe('emitOutcomes — attributes findings to the AWS account', () => {
+  it('stamps the account id into evidence and the visible description', () => {
+    const { ctx, passed } = captureCtx({
+      roleArn: 'arn:aws:iam::123456789012:role/CompAIAuditor',
+    });
+    emitOutcomes(ctx, [PASS_OUTCOME]);
+    expect(passed).toHaveLength(1);
+    expect(passed[0]!.evidence?.awsAccountId).toBe('123456789012');
+    expect(passed[0]!.evidence?.bucket).toBe('my-bucket'); // original evidence preserved
+    expect(passed[0]!.description).toContain('(AWS account 123456789012)');
+  });
+
+  it('attributes a fail outcome too', () => {
+    const { ctx, failed } = captureCtx({
+      roleArn: 'arn:aws:iam::999988887777:role/x',
+    });
+    emitOutcomes(ctx, [{ ...PASS_OUTCOME, kind: 'fail', severity: 'high' }]);
+    expect(failed[0]!.evidence?.awsAccountId).toBe('999988887777');
+    expect(failed[0]!.description).toContain('(AWS account 999988887777)');
+  });
+
+  it('leaves findings unattributed for key-auth connections (no role ARN)', () => {
+    const { ctx, passed } = captureCtx({
+      access_key_id: 'AKIA',
+      secret_access_key: 'secret',
+    });
+    emitOutcomes(ctx, [PASS_OUTCOME]);
+    expect(passed[0]!.evidence?.awsAccountId).toBeUndefined();
+    expect(passed[0]!.description).toBe(PASS_OUTCOME.description); // unchanged
   });
 });

--- a/packages/integration-platform/src/manifests/aws/checks/__tests__/aws-checks.test.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/__tests__/aws-checks.test.ts
@@ -524,4 +524,16 @@ describe('emitOutcomes — attributes findings to the AWS account', () => {
     expect(passed[0]!.evidence?.awsAccountId).toBeUndefined();
     expect(passed[0]!.description).toBe(PASS_OUTCOME.description); // unchanged
   });
+
+  it("includes the customer's connection name alongside the account when set", () => {
+    const { ctx, passed } = captureCtx({
+      roleArn: 'arn:aws:iam::123456789012:role/CompAIAuditor',
+      connectionName: 'Production AWS',
+    });
+    emitOutcomes(ctx, [PASS_OUTCOME]);
+    expect(passed[0]!.evidence?.awsConnectionName).toBe('Production AWS');
+    expect(passed[0]!.description).toContain(
+      '(AWS account 123456789012 — Production AWS)',
+    );
+  });
 });

--- a/packages/integration-platform/src/manifests/aws/checks/s3.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/s3.ts
@@ -10,7 +10,12 @@ import {
 } from '@aws-sdk/client-s3-control';
 import { TASK_TEMPLATES } from '../../../task-mappings';
 import type { CheckContext, IntegrationCheck } from '../../../types';
-import { resolveAwsSessionOrFail, type CheckOutcome, emitOutcomes } from './shared';
+import {
+  awsAccountIdFromCtx,
+  resolveAwsSessionOrFail,
+  type CheckOutcome,
+  emitOutcomes,
+} from './shared';
 
 export interface BpaFlags {
   blockPublicAcls: boolean;
@@ -184,14 +189,6 @@ async function gatherBuckets(
   return infos;
 }
 
-/** Account ID from the connection's role ARN (arn:aws:iam::ACCOUNT:role/...). */
-function accountIdFromCtx(ctx: CheckContext): string | null {
-  const arn = (ctx.credentials as Record<string, unknown>).roleArn;
-  if (typeof arn !== 'string') return null;
-  const parts = arn.split(':');
-  return parts.length >= 5 && parts[4] ? parts[4] : null;
-}
-
 export const s3EncryptionCheck: IntegrationCheck = {
   id: 'aws-s3-encryption',
   name: 'S3 — default encryption enabled',
@@ -252,7 +249,7 @@ export const s3PublicAccessCheck: IntegrationCheck = {
     // Account-level Block Public Access applies to every bucket. Read it once;
     // if denied/absent, fall back to bucket-level only (graceful).
     let accountBpa: BpaFlags | null = null;
-    const accountId = accountIdFromCtx(ctx);
+    const accountId = awsAccountIdFromCtx(ctx);
     if (accountId) {
       try {
         const s3control = new S3ControlClient({

--- a/packages/integration-platform/src/manifests/aws/checks/shared.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/shared.ts
@@ -255,26 +255,55 @@ export interface CheckOutcome {
   evidence?: Record<string, unknown>;
 }
 
-/** Map pure evaluator outcomes onto ctx.pass / ctx.fail. */
+/**
+ * The 12-digit AWS account ID from the connection's role ARN
+ * (`arn:aws:iam::ACCOUNT_ID:role/...`). Returns null for key-auth connections or
+ * when no role ARN is present. Used to attribute every finding to the AWS
+ * account it came from — essential when a customer connects multiple accounts.
+ */
+export function awsAccountIdFromCtx(ctx: CheckContext): string | null {
+  const arn = (ctx.credentials as Record<string, unknown>).roleArn;
+  if (typeof arn !== 'string') return null;
+  const parts = arn.split(':');
+  return parts.length >= 5 && parts[4] ? parts[4] : null;
+}
+
+/**
+ * Map pure evaluator outcomes onto ctx.pass / ctx.fail.
+ *
+ * Every finding is attributed to the AWS account it came from: checks run once
+ * per connected account, so without this the UI shows a single merged list with
+ * no way to tell which account each resource belongs to (a customer-reported
+ * gap when multiple AWS accounts are connected). The account id is added to the
+ * evidence and surfaced in the visible description.
+ */
 export function emitOutcomes(ctx: CheckContext, outcomes: CheckOutcome[]): void {
+  const accountId = awsAccountIdFromCtx(ctx);
+  const describe = (description: string) =>
+    accountId ? `${description} (AWS account ${accountId})` : description;
+
   for (const o of outcomes) {
     if (o.kind === 'pass') {
       ctx.pass({
         title: o.title,
-        description: o.description,
+        description: describe(o.description),
         resourceType: o.resourceType,
         resourceId: o.resourceId,
-        evidence: o.evidence ?? {},
+        evidence: accountId
+          ? { ...(o.evidence ?? {}), awsAccountId: accountId }
+          : (o.evidence ?? {}),
       });
     } else {
       ctx.fail({
         title: o.title,
-        description: o.description,
+        description: describe(o.description),
         resourceType: o.resourceType,
         resourceId: o.resourceId,
         severity: o.severity ?? 'medium',
         remediation: o.remediation ?? 'Review and remediate this finding.',
-        evidence: o.evidence,
+        evidence: accountId
+          ? { ...(o.evidence ?? {}), awsAccountId: accountId }
+          : o.evidence,
       });
     }
   }

--- a/packages/integration-platform/src/manifests/aws/checks/shared.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/shared.ts
@@ -269,6 +269,19 @@ export function awsAccountIdFromCtx(ctx: CheckContext): string | null {
 }
 
 /**
+ * The friendly connection name the customer gave this AWS account when they
+ * connected it (the "Connection Name" field, e.g. "Production AWS"). It is the
+ * customer's OWN label — we do not infer prod/stage from AWS — so it's shown
+ * alongside the account id when present. Returns null when unset.
+ */
+export function awsConnectionNameFromCtx(ctx: CheckContext): string | null {
+  const name = (ctx.credentials as Record<string, unknown>).connectionName;
+  return typeof name === 'string' && name.trim().length > 0
+    ? name.trim()
+    : null;
+}
+
+/**
  * Map pure evaluator outcomes onto ctx.pass / ctx.fail.
  *
  * Every finding is attributed to the AWS account it came from: checks run once
@@ -279,8 +292,21 @@ export function awsAccountIdFromCtx(ctx: CheckContext): string | null {
  */
 export function emitOutcomes(ctx: CheckContext, outcomes: CheckOutcome[]): void {
   const accountId = awsAccountIdFromCtx(ctx);
+  const connectionName = awsConnectionNameFromCtx(ctx);
+  // "AWS account 123456789012 — Production AWS" (name only shown when set).
+  const label = accountId
+    ? `AWS account ${accountId}${connectionName ? ` — ${connectionName}` : ''}`
+    : null;
   const describe = (description: string) =>
-    accountId ? `${description} (AWS account ${accountId})` : description;
+    label ? `${description} (${label})` : description;
+  const stamp = (evidence: Record<string, unknown> | undefined) =>
+    accountId
+      ? {
+          ...(evidence ?? {}),
+          awsAccountId: accountId,
+          ...(connectionName ? { awsConnectionName: connectionName } : {}),
+        }
+      : evidence;
 
   for (const o of outcomes) {
     if (o.kind === 'pass') {
@@ -289,9 +315,7 @@ export function emitOutcomes(ctx: CheckContext, outcomes: CheckOutcome[]): void 
         description: describe(o.description),
         resourceType: o.resourceType,
         resourceId: o.resourceId,
-        evidence: accountId
-          ? { ...(o.evidence ?? {}), awsAccountId: accountId }
-          : (o.evidence ?? {}),
+        evidence: stamp(o.evidence) ?? {},
       });
     } else {
       ctx.fail({
@@ -301,9 +325,7 @@ export function emitOutcomes(ctx: CheckContext, outcomes: CheckOutcome[]): void 
         resourceId: o.resourceId,
         severity: o.severity ?? 'medium',
         remediation: o.remediation ?? 'Review and remediate this finding.',
-        evidence: accountId
-          ? { ...(o.evidence ?? {}), awsAccountId: accountId }
-          : o.evidence,
+        evidence: stamp(o.evidence),
       });
     }
   }


### PR DESCRIPTION
## Customer report (Dustin)
> "that does not tell me the instance info. It is also not at all clear how to add the same check for another instance. I have given 3 aws instances to the system."

On the "S3 — default encryption enabled" evidence check he sees **31 buckets passing** but with **no indication of which of his 3 AWS accounts each belongs to**, and it's unclear how the other accounts are covered.

## Root cause (verified)
- Integration-platform checks run **per connection** (1 AWS account = 1 connection), so **all 3 accounts are already scanned** — this part isn't broken.
- But the **account is never put in the finding**. `s3.ts` already derived the account id (`accountIdFromCtx` → `roleArn`) for its own logic, yet evidence was just `{bucket, encrypted}`. The UI groups by check and shows no account → a merged, unlabeled list. So "which instance?" and "how do I add it for another instance?" are really one gap: **no per-account attribution.**

## Fix
All six AWS checks (s3, cloudtrail, ec2, iam, kms, rds) emit through the shared **`emitOutcomes()`**, so I stamp the account there in **one place**:
- `awsAccountIdFromCtx()` (moved to `shared.ts`, exported) derives the 12-digit account id from the connection's `roleArn`.
- Every finding now gets `evidence.awsAccountId` **and** the account appended to the visible description: `… (AWS account 123456789012)`.

So each result shows its account **regardless of how the UI groups them**, which also makes it clear all connected accounts are covered. No schema/API/UI change or migration. Key-auth connections (no role ARN) are left unattributed gracefully.

## Tests
`aws-checks.test.ts` (bun): `awsAccountIdFromCtx` extraction + malformed/missing → null; `emitOutcomes` stamps account into evidence + description on pass **and** fail, preserves original evidence, and leaves findings unattributed when there's no role ARN. **41 pass; package builds + typechecks clean.**

## Caveats / notes
- Covers the main pass/fail findings (which flow through `emitOutcomes`). The rare direct `ctx.fail()` error paths (e.g. "Could not assume AWS role", "Could not verify S3 encryption") are not stamped — edge cases, can follow up if needed.
- **Not live-tested** against the customer's accounts; needs a re-run after deploy so findings regenerate with the account.
- Bonus: once labeled, this also **reveals** whether all 3 of his accounts are actually producing results — if one account is missing, that's a separate connection/run issue we'd investigate then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multi-account AWS check findings by attributing each result to its AWS account, and shows the customer's connection name when set. Adds the account ID (and connection name) to evidence and descriptions so users can see which account each resource belongs to, with no schema or UI changes.

- **Bug Fixes**
  - Centralized account ID extraction via `awsAccountIdFromCtx()` (from `roleArn`) and used across all AWS checks.
  - `emitOutcomes()` stamps `awsAccountId` and optional `awsConnectionName` into evidence and appends "(AWS account … — name)" to pass/fail descriptions.
  - Gracefully skips attribution for key-based connections without a `roleArn`.
  - Added unit tests for extraction, pass/fail attribution, missing-ARN cases, and connection name labeling.

<sup>Written for commit 69c84c85badc226c40d9773d561548e20b84b6b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

