### PR TITLE
fix(people): respect "Send portal invite email" opt-out when adding users

### DIFF
--- a/apps/api/src/people/people-invite.service.spec.ts
+++ b/apps/api/src/people/people-invite.service.spec.ts
@@ -309,7 +309,11 @@ describe('PeopleInviteService', () => {
       });
 
       expect(results[0].success).toBe(true);
-      expect(results[0].emailSent).toBe(true);
+      // No portal invite was requested (sendPortalEmail omitted = false), so no
+      // email is sent and emailSent is not surfaced (the UI only warns on an
+      // actual send failure, never on an intentional skip).
+      expect(mockTriggerEmail).not.toHaveBeenCalled();
+      expect(results[0].emailSent).toBeUndefined();
       expect(mockDb.member.create).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({
@@ -437,9 +441,13 @@ describe('PeopleInviteService', () => {
 
       const results = await service.inviteMembers({
         ...baseParams,
-        invites: [{ email: 'emp@example.com', roles: ['employee'] }],
+        invites: [
+          { email: 'emp@example.com', roles: ['employee'], sendPortalEmail: true },
+        ],
       });
 
+      // A portal email was requested but the send failed — the member is still
+      // added and emailSent: false signals the UI to offer a resend.
       expect(results[0].success).toBe(true);
       expect(results[0].emailSent).toBe(false);
     });
@@ -543,6 +551,46 @@ describe('PeopleInviteService', () => {
           }),
         );
         expect(mockInviteEmail).not.toHaveBeenCalled();
+      });
+
+      // Regression: unchecking "Send portal invite email" when adding an
+      // employee via "+ Add User" must add the member WITHOUT emailing them.
+      // Previously the else-branch still sent an InviteEmail with a portal link.
+      it('employee only with portal UNchecked: adds member silently, sends no email', async () => {
+        (mockDb.organization.findUnique as jest.Mock).mockResolvedValue({
+          name: 'Test Org',
+        });
+        (mockDb.user.findFirst as jest.Mock).mockResolvedValue(null);
+        (mockDb.user.create as jest.Mock).mockResolvedValue({
+          id: 'usr_emp',
+          email: 'emp@example.com',
+        });
+        (mockDb.member.findFirst as jest.Mock).mockResolvedValue(null);
+        (mockDb.member.create as jest.Mock).mockResolvedValue({ id: 'mem_emp' });
+        (
+          mockDb.employeeTrainingVideoCompletion.createMany as jest.Mock
+        ).mockResolvedValue({ count: 5 });
+
+        const results = await service.inviteMembers({
+          ...baseParams,
+          invites: [
+            {
+              email: 'emp@example.com',
+              roles: ['employee'],
+              sendPortalEmail: false,
+            },
+          ],
+        });
+
+        // Member is still created...
+        expect(results[0].success).toBe(true);
+        expect(mockDb.member.create).toHaveBeenCalled();
+        // ...but NO email of any kind goes out when the portal invite is off.
+        expect(mockTriggerEmail).not.toHaveBeenCalled();
+        expect(mockInvitePortalEmail).not.toHaveBeenCalled();
+        expect(mockInviteEmail).not.toHaveBeenCalled();
+        // And no false "could not be sent" warning leaks to the UI.
+        expect(results[0].emailSent).toBeUndefined();
       });
 
       it('admin only (no portal): sends app email without portal link', async () => {

--- a/apps/api/src/people/people-invite.service.ts
+++ b/apps/api/src/people/people-invite.service.ts
@@ -106,7 +106,10 @@ export class PeopleInviteService {
           results.push({
             email: invite.email,
             success: true,
-            emailSent: result.emailSent,
+            // Only surface email status when we actually attempted to send, so
+            // the UI's "invite email could not be sent" warning never fires for
+            // an intentional skip (portal invite unchecked).
+            ...(shouldSendPortalEmail ? { emailSent: result.emailSent } : {}),
           });
         } else {
           await this.inviteWithCheck({
@@ -208,10 +211,12 @@ export class PeopleInviteService {
       await this.createTrainingVideoEntries(member.id, organizationId);
     }
 
-    // Send invite email (non-fatal)
-    let emailSent = true;
-    try {
-      if (sendPortalEmail) {
+    // Send the portal invite email only when requested (non-fatal). When the
+    // admin opts out ("Send portal invite email" unchecked) we add the member
+    // silently and send no email at all.
+    let emailSent = false;
+    if (sendPortalEmail) {
+      try {
         const inviteLink = this.buildPortalUrl(organizationId);
         await triggerEmail({
           to: email,
@@ -222,20 +227,14 @@ export class PeopleInviteService {
             email,
           }),
         });
-      } else {
-        const inviteLink = this.buildPortalUrl(organizationId);
-        await triggerEmail({
-          to: email,
-          subject: `You've been invited to join ${organization.name} on Comp AI`,
-          react: InviteEmail({ organizationName: organization.name, inviteLink }),
-        });
+        emailSent = true;
+      } catch (emailErr) {
+        emailSent = false;
+        this.logger.error(
+          `Portal invite email failed after member was added: ${email}`,
+          emailErr instanceof Error ? emailErr.message : 'Unknown error',
+        );
       }
-    } catch (emailErr) {
-      emailSent = false;
-      this.logger.error(
-        `Invite email failed after member was added: ${email}`,
-        emailErr instanceof Error ? emailErr.message : 'Unknown error',
-      );
     }
 
     return { emailSent };


### PR DESCRIPTION
## Bug
On the People page, adding a user via **+ Add User** and **unchecking "Send portal invite email"** still emailed the new user. The checkbox appeared to have no effect.

## Root cause
The frontend (`InviteMembersModal`) and the API DTO both pass `sendPortalEmail` through correctly. The defect is in `apps/api/src/people/people-invite.service.ts` → `addEmployeeWithoutInvite()` (the path taken for strictly-employee roles, i.e. the common People-page case):

```ts
if (sendPortalEmail) {
  /* InvitePortalEmail */          // checked  → portal email ✅
} else {
  const inviteLink = this.buildPortalUrl(organizationId);
  await triggerEmail({ ..., react: InviteEmail({ organizationName, inviteLink }) }); // UNCHECKED → STILL EMAILS ❌
}
```

The checkbox wasn't ignored — the `else` branch was written to send a *different* email (an `InviteEmail` containing a portal link) instead of **no** email. A method named `addEmployeeWithoutInvite` always sent an invite.

## Fix
- Send the portal invite email **only when requested**. When opted out, the member is added silently with no email.
- The caller no longer surfaces `emailSent` for an intentional skip, so the modal's *"invite email could not be sent"* warning (which keys off `emailSent === false`) doesn't fire when the admin deliberately suppressed the email.

Non-employee invites (admin/auditor/etc.) are unchanged — they still receive the app invitation needed to accept and join; the "Send portal invite email" toggle only governs the portal email.

## Tests
`apps/api` → `npx jest src/people/people-invite.service.spec.ts` → **19 passed**.
- Added a regression test: *employee + portal unchecked → member created, **no** email of any kind sent, no false `emailSent` signal.*
- Updated two existing specs that asserted the old always-send behavior.

## Notes for reviewer
- Scope is intentionally minimal: 2 files (`people-invite.service.ts` + its spec).
- `npx turbo run typecheck --filter=@trycompai/api` surfaces **pre-existing** errors in unrelated specs (`variables.controller`, `sync-gws.controller`, `risks`, `timelines`, `training`, `offboarding`) — none in `people`, none introduced by this PR. Left untouched to keep the fix focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the People page flow so unchecking "Send portal invite email" adds the user without emailing them. Also prevents the modal from showing a false "invite email could not be sent" warning when the admin opts out.

- **Bug Fixes**
  - Only send the portal invite when `sendPortalEmail === true`; unchecked adds the member silently.
  - Return `emailSent` only when an email send was attempted to avoid false modal warnings.
  - Added a regression test and updated two specs to cover the opt-out path.

<sup>Written for commit 18144fd7622b20a9db271b7357f3107d1ca080c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

