### PR TITLE
fix(policies): show a draft version's own content when editing it

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/policies/[policyId]/editor/components/PolicyDetails.tsx
+++ b/apps/app/src/app/(app)/[orgId]/policies/[policyId]/editor/components/PolicyDetails.tsx
@@ -57,6 +57,7 @@ import type { PolicyChatUIMessage } from '../types';
 import { PolicyAiAssistant } from './ai/policy-ai-assistant';
 import { useSuggestions } from '../hooks/use-suggestions';
 import { buildPositionMap } from '../lib/build-position-map';
+import { resolveInitialPolicyContent } from '../lib/resolve-initial-content';
 import { InlineEditBubble } from './ai/inline-edit-bubble';
 import { markdownToTipTapJSON } from './ai/markdown-utils';
 
@@ -197,12 +198,13 @@ export function PolicyContentManager({
   const [editorKey, setEditorKey] = useState(0);
   const [activeTab, setActiveTab] = useState<string>(displayFormat);
   const previousTabRef = useRef<string>(displayFormat);
-  const [currentContent, setCurrentContent] = useState<Array<JSONContent>>(() => {
-    const formattedContent = Array.isArray(policyContent)
-      ? policyContent
-      : [policyContent as JSONContent];
-    return formattedContent;
-  });
+  const [currentContent, setCurrentContent] = useState<Array<JSONContent>>(() =>
+    // When opening directly on a specific version (e.g. "Edit" a draft from the
+    // Versions tab, which remounts this tab fresh with a versionId in the URL),
+    // seed from that version's content — not the published policyContent — so a
+    // draft's saved edits don't appear to vanish. See resolve-initial-content.ts.
+    resolveInitialPolicyContent({ initialVersionId, versions, policyContent }),
+  );
 
   const [dismissedProposalKey, setDismissedProposalKey] = useState<string | null>(null);
   const [editorInstance, setEditorInstance] = useState<TipTapEditor | null>(null);

--- a/apps/app/src/app/(app)/[orgId]/policies/[policyId]/editor/lib/__tests__/resolve-initial-content.test.ts
+++ b/apps/app/src/app/(app)/[orgId]/policies/[policyId]/editor/lib/__tests__/resolve-initial-content.test.ts
@@ -1,0 +1,77 @@
+import type { JSONContent } from '@tiptap/react';
+import { describe, expect, it } from 'vitest';
+import { resolveInitialPolicyContent } from '../resolve-initial-content';
+
+const publishedContent: JSONContent[] = [
+  { type: 'paragraph', content: [{ type: 'text', text: 'published' }] },
+];
+const draftContent: JSONContent[] = [
+  { type: 'paragraph', content: [{ type: 'text', text: 'draft edit' }] },
+];
+
+describe('resolveInitialPolicyContent', () => {
+  it('seeds from the targeted version when initialVersionId matches a draft (the bug fix)', () => {
+    const result = resolveInitialPolicyContent({
+      initialVersionId: 'pv_draft',
+      versions: [
+        { id: 'pv_published', content: publishedContent },
+        { id: 'pv_draft', content: draftContent },
+      ],
+      policyContent: publishedContent,
+    });
+
+    expect(result).toEqual(draftContent);
+  });
+
+  it('falls back to policyContent when no initialVersionId is given', () => {
+    const result = resolveInitialPolicyContent({
+      initialVersionId: undefined,
+      versions: [{ id: 'pv_draft', content: draftContent }],
+      policyContent: publishedContent,
+    });
+
+    expect(result).toEqual(publishedContent);
+  });
+
+  it('falls back to policyContent when initialVersionId matches no known version', () => {
+    const result = resolveInitialPolicyContent({
+      initialVersionId: 'pv_missing',
+      versions: [{ id: 'pv_draft', content: draftContent }],
+      policyContent: publishedContent,
+    });
+
+    expect(result).toEqual(publishedContent);
+  });
+
+  it('wraps a single (non-array) version content into an array', () => {
+    const singleNode: JSONContent = { type: 'paragraph', content: [{ type: 'text', text: 'one' }] };
+    const result = resolveInitialPolicyContent({
+      initialVersionId: 'pv_draft',
+      versions: [{ id: 'pv_draft', content: singleNode }],
+      policyContent: publishedContent,
+    });
+
+    expect(result).toEqual([singleNode]);
+  });
+
+  it('wraps a single (non-array) policyContent fallback into an array', () => {
+    const singleNode: JSONContent = { type: 'paragraph', content: [{ type: 'text', text: 'pub' }] };
+    const result = resolveInitialPolicyContent({
+      initialVersionId: undefined,
+      versions: [],
+      policyContent: singleNode,
+    });
+
+    expect(result).toEqual([singleNode]);
+  });
+
+  it('returns an empty array for an empty draft version (does not fall back)', () => {
+    const result = resolveInitialPolicyContent({
+      initialVersionId: 'pv_draft',
+      versions: [{ id: 'pv_draft', content: [] }],
+      policyContent: publishedContent,
+    });
+
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/policies/[policyId]/editor/lib/resolve-initial-content.ts
+++ b/apps/app/src/app/(app)/[orgId]/policies/[policyId]/editor/lib/resolve-initial-content.ts
@@ -1,0 +1,51 @@
+import type { JSONContent } from '@tiptap/react';
+
+/** Minimal shape needed to resolve a version's editor content. */
+interface VersionContentSource {
+  id: string;
+  content: unknown;
+}
+
+interface ResolveInitialPolicyContentArgs {
+  /**
+   * The version the editor is opening on — e.g. the `versionId` in the URL when
+   * a draft is opened via "Edit" from the Versions tab. Undefined when simply
+   * viewing the current/published content.
+   */
+  initialVersionId?: string;
+  /** All known policy versions (each carrying its own content snapshot). */
+  versions: VersionContentSource[];
+  /** Fallback content: the published/current version's content. */
+  policyContent: JSONContent | JSONContent[];
+}
+
+/**
+ * Decide which content the policy editor should display on mount.
+ *
+ * The Content tab is unmounted when you switch tabs (the design-system Tabs do
+ * not keep inactive panels mounted), so clicking "Edit" on a draft from the
+ * Versions tab remounts it fresh with a `versionId` already in the URL. In that
+ * case the editor must seed from THAT version's content. Falling back to
+ * `policyContent` (which is always the published/current version's content) is
+ * what made a draft's saved edits appear to vanish.
+ *
+ * Pure and side-effect free so it can be unit-tested without mounting the editor.
+ */
+export function resolveInitialPolicyContent({
+  initialVersionId,
+  versions,
+  policyContent,
+}: ResolveInitialPolicyContentArgs): JSONContent[] {
+  if (initialVersionId) {
+    const version = versions.find((v) => v.id === initialVersionId);
+    if (version) {
+      return toContentArray(version.content);
+    }
+  }
+  return toContentArray(policyContent);
+}
+
+/** Normalize content to an array, matching the editor's existing handling. */
+function toContentArray(raw: unknown): JSONContent[] {
+  return Array.isArray(raw) ? (raw as JSONContent[]) : [raw as JSONContent];
+}


### PR DESCRIPTION
## Bug
Create a new policy version → edit the text → switch tabs → **Versions → Edit** the latest draft → the edit appears to vanish (reproduced; customer video confirms it reaches "Saved" first).

## Root cause (it's a *load* bug, not a save bug)
The edit **is** saved correctly to the draft version's `content`. The problem is what the editor displays when you re-open the draft.

In `PolicyContentManager` (`editor/components/PolicyDetails.tsx`):
- `currentContent` (what the editor shows) is seeded from the `policyContent` prop, which `PolicyPageTabs` always sets to the **published/current** version's content.
- `viewingVersion` is correctly the draft.
- The effect that swaps the draft's content into `currentContent` **early-returns on first mount**, because `prevInitialVersionIdRef` is initialized to `initialVersionId` (`prevRef === initialVersionId` → skip).

Switching tabs unmounts the Content tab (the design-system `Tabs` don't keep inactive panels mounted), so clicking **Edit** on a draft from the Versions tab **remounts** the tab fresh with `?versionId=…` already set — hitting that skip-on-mount path and showing the published content. (Editing via the in-editor version *dropdown* works, because `handleVersionSelect` sets the content explicitly — which is why it's intermittent.)

**Risk:** first edit isn't lost (it's safe in the DB), but a *follow-up* edit on top of the wrongly-shown published content would overwrite the draft — so worth fixing promptly.

## Fix
Seed `currentContent` from the `initialVersionId` version when present, via a new pure, unit-tested helper `resolveInitialPolicyContent`. `viewingVersion` was already correct, so this just aligns the displayed content with the selected version. **No save-path change.**

## Tests
`apps/app` → `npx vitest run resolve-initial` → **6/6 pass** (covers: seeds from the targeted draft, falls back to published when no/unknown version, single-node wrapping, empty-draft).

## Notes for reviewer
- Scope: `PolicyDetails.tsx` (1 seed line + import) + the helper + its test.
- Pre-existing issues in this area, **not** introduced by this PR (verified by reverting `PolicyDetails.tsx` to `origin/main`):
  - `PolicyDetails.test.tsx` → "renders editor as read-only when pending approval" fails identically on `origin/main`.
  - `apps/app` typecheck + several policy vitest files fail only on env grounds (`PointerEvent is not defined` in jsdom; `@trycompai/auth` needs internal packages built first; unrelated `*.test.tsx` prop drift) — none in the files this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an editor load bug where editing a draft from Versions > Edit showed the published content. The editor now loads the draft’s own content on mount, so saved edits are visible and not overwritten.

- **Bug Fixes**
  - Seed `currentContent` from the version in `initialVersionId` via `resolveInitialPolicyContent`, falling back to published content only when no match.
  - Updated `PolicyDetails.tsx` to use the helper; no changes to the save path.

<sup>Written for commit a10aa2a6a9621a2d1fd6501098795e7052486d1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

