### PR TITLE
fix(framework-editor): "Add Existing Control" links selected requirements, not all

### DIFF
--- a/apps/api/src/framework-editor/framework/dto/link-control.dto.ts
+++ b/apps/api/src/framework-editor/framework/dto/link-control.dto.ts
@@ -1,0 +1,18 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { ArrayNotEmpty, IsArray, IsOptional, IsString } from 'class-validator';
+
+export class LinkControlDto {
+  @ApiPropertyOptional({
+    description:
+      'Requirement ids (of this framework) to link the control to. ' +
+      'Omit to link the control to every requirement in the framework ' +
+      '(legacy bulk behavior used by the CLI).',
+    type: [String],
+    example: ['frk_rq_abc123'],
+  })
+  @IsOptional()
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  requirementIds?: string[];
+}

--- a/apps/api/src/framework-editor/framework/framework.controller.ts
+++ b/apps/api/src/framework-editor/framework/framework.controller.ts
@@ -11,10 +11,11 @@ import {
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { PlatformAdminGuard } from '../../auth/platform-admin.guard';
 import { CreateFrameworkDto } from './dto/create-framework.dto';
 import { ImportFrameworkDto } from './dto/import-framework.dto';
+import { LinkControlDto } from './dto/link-control.dto';
 import { UpdateFrameworkDto } from './dto/update-framework.dto';
 import { FrameworkExportService } from './framework-export.service';
 import { FrameworkEditorFrameworkService } from './framework.service';
@@ -100,12 +101,19 @@ export class FrameworkEditorFrameworkController {
   }
 
   @Post(':id/link-control/:controlId')
-  @ApiOperation({ summary: 'Link a control to a framework' })
+  @ApiOperation({
+    summary: 'Link a control to a framework',
+    description:
+      'Links a control to the framework. Pass requirementIds to link only ' +
+      'the selected requirements; omit it to link every requirement (legacy).',
+  })
+  @ApiBody({ type: LinkControlDto, required: false })
   async linkControl(
     @Param('id') id: string,
     @Param('controlId') controlId: string,
+    @Body() body: LinkControlDto = {},
   ) {
-    return this.frameworkService.linkControl(id, controlId);
+    return this.frameworkService.linkControl(id, controlId, body.requirementIds);
   }
 
   @Post(':id/link-task/:taskId')

--- a/apps/api/src/framework-editor/framework/framework.service.spec.ts
+++ b/apps/api/src/framework-editor/framework/framework.service.spec.ts
@@ -1,0 +1,77 @@
+jest.mock('@db', () => {
+  const dbMock = {
+    frameworkEditorFramework: {
+      findUnique: jest.fn(),
+    },
+    frameworkEditorRequirement: {
+      findMany: jest.fn(),
+    },
+    frameworkEditorControlTemplate: {
+      update: jest.fn(),
+    },
+  };
+  return { db: dbMock, Prisma: { PrismaClientKnownRequestError: class {} } };
+});
+
+import { BadRequestException, ConflictException } from '@nestjs/common';
+import { db } from '@db';
+import { FrameworkEditorFrameworkService } from './framework.service';
+
+const mockDb = db as jest.Mocked<typeof db>;
+
+describe('FrameworkEditorFrameworkService.linkControl', () => {
+  let service: FrameworkEditorFrameworkService;
+
+  beforeEach(() => {
+    service = new FrameworkEditorFrameworkService();
+    jest.clearAllMocks();
+    (mockDb.frameworkEditorFramework.findUnique as jest.Mock).mockResolvedValue({
+      id: 'frk_1',
+      requirements: [],
+    });
+    (mockDb.frameworkEditorRequirement.findMany as jest.Mock).mockResolvedValue([
+      { id: 'req_1' },
+      { id: 'req_2' },
+      { id: 'req_3' },
+    ]);
+    (mockDb.frameworkEditorControlTemplate.update as jest.Mock).mockResolvedValue({
+      id: 'ct_1',
+    });
+  });
+
+  it('links only the selected requirements when requirementIds is provided', async () => {
+    await service.linkControl('frk_1', 'ct_1', ['req_2']);
+
+    expect(mockDb.frameworkEditorControlTemplate.update).toHaveBeenCalledWith({
+      where: { id: 'ct_1' },
+      data: { requirements: { connect: [{ id: 'req_2' }] } },
+    });
+  });
+
+  it('links every framework requirement when requirementIds is omitted (legacy CLI path)', async () => {
+    await service.linkControl('frk_1', 'ct_1');
+
+    expect(mockDb.frameworkEditorControlTemplate.update).toHaveBeenCalledWith({
+      where: { id: 'ct_1' },
+      data: {
+        requirements: { connect: [{ id: 'req_1' }, { id: 'req_2' }, { id: 'req_3' }] },
+      },
+    });
+  });
+
+  it('rejects requirement ids that do not belong to the framework', async () => {
+    await expect(
+      service.linkControl('frk_1', 'ct_1', ['req_2', 'req_outsider']),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(mockDb.frameworkEditorControlTemplate.update).not.toHaveBeenCalled();
+  });
+
+  it('throws when the framework has no requirements at all', async () => {
+    (mockDb.frameworkEditorRequirement.findMany as jest.Mock).mockResolvedValue([]);
+
+    await expect(service.linkControl('frk_1', 'ct_1')).rejects.toBeInstanceOf(
+      ConflictException,
+    );
+    expect(mockDb.frameworkEditorControlTemplate.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/framework-editor/framework/framework.service.spec.ts
+++ b/apps/api/src/framework-editor/framework/framework.service.spec.ts
@@ -59,6 +59,18 @@ describe('FrameworkEditorFrameworkService.linkControl', () => {
     });
   });
 
+  it('treats a null requirementIds (JSON null past @IsOptional) as link-all, not a crash', async () => {
+    await expect(service.linkControl('frk_1', 'ct_1', null)).resolves.toEqual({
+      message: 'Control linked to framework',
+    });
+    expect(mockDb.frameworkEditorControlTemplate.update).toHaveBeenCalledWith({
+      where: { id: 'ct_1' },
+      data: {
+        requirements: { connect: [{ id: 'req_1' }, { id: 'req_2' }, { id: 'req_3' }] },
+      },
+    });
+  });
+
   it('rejects requirement ids that do not belong to the framework', async () => {
     await expect(
       service.linkControl('frk_1', 'ct_1', ['req_2', 'req_outsider']),

--- a/apps/api/src/framework-editor/framework/framework.service.ts
+++ b/apps/api/src/framework-editor/framework/framework.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Injectable,
   NotFoundException,
   ConflictException,
@@ -231,25 +232,54 @@ export class FrameworkEditorFrameworkService {
     }));
   }
 
-  async linkControl(frameworkId: string, controlId: string) {
+  async linkControl(
+    frameworkId: string,
+    controlId: string,
+    requirementIds?: string[],
+  ) {
     await this.findById(frameworkId);
 
-    const requirementIds = await db.frameworkEditorRequirement
-      .findMany({ where: { frameworkId }, select: { id: true } })
-      .then((reqs) => reqs.map((r) => ({ id: r.id })));
+    const frameworkRequirements = await db.frameworkEditorRequirement.findMany({
+      where: { frameworkId },
+      select: { id: true },
+    });
 
-    if (requirementIds.length === 0) {
+    if (frameworkRequirements.length === 0) {
       throw new ConflictException(
         'Framework has no requirements to link the control to',
       );
     }
 
+    // A control belongs to a framework only through its requirement links. When
+    // the caller passes requirementIds, link just those — this is the UI path,
+    // so adding an existing control no longer fans out to every requirement.
+    // When omitted, link all: the documented legacy bulk behavior the CLI uses.
+    let targetIds: { id: string }[];
+    if (requirementIds === undefined) {
+      targetIds = frameworkRequirements.map((r) => ({ id: r.id }));
+    } else {
+      const frameworkRequirementIds = new Set(
+        frameworkRequirements.map((r) => r.id),
+      );
+      const invalid = requirementIds.filter(
+        (id) => !frameworkRequirementIds.has(id),
+      );
+      if (invalid.length > 0) {
+        throw new BadRequestException(
+          `Requirement(s) not in this framework: ${invalid.join(', ')}`,
+        );
+      }
+      targetIds = requirementIds.map((id) => ({ id }));
+    }
+
     await db.frameworkEditorControlTemplate.update({
       where: { id: controlId },
-      data: { requirements: { connect: requirementIds } },
+      data: { requirements: { connect: targetIds } },
     });
 
-    this.logger.log(`Linked control ${controlId} to framework ${frameworkId}`);
+    this.logger.log(
+      `Linked control ${controlId} to framework ${frameworkId} (${targetIds.length} requirement(s))`,
+    );
     return { message: 'Control linked to framework' };
   }
 

--- a/apps/api/src/framework-editor/framework/framework.service.ts
+++ b/apps/api/src/framework-editor/framework/framework.service.ts
@@ -235,7 +235,7 @@ export class FrameworkEditorFrameworkService {
   async linkControl(
     frameworkId: string,
     controlId: string,
-    requirementIds?: string[],
+    requirementIds?: string[] | null,
   ) {
     await this.findById(frameworkId);
 
@@ -253,9 +253,10 @@ export class FrameworkEditorFrameworkService {
     // A control belongs to a framework only through its requirement links. When
     // the caller passes requirementIds, link just those — this is the UI path,
     // so adding an existing control no longer fans out to every requirement.
-    // When omitted, link all: the documented legacy bulk behavior the CLI uses.
+    // When omitted (undefined/null), link all: the documented legacy bulk
+    // behavior the CLI uses. (@IsOptional lets a JSON null through, so guard it.)
     let targetIds: { id: string }[];
-    if (requirementIds === undefined) {
+    if (requirementIds === undefined || requirementIds === null) {
       targetIds = frameworkRequirements.map((r) => ({ id: r.id }));
     } else {
       const frameworkRequirementIds = new Set(

--- a/apps/framework-editor/app/(pages)/controls/ControlsClientPage.tsx
+++ b/apps/framework-editor/app/(pages)/controls/ControlsClientPage.tsx
@@ -16,6 +16,7 @@ import {
   AddExistingItemDialog,
   type ExistingItemRaw,
 } from '../../components/AddExistingItemDialog';
+import type { RequirementOption } from '../../components/ControlRequirementSelect';
 import { ManageFamiliesDialog } from './ManageFamiliesDialog';
 import {
   ComboboxCell,
@@ -72,6 +73,24 @@ async function fetchRequirementsForFramework(
   return framework.requirements.map((r) =>
     toRequirementItem({ ...r, framework: { name: framework.name } }),
   );
+}
+
+// Requirement options for the "Add Existing Control" picker, oldest-first so
+// the just-created requirement sits at the bottom of the list.
+async function fetchFrameworkRequirementOptions(
+  frameworkId: string,
+): Promise<RequirementOption[]> {
+  const framework = await apiClient<{
+    requirements: Array<{
+      id: string;
+      name: string;
+      identifier: string | null;
+      createdAt?: string;
+    }>;
+  }>(`/framework/${frameworkId}`);
+  return [...framework.requirements]
+    .sort((a, b) => (a.createdAt ?? '').localeCompare(b.createdAt ?? ''))
+    .map((r) => ({ id: r.id, name: r.name, identifier: r.identifier }));
 }
 
 async function fetchAllTaskTemplates(): Promise<RelationalItem[]> {
@@ -484,6 +503,7 @@ export function ControlsClientPage({ initialControls, emptyMessage, frameworkId 
           itemType="control"
           existingItemIds={existingControlIds}
           fetchAllItems={fetchAllControlsForDialog}
+          fetchRequirements={() => fetchFrameworkRequirementOptions(frameworkId)}
         />
       )}
 

--- a/apps/framework-editor/app/components/AddExistingItemDialog.tsx
+++ b/apps/framework-editor/app/components/AddExistingItemDialog.tsx
@@ -16,23 +16,17 @@ import { Loader2, Search } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
+import {
+  extractApiErrorMessage,
+  extractFrameworkNames,
+  type ExistingItemRaw,
+} from './add-existing-item-helpers';
+import {
+  ControlRequirementSelect,
+  type RequirementOption,
+} from './ControlRequirementSelect';
 
-interface ControlTemplateWithFrameworks {
-  id: string;
-  name: string;
-  requirements?: Array<{
-    framework?: { id: string; name: string | null } | null;
-  }>;
-}
-
-export interface ExistingItemRaw {
-  id: string;
-  name: string;
-  controlTemplates?: ControlTemplateWithFrameworks[];
-  requirements?: Array<{
-    framework?: { id: string; name: string | null } | null;
-  }>;
-}
+export type { ExistingItemRaw };
 
 interface ExistingItemDisplay {
   id: string;
@@ -56,45 +50,9 @@ interface AddExistingItemDialogProps {
   itemType: ItemType;
   existingItemIds: Set<string>;
   fetchAllItems: () => Promise<ExistingItemRaw[]>;
-}
-
-// apiClient throws Error(<raw response body>); pull the NestJS `message`
-// field out so the user sees e.g. "Framework has no requirements to link
-// the control to" instead of a generic failure.
-function extractApiErrorMessage(error: unknown): string | null {
-  if (!(error instanceof Error) || !error.message) return null;
-  try {
-    const parsed: unknown = JSON.parse(error.message);
-    if (parsed && typeof parsed === 'object' && 'message' in parsed) {
-      const message = (parsed as { message?: unknown }).message;
-      if (typeof message === 'string') return message;
-    }
-  } catch {
-    // Not JSON — fall through to the raw message.
-  }
-  return error.message;
-}
-
-function extractFrameworkNames(item: ExistingItemRaw): string[] {
-  const names = new Set<string>();
-
-  if (item.controlTemplates) {
-    for (const ct of item.controlTemplates) {
-      if (ct.requirements) {
-        for (const req of ct.requirements) {
-          if (req.framework?.name) names.add(req.framework.name);
-        }
-      }
-    }
-  }
-
-  if (item.requirements) {
-    for (const req of item.requirements) {
-      if (req.framework?.name) names.add(req.framework.name);
-    }
-  }
-
-  return Array.from(names);
+  // When provided (controls only), linking runs a second step where the user
+  // picks which requirements to link to — instead of linking to all of them.
+  fetchRequirements?: () => Promise<RequirementOption[]>;
 }
 
 export function AddExistingItemDialog({
@@ -104,6 +62,7 @@ export function AddExistingItemDialog({
   itemType,
   existingItemIds,
   fetchAllItems,
+  fetchRequirements,
 }: AddExistingItemDialogProps) {
   const router = useRouter();
   const config = ITEM_TYPE_CONFIG[itemType];
@@ -114,11 +73,20 @@ export function AddExistingItemDialog({
   const [search, setSearch] = useState('');
   const [linkedIds, setLinkedIds] = useState<Set<string>>(new Set());
 
+  // Requirement-selection step (controls only).
+  const [pendingControl, setPendingControl] = useState<ExistingItemDisplay | null>(
+    null,
+  );
+  const [requirements, setRequirements] = useState<RequirementOption[]>([]);
+  const [isLoadingRequirements, setIsLoadingRequirements] = useState(false);
+
   useEffect(() => {
     if (!isOpen) {
       setSearch('');
       setAllItems([]);
       setLinkedIds(new Set());
+      setPendingControl(null);
+      setRequirements([]);
       return;
     }
 
@@ -149,15 +117,17 @@ export function AddExistingItemDialog({
       );
   }, [allItems, existingItemIds, linkedIds, search]);
 
-  const handleLink = useCallback(
-    async (item: ExistingItemDisplay) => {
-      setLinkingId(item.id);
+  const linkControl = useCallback(
+    async (controlId: string, controlName: string, requirementIds?: string[]) => {
+      setLinkingId(controlId);
       try {
-        await apiClient(`/framework/${frameworkId}/${config.linkPath}/${item.id}`, {
+        await apiClient(`/framework/${frameworkId}/${config.linkPath}/${controlId}`, {
           method: 'POST',
+          ...(requirementIds ? { body: JSON.stringify({ requirementIds }) } : {}),
         });
-        setLinkedIds((prev) => new Set(prev).add(item.id));
-        toast.success(`${config.label} "${item.name}" linked successfully`);
+        setLinkedIds((prev) => new Set(prev).add(controlId));
+        setPendingControl(null);
+        toast.success(`${config.label} "${controlName}" linked successfully`);
         router.refresh();
       } catch (error) {
         toast.error(
@@ -171,6 +141,28 @@ export function AddExistingItemDialog({
     [frameworkId, config, router],
   );
 
+  const handleLink = useCallback(
+    async (item: ExistingItemDisplay) => {
+      // Controls get a requirement-selection step so they link only to the
+      // chosen requirements rather than all of them.
+      if (fetchRequirements) {
+        setPendingControl(item);
+        setIsLoadingRequirements(true);
+        try {
+          setRequirements(await fetchRequirements());
+        } catch {
+          toast.error('Failed to load requirements');
+          setPendingControl(null);
+        } finally {
+          setIsLoadingRequirements(false);
+        }
+        return;
+      }
+      await linkControl(item.id, item.name);
+    },
+    [fetchRequirements, linkControl],
+  );
+
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[520px]">
@@ -182,6 +174,19 @@ export function AddExistingItemDialog({
           </DialogDescription>
         </DialogHeader>
 
+        {pendingControl ? (
+          <ControlRequirementSelect
+            controlName={pendingControl.name}
+            requirements={requirements}
+            isLoading={isLoadingRequirements}
+            isLinking={linkingId === pendingControl.id}
+            onBack={() => setPendingControl(null)}
+            onConfirm={(requirementIds) =>
+              linkControl(pendingControl.id, pendingControl.name, requirementIds)
+            }
+          />
+        ) : (
+          <>
         <div className="relative">
           <Search className="text-muted-foreground absolute left-2.5 top-2.5 h-4 w-4" />
           <Input
@@ -246,6 +251,8 @@ export function AddExistingItemDialog({
             </div>
           )}
         </ScrollArea>
+          </>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/apps/framework-editor/app/components/ControlRequirementSelect.test.tsx
+++ b/apps/framework-editor/app/components/ControlRequirementSelect.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ControlRequirementSelect,
+  type RequirementOption,
+} from './ControlRequirementSelect';
+
+vi.mock('@trycompai/ui', () => ({
+  Button: ({
+    children,
+    variant: _v,
+    size: _s,
+    ...props
+  }: { variant?: string; size?: string } & React.ComponentProps<'button'>) => (
+    <button {...props}>{children}</button>
+  ),
+  Input: (props: React.ComponentProps<'input'>) => <input {...props} />,
+  ScrollArea: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const REQS: RequirementOption[] = [
+  { id: 'req_1', identifier: 'AC-1', name: 'First' },
+  { id: 'req_2', identifier: 'AC-2', name: 'Second' },
+  { id: 'req_3', identifier: 'AC-2b', name: 'Newest' },
+];
+
+function setup(overrides: Partial<Parameters<typeof ControlRequirementSelect>[0]> = {}) {
+  const onConfirm = vi.fn();
+  const onBack = vi.fn();
+  render(
+    <ControlRequirementSelect
+      controlName="Assign account managers"
+      requirements={REQS}
+      isLoading={false}
+      isLinking={false}
+      onBack={onBack}
+      onConfirm={onConfirm}
+      {...overrides}
+    />,
+  );
+  return { onConfirm, onBack };
+}
+
+describe('ControlRequirementSelect', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('disables the confirm button until at least one requirement is selected', () => {
+    setup();
+    const confirm = screen.getByRole('button', {
+      name: /Link to .*requirement/i,
+    }) as HTMLButtonElement;
+    expect(confirm.disabled).toBe(true);
+
+    fireEvent.click(screen.getByText('AC-2b — Newest'));
+    expect(confirm.disabled).toBe(false);
+  });
+
+  it('confirms with only the selected requirement ids', () => {
+    const { onConfirm } = setup();
+    fireEvent.click(screen.getByText('AC-1 — First'));
+    fireEvent.click(screen.getByText('AC-2b — Newest'));
+    fireEvent.click(screen.getByRole('button', { name: /Link to 2 requirements/i }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm.mock.calls[0][0].sort()).toEqual(['req_1', 'req_3']);
+  });
+
+  it('renders requirements in the given order (newest last)', () => {
+    setup();
+    const labels = screen
+      .getAllByRole('button')
+      .map((b) => b.textContent)
+      .filter((t) => t?.includes('—'));
+    expect(labels[labels.length - 1]).toContain('Newest');
+  });
+
+  it('filters by search text', () => {
+    setup();
+    fireEvent.change(screen.getByPlaceholderText('Search requirements...'), {
+      target: { value: 'newest' },
+    });
+    expect(screen.queryByText('AC-1 — First')).toBeNull();
+    expect(screen.getByText('AC-2b — Newest')).toBeTruthy();
+  });
+
+  it('calls onBack', () => {
+    const { onBack } = setup();
+    fireEvent.click(screen.getByRole('button', { name: /Back/i }));
+    expect(onBack).toHaveBeenCalled();
+  });
+});

--- a/apps/framework-editor/app/components/ControlRequirementSelect.tsx
+++ b/apps/framework-editor/app/components/ControlRequirementSelect.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { Button, Input, ScrollArea } from '@trycompai/ui';
+import { ArrowLeft, Check, Loader2, Search } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+export interface RequirementOption {
+  id: string;
+  identifier: string | null;
+  name: string;
+}
+
+interface ControlRequirementSelectProps {
+  controlName: string;
+  requirements: RequirementOption[];
+  isLoading: boolean;
+  isLinking: boolean;
+  onBack: () => void;
+  onConfirm: (requirementIds: string[]) => void;
+}
+
+function requirementLabel(req: RequirementOption): string {
+  if (req.identifier && req.name) return `${req.identifier} — ${req.name}`;
+  return req.name || req.identifier || 'Unnamed requirement';
+}
+
+/**
+ * Second step of "Add Existing Control": pick which of the framework's
+ * requirements to link the control to. Requirements arrive oldest-first, so the
+ * just-created one sits at the bottom of the list.
+ */
+export function ControlRequirementSelect({
+  controlName,
+  requirements,
+  isLoading,
+  isLinking,
+  onBack,
+  onConfirm,
+}: ControlRequirementSelectProps) {
+  const [search, setSearch] = useState('');
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  const filtered = useMemo(() => {
+    const term = search.toLowerCase().trim();
+    if (!term) return requirements;
+    return requirements.filter((req) =>
+      requirementLabel(req).toLowerCase().includes(term),
+    );
+  }, [requirements, search]);
+
+  const toggle = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1 rounded-sm px-2"
+          onClick={onBack}
+          disabled={isLinking}
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Back
+        </Button>
+        <span className="text-muted-foreground truncate text-sm">
+          Link <span className="text-foreground font-medium">{controlName}</span> to
+          requirements
+        </span>
+      </div>
+
+      <div className="relative">
+        <Search className="text-muted-foreground absolute left-2.5 top-2.5 h-4 w-4" />
+        <Input
+          placeholder="Search requirements..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="rounded-sm pl-8"
+          autoFocus
+        />
+      </div>
+
+      <ScrollArea className="h-[280px] rounded-sm border">
+        {isLoading ? (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="text-muted-foreground py-12 text-center text-sm">
+            {search
+              ? `No requirements matching "${search}"`
+              : 'This framework has no requirements yet'}
+          </div>
+        ) : (
+          <div className="space-y-1 p-2">
+            {filtered.map((req) => {
+              const selected = selectedIds.has(req.id);
+              return (
+                <button
+                  key={req.id}
+                  type="button"
+                  onClick={() => toggle(req.id)}
+                  className={`hover:bg-muted/50 flex w-full items-center gap-2 rounded-sm p-2 text-left ${
+                    selected ? 'bg-muted/60' : ''
+                  }`}
+                >
+                  <span
+                    className={`flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border ${
+                      selected ? 'border-primary bg-primary text-primary-foreground' : 'border-border'
+                    }`}
+                  >
+                    {selected && <Check className="h-3 w-3" />}
+                  </span>
+                  <span className="truncate text-sm">{requirementLabel(req)}</span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </ScrollArea>
+
+      <div className="flex items-center justify-between">
+        <span className="text-muted-foreground text-xs">
+          {selectedIds.size} selected
+        </span>
+        <Button
+          size="sm"
+          className="rounded-sm"
+          disabled={selectedIds.size === 0 || isLinking}
+          onClick={() => onConfirm([...selectedIds])}
+        >
+          {isLinking ? <Loader2 className="mr-1 h-3 w-3 animate-spin" /> : null}
+          Link to {selectedIds.size || ''} requirement{selectedIds.size === 1 ? '' : 's'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/framework-editor/app/components/add-existing-item-helpers.test.ts
+++ b/apps/framework-editor/app/components/add-existing-item-helpers.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractApiErrorMessage,
+  extractFrameworkNames,
+  type ExistingItemRaw,
+} from './add-existing-item-helpers';
+
+describe('extractApiErrorMessage', () => {
+  it('pulls the NestJS message field out of a JSON error body', () => {
+    const error = new Error(
+      JSON.stringify({ message: 'Requirement(s) not in this framework: x', statusCode: 400 }),
+    );
+    expect(extractApiErrorMessage(error)).toBe('Requirement(s) not in this framework: x');
+  });
+
+  it('falls back to the raw message for non-JSON errors', () => {
+    expect(extractApiErrorMessage(new Error('boom'))).toBe('boom');
+  });
+
+  it('returns null for non-Error / empty inputs', () => {
+    expect(extractApiErrorMessage(undefined)).toBeNull();
+    expect(extractApiErrorMessage(new Error(''))).toBeNull();
+  });
+});
+
+describe('extractFrameworkNames', () => {
+  it('collects unique framework names from linked requirements', () => {
+    const item: ExistingItemRaw = {
+      id: 'ct_1',
+      name: 'Control',
+      requirements: [
+        { framework: { id: 'f1', name: 'SOC 2' } },
+        { framework: { id: 'f2', name: 'ISO 27001' } },
+        { framework: { id: 'f1', name: 'SOC 2' } },
+      ],
+    };
+    expect(extractFrameworkNames(item).sort()).toEqual(['ISO 27001', 'SOC 2']);
+  });
+
+  it('also reads framework names nested under controlTemplates', () => {
+    const item: ExistingItemRaw = {
+      id: 'p_1',
+      name: 'Policy',
+      controlTemplates: [
+        { id: 'ct', name: 'C', requirements: [{ framework: { id: 'f', name: 'HIPAA' } }] },
+      ],
+    };
+    expect(extractFrameworkNames(item)).toEqual(['HIPAA']);
+  });
+
+  it('returns an empty array when there are no framework links', () => {
+    expect(extractFrameworkNames({ id: 'x', name: 'X' })).toEqual([]);
+  });
+});

--- a/apps/framework-editor/app/components/add-existing-item-helpers.ts
+++ b/apps/framework-editor/app/components/add-existing-item-helpers.ts
@@ -1,0 +1,44 @@
+export interface ExistingItemRaw {
+  id: string;
+  name: string;
+  controlTemplates?: Array<{
+    id: string;
+    name: string;
+    requirements?: Array<{ framework?: { id: string; name: string | null } | null }>;
+  }>;
+  requirements?: Array<{ framework?: { id: string; name: string | null } | null }>;
+}
+
+// apiClient throws Error(<raw response body>); pull the NestJS `message`
+// field out so the user sees e.g. "Framework has no requirements to link
+// the control to" instead of a generic failure.
+export function extractApiErrorMessage(error: unknown): string | null {
+  if (!(error instanceof Error) || !error.message) return null;
+  try {
+    const parsed: unknown = JSON.parse(error.message);
+    if (parsed && typeof parsed === 'object' && 'message' in parsed) {
+      const message = (parsed as { message?: unknown }).message;
+      if (typeof message === 'string') return message;
+    }
+  } catch {
+    // Not JSON — fall through to the raw message.
+  }
+  return error.message;
+}
+
+// Frameworks an item already belongs to (shown as badges), derived from the
+// frameworks of its linked requirements.
+export function extractFrameworkNames(item: ExistingItemRaw): string[] {
+  const names = new Set<string>();
+
+  for (const ct of item.controlTemplates ?? []) {
+    for (const req of ct.requirements ?? []) {
+      if (req.framework?.name) names.add(req.framework.name);
+    }
+  }
+  for (const req of item.requirements ?? []) {
+    if (req.framework?.name) names.add(req.framework.name);
+  }
+
+  return Array.from(names);
+}


### PR DESCRIPTION
## Bug (Staging, "Strange linking issues")

Adding an existing control to a framework linked it to **every** requirement in the framework — on NIST SP 800-53 low, one control → **149 requirements linked**.

Reporter's ask: *"Stop the controls tab from linking any requirements at all. It's better if we can select them — the newly created requirement is at the bottom of the list."*

## Root cause (reproduced)

A control's framework membership exists only through links to that framework's requirements. `linkControl` (the "Add Existing Control" path, `POST /framework/:id/link-control/:controlId`) connected the control to **all** of them. Verified: a fresh control links to 0 requirements; the link-control path linked it to all (5/5 test, 149/149 NIST). Exact follow-up flagged in #3072.

## Fix

- **Backend** `linkControl(frameworkId, controlId, requirementIds?)`: when `requirementIds` is given, link only those (validated to belong to the framework; invalid → 400). When omitted, the legacy link-all behavior is **unchanged** — the framework-editor CLI documents and relies on it.
- **Frontend** "Add Existing Control" gains a requirement-selection step (search + checkboxes, ≥1 required), listed **oldest-first so the newest requirement is at the bottom**. Tasks/policies in the shared dialog are untouched.
- Extracted pure helpers to `add-existing-item-helpers.ts` to stay under the 300-line cap.

## Testing

- API spec: selective / legacy / invalid-id (400) / no-requirements (409).
- Frontend unit tests for helpers + `ControlRequirementSelect`. 26/26 framework-editor tests pass.
- API reproduction + fix verification; Playwright E2E (6/6) of the dialog→API flow; DB confirmed only the selected requirement got the control (others = 0, no fan-out).
- Typecheck clean (remaining API errors are pre-existing spec issues on main).

Internal admin endpoint (`PlatformAdminGuard`), not in public OpenAPI/MCP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)