### PR TITLE
feat(framework-editor): multi-line editor for long control descriptions

### DIFF
--- a/apps/framework-editor/app/(pages)/controls/ControlsClientPage.tsx
+++ b/apps/framework-editor/app/(pages)/controls/ControlsClientPage.tsx
@@ -253,6 +253,8 @@ export function ControlsClientPage({ initialControls, emptyMessage, frameworkId 
             rowId={row.original.id}
             columnId="description"
             onUpdate={updateCell}
+            expandable
+            expandTitle="Edit Control Description"
           />
         ),
       }),

--- a/apps/framework-editor/app/components/table/EditableCell.test.tsx
+++ b/apps/framework-editor/app/components/table/EditableCell.test.tsx
@@ -1,0 +1,123 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EditableCell } from './EditableCell';
+
+// The ui package ships untranspiled JSX in dist; stub the bits the cell uses.
+vi.mock('@trycompai/ui', () => ({
+  Button: ({
+    children,
+    variant: _v,
+    ...props
+  }: { variant?: string } & React.ComponentProps<'button'>) => (
+    <button {...props}>{children}</button>
+  ),
+  Textarea: (props: React.ComponentProps<'textarea'>) => <textarea {...props} />,
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div role="dialog">{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+function setup(props: Partial<Parameters<typeof EditableCell>[0]> = {}) {
+  const onUpdate = vi.fn();
+  render(
+    <EditableCell
+      value="The organization shall assign account managers."
+      rowId="row-1"
+      columnId="description"
+      onUpdate={onUpdate}
+      {...props}
+    />,
+  );
+  return { onUpdate };
+}
+
+describe('EditableCell — non-expandable (default)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders no expand affordance and no dialog', () => {
+    setup();
+    expect(screen.queryByRole('button', { name: /large editor/i })).toBeNull();
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('click switches to single-line input and commits on Enter', () => {
+    const { onUpdate } = setup();
+    fireEvent.click(screen.getByText(/assign account managers/i));
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    expect(input.tagName).toBe('INPUT');
+    fireEvent.change(input, { target: { value: 'New value' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onUpdate).toHaveBeenCalledWith('row-1', 'description', 'New value');
+  });
+});
+
+describe('EditableCell — expandable', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('shows an expand affordance', () => {
+    setup({ expandable: true });
+    expect(screen.getByRole('button', { name: /large editor/i })).toBeTruthy();
+  });
+
+  it('right-click opens the multi-line editor with the current value', () => {
+    setup({ expandable: true, expandTitle: 'Edit Control Description' });
+    fireEvent.contextMenu(screen.getByText(/assign account managers/i));
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    expect(screen.getByText('Edit Control Description')).toBeTruthy();
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    expect(textarea.tagName).toBe('TEXTAREA');
+    expect(textarea.value).toBe('The organization shall assign account managers.');
+  });
+
+  it('clicking the expand icon opens the editor without entering inline edit', () => {
+    setup({ expandable: true });
+    fireEvent.click(screen.getByRole('button', { name: /large editor/i }));
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    expect(textarea.tagName).toBe('TEXTAREA');
+  });
+
+  it('Save commits the edited multi-line value', () => {
+    const { onUpdate } = setup({ expandable: true });
+    fireEvent.contextMenu(screen.getByText(/assign account managers/i));
+    const textarea = screen.getByRole('textbox');
+    fireEvent.change(textarea, { target: { value: 'Line 1\nLine 2\nLine 3' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(onUpdate).toHaveBeenCalledWith('row-1', 'description', 'Line 1\nLine 2\nLine 3');
+  });
+
+  it('Save is disabled until the value changes', () => {
+    setup({ expandable: true });
+    fireEvent.contextMenu(screen.getByText(/assign account managers/i));
+    const save = screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'changed' } });
+    expect(save.disabled).toBe(false);
+  });
+
+  it('Cancel closes without committing', () => {
+    const { onUpdate } = setup({ expandable: true });
+    fireEvent.contextMenu(screen.getByText(/assign account managers/i));
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'discarded' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onUpdate).not.toHaveBeenCalled();
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('still supports the quick single-line edit on normal click', () => {
+    const { onUpdate } = setup({ expandable: true });
+    fireEvent.click(screen.getByText(/assign account managers/i));
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    expect(input.tagName).toBe('INPUT');
+    fireEvent.change(input, { target: { value: 'quick edit' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onUpdate).toHaveBeenCalledWith('row-1', 'description', 'quick edit');
+  });
+
+  it('does nothing expandable when disabled', () => {
+    setup({ expandable: true, disabled: true });
+    expect(screen.queryByRole('button', { name: /large editor/i })).toBeNull();
+  });
+});

--- a/apps/framework-editor/app/components/table/EditableCell.tsx
+++ b/apps/framework-editor/app/components/table/EditableCell.tsx
@@ -1,5 +1,15 @@
 'use client';
 
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Textarea,
+} from '@trycompai/ui';
+import { Maximize2 } from 'lucide-react';
 import { useState } from 'react';
 
 interface EditableCellProps {
@@ -9,6 +19,11 @@ interface EditableCellProps {
   onUpdate: (rowId: string, columnId: string, value: string) => void;
   disabled?: boolean;
   placeholder?: string;
+  // When set, the cell keeps the quick single-line edit on click but also
+  // offers a large multi-line editor (hover icon or right-click) for long
+  // values like control descriptions.
+  expandable?: boolean;
+  expandTitle?: string;
 }
 
 export function EditableCell({
@@ -18,9 +33,13 @@ export function EditableCell({
   onUpdate,
   disabled = false,
   placeholder = 'Click to edit',
+  expandable = false,
+  expandTitle = 'Edit',
 }: EditableCellProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState(value ?? '');
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [expandValue, setExpandValue] = useState(value ?? '');
 
   const handleBlur = () => {
     setIsEditing(false);
@@ -37,6 +56,24 @@ export function EditableCell({
       setEditValue(value ?? '');
       setIsEditing(false);
     }
+  };
+
+  const handleStartEditing = () => {
+    setEditValue(value ?? '');
+    setIsEditing(true);
+  };
+
+  const handleOpenExpanded = () => {
+    if (disabled) return;
+    setExpandValue(value ?? '');
+    setIsExpanded(true);
+  };
+
+  const handleExpandSave = () => {
+    if (expandValue !== (value ?? '')) {
+      onUpdate(rowId, columnId, expandValue);
+    }
+    setIsExpanded(false);
   };
 
   if (disabled) {
@@ -61,15 +98,65 @@ export function EditableCell({
     );
   }
 
+  if (!expandable) {
+    return (
+      <span
+        className="hover:bg-muted/50 block cursor-text truncate px-2 py-1.5 text-sm"
+        onClick={handleStartEditing}
+      >
+        {value || <span className="text-muted-foreground italic">{placeholder}</span>}
+      </span>
+    );
+  }
+
   return (
-    <span
-      className="hover:bg-muted/50 block cursor-text truncate px-2 py-1.5 text-sm"
-      onClick={() => {
-        setEditValue(value ?? '');
-        setIsEditing(true);
+    <div
+      className="group relative"
+      onContextMenu={(e) => {
+        e.preventDefault();
+        handleOpenExpanded();
       }}
     >
-      {value || <span className="text-muted-foreground italic">{placeholder}</span>}
-    </span>
+      <span
+        className="hover:bg-muted/50 block cursor-text truncate px-2 py-1.5 pr-7 text-sm"
+        onClick={handleStartEditing}
+      >
+        {value || <span className="text-muted-foreground italic">{placeholder}</span>}
+      </span>
+      <button
+        type="button"
+        aria-label="Open large editor"
+        title="Open large editor (or right-click)"
+        className="text-muted-foreground hover:text-foreground absolute right-1 top-1.5 rounded-xs p-0.5 opacity-0 transition-opacity group-hover:opacity-100"
+        onClick={(e) => {
+          e.stopPropagation();
+          handleOpenExpanded();
+        }}
+      >
+        <Maximize2 className="h-3.5 w-3.5" />
+      </button>
+
+      <Dialog open={isExpanded} onOpenChange={setIsExpanded}>
+        <DialogContent className="sm:max-w-[760px]">
+          <DialogHeader>
+            <DialogTitle>{expandTitle}</DialogTitle>
+          </DialogHeader>
+          <Textarea
+            value={expandValue}
+            onChange={(e) => setExpandValue(e.target.value)}
+            autoFocus
+            className="min-h-[260px] font-mono text-sm"
+          />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsExpanded(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleExpandSave} disabled={expandValue === (value ?? '')}>
+              Save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
   );
 }


### PR DESCRIPTION
## Request

> 30 chars on 1 line is not enough. As frameworks get more complex, control descriptions become 1–2k characters. It's very difficult to check wording or edit when only ~30 characters are visible. Can we have a right-click option that opens a multi-line text box (e.g. 100×10) so whole statements can be read and edited?

## What this does

The controls grid edited descriptions through a single-line `<input>` (`EditableCell`) — fine for a control *name*, painful for a long description. Tasks already had a roomy modal editor (`MarkdownCell`); controls didn't.

`EditableCell` now has an opt-in **`expandable`** mode used only by the controls **Description** column:

- A hover **⤢ icon** *and* **right-click** both open a centered **multi-line editor** — a ~10-row textarea (`min-h-260px`, `sm:max-w-[760px]`) showing the whole description, with **Cancel / Save**.
- **Normal click still does the quick single-line edit** — nothing lost.
- Editing/Save flows through the same `onUpdate` → the row goes dirty and persists on **Commit Changes**, exactly like inline edits.

Per the options discussed: **expand-icon + right-click** trigger, **centered modal** (consistent with the existing Tasks editor), **Controls only**. Requirements were intentionally left out of scope.

Every other cell is **byte-for-byte unaffected** — the new behavior is gated behind the `expandable` prop (default `false`), so name/identifier/requirement-description cells render exactly as before.

## Screenshot

Right-click (or hover ⤢) on a control's Description → full text, readable and editable:

<img width="900" alt="Edit Control Description modal" src="https://github.com/user-attachments/assets/placeholder" />

_(Editor caught mid fade-in in the local capture; it's a standard centered dialog.)_

## Testing

- **10 unit tests** on `EditableCell`: hover icon present only when expandable; right-click opens the editor with the full value; expand-icon opens it without entering inline edit; Save commits the multi-line value; Save disabled until changed; Cancel discards; quick single-line edit still works; disabled hides the affordance; non-expandable cells render unchanged.
- **Full framework-editor suite green** (36 tests).
- **Playwright E2E** (9/9) on the real app: right-click opens the editor with a 380-char description, textarea is tall/multi-line (not a 1-line input), Save → Commit persists, and reload + the hover ⤢ icon shows the saved multi-line text.
- `turbo run typecheck --filter=@trycompai/framework-editor` clean.

## Notes

- Right-click suppresses the native context menu on the description cell (the requested gesture); the hover ⤢ icon makes it discoverable and gives a non-right-click path.
- Uses `@trycompai/ui` + `lucide-react` to match this app's convention (43 / 23 files; the sibling `MarkdownCell` uses the same imports) rather than `@trycompai/design-system`, which framework-editor doesn't use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a multi-line editor for long control descriptions in the controls grid. Right-click or the expand icon opens a centered modal; normal click still does quick inline edit.

- **New Features**
  - `EditableCell` supports `expandable` and `expandTitle`.
  - Description column opts in: right-click or expand icon opens a modal with a multi-line `@trycompai/ui` textarea; Cancel/Save with Save only when changed.
  - Inline single-line editing is unchanged; Save uses the existing `onUpdate` flow.
  - Behavior is gated by `expandable`, so other cells are unaffected.

<sup>Written for commit 4896365bd5bb41392498dfdc4691eb6ecc056128. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

