### PR TITLE
feat(evidence-forms): add Account Types document type (CS-513)

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/documents/components/CompanySubmissionWizard.account-types.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/documents/components/CompanySubmissionWizard.account-types.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+vi.mock('@/lib/api-client', () => ({ api: { post: vi.fn() } }));
+vi.mock('@/components/file-uploader', () => ({ FileUploader: () => <div /> }));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+// Light design-system mock: render a Select as a native <select> so the
+// dropdown options and matrix cells are queryable in jsdom.
+vi.mock('@trycompai/design-system', () => {
+  const Passthrough = ({ children }: any) => <div>{children}</div>;
+  return {
+    Alert: Passthrough,
+    Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+    Field: Passthrough,
+    FieldError: () => null,
+    FieldGroup: Passthrough,
+    FieldLabel: ({ children, htmlFor }: any) => <label htmlFor={htmlFor}>{children}</label>,
+    Input: (props: any) => <input {...props} />,
+    Section: Passthrough,
+    Text: ({ children }: any) => <span>{children}</span>,
+    Textarea: (props: any) => <textarea {...props} />,
+    Select: ({ value, onValueChange, children }: any) => (
+      <select
+        data-testid="ds-select"
+        value={value}
+        onChange={(e) => onValueChange?.(e.target.value)}
+      >
+        {children}
+      </select>
+    ),
+    SelectContent: ({ children }: any) => <>{children}</>,
+    SelectItem: ({ value, children }: any) => <option value={value}>{children}</option>,
+    SelectTrigger: () => null,
+    SelectValue: () => null,
+  };
+});
+
+import { CompanySubmissionWizard } from './CompanySubmissionWizard';
+
+describe('CompanySubmissionWizard — account-types rendering', () => {
+  it('renders the 10 seeded rows with Allowed/Disallowed dropdowns and prefilled values', async () => {
+    render(<CompanySubmissionWizard organizationId="org_test" formType="account-types" />);
+
+    // The Account Types table (matrix) lives on the second step.
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    // 10 default rows → 10 status dropdowns, each offering Allowed/Disallowed.
+    await waitFor(() => {
+      expect(screen.getAllByTestId('ds-select')).toHaveLength(10);
+    });
+    const selects = screen.getAllByTestId('ds-select') as HTMLSelectElement[];
+    const options = within(selects[0]).getAllByRole('option').map((o) => o.textContent);
+    expect(options).toEqual(['Allowed', 'Disallowed']);
+
+    // First row is pre-filled per the spec.
+    expect(selects[0].value).toBe('Allowed');
+    expect(screen.getByDisplayValue('Individual')).toBeTruthy();
+    expect(screen.getByDisplayValue('Needed by each employee/worker')).toBeTruthy();
+    // A Disallowed default row has a blank justification.
+    expect(screen.getByDisplayValue('Developer')).toBeTruthy();
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/documents/components/CompanySubmissionWizard.tsx
+++ b/apps/app/src/app/(app)/[orgId]/documents/components/CompanySubmissionWizard.tsx
@@ -64,6 +64,46 @@ function createEmptyMatrixRow(columns: ReadonlyArray<MatrixColumnDefinition>): M
   return Object.fromEntries(columns.map((column) => [column.key, '']));
 }
 
+// A single matrix cell: a dropdown when the column declares `type: 'select'`,
+// otherwise a free-text input.
+function MatrixCellControl({
+  id,
+  column,
+  value,
+  onChange,
+}: {
+  id: string;
+  column: MatrixColumnDefinition;
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  if (column.type === 'select' && column.options) {
+    return (
+      <Select value={value} onValueChange={(next) => onChange(next ?? '')}>
+        <SelectTrigger id={id}>
+          <SelectValue placeholder={column.placeholder ?? 'Select...'} />
+        </SelectTrigger>
+        <SelectContent>
+          {column.options.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+  }
+
+  return (
+    <Input
+      id={id}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      placeholder={column.placeholder}
+    />
+  );
+}
+
 export function CompanySubmissionWizard({
   organizationId,
   formType,
@@ -150,7 +190,11 @@ export function CompanySubmissionWizard({
     }
 
     for (const matrixField of matrixFields) {
-      defaults[matrixField.key] = [createEmptyMatrixRow(matrixField.columns)];
+      const seedRows = matrixField.defaultRows;
+      defaults[matrixField.key] =
+        seedRows && seedRows.length > 0
+          ? seedRows.map((row) => ({ ...createEmptyMatrixRow(matrixField.columns), ...row }))
+          : [createEmptyMatrixRow(matrixField.columns)];
     }
 
     return defaults;
@@ -783,18 +827,13 @@ export function CompanySubmissionWizard({
                                       {column.description}
                                     </Text>
                                   )}
-                                  <Input
+                                  <MatrixCellControl
                                     id={`${field.key}-${rowIndex}-${column.key}`}
+                                    column={column}
                                     value={row[column.key] ?? ''}
-                                    onChange={(event) =>
-                                      updateMatrixCell(
-                                        field,
-                                        rowIndex,
-                                        column.key,
-                                        event.target.value,
-                                      )
+                                    onChange={(value) =>
+                                      updateMatrixCell(field, rowIndex, column.key, value)
                                     }
-                                    placeholder={column.placeholder}
                                   />
                                 </Field>
                               ))}
@@ -948,13 +987,13 @@ export function CompanySubmissionWizard({
                                   {column.description}
                                 </Text>
                               )}
-                              <Input
+                              <MatrixCellControl
                                 id={`${field.key}-${rowIndex}-${column.key}`}
+                                column={column}
                                 value={row[column.key] ?? ''}
-                                onChange={(event) =>
-                                  updateMatrixCell(field, rowIndex, column.key, event.target.value)
+                                onChange={(value) =>
+                                  updateMatrixCell(field, rowIndex, column.key, value)
                                 }
-                                placeholder={column.placeholder}
                               />
                             </Field>
                           ))}

--- a/apps/app/src/app/(app)/[orgId]/documents/components/account-types-form.test.ts
+++ b/apps/app/src/app/(app)/[orgId]/documents/components/account-types-form.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import {
+  evidenceFormDefinitions,
+  evidenceFormSubmissionSchemaMap,
+} from '@/app/(app)/[orgId]/documents/forms';
+
+const schema = evidenceFormSubmissionSchemaMap['account-types'];
+const definition = evidenceFormDefinitions['account-types'];
+
+function submission(rows: Array<Record<string, string>>) {
+  return { submissionDate: '2026-06-10', accountTypeRows: rows };
+}
+
+describe('account-types document type definition', () => {
+  it('has the requested title and intro', () => {
+    expect(definition.title).toBe('New Account Types Submission');
+    expect(definition.description).toBe('Document allowed Account types, with justification.');
+  });
+
+  it('exposes an Allowed/Disallowed dropdown column and a justification column', () => {
+    const matrix = definition.fields.find((f) => f.type === 'matrix');
+    const columns = matrix?.columns ?? [];
+    const status = columns.find((c) => c.key === 'status');
+    expect(status?.type).toBe('select');
+    expect(status?.options?.map((o) => o.value)).toEqual(['Allowed', 'Disallowed']);
+    expect(columns.map((c) => c.key)).toEqual(['accountType', 'status', 'justification']);
+  });
+
+  it('ships the 10 default rows from the spec, pre-filled correctly', () => {
+    const matrix = definition.fields.find((f) => f.type === 'matrix');
+    const rows = matrix?.defaultRows ?? [];
+    expect(rows).toHaveLength(10);
+    expect(rows[0]).toMatchObject({
+      accountType: 'Individual',
+      status: 'Allowed',
+      justification: 'Needed by each employee/worker',
+    });
+    expect(rows.find((r) => r.accountType === 'Developer')).toMatchObject({
+      status: 'Disallowed',
+      justification: '',
+    });
+    // Every Allowed default row carries a justification (so defaults pass validation).
+    for (const row of rows) {
+      if (row.status === 'Allowed') expect(row.justification.trim().length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('account-types conditional validation', () => {
+  it('accepts the shipped default rows as-is', () => {
+    const matrix = definition.fields.find((f) => f.type === 'matrix');
+    const rows = [...(matrix?.defaultRows ?? [])];
+    expect(schema.safeParse(submission(rows)).success).toBe(true);
+  });
+
+  it('requires a justification when a row is Allowed', () => {
+    const result = schema.safeParse(
+      submission([{ accountType: 'Contractor', status: 'Allowed', justification: '' }]),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) => i.path.includes('justification'));
+      expect(issue?.message).toMatch(/justification is required/i);
+    }
+  });
+
+  it('allows a blank justification when a row is Disallowed', () => {
+    const result = schema.safeParse(
+      submission([{ accountType: 'Guest account', status: 'Disallowed', justification: '' }]),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a status that is neither Allowed nor Disallowed', () => {
+    const result = schema.safeParse(
+      submission([{ accountType: 'Weird', status: 'Maybe', justification: '' }]),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it('requires at least one filled account-type row', () => {
+    const result = schema.safeParse(
+      submission([{ accountType: '', status: '', justification: '' }]),
+    );
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/documents/components/account-types-form.test.ts
+++ b/apps/app/src/app/(app)/[orgId]/documents/components/account-types-form.test.ts
@@ -17,12 +17,13 @@ describe('account-types document type definition', () => {
     expect(definition.description).toBe('Document allowed Account types, with justification.');
   });
 
-  it('is optional so it does not change the org-wide expected-documents score', () => {
-    // The global documents-progress scorers count `!hidden && !optional` forms.
-    // Account Types is NIST-specific and must stay out of that count for every
-    // org; it still counts for any control it is explicitly linked to.
+  it('is hidden + optional so it stays out of the global browse list and scores', () => {
+    // NIST-specific: must not appear in every org's Documents browse list
+    // (hidden) and must not change the org-wide expected-documents score
+    // (the scorers count `!hidden && !optional`). It is still reachable and
+    // counted via any control it is explicitly linked to.
+    expect(definition.hidden).toBe(true);
     expect(definition.optional).toBe(true);
-    expect(definition.hidden).toBeFalsy();
   });
 
   it('exposes an Allowed/Disallowed dropdown column and a justification column', () => {

--- a/apps/app/src/app/(app)/[orgId]/documents/components/account-types-form.test.ts
+++ b/apps/app/src/app/(app)/[orgId]/documents/components/account-types-form.test.ts
@@ -17,6 +17,14 @@ describe('account-types document type definition', () => {
     expect(definition.description).toBe('Document allowed Account types, with justification.');
   });
 
+  it('is optional so it does not change the org-wide expected-documents score', () => {
+    // The global documents-progress scorers count `!hidden && !optional` forms.
+    // Account Types is NIST-specific and must stay out of that count for every
+    // org; it still counts for any control it is explicitly linked to.
+    expect(definition.optional).toBe(true);
+    expect(definition.hidden).toBeFalsy();
+  });
+
   it('exposes an Allowed/Disallowed dropdown column and a justification column', () => {
     const matrix = definition.fields.find((f) => f.type === 'matrix');
     const columns = matrix?.columns ?? [];

--- a/apps/app/src/app/(app)/[orgId]/documents/components/submission-utils.tsx
+++ b/apps/app/src/app/(app)/[orgId]/documents/components/submission-utils.tsx
@@ -98,6 +98,8 @@ export type MatrixColumnDefinition = {
   required?: boolean;
   placeholder?: string;
   description?: string;
+  type?: 'text' | 'select';
+  options?: ReadonlyArray<{ label: string; value: string }>;
 };
 
 export function isMatrixField(

--- a/apps/app/src/app/(app)/[orgId]/frameworks/[frameworkInstanceId]/controls/[controlId]/components/documentTypeLabels.ts
+++ b/apps/app/src/app/(app)/[orgId]/frameworks/[frameworkInstanceId]/controls/[controlId]/components/documentTypeLabels.ts
@@ -19,6 +19,7 @@ export const DOCUMENT_TYPE_LABELS: Record<EvidenceFormType, string> = {
   employee_performance_evaluation: 'Employee Performance Evaluation',
   network_diagram: 'Network Diagram',
   tabletop_exercise: 'Tabletop Exercise',
+  account_types: 'Account Types',
 };
 
 export const ALL_DOCUMENT_TYPES = Object.keys(

--- a/apps/framework-editor/app/(pages)/controls/document-type-options.ts
+++ b/apps/framework-editor/app/(pages)/controls/document-type-options.ts
@@ -18,6 +18,7 @@ export const DOCUMENT_TYPE_OPTIONS: MultiSelectOption[] = [
   { value: 'tabletop_exercise', label: 'Incident Response Tabletop Exercise', category: 'Security' },
   { value: 'whistleblower_report', label: 'Whistleblower Report', category: 'People' },
   { value: 'employee_performance_evaluation', label: 'Employee Performance Evaluation', category: 'People' },
+  { value: 'account_types', label: 'Account Types', category: 'Security' },
 ];
 
 export function getDocumentTypeLabel(value: string): string {

--- a/packages/company/src/evidence-forms/db-form-type-map.ts
+++ b/packages/company/src/evidence-forms/db-form-type-map.ts
@@ -14,6 +14,7 @@ export const EXTERNAL_TO_DB_EVIDENCE_FORM_TYPE = {
   'employee-performance-evaluation': 'employee_performance_evaluation',
   'network-diagram': 'network_diagram',
   'tabletop-exercise': 'tabletop_exercise',
+  'account-types': 'account_types',
 } as const satisfies Record<EvidenceFormType, string>;
 
 export type DbEvidenceFormTypeValue = (typeof EXTERNAL_TO_DB_EVIDENCE_FORM_TYPE)[EvidenceFormType];
@@ -31,6 +32,7 @@ export const DB_TO_EXTERNAL_EVIDENCE_FORM_TYPE = {
   employee_performance_evaluation: 'employee-performance-evaluation',
   network_diagram: 'network-diagram',
   tabletop_exercise: 'tabletop-exercise',
+  account_types: 'account-types',
 } as const satisfies Record<DbEvidenceFormTypeValue, EvidenceFormType>;
 
 export function toDbEvidenceFormTypeValue(formType: EvidenceFormType): DbEvidenceFormTypeValue {

--- a/packages/company/src/evidence-forms/definitions.ts
+++ b/packages/company/src/evidence-forms/definitions.ts
@@ -583,6 +583,58 @@ Injects: At 10:30, media contacts the company about the incident.`,
       },
     ],
   },
+  'account-types': {
+    type: 'account-types',
+    title: 'New Account Types Submission',
+    description: 'Document allowed Account types, with justification.',
+    category: 'Security',
+    submissionDateMode: 'custom',
+    portalAccessible: false,
+    fields: [
+      {
+        key: 'accountTypeRows',
+        label: 'Account Types',
+        type: 'matrix',
+        required: true,
+        addRowLabel: 'Add account type',
+        columns: [
+          {
+            key: 'accountType',
+            label: 'Account Type',
+            required: true,
+            placeholder: 'e.g. Individual',
+          },
+          {
+            key: 'status',
+            label: 'Allowed / Disallowed',
+            required: true,
+            type: 'select',
+            options: [
+              { label: 'Allowed', value: 'Allowed' },
+              { label: 'Disallowed', value: 'Disallowed' },
+            ],
+          },
+          {
+            key: 'justification',
+            label: 'Justification',
+            placeholder: 'Required when Allowed',
+          },
+        ],
+        defaultRows: [
+          { accountType: 'Individual', status: 'Allowed', justification: 'Needed by each employee/worker' },
+          { accountType: 'System/Sysadmin', status: 'Allowed', justification: 'Required by administrators' },
+          { accountType: 'Developer', status: 'Disallowed', justification: '' },
+          { accountType: 'Service account', status: 'Allowed', justification: 'Needed for background services' },
+          { accountType: 'Shared account', status: 'Disallowed', justification: '' },
+          { accountType: 'Group account', status: 'Disallowed', justification: '' },
+          { accountType: 'Emergency account', status: 'Disallowed', justification: '' },
+          { accountType: 'Anonymous account', status: 'Disallowed', justification: '' },
+          { accountType: 'Temporary account', status: 'Disallowed', justification: '' },
+          { accountType: 'Guest account', status: 'Disallowed', justification: '' },
+        ],
+      },
+    ],
+  },
 };
 
 export const evidenceFormDefinitionList = Object.values(evidenceFormDefinitions);

--- a/packages/company/src/evidence-forms/definitions.ts
+++ b/packages/company/src/evidence-forms/definitions.ts
@@ -590,10 +590,13 @@ Injects: At 10:30, media contacts the company about the incident.`,
     category: 'Security',
     submissionDateMode: 'custom',
     portalAccessible: false,
-    // NIST-specific: relevant only to orgs that link it to a control, so it is
-    // NOT counted in the org-wide "expected documents" score (which would ding
-    // every org). It still appears in the documents UI and counts for any
-    // control it is linked to (per-control scoring uses the linked types).
+    // NIST-specific: it should not appear in the global Documents browse list
+    // (hidden) and must not affect the org-wide "expected documents" score
+    // (optional). It stays fully usable where it matters: CS links it to a
+    // control in the Framework Editor, and the customer reaches/submits it from
+    // that control's Documents tab (the form route and per-control scoring use
+    // the linked types, not these flags).
+    hidden: true,
     optional: true,
     fields: [
       {

--- a/packages/company/src/evidence-forms/definitions.ts
+++ b/packages/company/src/evidence-forms/definitions.ts
@@ -590,6 +590,11 @@ Injects: At 10:30, media contacts the company about the incident.`,
     category: 'Security',
     submissionDateMode: 'custom',
     portalAccessible: false,
+    // NIST-specific: relevant only to orgs that link it to a control, so it is
+    // NOT counted in the org-wide "expected documents" score (which would ding
+    // every org). It still appears in the documents UI and counts for any
+    // control it is linked to (per-control scoring uses the linked types).
+    optional: true,
     fields: [
       {
         key: 'accountTypeRows',

--- a/packages/company/src/evidence-forms/form-types.ts
+++ b/packages/company/src/evidence-forms/form-types.ts
@@ -13,6 +13,7 @@ export const evidenceFormTypeSchema = z.enum([
   'employee-performance-evaluation',
   'network-diagram',
   'tabletop-exercise',
+  'account-types',
 ]);
 
 export type EvidenceFormType = z.infer<typeof evidenceFormTypeSchema>;

--- a/packages/company/src/evidence-forms/submission-schemas.ts
+++ b/packages/company/src/evidence-forms/submission-schemas.ts
@@ -185,6 +185,60 @@ const tabletopExerciseDataSchema = z.object({
   evidenceFile: evidenceFormFileSchema.optional(),
 });
 
+// Lenient row schema so the pre-seeded default rows parse before the
+// superRefine applies the conditional (Allowed ⇒ Justification) rule.
+const accountTypeRowSchemaLenient = z.object({
+  accountType: z.string().default(''),
+  status: z.string().default(''),
+  justification: z.string().default(''),
+});
+
+const accountTypesDataSchema = z
+  .object({
+    submissionDate: required('Submission date'),
+    accountTypeRows: z.array(accountTypeRowSchemaLenient).optional(),
+  })
+  .superRefine((data, ctx) => {
+    const rows = data.accountTypeRows ?? [];
+    const isRowEmpty = (row: { accountType: string; status: string; justification: string }) =>
+      !row.accountType.trim() && !row.status.trim() && !row.justification.trim();
+
+    if (!rows.some((row) => !isRowEmpty(row))) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Add at least one account type',
+        path: ['accountTypeRows'],
+      });
+      return;
+    }
+
+    rows.forEach((row, i) => {
+      if (isRowEmpty(row)) return;
+      if (!row.accountType.trim()) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Account type is required',
+          path: ['accountTypeRows', i, 'accountType'],
+        });
+      }
+      if (row.status !== 'Allowed' && row.status !== 'Disallowed') {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Select Allowed or Disallowed',
+          path: ['accountTypeRows', i, 'status'],
+        });
+      }
+      // Conditional rule: justification is mandatory only when Allowed.
+      if (row.status === 'Allowed' && !row.justification.trim()) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Justification is required when the account type is Allowed',
+          path: ['accountTypeRows', i, 'justification'],
+        });
+      }
+    });
+  });
+
 export const evidenceFormSubmissionSchemaMap = {
   meeting: meetingDataSchema,
   'board-meeting': meetingDataSchema,
@@ -198,4 +252,5 @@ export const evidenceFormSubmissionSchemaMap = {
   'employee-performance-evaluation': employeePerformanceEvaluationDataSchema,
   'network-diagram': networkDiagramDataSchema,
   'tabletop-exercise': tabletopExerciseDataSchema,
+  'account-types': accountTypesDataSchema,
 } as const satisfies Record<EvidenceFormType, z.ZodTypeAny>;

--- a/packages/company/src/evidence-forms/types.ts
+++ b/packages/company/src/evidence-forms/types.ts
@@ -6,6 +6,10 @@ export type EvidenceFormMatrixColumnDefinition = {
   required?: boolean;
   placeholder?: string;
   description?: string;
+  // Defaults to a free-text input. Set to 'select' to render a dropdown
+  // picklist using `options`.
+  type?: 'text' | 'select';
+  options?: ReadonlyArray<{ label: string; value: string }>;
 };
 
 export type EvidenceFormFieldDefinition = {
@@ -19,6 +23,8 @@ export type EvidenceFormFieldDefinition = {
   accept?: string;
   columns?: ReadonlyArray<EvidenceFormMatrixColumnDefinition>;
   addRowLabel?: string;
+  // Matrix only: rows the form is pre-seeded with (keyed by column key).
+  defaultRows?: ReadonlyArray<Readonly<Record<string, string>>>;
 };
 
 export type EvidenceFormDefinition = {

--- a/packages/db/prisma/migrations/20260610133701_add_account_types_evidence_form_type/migration.sql
+++ b/packages/db/prisma/migrations/20260610133701_add_account_types_evidence_form_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "EvidenceFormType" ADD VALUE 'account-types';

--- a/packages/db/prisma/schema/shared.prisma
+++ b/packages/db/prisma/schema/shared.prisma
@@ -69,6 +69,7 @@ enum EvidenceFormType {
   employee_performance_evaluation @map("employee-performance-evaluation")
   network_diagram                 @map("network-diagram")
   tabletop_exercise               @map("tabletop-exercise")
+  account_types                   @map("account-types")
 }
 
 model GlobalVendors {


### PR DESCRIPTION
## CS-513 — new "Account Types" document type

Adds an **Account Types** evidence document type so CS can link it to NIST SP 800-53 controls in the framework editor. (Needed this week — w/b 8 June.)

### What it is
- **Document type:** Account Types · **Form title:** "New Account Types Submission" · **Intro:** "Document allowed Account types, with justification."
- A table with **Account Type / Allowed‑Disallowed / Justification**, where **Allowed/Disallowed is a dropdown**, pre‑seeded with the 10 standard account types from the ticket.
- **Conditional rule:** Justification is required only when a row is **Allowed**; **Disallowed** rows may leave it blank.

### Platform additions (small, reusable)
Adding this exposed two gaps in the evidence-form platform that I filled generically:
1. **Dropdown matrix columns** — matrix columns were text-only; they can now be `type: 'select'` with `options` (rendered via a new shared `MatrixCellControl`).
2. **Seeded default rows** — a matrix could only start with one empty row; it can now ship `defaultRows`.

### Touch points (this is the current code-only path to add a document type)
- `EvidenceFormType` enum + migration (`packages/db`)
- `@trycompai/company`: `form-types`, `db-form-type-map`, `types`, `definitions`, `submission-schemas`
- App wizard renders select columns + seeded rows
- framework-editor `DOCUMENT_TYPE_OPTIONS` + app `DOCUMENT_TYPE_LABELS`

TS-exhaustive `Record<EvidenceFormType, …>` maps mean a missed touch point fails the build — so coverage is compiler-enforced.

### Testing
- **8 unit specs**: title/intro, the dropdown column + options, the 10 default rows, and conditional validation (Allowed⇒justification required; Disallowed blank ok; invalid status rejected; empty rejected; the shipped defaults validate).
- **1 wizard render spec**: the real wizard renders 10 seeded rows, Allowed/Disallowed dropdowns, and prefilled values.
- `turbo run typecheck` clean for framework-editor and for the changed app files. (One unrelated pre-existing failure in `CompanyFormPageClient.test.tsx` — a stale `swr` mock missing `useSWRConfig`, identical to origin/main, not touched here.)

### Important context — this is the bottleneck, not the cure
This PR is the **tactical** deliverable. It still required an engineer + deploy across ~8 files, which is exactly the bottleneck CS-513 is about. The **self-service form builder** (CS authors document types with no deploy) is a separate, larger project I'm starting next; this document type will coexist with DB-defined ones once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Account Types evidence form so CS can link it to NIST SP 800-53 controls (CS-513). Extends matrix fields with dropdowns and default rows, and marks this form optional and hidden so it doesn’t affect org-wide scores or appear in the global Documents list.

- New Features
  - Account Types document: table with Account Type, Allowed/Disallowed (dropdown), Justification; 10 pre-seeded rows; justification required only when Allowed.
  - Platform: matrix columns can be `type: 'select'` with `options` (rendered by `MatrixCellControl`); matrix fields can define `defaultRows`. Wizard renders both; document type labels/options added in the framework editor and app.
  - Visibility/scoring: `hidden: true` removes it from the global Documents browse list; `optional: true` keeps it out of org-wide “expected documents” scoring while remaining linkable to controls.

- Migration
  - Adds `account-types` to the `EvidenceFormType` enum (Prisma migration) and updates `@trycompai/company` type maps.

<sup>Written for commit 030ee4046a2734c78727f95fb936090142c39cd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

