### PR TITLE
feat(framework-editor): multi-line editor for Requirement descriptions (CS-513)

### DIFF
--- a/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/FrameworkRequirementsClientPage.expandable.test.tsx
+++ b/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/FrameworkRequirementsClientPage.expandable.test.tsx
@@ -1,0 +1,81 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+// Capture every EditableCell invocation so we can assert which columns are
+// expandable (the multi-line editor Joe asked for on Requirement descriptions).
+const editableCellProps: Array<{ columnId: string; expandable?: boolean; expandTitle?: string }> =
+  vi.hoisted(() => []);
+
+vi.mock('../../../components/table', () => ({
+  ComboboxCell: () => null,
+  DateCell: () => null,
+  RelationalCell: () => null,
+  EditableCell: (props: { columnId: string; expandable?: boolean; expandTitle?: string }) => {
+    editableCellProps.push({
+      columnId: props.columnId,
+      expandable: props.expandable,
+      expandTitle: props.expandTitle,
+    });
+    return null;
+  },
+}));
+
+vi.mock('./components/EditFrameworkDialog', () => ({ EditFrameworkDialog: () => null }));
+vi.mock('./components/DeleteFrameworkDialog', () => ({ DeleteFrameworkDialog: () => null }));
+vi.mock('@/app/lib/api-client', () => ({ apiClient: vi.fn() }));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }) }));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('@trycompai/ui', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+}));
+
+vi.mock('./hooks/useRequirementChangeTracking', () => ({
+  simpleUUID: () => 'temp-id',
+  useRequirementChangeTracking: () => ({
+    data: [
+      {
+        id: 'req_1',
+        name: 'Account Management',
+        identifier: 'AC-2',
+        description: 'The organization manages information system accounts...',
+        requirementFamily: 'AC',
+        controlTemplates: [],
+        controlTemplatesLength: 0,
+        createdAt: new Date('2026-01-01'),
+        updatedAt: new Date('2026-01-01'),
+      },
+    ],
+    updateCell: vi.fn(),
+    updateRelational: vi.fn(),
+    addRow: vi.fn(),
+    deleteRow: vi.fn(),
+    getRowClassName: () => '',
+    handleCommit: vi.fn(),
+    handleCancel: vi.fn(),
+    isDirty: false,
+    createdIds: new Set<string>(),
+    changesSummary: '',
+  }),
+}));
+
+import { FrameworkRequirementsClientPage } from './FrameworkRequirementsClientPage';
+
+describe('FrameworkRequirementsClientPage — Description column', () => {
+  it('makes the Description column expandable (multi-line editor) but not Identifier/Name', () => {
+    render(
+      <FrameworkRequirementsClientPage
+        frameworkDetails={{ id: 'frk_1', name: 'NIST', version: '1', description: '', visible: true }}
+        initialRequirements={[]}
+      />,
+    );
+
+    const description = editableCellProps.find((p) => p.columnId === 'description');
+    expect(description?.expandable).toBe(true);
+    expect(description?.expandTitle).toBe('Edit Requirement Description');
+
+    // The short single-line columns stay as plain inline edits.
+    for (const columnId of ['identifier', 'name']) {
+      expect(editableCellProps.find((p) => p.columnId === columnId)?.expandable).toBeFalsy();
+    }
+  });
+});

--- a/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/FrameworkRequirementsClientPage.tsx
+++ b/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/FrameworkRequirementsClientPage.tsx
@@ -161,6 +161,8 @@ export function FrameworkRequirementsClientPage({
             rowId={row.original.id}
             columnId="description"
             onUpdate={updateCell}
+            expandable
+            expandTitle="Edit Requirement Description"
           />
         ),
       }),


### PR DESCRIPTION
## CS-513 follow-up — multi-line editor on **Requirement** descriptions

#3078 added the expandable multi-line description editor to the framework editor's **Controls** tab. The customer (Joe) confirmed that implementation is "perfectly intuitive" — but clarified the field he actually needs it on is the **Requirements** tab → **Description** column (NIST requirements are "controls" in their terminology; the original ticket said "control description").

This enables the exact same editor there:
- Hover a Requirement Description cell → ⤢ icon → click; or right-click the cell → the large editor opens.
- Normal click still does the quick single-line edit.

`EditableCell` already supports `expandable` (from #3078); this just turns it on for the Requirements grid's Description column with the title "Edit Requirement Description". No behavior change to any other cell.

### Testing
- New test asserts the Requirements Description column is `expandable` (and Identifier/Name are not).
- Full framework-editor suite green (37 tests). `turbo run typecheck` clean.

No discoverability changes — Joe approved the existing hover-icon + right-click approach as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an expandable multi-line editor to Requirement Description cells in the Framework editor to make long descriptions easier to edit, matching the Controls tab behavior. Other cells stay single-line; open via the hover expand icon or by right-clicking the cell.

<sup>Written for commit 750fa177c680a8a6023e4e6d250e503e386deb48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

