### PR TITLE
fix(framework-editor): default Controls tab to Name A-Z sort (CS-511)

### DIFF
--- a/apps/framework-editor/app/(pages)/controls/ControlsClientPage.sort.test.tsx
+++ b/apps/framework-editor/app/(pages)/controls/ControlsClientPage.sort.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+// Stub heavy deps; render each cell's value as text so we can read row order.
+vi.mock('@/app/lib/api-client', () => ({ apiClient: vi.fn() }));
+vi.mock('../../components/AddExistingItemDialog', () => ({ AddExistingItemDialog: () => null }));
+vi.mock('./ManageFamiliesDialog', () => ({ ManageFamiliesDialog: () => null }));
+vi.mock('@trycompai/ui', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+}));
+vi.mock('../../components/table', () => ({
+  ComboboxCell: () => null,
+  DateCell: () => null,
+  MultiSelectCell: () => null,
+  RelationalCell: () => null,
+  EditableCell: ({ value, columnId }: { value: string | null; columnId: string }) => (
+    <span data-testid={`cell-${columnId}`}>{value}</span>
+  ),
+}));
+
+function gridRow(id: string, name: string) {
+  return {
+    id,
+    name,
+    description: '',
+    controlFamily: null,
+    policyTemplates: [],
+    requirements: [],
+    taskTemplates: [],
+    documentTypes: [],
+    policyTemplatesLength: 0,
+    requirementsLength: 0,
+    taskTemplatesLength: 0,
+    documentTypesLength: 0,
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+  };
+}
+
+// Rows are returned in deliberately non-alphabetical (creation-ish) order.
+vi.mock('./hooks/useChangeTracking', () => ({
+  simpleUUID: () => 'temp-id',
+  useChangeTracking: () => ({
+    data: [gridRow('c1', 'Zebra control'), gridRow('c2', 'Apple control'), gridRow('c3', 'Mango control')],
+    updateCell: vi.fn(),
+    batchUpdateCells: vi.fn(),
+    updateRelational: vi.fn(),
+    addRow: vi.fn(),
+    deleteRow: vi.fn(),
+    getRowClassName: () => '',
+    handleCommit: vi.fn(),
+    handleCancel: vi.fn(),
+    isDirty: false,
+    createdIds: new Set<string>(),
+    changesSummary: '',
+  }),
+}));
+
+vi.mock('./hooks/useFamiliesManagement', () => ({
+  useFamiliesManagement: () => ({
+    families: [],
+    uniqueFamilies: [],
+    manageFamiliesOpen: false,
+    setManageFamiliesOpen: vi.fn(),
+    handleRenameFamily: vi.fn(),
+    handleDeleteFamily: vi.fn(),
+  }),
+}));
+
+import { ControlsClientPage } from './ControlsClientPage';
+
+describe('ControlsClientPage default sort (CS-511)', () => {
+  it('opens with controls sorted by Name A–Z regardless of input order', () => {
+    render(<ControlsClientPage initialControls={[]} frameworkId="frk_1" />);
+
+    const names = screen.getAllByTestId('cell-name').map((el) => el.textContent);
+    expect(names).toEqual(['Apple control', 'Mango control', 'Zebra control']);
+  });
+});

--- a/apps/framework-editor/app/(pages)/controls/ControlsClientPage.tsx
+++ b/apps/framework-editor/app/(pages)/controls/ControlsClientPage.tsx
@@ -408,7 +408,9 @@ export function ControlsClientPage({ initialControls, emptyMessage, frameworkId 
     [uniqueFamilies, updateCell, updateRelational, deleteRow, createdIds, handleDocumentTypesUpdate, frameworkId, getRequirementItems],
   );
 
-  const [sorting, setSorting] = useState<SortingState>([]);
+  // Default to Name A–Z so the tab always opens in a predictable order
+  // (the grid remounts on every tab switch, resetting this state).
+  const [sorting, setSorting] = useState<SortingState>([{ id: 'name', desc: false }]);
 
   const table = useReactTable({
     data,


### PR DESCRIPTION
## CS-511 — Controls tab default sort

> Whenever I open the Controls tab, the sort order is haphazard… please change so that it always opens in Name column order, alphabetically, A-Z.

### Cause
The Controls grid initialized its sort state to `[]` (no sort), so rows rendered in arbitrary creation order. Because each framework tab is a separate route, the grid remounts on every tab switch and that state resets — hence "lost when moving tabs."

### Fix
Default the sort state to the **Name** column ascending:
```ts
useState<SortingState>([{ id: 'name', desc: false }])
```
So the tab always opens Name A–Z. Users can still re-sort by any column while they're on the tab; it just resets to A–Z on reopen (which is the requested behavior). This mirrors the Requirements tab, which already defaults its sort.

### Testing
- New render test: given controls in non-alphabetical order (Zebra/Apple/Mango), the grid renders them A–Z (Apple/Mango/Zebra).
- Full framework-editor suite green (38 tests); `turbo run typecheck` clean.

Nuisance-level fix, scoped to the framework editor's Controls grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default the Controls tab to sort by Name A–Z on open for a predictable order, matching the Requirements tab. Addresses CS-511.

- **Bug Fixes**
  - Initialize default `sorting` to `[{ id: 'name', desc: false }]` so the grid opens A–Z; users can still re-sort while on the tab.
  - Add a render test to verify A–Z output from non-alphabetical input.

<sup>Written for commit 2b30fa74b0422505203d9b0b760f02608c64697e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

