### PR TITLE
feat(integration-platform): scan all enabled Azure subscriptions (CS-534 part 2)

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/IntegrationProviderHero.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/IntegrationProviderHero.tsx
@@ -138,17 +138,24 @@ export function IntegrationProviderHero({
                               />
                             </div>
                           )}
-                          <div className="flex shrink-0 items-center p-0.5">
-                            <Button
-                              variant="ghost"
-                              size="xs"
-                              onClick={onAddAccount}
-                              iconLeft={<Add size={12} />}
-                              aria-label="Add another account"
-                            >
-                              Add
-                            </Button>
-                          </div>
+                          {/* The OAuth callback reuses the org's existing
+                              connection, so a second OAuth connect silently
+                              merges into the first — only offer "Add" where
+                              the connect flow can actually create another. */}
+                          {provider.supportsMultipleConnections &&
+                            provider.authType !== 'oauth2' && (
+                              <div className="flex shrink-0 items-center p-0.5">
+                                <Button
+                                  variant="ghost"
+                                  size="xs"
+                                  onClick={onAddAccount}
+                                  iconLeft={<Add size={12} />}
+                                  aria-label="Add another account"
+                                >
+                                  Add
+                                </Button>
+                              </div>
+                            )}
                         </div>
                       </div>
                     </div>

--- a/packages/integration-platform/src/manifests/azure/checks/__tests__/azure-checks.test.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/__tests__/azure-checks.test.ts
@@ -4,6 +4,7 @@ import type {
   CheckVariableValues,
   IntegrationCheck,
 } from '../../../../types';
+import { azureManifest } from '../../index';
 import { rbacLeastPrivilegeCheck } from '../entra-id';
 import { keyVaultProtectionCheck, keyVaultRbacCheck } from '../key-vault';
 import { monitorLoggingAlertingCheck } from '../monitor';
@@ -761,5 +762,65 @@ describe('Azure multi-subscription scanning', () => {
     expect(out.passed).toHaveLength(0);
     expect(out.failed).toHaveLength(1);
     expect(out.failed[0]!.title).toMatch(/Could not verify Azure subscription scope/);
+  });
+});
+
+describe('entra-id multi-subscription wildcard isolation (cubic finding on #3090)', () => {
+  it('an MG wildcard role referenced only by one subscription is reported exactly once', async () => {
+    const MG_DEF_ID = '/providers/Microsoft.Management/managementGroups/mg1/providers/Microsoft.Authorization/roleDefinitions/wild';
+    let mgDefFetches = 0;
+    const { failed } = await run(
+      rbacLeastPrivilegeCheck,
+      (url: string) => {
+        if (url.includes('/subscriptions?api-version')) {
+          return {
+            value: [
+              { subscriptionId: 'sub-a', state: 'Enabled' },
+              { subscriptionId: 'sub-b', state: 'Enabled' },
+            ],
+          };
+        }
+        if (url.startsWith(MG_DEF_ID)) {
+          mgDefFetches++;
+          return {
+            id: MG_DEF_ID,
+            properties: {
+              roleName: 'MG Wildcard',
+              type: 'CustomRole',
+              permissions: [{ actions: ['*'], dataActions: [] }],
+            },
+          };
+        }
+        if (url.includes('roleDefinitions')) {
+          return { value: [{ id: 'reader', properties: { roleName: 'Reader', type: 'BuiltInRole', permissions: [] } }] };
+        }
+        if (url.includes('roleAssignments')) {
+          // only sub-a has an assignment referencing the MG wildcard role
+          return url.includes('sub-a')
+            ? { value: [{ properties: { roleDefinitionId: MG_DEF_ID, principalId: 'p1', principalType: 'User' } }] }
+            : { value: [] };
+        }
+        return { value: [] };
+      },
+      {},
+    );
+    const wildcardFindings = failed.filter((f) => f.title.match(/[Ww]ildcard/));
+    expect(wildcardFindings).toHaveLength(1);
+    // the shared cache still prevents refetching across subscriptions
+    expect(mgDefFetches).toBe(1);
+  });
+});
+
+describe('azure subscription picker fetchOptions', () => {
+  it('returns [] instead of throwing when subscriptions cannot be listed', async () => {
+    const variable = azureManifest.variables?.find((v) => v.id === 'subscription_ids');
+    expect(variable?.fetchOptions).toBeDefined();
+    const ctx = {
+      fetch: async () => {
+        throw new Error('HTTP 403: Forbidden');
+      },
+    } as unknown as Parameters<NonNullable<typeof variable.fetchOptions>>[0];
+    const options = await variable!.fetchOptions!(ctx);
+    expect(options).toEqual([]);
   });
 });

--- a/packages/integration-platform/src/manifests/azure/checks/__tests__/azure-checks.test.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/__tests__/azure-checks.test.ts
@@ -670,3 +670,96 @@ describe('Azure read-failure remediation gating', () => {
     expect(f!.evidence).toMatchObject({ readError: 'HTTP 500: boom' });
   });
 });
+
+describe('Azure multi-subscription scanning', () => {
+  const SUBS = {
+    value: [
+      { subscriptionId: 'sub-a', state: 'Enabled', displayName: 'A' },
+      { subscriptionId: 'sub-b', state: 'Enabled', displayName: 'B' },
+      { subscriptionId: 'sub-old', state: 'Disabled', displayName: 'Old' },
+    ],
+  };
+  const serverIn = (sub: string) => ({
+    value: [
+      {
+        id: `/subscriptions/${sub}/resourceGroups/rg/providers/Microsoft.Sql/servers/s-${sub}`,
+        name: `s-${sub}`,
+        properties: { minimalTlsVersion: '1.2' },
+      },
+    ],
+  });
+
+  it('scans every Enabled subscription when none are selected (Disabled excluded)', async () => {
+    const seen: string[] = [];
+    const out = await run(
+      sqlTlsCheck,
+      (url: string) => {
+        if (url.includes('/subscriptions?api-version')) return SUBS;
+        const m = url.match(/subscriptions\/(sub-\w+)\/providers\/Microsoft.Sql\/servers\?/);
+        if (m) {
+          seen.push(m[1]!);
+          return serverIn(m[1]!);
+        }
+        return {};
+      },
+      {},
+    );
+    expect(seen).toEqual(['sub-a', 'sub-b']);
+    expect(out.passed).toHaveLength(2);
+    expect(out.failed).toHaveLength(0);
+  });
+
+  it('scopes to the selected subscription_ids when set', async () => {
+    const seen: string[] = [];
+    const out = await run(
+      sqlTlsCheck,
+      (url: string) => {
+        const m = url.match(/subscriptions\/(sub-\w+)\/providers\/Microsoft.Sql\/servers\?/);
+        if (m) {
+          seen.push(m[1]!);
+          return serverIn(m[1]!);
+        }
+        return {};
+      },
+      { subscription_ids: ['sub-b'] },
+    );
+    expect(seen).toEqual(['sub-b']);
+    expect(out.passed).toHaveLength(1);
+  });
+
+  it('falls back to the legacy subscription_id when subscriptions cannot be listed', async () => {
+    const seen: string[] = [];
+    const out = await run(
+      sqlTlsCheck,
+      (url: string) => {
+        if (url.includes('/subscriptions?api-version')) {
+          throw new Error('HTTP 403: Forbidden');
+        }
+        const m = url.match(/subscriptions\/(sub-\w+)\/providers\/Microsoft.Sql\/servers\?/);
+        if (m) {
+          seen.push(m[1]!);
+          return serverIn(m[1]!);
+        }
+        return {};
+      },
+      { subscription_id: 'sub-legacy' },
+    );
+    expect(seen).toEqual(['sub-legacy']);
+    expect(out.passed).toHaveLength(1);
+    expect(out.failed).toHaveLength(0);
+  });
+
+  it('emits an explicit scope finding when nothing is visible and no legacy value exists', async () => {
+    const out = await run(
+      sqlTlsCheck,
+      (url: string) => {
+        if (url.includes('/subscriptions?api-version')) return { value: [] };
+        return {};
+      },
+      {},
+    );
+    expect(out.passed).toHaveLength(0);
+    expect(out.failed).toHaveLength(1);
+    expect(out.failed[0]!.title).toMatch(/Could not verify Azure subscription scope/);
+  });
+});

--- a/packages/integration-platform/src/manifests/azure/checks/entra-id.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/entra-id.ts
@@ -94,19 +94,29 @@ async function runRbacLeastPrivilegeForSubscription(
     // Assignments can reference role definitions scoped to a management group or
     // resource group, which won't appear in the subscription-scope list above.
     // Resolve any missing definition directly so privileged principals aren't
-    // undercounted. Cache by id to avoid refetching shared definitions.
+    // undercounted. The shared cross-subscription cache (resolvedDefs) only
+    // avoids refetching; the wildcard scan below must see ONLY definitions
+    // referenced by THIS subscription's assignments (subResolvedDefs), or a
+    // wildcard role from another subscription's loop would be re-reported here.
     const resolveFailures: ReadFailure[] = [];
+    const subResolvedDefs = new Map<string, RoleDefinition>();
     const resolveDef = async (
       roleDefinitionId: string,
     ): Promise<RoleDefinition | null> => {
-      const cached = defMap.get(roleDefinitionId) ?? resolvedDefs.get(roleDefinitionId);
-      if (cached) return cached;
+      const own = defMap.get(roleDefinitionId);
+      if (own) return own;
+      const shared = resolvedDefs.get(roleDefinitionId);
+      if (shared) {
+        subResolvedDefs.set(roleDefinitionId, shared);
+        return shared;
+      }
       try {
         const def = await ctx.fetch<RoleDefinition>(
           `${roleDefinitionId}?api-version=2022-04-01`,
         );
         if (def?.properties) {
           resolvedDefs.set(roleDefinitionId, def);
+          subResolvedDefs.set(roleDefinitionId, def);
           return def;
         }
         return null;
@@ -203,7 +213,7 @@ async function runRbacLeastPrivilegeForSubscription(
     const allDefs = new Map<string, RoleDefinition>(
       definitions.map((d) => [d.id, d]),
     );
-    for (const [id, def] of resolvedDefs) allDefs.set(id, def);
+    for (const [id, def] of subResolvedDefs) allDefs.set(id, def);
 
     const wildcardRoles = [...allDefs.values()].filter(
       (d) =>

--- a/packages/integration-platform/src/manifests/azure/checks/entra-id.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/entra-id.ts
@@ -6,7 +6,7 @@ import {
   toHttpReadFailure,
   type ReadFailure,
 } from '../../http-read-failure';
-import { ARM_BASE, armListAllOrFail, resolveAzureSubscriptionId } from './shared';
+import { ARM_BASE, armListAllOrFail, resolveAzureSubscriptionIds } from './shared';
 
 interface RoleAssignment {
   properties: { roleDefinitionId: string; principalId: string; principalType: string };
@@ -66,16 +66,14 @@ function defIsPrivileged(def: RoleDefinition): boolean {
  * Role-based Access Controls. Flags excessive privileged assignments, wildcard
  * custom roles, and service principals holding privileged roles.
  */
-export const rbacLeastPrivilegeCheck: IntegrationCheck = {
-  id: 'azure-rbac-least-privilege',
-  name: 'Azure RBAC — least privilege',
-  description:
-    'Flags excessive privileged role assignments, custom roles with wildcard permissions, and service principals with privileged roles.',
-  service: 'entra-id',
-  taskMapping: TASK_TEMPLATES.rolebasedAccessControls,
-  run: async (ctx: CheckContext) => {
-    const sub = await resolveAzureSubscriptionId(ctx);
-    if (!sub) return;
+async function runRbacLeastPrivilegeForSubscription(
+  ctx: CheckContext,
+  sub: string,
+  // Shared across subscriptions: management-group/resource-group role
+  // definitions are tenant-level, so re-fetching them per subscription only
+  // burns budget.
+  resolvedDefs: Map<string, RoleDefinition>,
+): Promise<void> {
 
     const [assignments, definitions] = await Promise.all([
       armListAllOrFail<RoleAssignment>(
@@ -97,7 +95,6 @@ export const rbacLeastPrivilegeCheck: IntegrationCheck = {
     // resource group, which won't appear in the subscription-scope list above.
     // Resolve any missing definition directly so privileged principals aren't
     // undercounted. Cache by id to avoid refetching shared definitions.
-    const resolvedDefs = new Map<string, RoleDefinition>();
     const resolveFailures: ReadFailure[] = [];
     const resolveDef = async (
       roleDefinitionId: string,
@@ -250,6 +247,21 @@ export const rbacLeastPrivilegeCheck: IntegrationCheck = {
           assignmentsEvaluated: assignments.length,
         },
       });
+    }
+}
+
+export const rbacLeastPrivilegeCheck: IntegrationCheck = {
+  id: 'azure-rbac-least-privilege',
+  name: 'Azure RBAC — least privilege',
+  description:
+    'Flags excessive privileged role assignments, custom roles with wildcard permissions, and service principals with privileged roles.',
+  service: 'entra-id',
+  taskMapping: TASK_TEMPLATES.rolebasedAccessControls,
+  run: async (ctx: CheckContext) => {
+    const subs = await resolveAzureSubscriptionIds(ctx);
+    const resolvedDefs = new Map<string, RoleDefinition>();
+    for (const sub of subs) {
+      await runRbacLeastPrivilegeForSubscription(ctx, sub, resolvedDefs);
     }
   },
 };

--- a/packages/integration-platform/src/manifests/azure/checks/key-vault.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/key-vault.ts
@@ -1,6 +1,6 @@
 import { TASK_TEMPLATES } from '../../../task-mappings';
 import type { CheckContext, FindingSeverity, IntegrationCheck } from '../../../types';
-import { ARM_BASE, armListAllOrFail, resolveAzureSubscriptionId } from './shared';
+import { ARM_BASE, armListAllOrFail, resolveAzureSubscriptionIds } from './shared';
 
 interface KeyVault {
   id: string;
@@ -26,16 +26,7 @@ async function listVaults(
 }
 
 /** Soft delete + purge protection + no public access on Key Vaults → Secure Secrets. */
-export const keyVaultProtectionCheck: IntegrationCheck = {
-  id: 'azure-key-vault-protection',
-  name: 'Key Vault — soft delete, purge protection, no public access',
-  description:
-    'Verify Key Vaults enable soft delete and purge protection and restrict public network access.',
-  service: 'key-vault',
-  taskMapping: TASK_TEMPLATES.secureSecrets,
-  run: async (ctx: CheckContext) => {
-    const sub = await resolveAzureSubscriptionId(ctx);
-    if (!sub) return;
+async function runKeyVaultProtectionForSubscription(ctx: CheckContext, sub: string): Promise<void> {
     const vaults = await listVaults(ctx, sub);
     if (!vaults) return;
     if (vaults.length === 0) return;
@@ -87,20 +78,25 @@ export const keyVaultProtectionCheck: IntegrationCheck = {
         });
       }
     }
+}
+
+export const keyVaultProtectionCheck: IntegrationCheck = {
+  id: 'azure-key-vault-protection',
+  name: 'Key Vault — soft delete, purge protection, no public access',
+  description:
+    'Verify Key Vaults enable soft delete and purge protection and restrict public network access.',
+  service: 'key-vault',
+  taskMapping: TASK_TEMPLATES.secureSecrets,
+  run: async (ctx: CheckContext) => {
+    const subs = await resolveAzureSubscriptionIds(ctx);
+    for (const sub of subs) {
+      await runKeyVaultProtectionForSubscription(ctx, sub);
+    }
   },
 };
 
 /** Azure RBAC authorization (not legacy access policies) on Key Vaults → Role-based Access Controls. */
-export const keyVaultRbacCheck: IntegrationCheck = {
-  id: 'azure-key-vault-rbac',
-  name: 'Key Vault — RBAC authorization',
-  description:
-    'Verify Key Vaults use Azure RBAC instead of legacy vault access policies.',
-  service: 'key-vault',
-  taskMapping: TASK_TEMPLATES.rolebasedAccessControls,
-  run: async (ctx: CheckContext) => {
-    const sub = await resolveAzureSubscriptionId(ctx);
-    if (!sub) return;
+async function runKeyVaultRbacForSubscription(ctx: CheckContext, sub: string): Promise<void> {
     const vaults = await listVaults(ctx, sub);
     if (!vaults) return;
     if (vaults.length === 0) return;
@@ -128,6 +124,20 @@ export const keyVaultRbacCheck: IntegrationCheck = {
           },
         });
       }
+    }
+}
+
+export const keyVaultRbacCheck: IntegrationCheck = {
+  id: 'azure-key-vault-rbac',
+  name: 'Key Vault — RBAC authorization',
+  description:
+    'Verify Key Vaults use Azure RBAC instead of legacy vault access policies.',
+  service: 'key-vault',
+  taskMapping: TASK_TEMPLATES.rolebasedAccessControls,
+  run: async (ctx: CheckContext) => {
+    const subs = await resolveAzureSubscriptionIds(ctx);
+    for (const sub of subs) {
+      await runKeyVaultRbacForSubscription(ctx, sub);
     }
   },
 };

--- a/packages/integration-platform/src/manifests/azure/checks/monitor.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/monitor.ts
@@ -5,7 +5,7 @@ import {
   toHttpReadFailure,
   type ReadFailure,
 } from '../../http-read-failure';
-import { ARM_BASE, armListAll, resolveAzureSubscriptionId } from './shared';
+import { ARM_BASE, armListAll, resolveAzureSubscriptionIds } from './shared';
 
 interface ActivityLogAlert {
   properties?: {
@@ -31,16 +31,7 @@ const RECOMMENDED_ALERTS = [
 ];
 
 /** Activity log alerts for critical ops + subscription log export → Monitoring & Alerting. */
-export const monitorLoggingAlertingCheck: IntegrationCheck = {
-  id: 'azure-monitor-logging-alerting',
-  name: 'Azure Monitor — alerts and log export',
-  description:
-    'Verify activity log alerts exist for critical operations and subscription logs are exported.',
-  service: 'monitor',
-  taskMapping: TASK_TEMPLATES.monitoringAlerting,
-  run: async (ctx: CheckContext) => {
-    const sub = await resolveAzureSubscriptionId(ctx);
-    if (!sub) return;
+async function runMonitorLoggingAlertingForSubscription(ctx: CheckContext, sub: string): Promise<void> {
     let evaluated = false;
 
     let alertsReadFailure: ReadFailure | undefined;
@@ -179,6 +170,20 @@ export const monitorLoggingAlertingCheck: IntegrationCheck = {
 
     if (!evaluated) {
       ctx.log('Azure monitor check: could not read monitor data — skipping');
+    }
+}
+
+export const monitorLoggingAlertingCheck: IntegrationCheck = {
+  id: 'azure-monitor-logging-alerting',
+  name: 'Azure Monitor — alerts and log export',
+  description:
+    'Verify activity log alerts exist for critical operations and subscription logs are exported.',
+  service: 'monitor',
+  taskMapping: TASK_TEMPLATES.monitoringAlerting,
+  run: async (ctx: CheckContext) => {
+    const subs = await resolveAzureSubscriptionIds(ctx);
+    for (const sub of subs) {
+      await runMonitorLoggingAlertingForSubscription(ctx, sub);
     }
   },
 };

--- a/packages/integration-platform/src/manifests/azure/checks/mysql-flexible.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/mysql-flexible.ts
@@ -6,7 +6,7 @@ import {
   toHttpReadFailure,
   type ReadFailure,
 } from '../../http-read-failure';
-import { ARM_BASE, armListAllOrFail, resolveAzureSubscriptionId } from './shared';
+import { ARM_BASE, armListAllOrFail, resolveAzureSubscriptionIds } from './shared';
 
 // Pinned stable api-version for Azure Database for MySQL Flexible Server.
 const MYSQL_API_VERSION = '2023-12-30';
@@ -108,16 +108,7 @@ async function readConfigValue(
  * Flexible Server resource type (Microsoft.DBforMySQL/flexibleServers), whose
  * TLS enforcement lives in server parameters rather than a top-level property.
  */
-export const mysqlFlexibleTlsCheck: IntegrationCheck = {
-  id: 'azure-mysql-flexible-tls',
-  name: 'Database for MySQL — TLS 1.2 enforced',
-  description:
-    'Verify Azure Database for MySQL Flexible Servers require secure transport and a minimum TLS version of 1.2.',
-  service: 'mysql-flexible',
-  taskMapping: TASK_TEMPLATES.tlsHttps,
-  run: async (ctx: CheckContext) => {
-    const sub = await resolveAzureSubscriptionId(ctx);
-    if (!sub) return;
+async function runMysqlFlexibleTlsForSubscription(ctx: CheckContext, sub: string): Promise<void> {
     const servers = await listMySqlFlexibleServers(ctx, sub);
     if (!servers) return;
     if (servers.length === 0) return;
@@ -180,6 +171,20 @@ export const mysqlFlexibleTlsCheck: IntegrationCheck = {
           evidence: { server: s.name, requireSecureTransport, tlsVersion },
         });
       }
+    }
+}
+
+export const mysqlFlexibleTlsCheck: IntegrationCheck = {
+  id: 'azure-mysql-flexible-tls',
+  name: 'Database for MySQL — TLS 1.2 enforced',
+  description:
+    'Verify Azure Database for MySQL Flexible Servers require secure transport and a minimum TLS version of 1.2.',
+  service: 'mysql-flexible',
+  taskMapping: TASK_TEMPLATES.tlsHttps,
+  run: async (ctx: CheckContext) => {
+    const subs = await resolveAzureSubscriptionIds(ctx);
+    for (const sub of subs) {
+      await runMysqlFlexibleTlsForSubscription(ctx, sub);
     }
   },
 };

--- a/packages/integration-platform/src/manifests/azure/checks/network.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/network.ts
@@ -1,6 +1,6 @@
 import { TASK_TEMPLATES } from '../../../task-mappings';
 import type { CheckContext, FindingSeverity, IntegrationCheck } from '../../../types';
-import { ARM_BASE, armListAllOrFail, resolveAzureSubscriptionId } from './shared';
+import { ARM_BASE, armListAllOrFail, resolveAzureSubscriptionIds } from './shared';
 
 interface SecurityRule {
   name: string;
@@ -71,16 +71,7 @@ function rulePorts(r: SecurityRule): string[] {
 }
 
 /** NSG inbound rules open to the internet on sensitive ports → Production Firewall / no public access. */
-export const nsgNoOpenPortsCheck: IntegrationCheck = {
-  id: 'azure-nsg-no-open-ports',
-  name: 'Network — no NSG ports open to the internet',
-  description:
-    'Flags NSG inbound rules that allow SSH, RDP, database ports, or all ports from the internet.',
-  service: 'network-watcher',
-  taskMapping: TASK_TEMPLATES.productionFirewallNopublicaccessControls,
-  run: async (ctx: CheckContext) => {
-    const sub = await resolveAzureSubscriptionId(ctx);
-    if (!sub) return;
+async function runNsgNoOpenPortsForSubscription(ctx: CheckContext, sub: string): Promise<void> {
     const nsgs = await armListAllOrFail<Nsg>(
       ctx,
       `${ARM_BASE}/subscriptions/${sub}/providers/Microsoft.Network/networkSecurityGroups?api-version=2023-11-01`,
@@ -148,6 +139,20 @@ export const nsgNoOpenPortsCheck: IntegrationCheck = {
           },
         });
       }
+    }
+}
+
+export const nsgNoOpenPortsCheck: IntegrationCheck = {
+  id: 'azure-nsg-no-open-ports',
+  name: 'Network — no NSG ports open to the internet',
+  description:
+    'Flags NSG inbound rules that allow SSH, RDP, database ports, or all ports from the internet.',
+  service: 'network-watcher',
+  taskMapping: TASK_TEMPLATES.productionFirewallNopublicaccessControls,
+  run: async (ctx: CheckContext) => {
+    const subs = await resolveAzureSubscriptionIds(ctx);
+    for (const sub of subs) {
+      await runNsgNoOpenPortsForSubscription(ctx, sub);
     }
   },
 };

--- a/packages/integration-platform/src/manifests/azure/checks/postgresql-flexible.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/postgresql-flexible.ts
@@ -6,7 +6,7 @@ import {
   toHttpReadFailure,
   type ReadFailure,
 } from '../../http-read-failure';
-import { ARM_BASE, armListAllOrFail, resolveAzureSubscriptionId } from './shared';
+import { ARM_BASE, armListAllOrFail, resolveAzureSubscriptionIds } from './shared';
 
 // Pinned stable api-version for Azure Database for PostgreSQL Flexible Server.
 // NOTE: PostgreSQL is a SEPARATE resource provider from MySQL with its own
@@ -112,16 +112,7 @@ async function readConfig(
  * customer running only PostgreSQL Flexible Server gets 0 servers found by the
  * Azure SQL check → "0 passed" for the TLS task (the reported bug class).
  */
-export const postgresqlFlexibleTlsCheck: IntegrationCheck = {
-  id: 'azure-postgresql-flexible-tls',
-  name: 'Database for PostgreSQL — TLS 1.2 enforced',
-  description:
-    'Verify Azure Database for PostgreSQL Flexible Servers require secure transport and a minimum TLS version of 1.2.',
-  service: 'postgresql-flexible',
-  taskMapping: TASK_TEMPLATES.tlsHttps,
-  run: async (ctx: CheckContext) => {
-    const sub = await resolveAzureSubscriptionId(ctx);
-    if (!sub) return;
+async function runPostgresqlFlexibleTlsForSubscription(ctx: CheckContext, sub: string): Promise<void> {
     const servers = await listPgFlexibleServers(ctx, sub);
     if (!servers) return;
     if (servers.length === 0) return;
@@ -181,6 +172,20 @@ export const postgresqlFlexibleTlsCheck: IntegrationCheck = {
           evidence,
         });
       }
+    }
+}
+
+export const postgresqlFlexibleTlsCheck: IntegrationCheck = {
+  id: 'azure-postgresql-flexible-tls',
+  name: 'Database for PostgreSQL — TLS 1.2 enforced',
+  description:
+    'Verify Azure Database for PostgreSQL Flexible Servers require secure transport and a minimum TLS version of 1.2.',
+  service: 'postgresql-flexible',
+  taskMapping: TASK_TEMPLATES.tlsHttps,
+  run: async (ctx: CheckContext) => {
+    const subs = await resolveAzureSubscriptionIds(ctx);
+    for (const sub of subs) {
+      await runPostgresqlFlexibleTlsForSubscription(ctx, sub);
     }
   },
 };

--- a/packages/integration-platform/src/manifests/azure/checks/shared.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/shared.ts
@@ -3,35 +3,104 @@ import { remediationForReadFailure, toHttpReadFailure } from '../../http-read-fa
 
 const ARM = 'https://management.azure.com';
 
-/**
- * Resolve the Azure subscription to scan: the user-set `subscription_id`
- * variable, else the first enabled subscription the token can see. Returns
- * null when none — the check should then no-op (no false pass).
- */
-export async function resolveAzureSubscriptionId(
-  ctx: CheckContext,
-): Promise<string | null> {
+/** Fan-out bound for auto-discovered subscriptions (13 checks × N subs). */
+const MAX_SUBSCRIPTIONS = 50;
+
+/** The legacy single-subscription variable, auto-saved by the Cloud Tests
+ * setup. It is a detection cache, not a deliberate scope choice, so the
+ * evidence checks only use it when subscriptions cannot be listed. */
+function legacySubscriptionId(ctx: CheckContext): string | null {
   const configured = ctx.variables.subscription_id;
-  if (typeof configured === 'string' && configured.trim().length > 0) {
-    return configured.trim();
+  return typeof configured === 'string' && configured.trim().length > 0
+    ? configured.trim()
+    : null;
+}
+
+/**
+ * Resolve the Azure subscriptions a check should evaluate: the user-selected
+ * `subscription_ids` variable if present, otherwise ALL Enabled subscriptions
+ * the token can see (mirrors how GCP scans all active projects). Previously
+ * only the first Enabled subscription was scanned — silently skipping the
+ * rest in multi-subscription tenants.
+ *
+ * Returns [] only after emitting an explicit "could not verify" finding, so
+ * a scope failure never leaves the mapped tasks silently stale.
+ */
+export async function resolveAzureSubscriptionIds(
+  ctx: CheckContext,
+): Promise<string[]> {
+  const selected = ctx.variables.subscription_ids;
+  if (Array.isArray(selected)) {
+    const cleaned = selected
+      .filter((s): s is string => typeof s === 'string')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    if (cleaned.length > 0) return cleaned;
   }
+
+  const legacy = legacySubscriptionId(ctx);
   try {
     const data = await ctx.fetch<{
       value?: Array<{ subscriptionId: string; state?: string }>;
     }>(`${ARM}/subscriptions?api-version=2020-01-01`);
-    const subs = data.value ?? [];
-    // Only auto-select an Enabled subscription. Falling back to the first
-    // subscription regardless of state could pick a Disabled/PastDue one whose
-    // API calls fail; returning null instead makes the check no-op cleanly (the
-    // user can set subscription_id explicitly).
-    const active = subs.find((s) => s.state === 'Enabled');
-    return active?.subscriptionId ?? null;
+    // Only Enabled subscriptions — a Disabled/PastDue one would fail every
+    // API call and drown the run in false "could not verify" findings.
+    const enabled = (data.value ?? [])
+      .filter((s) => s.state === 'Enabled')
+      .map((s) => s.subscriptionId);
+    if (enabled.length > 0) {
+      if (legacy && (enabled.length > 1 || enabled[0] !== legacy)) {
+        ctx.log(
+          `Azure: scanning all ${enabled.length} enabled subscription(s); set subscription_ids to scope explicitly (legacy subscription_id is no longer used for scoping)`,
+        );
+      }
+      // Bound the fan-out so a giant tenant can't blow the run budget —
+      // loudly, so capped coverage is never mistaken for full coverage.
+      if (enabled.length > MAX_SUBSCRIPTIONS) {
+        ctx.warn(
+          `Azure: ${enabled.length} enabled subscriptions found; scanning the first ${MAX_SUBSCRIPTIONS} — set subscription_ids to scope explicitly`,
+          { enabled: enabled.length, scanned: MAX_SUBSCRIPTIONS },
+        );
+        return enabled.slice(0, MAX_SUBSCRIPTIONS);
+      }
+      return enabled;
+    }
+    // Nothing visible via the list call — the token may lack list permission
+    // at root scope while still having Reader on one subscription.
+    if (legacy) return [legacy];
+    ctx.fail({
+      title: 'Could not verify Azure subscription scope',
+      description:
+        'No enabled Azure subscription is visible to the connection, so nothing could be scanned.',
+      resourceType: 'azure-subscription',
+      resourceId: 'unknown',
+      severity: 'medium',
+      remediation:
+        'Grant the connection Reader access to at least one subscription (or select subscriptions in the integration settings), then re-run the check.',
+      evidence: { enabledSubscriptionsVisible: 0 },
+    });
+    return [];
   } catch (err) {
-    ctx.warn(
-      'Failed to auto-detect Azure subscription; set subscription_id manually',
-      { error: err instanceof Error ? err.message : String(err) },
-    );
-    return null;
+    if (legacy) {
+      ctx.log(
+        `Azure: could not list subscriptions (${err instanceof Error ? err.message : String(err)}); falling back to the detected subscription_id`,
+      );
+      return [legacy];
+    }
+    const failure = toHttpReadFailure(err);
+    ctx.fail({
+      title: 'Could not verify Azure subscription scope',
+      description: `Azure subscriptions could not be listed (${failure.error}), so nothing could be scanned.`,
+      resourceType: 'azure-subscription',
+      resourceId: 'unknown',
+      severity: 'medium',
+      remediation: remediationForReadFailure(
+        failure,
+        'Grant the connection Reader access to the subscription(s), then re-run the check.',
+      ),
+      evidence: { readError: failure.error },
+    });
+    return [];
   }
 }
 

--- a/packages/integration-platform/src/manifests/azure/checks/sql.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/sql.ts
@@ -5,7 +5,7 @@ import {
   toHttpReadFailure,
   type ReadFailure,
 } from '../../http-read-failure';
-import { ARM_BASE, armListAll, armListAllOrFail, resolveAzureSubscriptionId } from './shared';
+import { ARM_BASE, armListAll, armListAllOrFail, resolveAzureSubscriptionIds } from './shared';
 
 interface SqlServer {
   id: string;
@@ -32,15 +32,7 @@ async function listSqlServers(
 }
 
 /** SQL Server minimum TLS 1.2 → TLS / HTTPS. */
-export const sqlTlsCheck: IntegrationCheck = {
-  id: 'azure-sql-tls',
-  name: 'SQL Database — TLS 1.2 enforced',
-  description: 'Verify SQL Servers require a minimum TLS version of 1.2.',
-  service: 'sql-database',
-  taskMapping: TASK_TEMPLATES.tlsHttps,
-  run: async (ctx: CheckContext) => {
-    const sub = await resolveAzureSubscriptionId(ctx);
-    if (!sub) return;
+async function runSqlTlsForSubscription(ctx: CheckContext, sub: string): Promise<void> {
     const servers = await listSqlServers(ctx, sub);
     if (!servers) return;
     if (servers.length === 0) return;
@@ -68,20 +60,24 @@ export const sqlTlsCheck: IntegrationCheck = {
         });
       }
     }
+}
+
+export const sqlTlsCheck: IntegrationCheck = {
+  id: 'azure-sql-tls',
+  name: 'SQL Database — TLS 1.2 enforced',
+  description: 'Verify SQL Servers require a minimum TLS version of 1.2.',
+  service: 'sql-database',
+  taskMapping: TASK_TEMPLATES.tlsHttps,
+  run: async (ctx: CheckContext) => {
+    const subs = await resolveAzureSubscriptionIds(ctx);
+    for (const sub of subs) {
+      await runSqlTlsForSubscription(ctx, sub);
+    }
   },
 };
 
 /** SQL Server no public network / wide-open firewall → Production Firewall / no public access. */
-export const sqlPublicAccessCheck: IntegrationCheck = {
-  id: 'azure-sql-no-public-access',
-  name: 'SQL Database — no public access',
-  description:
-    'Verify SQL Servers disable public network access and have no wide-open firewall rules.',
-  service: 'sql-database',
-  taskMapping: TASK_TEMPLATES.productionFirewallNopublicaccessControls,
-  run: async (ctx: CheckContext) => {
-    const sub = await resolveAzureSubscriptionId(ctx);
-    if (!sub) return;
+async function runSqlPublicAccessForSubscription(ctx: CheckContext, sub: string): Promise<void> {
     const servers = await listSqlServers(ctx, sub);
     if (!servers) return;
     if (servers.length === 0) return;
@@ -184,6 +180,20 @@ export const sqlPublicAccessCheck: IntegrationCheck = {
         });
       }
     }
+}
+
+export const sqlPublicAccessCheck: IntegrationCheck = {
+  id: 'azure-sql-no-public-access',
+  name: 'SQL Database — no public access',
+  description:
+    'Verify SQL Servers disable public network access and have no wide-open firewall rules.',
+  service: 'sql-database',
+  taskMapping: TASK_TEMPLATES.productionFirewallNopublicaccessControls,
+  run: async (ctx: CheckContext) => {
+    const subs = await resolveAzureSubscriptionIds(ctx);
+    for (const sub of subs) {
+      await runSqlPublicAccessForSubscription(ctx, sub);
+    }
   },
 };
 
@@ -192,15 +202,7 @@ interface AuditingSetting {
 }
 
 /** SQL Server auditing enabled → Monitoring & Alerting. */
-export const sqlAuditingCheck: IntegrationCheck = {
-  id: 'azure-sql-auditing',
-  name: 'SQL Database — auditing enabled',
-  description: 'Verify SQL Servers have auditing enabled to track database operations.',
-  service: 'sql-database',
-  taskMapping: TASK_TEMPLATES.monitoringAlerting,
-  run: async (ctx: CheckContext) => {
-    const sub = await resolveAzureSubscriptionId(ctx);
-    if (!sub) return;
+async function runSqlAuditingForSubscription(ctx: CheckContext, sub: string): Promise<void> {
     const servers = await listSqlServers(ctx, sub);
     if (!servers) return;
     if (servers.length === 0) return;
@@ -254,6 +256,19 @@ export const sqlAuditingCheck: IntegrationCheck = {
           evidence: { server: s.name, state: auditing.properties?.state ?? null },
         });
       }
+    }
+}
+
+export const sqlAuditingCheck: IntegrationCheck = {
+  id: 'azure-sql-auditing',
+  name: 'SQL Database — auditing enabled',
+  description: 'Verify SQL Servers have auditing enabled to track database operations.',
+  service: 'sql-database',
+  taskMapping: TASK_TEMPLATES.monitoringAlerting,
+  run: async (ctx: CheckContext) => {
+    const subs = await resolveAzureSubscriptionIds(ctx);
+    for (const sub of subs) {
+      await runSqlAuditingForSubscription(ctx, sub);
     }
   },
 };

--- a/packages/integration-platform/src/manifests/azure/checks/storage.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/storage.ts
@@ -1,6 +1,6 @@
 import { TASK_TEMPLATES } from '../../../task-mappings';
 import type { CheckContext, IntegrationCheck } from '../../../types';
-import { ARM_BASE, armListAllOrFail, resolveAzureSubscriptionId } from './shared';
+import { ARM_BASE, armListAllOrFail, resolveAzureSubscriptionIds } from './shared';
 
 interface StorageAccount {
   id: string;
@@ -36,16 +36,7 @@ async function listStorageAccounts(
 }
 
 /** HTTPS-only + minimum TLS 1.2 on storage accounts → TLS / HTTPS. */
-export const storageHttpsTlsCheck: IntegrationCheck = {
-  id: 'azure-storage-https-tls',
-  name: 'Storage — HTTPS and TLS 1.2 enforced',
-  description:
-    'Verify storage accounts enforce HTTPS-only traffic and a minimum TLS version of 1.2.',
-  service: 'storage-account',
-  taskMapping: TASK_TEMPLATES.tlsHttps,
-  run: async (ctx: CheckContext) => {
-    const sub = await resolveAzureSubscriptionId(ctx);
-    if (!sub) return;
+async function runStorageHttpsTlsForSubscription(ctx: CheckContext, sub: string): Promise<void> {
     const accounts = await listStorageAccounts(ctx, sub);
     if (!accounts) return;
     if (accounts.length === 0) return;
@@ -85,20 +76,25 @@ export const storageHttpsTlsCheck: IntegrationCheck = {
         });
       }
     }
+}
+
+export const storageHttpsTlsCheck: IntegrationCheck = {
+  id: 'azure-storage-https-tls',
+  name: 'Storage — HTTPS and TLS 1.2 enforced',
+  description:
+    'Verify storage accounts enforce HTTPS-only traffic and a minimum TLS version of 1.2.',
+  service: 'storage-account',
+  taskMapping: TASK_TEMPLATES.tlsHttps,
+  run: async (ctx: CheckContext) => {
+    const subs = await resolveAzureSubscriptionIds(ctx);
+    for (const sub of subs) {
+      await runStorageHttpsTlsForSubscription(ctx, sub);
+    }
   },
 };
 
 /** No public blob/network access on storage accounts → Production Firewall / no public access. */
-export const storagePublicAccessCheck: IntegrationCheck = {
-  id: 'azure-storage-no-public-access',
-  name: 'Storage — no public access',
-  description:
-    'Verify storage accounts disable anonymous blob access and public network access.',
-  service: 'storage-account',
-  taskMapping: TASK_TEMPLATES.productionFirewallNopublicaccessControls,
-  run: async (ctx: CheckContext) => {
-    const sub = await resolveAzureSubscriptionId(ctx);
-    if (!sub) return;
+async function runStoragePublicAccessForSubscription(ctx: CheckContext, sub: string): Promise<void> {
     const accounts = await listStorageAccounts(ctx, sub);
     if (!accounts) return;
     if (accounts.length === 0) return;
@@ -146,20 +142,25 @@ export const storagePublicAccessCheck: IntegrationCheck = {
         });
       }
     }
+}
+
+export const storagePublicAccessCheck: IntegrationCheck = {
+  id: 'azure-storage-no-public-access',
+  name: 'Storage — no public access',
+  description:
+    'Verify storage accounts disable anonymous blob access and public network access.',
+  service: 'storage-account',
+  taskMapping: TASK_TEMPLATES.productionFirewallNopublicaccessControls,
+  run: async (ctx: CheckContext) => {
+    const subs = await resolveAzureSubscriptionIds(ctx);
+    for (const sub of subs) {
+      await runStoragePublicAccessForSubscription(ctx, sub);
+    }
   },
 };
 
 /** Service-side encryption enabled on storage accounts → Encryption at Rest. */
-export const storageEncryptionCheck: IntegrationCheck = {
-  id: 'azure-storage-encryption-at-rest',
-  name: 'Storage — encryption at rest enabled',
-  description:
-    'Verify storage accounts have blob and file service encryption enabled.',
-  service: 'storage-account',
-  taskMapping: TASK_TEMPLATES.encryptionAtRest,
-  run: async (ctx: CheckContext) => {
-    const sub = await resolveAzureSubscriptionId(ctx);
-    if (!sub) return;
+async function runStorageEncryptionForSubscription(ctx: CheckContext, sub: string): Promise<void> {
     const accounts = await listStorageAccounts(ctx, sub);
     if (!accounts) return;
     if (accounts.length === 0) return;
@@ -186,6 +187,20 @@ export const storageEncryptionCheck: IntegrationCheck = {
           evidence: { account: a.name, blobEnabled: blobOk, fileEnabled: fileOk },
         });
       }
+    }
+}
+
+export const storageEncryptionCheck: IntegrationCheck = {
+  id: 'azure-storage-encryption-at-rest',
+  name: 'Storage — encryption at rest enabled',
+  description:
+    'Verify storage accounts have blob and file service encryption enabled.',
+  service: 'storage-account',
+  taskMapping: TASK_TEMPLATES.encryptionAtRest,
+  run: async (ctx: CheckContext) => {
+    const subs = await resolveAzureSubscriptionIds(ctx);
+    for (const sub of subs) {
+      await runStorageEncryptionForSubscription(ctx, sub);
     }
   },
 };

--- a/packages/integration-platform/src/manifests/azure/index.ts
+++ b/packages/integration-platform/src/manifests/azure/index.ts
@@ -97,6 +97,35 @@ Our integration only makes read-only API calls for security scanning.`,
 
   variables: [
     {
+      id: 'subscription_ids',
+      label: 'Azure Subscriptions',
+      type: 'multi-select',
+      required: false,
+      helpText:
+        'Select which subscriptions to scan. Leave empty to scan all enabled subscriptions.',
+      fetchOptions: async (ctx) => {
+        const data = await ctx.fetch<{
+          value?: Array<{
+            subscriptionId: string;
+            displayName?: string;
+            state?: string;
+          }>;
+        }>('https://management.azure.com/subscriptions?api-version=2020-01-01');
+        return (data.value ?? [])
+          .filter((s) => s.state === 'Enabled')
+          .sort((a, b) => (a.displayName ?? '').localeCompare(b.displayName ?? ''))
+          .map((s) => ({
+            value: s.subscriptionId,
+            label: s.displayName
+              ? `${s.displayName} (${s.subscriptionId})`
+              : s.subscriptionId,
+          }));
+      },
+    },
+    {
+      // Kept for the Cloud Tests product, which auto-detects and reads this
+      // value on its own path. The evidence checks scope via subscription_ids
+      // and only fall back to this when subscriptions cannot be listed.
       id: 'subscription_id',
       label: 'Azure Subscription ID',
       type: 'text',

--- a/packages/integration-platform/src/manifests/azure/index.ts
+++ b/packages/integration-platform/src/manifests/azure/index.ts
@@ -104,22 +104,28 @@ Our integration only makes read-only API calls for security scanning.`,
       helpText:
         'Select which subscriptions to scan. Leave empty to scan all enabled subscriptions.',
       fetchOptions: async (ctx) => {
-        const data = await ctx.fetch<{
-          value?: Array<{
-            subscriptionId: string;
-            displayName?: string;
-            state?: string;
-          }>;
-        }>('https://management.azure.com/subscriptions?api-version=2020-01-01');
-        return (data.value ?? [])
-          .filter((s) => s.state === 'Enabled')
-          .sort((a, b) => (a.displayName ?? '').localeCompare(b.displayName ?? ''))
-          .map((s) => ({
-            value: s.subscriptionId,
-            label: s.displayName
-              ? `${s.displayName} (${s.subscriptionId})`
-              : s.subscriptionId,
-          }));
+        try {
+          const data = await ctx.fetch<{
+            value?: Array<{
+              subscriptionId: string;
+              displayName?: string;
+              state?: string;
+            }>;
+          }>('https://management.azure.com/subscriptions?api-version=2020-01-01');
+          return (data.value ?? [])
+            .filter((s) => s.state === 'Enabled')
+            .sort((a, b) => (a.displayName ?? '').localeCompare(b.displayName ?? ''))
+            .map((s) => ({
+              value: s.subscriptionId,
+              label: s.displayName
+                ? `${s.displayName} (${s.subscriptionId})`
+                : s.subscriptionId,
+            }));
+        } catch {
+          // Graceful empty picker (matches the GCP project_ids precedent) —
+          // the user can still rely on scan-all or the legacy subscription_id.
+          return [];
+        }
       },
     },
     {

--- a/packages/integration-platform/src/manifests/gcp/checks/__tests__/gcp-checks.test.ts
+++ b/packages/integration-platform/src/manifests/gcp/checks/__tests__/gcp-checks.test.ts
@@ -124,6 +124,23 @@ describe('GCP read-failure remediation gating', () => {
   });
 });
 
+describe('GCP project scope failure', () => {
+  it('emits an explicit scope finding when project discovery fails', async () => {
+    const err = new Error('HTTP 500: boom');
+    (err as Error & { status: number }).status = 500;
+    const out = await runCheck(vpcOpenFirewallsCheck, {
+      variables: {},
+      fetch: () => {
+        throw err;
+      },
+    });
+    expect(out.failed).toHaveLength(1);
+    expect(out.failed[0]!.title).toMatch(/Could not verify GCP project scope/);
+    expect(out.failed[0]!.remediation).toMatch(/re-run/i);
+    expect(out.failed[0]!.evidence).toMatchObject({ readError: 'HTTP 500: boom' });
+  });
+});
+
 describe('GCP IAM primitive roles check', () => {
   it('fails on roles/owner binding (high)', async () => {
     const { passed, failed } = await runCheck(iamPrimitiveRolesCheck, {

--- a/packages/integration-platform/src/manifests/gcp/checks/shared.ts
+++ b/packages/integration-platform/src/manifests/gcp/checks/shared.ts
@@ -1,11 +1,12 @@
 import type { CheckContext } from '../../../types';
+import { remediationForReadFailure, toHttpReadFailure } from '../../http-read-failure';
 
 /**
  * Resolve which GCP projects a check should evaluate: the user-selected
  * `project_ids` variable if present, otherwise a bounded best-effort
- * detection of active projects. Returns [] when none can be resolved — the
- * check should then no-op (emit neither pass nor fail) rather than produce a
- * false pass.
+ * detection of active projects. Returns [] when none can be resolved; a
+ * discovery FAILURE emits an explicit "could not verify" finding first, so
+ * the mapped task never goes silently stale.
  */
 export async function resolveGcpProjectIds(ctx: CheckContext): Promise<string[]> {
   const selected = ctx.variables.project_ids;
@@ -54,8 +55,20 @@ export async function resolveGcpProjectIds(ctx: CheckContext): Promise<string[]>
     }
     return projectIds;
   } catch (err) {
-    ctx.warn('GCP project auto-discovery failed; checks will be skipped', {
-      error: err instanceof Error ? err.message : String(err),
+    // Surface the scope failure as an explicit finding — a silent [] would
+    // leave every mapped task stale with no signal anything went wrong.
+    const failure = toHttpReadFailure(err);
+    ctx.fail({
+      title: 'Could not verify GCP project scope',
+      description: `GCP projects could not be listed (${failure.error}), so nothing could be scanned.`,
+      resourceType: 'gcp-project',
+      resourceId: 'unknown',
+      severity: 'medium',
+      remediation: remediationForReadFailure(
+        failure,
+        'Grant resourcemanager.projects.get to the connection (or select projects in the integration settings), then re-run the check.',
+      ),
+      evidence: { readError: failure.error },
     });
     return [];
   }


### PR DESCRIPTION
Part 2 of [CS-534](https://linear.app/compai/issue/CS-534) — **the deliberate behavior change**, stacked on part 1 (#3089). ⚠️ Needs a CX heads-up before deploy (draft below).

## The gap

Azure evidence checks scanned only the **first Enabled subscription** and silently skipped the rest — a compliance product reporting partial coverage as full coverage. GCP already scans all projects; this brings Azure to parity.

## Changes

- **`subscription_ids` multi-select** with a live subscription picker (mirrors GCP's `project_ids`). Explicit selection always wins.
- **`resolveAzureSubscriptionIds`**: selected ids → else **all Enabled subscriptions** → legacy `subscription_id` only when subscriptions can't be listed. The legacy value is auto-saved by Cloud Tests detection (a cache, not a scope choice) — and **Cloud Tests is untouched**, it keeps reading `subscription_id` on its own path (verified zero cross-references).
- **All 13 Azure checks** loop subscriptions via extracted per-subscription helpers — bodies **byte-identical** to before (mechanically verified), so internal early-returns now correctly skip only that subscription.
- **Fan-out bounded at 50 subscriptions** with a loud warning (never silent partial coverage), and entra-id's tenant-level role-definition cache is shared across subscriptions.
- **Scope failures are now findings**: "Could not verify Azure subscription scope" / "Could not verify GCP project scope" instead of silently skipping every check and leaving tasks stale.
- **"Add another account" hidden for OAuth providers** (`IntegrationProviderHero`): the OAuth callback reuses the org's existing connection, so a second connect silently merged into the first. (The review caught that my first attempt gated a dead component — `ConnectionSection.tsx` has zero importers; reverted that and gated the live button.)

## Customer impact (the honest version)

| Existing customer | After deploy |
|---|---|
| One subscription | **Identical findings** — verified per check |
| Multiple subscriptions, never scoped | New findings from previously-unscanned subscriptions (the point of the fix); tasks may flip to failed + status emails |
| **Deliberately typed** `subscription_id` to exclude subs | **Gets un-scoped** — must re-select in the new picker. Called out in the CX note; no migration seeds the new variable because most legacy values are auto-detected, and freezing those would preserve the blind spot |

## Verification

- 192 tests pass (5 new: all-Enabled fan-out with Disabled exclusion, explicit selection, legacy fallback on list failure, scope-finding emission, GCP scope finding)
- 3-reviewer adversarial pass: all 13 helper bodies verified byte-identical; per-subscription return semantics verified per check; single-subscription invariant verified; Cloud Tests isolation verified; their findings (dead-component gate, fan-out bound, shared cache) fixed before commit
- Known limitation (deliberate): subscription-scoped findings are attributed by subscription GUID in `resourceId`; showing display names is a UI follow-up

## CX note draft

> Azure integration update: we now scan **all** enabled subscriptions in your tenant (previously only one was scanned). New findings after this deploy are from the expanded coverage, not a regression. To scan specific subscriptions only, select them in Integrations → Azure → Settings → "Azure Subscriptions".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scans all enabled Azure subscriptions by default and adds a `subscription_ids` picker to scope scans, closing CS-534’s coverage gap. Also surfaces Azure/GCP scope discovery failures as findings and hides “Add account” for OAuth; if you used `subscription_id` to narrow scope, re-select in `subscription_ids`.

- **New Features**
  - Azure scans all Enabled subscriptions; use `subscription_ids` to scope explicitly. Falls back to legacy `subscription_id` only when subscriptions can’t be listed. Fan-out capped at 50 with a warning.
  - All 13 Azure checks now loop per subscription (logic unchanged). Entra role-definition cache is shared across subscriptions to dedupe fetches.
  - Scope discovery failures emit findings: “Could not verify Azure subscription scope” and “Could not verify GCP project scope” (no silent skips).
  - “Add another account” is hidden for OAuth providers.

- **Bug Fixes**
  - Entra ID RBAC: wildcard-role scan is isolated per subscription so a management-group wildcard referenced in one subscription isn’t re-reported in others; the cross-subscription cache only dedupes fetches.
  - Azure subscription picker: `fetchOptions` now returns [] on list failure (graceful, matches GCP).

<sup>Written for commit ae55a2667d53b5218b102dfecebc37191a462e61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

