### PR TITLE
fix(integration-platform): stamp account attribution on account-level AWS findings

### DIFF
--- a/packages/integration-platform/src/manifests/aws/checks/__tests__/aws-checks.test.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/__tests__/aws-checks.test.ts
@@ -20,6 +20,7 @@ import {
   awsAccountIdFromCtx,
   emitOutcomes,
   resolveAwsCredentialInputs,
+  resolveAwsSessionOrFail,
   combineReadFailures,
   remediationForReadFailure,
   toReadFailure,
@@ -884,5 +885,33 @@ describe('emitOutcomes — attributes findings to the AWS account', () => {
     expect(passed[0]!.description).toContain(
       '(AWS account 123456789012 — Production AWS)',
     );
+  });
+});
+
+describe('account-level findings carry AWS account attribution (cubic finding on CS-533)', () => {
+  it('resolveAwsSessionOrFail failures are stamped with the account from the role ARN', async () => {
+    const failed: Array<{ description: string; evidence?: Record<string, unknown> }> = [];
+    const ctx = {
+      credentials: {
+        roleArn: 'arn:aws:iam::123456789012:role/x',
+        externalId: 'eid',
+        regions: ['us-east-1'],
+        connectionName: 'Prod AWS',
+        __resolvedSessionError: 'assume failed for test',
+      },
+      fail: (r: { description: string; evidence?: Record<string, unknown> }) => failed.push(r),
+      pass: () => {},
+      log: () => {},
+    } as unknown as Parameters<typeof resolveAwsSessionOrFail>[0];
+
+    const session = await resolveAwsSessionOrFail(ctx);
+    expect(session).toBeNull();
+    expect(failed).toHaveLength(1);
+    expect(failed[0]!.evidence).toMatchObject({
+      awsAccountId: '123456789012',
+      awsConnectionName: 'Prod AWS',
+      error: 'assume failed for test',
+    });
+    expect(failed[0]!.description).toContain('AWS account 123456789012');
   });
 });

--- a/packages/integration-platform/src/manifests/aws/checks/cloudtrail.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/cloudtrail.ts
@@ -228,23 +228,26 @@ export const cloudTrailEnabledCheck: IntegrationCheck = {
     // permissions/transient error) — report it as unverified instead.
     if (trails.length === 0 && regionFailures.length > 0) {
       const combined = combineReadFailures(regionFailures.map((r) => r.failure));
-      ctx.fail({
-        title: 'Could not verify CloudTrail configuration',
-        description: `CloudTrail trails could not be listed in: ${regionFailures.map((r) => r.region).join(', ')}, so trail configuration is unverified.`,
-        resourceType: 'aws-cloudtrail',
-        resourceId: 'account',
-        severity: 'medium',
-        remediation: remediationForReadFailure(
-          combined,
-          'Grant cloudtrail:DescribeTrails to the integration role in all enabled regions, then re-run the check.',
-        ),
-        evidence: {
-          failedRegions: regionFailures.map((r) => ({
-            region: r.region,
-            error: r.failure.error,
-          })),
+      emitOutcomes(ctx, [
+        {
+          kind: 'fail',
+          title: 'Could not verify CloudTrail configuration',
+          description: `CloudTrail trails could not be listed in: ${regionFailures.map((r) => r.region).join(', ')}, so trail configuration is unverified.`,
+          resourceType: 'aws-cloudtrail',
+          resourceId: 'account',
+          severity: 'medium',
+          remediation: remediationForReadFailure(
+            combined,
+            'Grant cloudtrail:DescribeTrails to the integration role in all enabled regions, then re-run the check.',
+          ),
+          evidence: {
+            failedRegions: regionFailures.map((r) => ({
+              region: r.region,
+              error: r.failure.error,
+            })),
+          },
         },
-      });
+      ]);
       return;
     }
 

--- a/packages/integration-platform/src/manifests/aws/checks/ec2.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/ec2.ts
@@ -148,23 +148,26 @@ export const ec2SecurityGroupsCheck: IntegrationCheck = {
     // total/partial read failure end as a silent clean run (no findings).
     if (regionFailures.length > 0) {
       const regions = regionFailures.map((r) => r.region);
-      ctx.fail({
-        title: 'Could not verify security groups in some regions',
-        description: `Security groups could not be listed in: ${regions.join(', ')}. Internet exposure in those regions is unverified.`,
-        resourceType: 'aws-security-group',
-        resourceId: `regions:${regions.join(',')}`,
-        severity: 'medium',
-        remediation: remediationForReadFailure(
-          combineReadFailures(regionFailures.map((r) => r.failure)),
-          'Grant ec2:DescribeSecurityGroups to the integration role in all enabled regions, then re-run the check.',
-        ),
-        evidence: {
-          failedRegions: regionFailures.map((r) => ({
-            region: r.region,
-            error: r.failure.error,
-          })),
+      emitOutcomes(ctx, [
+        {
+          kind: 'fail',
+          title: 'Could not verify security groups in some regions',
+          description: `Security groups could not be listed in: ${regions.join(', ')}. Internet exposure in those regions is unverified.`,
+          resourceType: 'aws-security-group',
+          resourceId: `regions:${regions.join(',')}`,
+          severity: 'medium',
+          remediation: remediationForReadFailure(
+            combineReadFailures(regionFailures.map((r) => r.failure)),
+            'Grant ec2:DescribeSecurityGroups to the integration role in all enabled regions, then re-run the check.',
+          ),
+          evidence: {
+            failedRegions: regionFailures.map((r) => ({
+              region: r.region,
+              error: r.failure.error,
+            })),
+          },
         },
-      });
+      ]);
     }
     if (sgs.length === 0) return;
     emitOutcomes(ctx, evaluateSecurityGroups(sgs));

--- a/packages/integration-platform/src/manifests/aws/checks/iam.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/iam.ts
@@ -187,18 +187,21 @@ export const iamAccountSecurityCheck: IntegrationCheck = {
     // password-policy findings now so they aren't lost if the summary read
     // fails below.
     if (policyReadFailure) {
-      ctx.fail({
-        title: 'Could not verify IAM password policy',
-        description: `The IAM account password policy could not be read (${policyReadFailure.error}), so password-policy strength is unverified.`,
-        resourceType: 'aws-account',
-        resourceId: 'account',
-        severity: 'medium',
-        remediation: remediationForReadFailure(
-          policyReadFailure,
-          'Grant iam:GetAccountPasswordPolicy to the integration role, then re-run the check.',
-        ),
-        evidence: { readError: policyReadFailure.error },
-      });
+      emitOutcomes(ctx, [
+        {
+          kind: 'fail',
+          title: 'Could not verify IAM password policy',
+          description: `The IAM account password policy could not be read (${policyReadFailure.error}), so password-policy strength is unverified.`,
+          resourceType: 'aws-account',
+          resourceId: 'account',
+          severity: 'medium',
+          remediation: remediationForReadFailure(
+            policyReadFailure,
+            'Grant iam:GetAccountPasswordPolicy to the integration role, then re-run the check.',
+          ),
+          evidence: { readError: policyReadFailure.error },
+        },
+      ]);
     } else {
       emitOutcomes(ctx, evaluatePasswordPolicy(passwordPolicy));
     }
@@ -213,18 +216,21 @@ export const iamAccountSecurityCheck: IntegrationCheck = {
       // check with a bare error (or omitting those critical findings).
       const failure = toReadFailure(err);
       ctx.log(`IAM: could not read account summary: ${failure.error}`);
-      ctx.fail({
-        title: 'Could not verify IAM account summary',
-        description: `The IAM account summary (root MFA, root access keys) could not be read (${failure.error}), so root-account security is unverified.`,
-        resourceType: 'aws-account',
-        resourceId: 'account',
-        severity: 'medium',
-        remediation: remediationForReadFailure(
-          failure,
-          'Grant iam:GetAccountSummary to the integration role, then re-run the check.',
-        ),
-        evidence: { readError: failure.error },
-      });
+      emitOutcomes(ctx, [
+        {
+          kind: 'fail',
+          title: 'Could not verify IAM account summary',
+          description: `The IAM account summary (root MFA, root access keys) could not be read (${failure.error}), so root-account security is unverified.`,
+          resourceType: 'aws-account',
+          resourceId: 'account',
+          severity: 'medium',
+          remediation: remediationForReadFailure(
+            failure,
+            'Grant iam:GetAccountSummary to the integration role, then re-run the check.',
+          ),
+          evidence: { readError: failure.error },
+        },
+      ]);
     }
   },
 };

--- a/packages/integration-platform/src/manifests/aws/checks/kms.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/kms.ts
@@ -201,25 +201,28 @@ export const kmsKeyRotationCheck: IntegrationCheck = {
       if (failedKeys.length > 0) {
         parts.push(`metadata could not be read for ${failedKeys.length} key(s)`);
       }
-      ctx.fail({
-        title: 'Could not verify KMS keys',
-        description: `${parts.join('; ')} — rotation eligibility/status is unverified.`,
-        resourceType: 'aws-kms-key',
-        resourceId: 'account',
-        severity: 'medium',
-        remediation: remediationForReadFailure(
-          combineReadFailures(unreadable.map((u) => u.failure)),
-          'Grant kms:ListKeys, kms:DescribeKey, and kms:GetKeyRotationStatus to the integration role in all enabled regions, then re-run the check.',
-        ),
-        evidence: {
-          failedRegions,
-          failedKeyCount: failedKeys.length,
-          // first few per-key errors so the cause is visible without log digging
-          keyReadErrors: failedKeys
-            .slice(0, 5)
-            .map((u) => ({ keyId: u.id, error: u.failure.error })),
+      emitOutcomes(ctx, [
+        {
+          kind: 'fail',
+          title: 'Could not verify KMS keys',
+          description: `${parts.join('; ')} — rotation eligibility/status is unverified.`,
+          resourceType: 'aws-kms-key',
+          resourceId: 'account',
+          severity: 'medium',
+          remediation: remediationForReadFailure(
+            combineReadFailures(unreadable.map((u) => u.failure)),
+            'Grant kms:ListKeys, kms:DescribeKey, and kms:GetKeyRotationStatus to the integration role in all enabled regions, then re-run the check.',
+          ),
+          evidence: {
+            failedRegions,
+            failedKeyCount: failedKeys.length,
+            // first few per-key errors so the cause is visible without log digging
+            keyReadErrors: failedKeys
+              .slice(0, 5)
+              .map((u) => ({ keyId: u.id, error: u.failure.error })),
+          },
         },
-      });
+      ]);
     }
 
     // Rotation-eligible keys each produce an outcome (incl. could-not-verify for

--- a/packages/integration-platform/src/manifests/aws/checks/rds.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/rds.ts
@@ -242,23 +242,26 @@ function failUnverifiedRegions(
     }
   }
   const regions = [...byRegion.keys()];
-  ctx.fail({
-    title: `Could not verify RDS ${what} in some regions`,
-    description: `RDS resources could not be listed in: ${regions.join(', ')}, so ${what} in those regions is unverified.`,
-    resourceType: 'aws-rds',
-    resourceId: `regions:${regions.join(',')}`,
-    severity: 'medium',
-    remediation: remediationForReadFailure(
-      combineReadFailures([...byRegion.values()]),
-      'Grant rds:DescribeDBInstances and rds:DescribeDBClusters to the integration role in all enabled regions, then re-run the check.',
-    ),
-    evidence: {
-      failedRegions: [...byRegion.entries()].map(([region, failure]) => ({
-        region,
-        error: failure.error,
-      })),
+  emitOutcomes(ctx, [
+    {
+      kind: 'fail',
+      title: `Could not verify RDS ${what} in some regions`,
+      description: `RDS resources could not be listed in: ${regions.join(', ')}, so ${what} in those regions is unverified.`,
+      resourceType: 'aws-rds',
+      resourceId: `regions:${regions.join(',')}`,
+      severity: 'medium',
+      remediation: remediationForReadFailure(
+        combineReadFailures([...byRegion.values()]),
+        'Grant rds:DescribeDBInstances and rds:DescribeDBClusters to the integration role in all enabled regions, then re-run the check.',
+      ),
+      evidence: {
+        failedRegions: [...byRegion.entries()].map(([region, failure]) => ({
+          region,
+          error: failure.error,
+        })),
+      },
     },
-  });
+  ]);
 }
 
 export const rdsEncryptionCheck: IntegrationCheck = {

--- a/packages/integration-platform/src/manifests/aws/checks/s3.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/s3.ts
@@ -153,17 +153,20 @@ export const s3EncryptionCheck: IntegrationCheck = {
         clientForRegion,
       });
     } catch (err) {
-      ctx.fail({
-        title: 'Could not verify S3 encryption',
-        description:
-          'S3 buckets could not be listed, so default encryption could not be verified.',
-        resourceType: 'aws-account',
-        resourceId: 'account',
-        severity: 'medium',
-        remediation:
-          'Grant s3:ListAllMyBuckets (and s3:GetEncryptionConfiguration) to the integration role, then re-run the check.',
-        evidence: { error: err instanceof Error ? err.message : String(err) },
-      });
+      emitOutcomes(ctx, [
+        {
+          kind: 'fail',
+          title: 'Could not verify S3 encryption',
+          description:
+            'S3 buckets could not be listed, so default encryption could not be verified.',
+          resourceType: 'aws-account',
+          resourceId: 'account',
+          severity: 'medium',
+          remediation:
+            'Grant s3:ListAllMyBuckets (and s3:GetEncryptionConfiguration) to the integration role, then re-run the check.',
+          evidence: { error: err instanceof Error ? err.message : String(err) },
+        },
+      ]);
       return;
     }
     if (buckets.length === 0) return;
@@ -222,17 +225,20 @@ export const s3PublicAccessCheck: IntegrationCheck = {
         clientForRegion,
       });
     } catch (err) {
-      ctx.fail({
-        title: 'Could not verify S3 public access',
-        description:
-          'S3 buckets could not be listed, so Block Public Access could not be verified.',
-        resourceType: 'aws-account',
-        resourceId: 'account',
-        severity: 'medium',
-        remediation:
-          'Grant s3:ListAllMyBuckets (and s3:GetBucketPublicAccessBlock) to the integration role, then re-run the check.',
-        evidence: { error: err instanceof Error ? err.message : String(err) },
-      });
+      emitOutcomes(ctx, [
+        {
+          kind: 'fail',
+          title: 'Could not verify S3 public access',
+          description:
+            'S3 buckets could not be listed, so Block Public Access could not be verified.',
+          resourceType: 'aws-account',
+          resourceId: 'account',
+          severity: 'medium',
+          remediation:
+            'Grant s3:ListAllMyBuckets (and s3:GetBucketPublicAccessBlock) to the integration role, then re-run the check.',
+          evidence: { error: err instanceof Error ? err.message : String(err) },
+        },
+      ]);
       return;
     }
     if (buckets.length === 0) return;

--- a/packages/integration-platform/src/manifests/aws/checks/shared.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/shared.ts
@@ -228,17 +228,20 @@ export async function resolveAwsSessionOrFail(
   try {
     return await assumeAwsSession(ctx);
   } catch (err) {
-    ctx.fail({
-      title: 'Could not assume AWS role',
-      description:
-        'The cross-account IAM role could not be assumed, so this check could not be verified.',
-      resourceType: 'aws-account',
-      resourceId: 'account',
-      severity: 'medium',
-      remediation:
-        'Verify the role ARN and external ID are correct and the role trust policy allows Comp to assume it, then re-run the check.',
-      evidence: { error: err instanceof Error ? err.message : String(err) },
-    });
+    emitOutcomes(ctx, [
+      {
+        kind: 'fail',
+        title: 'Could not assume AWS role',
+        description:
+          'The cross-account IAM role could not be assumed, so this check could not be verified.',
+        resourceType: 'aws-account',
+        resourceId: 'account',
+        severity: 'medium',
+        remediation:
+          'Verify the role ARN and external ID are correct and the role trust policy allows Comp to assume it, then re-run the check.',
+        evidence: { error: err instanceof Error ? err.message : String(err) },
+      },
+    ]);
     return null;
   }
 }


### PR DESCRIPTION
Fixes the [cubic finding on #3086](https://github.com/trycompai/comp/pull/3086): the new `iam.ts` password-policy finding bypassed `emitOutcomes` (the shared path that stamps `awsAccountId`/`awsConnectionName`) — and investigation showed the same gap in **every account-level finding** across the AWS checks, most pre-existing:

- `shared.ts` — "Could not assume AWS role" (emitted by all 8 checks)
- `s3.ts` ×2, `ec2.ts`, `rds.ts`, `kms.ts`, `cloudtrail.ts` — the aggregate "Could not verify …" findings
- `iam.ts` ×2 — password policy (new in #3086) + account summary (pre-existing)

In a multi-account org (they exist — the CS-532 customer has two connections), the merged task panel showed these findings with no way to tell which AWS account they belong to.

**Fix**: all 9 sites now route through `emitOutcomes`, which stamps the account id + connection name into evidence and appends "(AWS account … — name)" to the description — identical to every per-resource finding since #3065. `emitOutcomes`' own internal `ctx.fail` is untouched (no recursion).

**No verdict changes** — same findings, same titles/severities, now attributable. 178 tests pass (1 new: asserts the assume-role failure finding carries `awsAccountId`, `awsConnectionName`, and the account label in the description). Attribution is a no-op when `roleArn` is absent (key-auth/test contexts), so untouched tests stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AWS account attribution to all account-level AWS findings by routing them through `emitOutcomes`. Fixes missing account labels in multi-account orgs with no verdict changes.

- **Bug Fixes**
  - Routed 9 account-level failure paths to `emitOutcomes` (`shared.ts` assume-role failure; aggregate “could not verify” findings in `s3.ts`, `ec2.ts`, `rds.ts`, `kms.ts`, `cloudtrail.ts`; IAM password policy and account summary in `iam.ts`).
  - Findings now stamp `awsAccountId` and `awsConnectionName` in evidence and append the account label to descriptions; no-op when `roleArn` is absent.
  - Added a test for `resolveAwsSessionOrFail` to assert attribution on assume-role failures; existing tests unchanged.

<sup>Written for commit ca3090fe54c506697a316753ce90c0ae29a64e7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

