### PR TITLE
fix(trust): reset the certificate file input on every selection, not only success

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/ComplianceFramework.tsx
+++ b/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/ComplianceFramework.tsx
@@ -175,9 +175,6 @@ export function ComplianceFramework({
       try {
         await onFileUpload(file, frameworkKey);
         toast.success('Certificate uploaded successfully');
-        if (fileInputRef.current) {
-          fileInputRef.current.value = '';
-        }
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Failed to upload certificate';
         toast.error(message);
@@ -330,6 +327,10 @@ export function ComplianceFramework({
                 className="hidden"
                 onChange={async (e) => {
                   const file = e.target.files?.[0];
+                  // Always reset the input: browsers skip onChange when the
+                  // same file is re-selected, which would block retrying after
+                  // a failed upload or a rejected (non-PDF/too-large) file.
+                  e.target.value = '';
                   if (file) {
                     await processFile(file);
                   }


### PR DESCRIPTION
Fixes the cubic finding on the production deploy PR: a **failed** certificate upload left the file input's value set, and browsers don't fire `onChange` when the user re-selects the same file — so retrying the exact file silently did nothing.

Investigation showed it's broader than the report: the two **validation rejections** (non-PDF, >100MB) had the same dead-end, since they early-return before the success-path reset.

**Fix**: reset `e.target.value` in `onChange` immediately after grabbing the file — one place covers success, failure, and rejection (the previous success-only reset in `processFile` is removed as redundant). Drag-and-drop is unaffected (doesn't use the input value).

Typecheck clean on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reset the certificate upload file input on every selection so users can retry the same file after a failed upload or validation rejection. Fixes the dead-end where browsers skip onChange when re-selecting the same file.

- **Bug Fixes**
  - Clear `e.target.value` in `onChange` right after reading the file, covering success, failure, and validation rejects.
  - Remove the redundant success-only reset in `processFile`; drag-and-drop remains unchanged.

<sup>Written for commit 7d51e2cce240395bccf2e42a19843a6486fc9713. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

