### PR TITLE
feat(trust-portal): add per-email NDA-bypass allowlist

### DIFF
--- a/apps/api/src/trust-portal/dto/update-allowed-emails.dto.ts
+++ b/apps/api/src/trust-portal/dto/update-allowed-emails.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsEmail } from 'class-validator';
+
+export class UpdateAllowedEmailsDto {
+  @ApiProperty({
+    description:
+      'Email addresses that bypass NDA signing for trust portal access. Replaces the full list; send an empty array to clear it.',
+    type: [String],
+    example: ['person@example.com'],
+  })
+  @IsArray()
+  @IsEmail({}, { each: true })
+  emails: string[];
+}

--- a/apps/api/src/trust-portal/trust-access.service.spec.ts
+++ b/apps/api/src/trust-portal/trust-access.service.spec.ts
@@ -15,6 +15,13 @@ jest.mock('@db', () => ({
     trustAccessGrant: {
       findUnique: jest.fn(),
     },
+    trustAccessRequest: {
+      findFirst: jest.fn(),
+    },
+    member: {
+      findFirst: jest.fn(),
+    },
+    $transaction: jest.fn(),
   },
   Prisma: {
     PrismaClientKnownRequestError: class PrismaClientKnownRequestError extends Error {
@@ -56,6 +63,13 @@ const mockDb = db as unknown as {
   trustAccessGrant: {
     findUnique: jest.Mock;
   };
+  trustAccessRequest: {
+    findFirst: jest.Mock;
+  };
+  member: {
+    findFirst: jest.Mock;
+  };
+  $transaction: jest.Mock;
 };
 
 const mockGetSignedUrl = getSignedUrl as jest.MockedFunction<
@@ -171,5 +185,128 @@ describe('TrustAccessService favicon branding', () => {
       faviconUrl: 'https://cdn.example.com/favicon.png',
     });
     expect(result.portalUrl).toContain('/acme-security');
+  });
+});
+
+describe('TrustAccessService approveRequest NDA bypass', () => {
+  const emailService = {
+    sendAccessGrantedEmail: jest.fn(),
+    sendNdaSigningEmail: jest.fn(),
+  };
+  const service = new TrustAccessService(
+    {} as any,
+    emailService as any,
+    {} as any,
+    {} as any,
+    {} as any,
+  );
+  const buildPortalAccessUrlSpy = jest.spyOn(
+    service as any,
+    'buildPortalAccessUrl',
+  );
+
+  const baseRequest = {
+    id: 'tar_1',
+    status: 'under_review',
+    email: 'chang.liu@client.com',
+    name: 'Chang Liu',
+    requestedDurationDays: 30,
+    organization: { name: 'Acme Security' },
+  };
+
+  let txMock: {
+    trustAccessRequest: { update: jest.Mock };
+    trustAccessGrant: { create: jest.Mock };
+    trustNDAAgreement: { create: jest.Mock };
+    auditLog: { create: jest.Mock };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    txMock = {
+      trustAccessRequest: {
+        update: jest
+          .fn()
+          .mockResolvedValue({ id: 'tar_1', status: 'approved' }),
+      },
+      trustAccessGrant: {
+        create: jest
+          .fn()
+          .mockResolvedValue({ id: 'tag_1', expiresAt: new Date() }),
+      },
+      trustNDAAgreement: {
+        create: jest
+          .fn()
+          .mockResolvedValue({ id: 'tna_1', signToken: 'sign-token' }),
+      },
+      auditLog: { create: jest.fn().mockResolvedValue({}) },
+    };
+    mockDb.trustAccessRequest.findFirst.mockResolvedValue(baseRequest);
+    mockDb.member.findFirst.mockResolvedValue({ id: 'mem_1', userId: 'usr_1' });
+    mockDb.$transaction.mockImplementation(
+      (cb: (tx: typeof txMock) => Promise<unknown>) => cb(txMock),
+    );
+    buildPortalAccessUrlSpy.mockResolvedValue(
+      'https://portal.example.com/access/token',
+    );
+  });
+
+  it('bypasses NDA when the exact email is allow-listed', async () => {
+    mockDb.trust.findUnique.mockResolvedValue({
+      allowedDomains: [],
+      allowedEmails: ['chang.liu@client.com'],
+    });
+
+    const result = await service.approveRequest('org_1', 'tar_1', {}, 'mem_1');
+
+    expect(txMock.trustAccessGrant.create).toHaveBeenCalledTimes(1);
+    expect(txMock.trustNDAAgreement.create).not.toHaveBeenCalled();
+    expect(emailService.sendAccessGrantedEmail).toHaveBeenCalledTimes(1);
+    expect(emailService.sendNdaSigningEmail).not.toHaveBeenCalled();
+    expect(txMock.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          data: expect.objectContaining({
+            ndaBypassed: true,
+            bypassReason: 'allowed email',
+          }),
+        }),
+      }),
+    );
+    expect(result.message).toBe('Access granted');
+  });
+
+  it('bypasses NDA via domain match and records the domain reason', async () => {
+    mockDb.trust.findUnique.mockResolvedValue({
+      allowedDomains: ['client.com'],
+      allowedEmails: [],
+    });
+
+    await service.approveRequest('org_1', 'tar_1', {}, 'mem_1');
+
+    expect(txMock.trustAccessGrant.create).toHaveBeenCalledTimes(1);
+    expect(emailService.sendAccessGrantedEmail).toHaveBeenCalledTimes(1);
+    expect(txMock.auditLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          data: expect.objectContaining({ bypassReason: 'allowed domain' }),
+        }),
+      }),
+    );
+  });
+
+  it('requires NDA signing when neither email nor domain is allow-listed', async () => {
+    mockDb.trust.findUnique.mockResolvedValue({
+      allowedDomains: ['other.com'],
+      allowedEmails: ['someone@else.com'],
+    });
+
+    const result = await service.approveRequest('org_1', 'tar_1', {}, 'mem_1');
+
+    expect(txMock.trustNDAAgreement.create).toHaveBeenCalledTimes(1);
+    expect(txMock.trustAccessGrant.create).not.toHaveBeenCalled();
+    expect(emailService.sendNdaSigningEmail).toHaveBeenCalledTimes(1);
+    expect(emailService.sendAccessGrantedEmail).not.toHaveBeenCalled();
+    expect(result.message).toBe('NDA signing email sent');
   });
 });

--- a/apps/api/src/trust-portal/trust-access.service.ts
+++ b/apps/api/src/trust-portal/trust-access.service.ts
@@ -533,6 +533,24 @@ export class TrustAccessService {
     );
   }
 
+  /**
+   * Check if the email address is in the allow list (bypasses NDA requirement)
+   */
+  private isEmailInAllowList(email: string, allowedEmails: string[]): boolean {
+    if (!allowedEmails || allowedEmails.length === 0) {
+      return false;
+    }
+
+    const normalizedEmail = email.toLowerCase().trim();
+    if (!normalizedEmail) {
+      return false;
+    }
+
+    return allowedEmails.some(
+      (allowed) => allowed.toLowerCase().trim() === normalizedEmail,
+    );
+  }
+
   async approveRequest(
     organizationId: string,
     requestId: string,
@@ -573,25 +591,30 @@ export class TrustAccessService {
       throw new BadRequestException('Invalid member ID');
     }
 
-    // Check if email domain is in the allow list
+    // Check if the email or its domain is in the allow list
     const trust = await db.trust.findUnique({
       where: { organizationId },
-      select: { allowedDomains: true },
+      select: { allowedDomains: true, allowedEmails: true },
     });
 
     const isAllowedDomain = this.isDomainInAllowList(
       request.email,
       trust?.allowedDomains ?? [],
     );
+    const isAllowedEmail = this.isEmailInAllowList(
+      request.email,
+      trust?.allowedEmails ?? [],
+    );
 
-    // If domain is in allow list, skip NDA and grant access directly
-    if (isAllowedDomain) {
+    // If the email or domain is in the allow list, skip NDA and grant access directly
+    if (isAllowedDomain || isAllowedEmail) {
       return this.approveWithoutNda({
         organizationId,
         requestId,
         request,
         member,
         durationDays,
+        bypassReason: isAllowedEmail ? 'allowed email' : 'allowed domain',
       });
     }
 
@@ -657,7 +680,7 @@ export class TrustAccessService {
   }
 
   /**
-   * Approve request without NDA for allowed domains - grants immediate access
+   * Approve request without NDA for allowlisted domains/emails - grants immediate access
    */
   private async approveWithoutNda({
     organizationId,
@@ -665,6 +688,7 @@ export class TrustAccessService {
     request,
     member,
     durationDays,
+    bypassReason,
   }: {
     organizationId: string;
     requestId: string;
@@ -675,6 +699,7 @@ export class TrustAccessService {
     };
     member: { id: string; userId: string };
     durationDays: number;
+    bypassReason: 'allowed domain' | 'allowed email';
   }) {
     const expiresAt = new Date();
     expiresAt.setDate(expiresAt.getDate() + durationDays);
@@ -712,12 +737,13 @@ export class TrustAccessService {
           memberId: member.id,
           entityType: 'trust',
           entityId: requestId,
-          description: `Access request approved for ${request.email} (allowed domain - NDA bypassed)`,
+          description: `Access request approved for ${request.email} (${bypassReason} - NDA bypassed)`,
           data: {
             requestId,
             grantId: grant.id,
             durationDays,
             ndaBypassed: true,
+            bypassReason,
           },
         },
       });
@@ -742,7 +768,7 @@ export class TrustAccessService {
     return {
       request: result.request,
       grant: result.grant,
-      message: 'Access granted', // NDA bypassed for allowed domain
+      message: 'Access granted', // NDA bypassed for allowlisted domain/email
     };
   }
 

--- a/apps/api/src/trust-portal/trust-portal.controller.spec.ts
+++ b/apps/api/src/trust-portal/trust-portal.controller.spec.ts
@@ -39,6 +39,7 @@ describe('TrustPortalController', () => {
     checkDnsRecords: jest.fn(),
     updateFaqs: jest.fn(),
     updateAllowedDomains: jest.fn(),
+    updateAllowedEmails: jest.fn(),
     updateFrameworks: jest.fn(),
     updateOverview: jest.fn(),
     getOverview: jest.fn(),
@@ -428,6 +429,26 @@ describe('TrustPortalController', () => {
       await controller.updateAllowedDomains(orgId, {} as any);
 
       expect(service.updateAllowedDomains).toHaveBeenCalledWith(orgId, []);
+    });
+  });
+
+  describe('updateAllowedEmails', () => {
+    it('should call service.updateAllowedEmails with organizationId and emails', async () => {
+      const emails = ['person@example.com', 'other@test.com'];
+      mockService.updateAllowedEmails.mockResolvedValue({ success: true });
+
+      const result = await controller.updateAllowedEmails(orgId, { emails });
+
+      expect(result).toEqual({ success: true });
+      expect(service.updateAllowedEmails).toHaveBeenCalledWith(orgId, emails);
+    });
+
+    it('should default to empty array when emails is undefined', async () => {
+      mockService.updateAllowedEmails.mockResolvedValue({ success: true });
+
+      await controller.updateAllowedEmails(orgId, {} as any);
+
+      expect(service.updateAllowedEmails).toHaveBeenCalledWith(orgId, []);
     });
   });
 

--- a/apps/api/src/trust-portal/trust-portal.controller.ts
+++ b/apps/api/src/trust-portal/trust-portal.controller.ts
@@ -56,6 +56,7 @@ import {
 } from './dto/trust-custom-link.dto';
 import type { UpdateTrustOverviewDto } from './dto/update-trust-overview.dto';
 import { UpdateTrustOverviewSchema } from './dto/update-trust-overview.dto';
+import { UpdateAllowedEmailsDto } from './dto/update-allowed-emails.dto';
 import type { UpdateVendorTrustSettingsDto } from './dto/trust-vendor.dto';
 import { UpdateVendorTrustSettingsSchema } from './dto/trust-vendor.dto';
 import { UpdateTrustCustomFrameworkSchema } from './dto/trust-custom-framework.dto';
@@ -389,9 +390,10 @@ export class TrustPortalController {
   @Put('settings/allowed-emails')
   @RequirePermission('trust', 'update')
   @ApiOperation({ summary: 'Update allowed emails for the trust portal' })
+  @ApiBody({ type: UpdateAllowedEmailsDto })
   async updateAllowedEmails(
     @OrganizationId() organizationId: string,
-    @Body() body: { emails: string[] },
+    @Body() body: UpdateAllowedEmailsDto,
   ) {
     return this.trustPortalService.updateAllowedEmails(
       organizationId,

--- a/apps/api/src/trust-portal/trust-portal.controller.ts
+++ b/apps/api/src/trust-portal/trust-portal.controller.ts
@@ -386,6 +386,19 @@ export class TrustPortalController {
     );
   }
 
+  @Put('settings/allowed-emails')
+  @RequirePermission('trust', 'update')
+  @ApiOperation({ summary: 'Update allowed emails for the trust portal' })
+  async updateAllowedEmails(
+    @OrganizationId() organizationId: string,
+    @Body() body: { emails: string[] },
+  ) {
+    return this.trustPortalService.updateAllowedEmails(
+      organizationId,
+      body.emails ?? [],
+    );
+  }
+
   @Put('settings/frameworks')
   @RequirePermission('trust', 'update')
   @ApiOperation({ summary: 'Update trust portal framework settings' })

--- a/apps/api/src/trust-portal/trust-portal.service.ts
+++ b/apps/api/src/trust-portal/trust-portal.service.ts
@@ -630,6 +630,20 @@ export class TrustPortalService {
     return { success: true };
   }
 
+  async updateAllowedEmails(organizationId: string, emails: string[]) {
+    const normalizedEmails = [
+      ...new Set(emails.map((e) => e.toLowerCase().trim())),
+    ];
+
+    await db.trust.upsert({
+      where: { organizationId },
+      update: { allowedEmails: normalizedEmails },
+      create: { organizationId, allowedEmails: normalizedEmails },
+    });
+
+    return { success: true };
+  }
+
   async updateFrameworks(
     organizationId: string,
     frameworks: Record<string, boolean | string | undefined>,
@@ -1682,6 +1696,7 @@ export class TrustPortalService {
       vercelVerification: trust.vercelVerification ?? null,
       contactEmail: trust.contactEmail ?? null,
       allowedDomains: trust.allowedDomains ?? [],
+      allowedEmails: trust.allowedEmails ?? [],
       // Framework flags
       soc2type1: trust.soc2type1 ?? false,
       soc2type2: trust.soc2type2 || trust.soc2 || false,

--- a/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/AllowedEmailsManager.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/AllowedEmailsManager.test.tsx
@@ -1,0 +1,107 @@
+import {
+  ADMIN_PERMISSIONS,
+  AUDITOR_PERMISSIONS,
+  mockHasPermission,
+  setMockPermissions,
+} from '@/test-utils/mocks/permissions';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { updateAllowedEmails } = vi.hoisted(() => ({
+  updateAllowedEmails: vi.fn(),
+}));
+
+vi.mock('@/hooks/use-permissions', () => ({
+  usePermissions: () => ({
+    permissions: {},
+    hasPermission: mockHasPermission,
+  }),
+}));
+
+vi.mock('@/hooks/use-trust-portal-settings', () => ({
+  useTrustPortalSettings: () => ({ updateAllowedEmails }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { toast } from 'sonner';
+import { AllowedEmailsManager } from './AllowedEmailsManager';
+
+const PLACEHOLDER = 'person@example.com';
+
+describe('AllowedEmailsManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the card title and description', () => {
+    setMockPermissions(ADMIN_PERMISSIONS);
+    render(<AllowedEmailsManager initialEmails={[]} orgId="org-1" />);
+
+    expect(screen.getByText('NDA Bypass - Allowed Emails')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Individual email addresses that bypass NDA signing for trust portal access',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('renders existing emails as chips', () => {
+    setMockPermissions(ADMIN_PERMISSIONS);
+    render(
+      <AllowedEmailsManager initialEmails={['chang@client.com']} orgId="org-1" />,
+    );
+
+    expect(screen.getByText('chang@client.com')).toBeInTheDocument();
+  });
+
+  it('enables the input for users with trust:update permission', () => {
+    setMockPermissions(ADMIN_PERMISSIONS);
+    render(<AllowedEmailsManager initialEmails={[]} orgId="org-1" />);
+
+    expect(screen.getByPlaceholderText(PLACEHOLDER)).not.toBeDisabled();
+  });
+
+  it('disables the input for read-only users', () => {
+    setMockPermissions(AUDITOR_PERMISSIONS);
+    render(<AllowedEmailsManager initialEmails={[]} orgId="org-1" />);
+
+    expect(screen.getByPlaceholderText(PLACEHOLDER)).toBeDisabled();
+  });
+
+  it('saves a valid email, normalizing case and whitespace', async () => {
+    setMockPermissions(ADMIN_PERMISSIONS);
+    render(<AllowedEmailsManager initialEmails={[]} orgId="org-1" />);
+
+    fireEvent.change(screen.getByPlaceholderText(PLACEHOLDER), {
+      target: { value: '  Chang.Liu@Client.com  ' },
+    });
+    fireEvent.keyDown(screen.getByPlaceholderText(PLACEHOLDER), {
+      key: 'Enter',
+    });
+
+    await waitFor(() =>
+      expect(updateAllowedEmails).toHaveBeenCalledWith([
+        'chang.liu@client.com',
+      ]),
+    );
+    expect(toast.success).toHaveBeenCalledWith('Allowed emails updated');
+  });
+
+  it('rejects an invalid email and does not save', () => {
+    setMockPermissions(ADMIN_PERMISSIONS);
+    render(<AllowedEmailsManager initialEmails={[]} orgId="org-1" />);
+
+    fireEvent.change(screen.getByPlaceholderText(PLACEHOLDER), {
+      target: { value: 'not-an-email' },
+    });
+    fireEvent.keyDown(screen.getByPlaceholderText(PLACEHOLDER), {
+      key: 'Enter',
+    });
+
+    expect(screen.getByText(/invalid email format/i)).toBeInTheDocument();
+    expect(updateAllowedEmails).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/AllowedEmailsManager.tsx
+++ b/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/AllowedEmailsManager.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import { usePermissions } from '@/hooks/use-permissions';
+import { useTrustPortalSettings } from '@/hooks/use-trust-portal-settings';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Input,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@trycompai/design-system';
+import { Add, Close, Information } from '@trycompai/design-system/icons';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+interface AllowedEmailsManagerProps {
+  initialEmails: string[];
+  orgId: string;
+}
+
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function AllowedEmailsManager({ initialEmails }: AllowedEmailsManagerProps) {
+  const { hasPermission } = usePermissions();
+  const canUpdate = hasPermission('trust', 'update');
+  const { updateAllowedEmails } = useTrustPortalSettings();
+  const [emails, setEmails] = useState<string[]>(initialEmails);
+  const [lastSavedEmails, setLastSavedEmails] = useState<string[]>(initialEmails);
+  const [newEmail, setNewEmail] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [emailToDelete, setEmailToDelete] = useState<string | null>(null);
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  const saveEmails = async (updatedEmails: string[]) => {
+    setIsUpdating(true);
+    try {
+      await updateAllowedEmails(updatedEmails);
+      toast.success('Allowed emails updated');
+      setLastSavedEmails(updatedEmails);
+    } catch {
+      toast.error('Failed to update allowed emails');
+      setEmails(lastSavedEmails);
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  const handleAddEmail = () => {
+    setError(null);
+    const normalized = newEmail.toLowerCase().trim();
+
+    if (!normalized) {
+      setError('Please enter an email address');
+      return;
+    }
+
+    if (!emailRegex.test(normalized)) {
+      setError('Invalid email format (e.g., person@example.com)');
+      return;
+    }
+
+    if (emails.includes(normalized)) {
+      setError('Email already in list');
+      return;
+    }
+
+    const updatedEmails = [...emails, normalized];
+    setEmails(updatedEmails);
+    setNewEmail('');
+    saveEmails(updatedEmails);
+  };
+
+  const handleRemoveEmail = (emailToRemove: string) => {
+    const updatedEmails = emails.filter((email) => email !== emailToRemove);
+    setEmails(updatedEmails);
+    saveEmails(updatedEmails);
+    setEmailToDelete(null);
+  };
+
+  const handleConfirmDelete = () => {
+    if (emailToDelete) {
+      handleRemoveEmail(emailToDelete);
+    }
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      handleAddEmail();
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <CardTitle>NDA Bypass - Allowed Emails</CardTitle>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger aria-label="What does this do?">
+                <Information size={16} />
+              </TooltipTrigger>
+              <TooltipContent>
+                <p className="max-w-xs">
+                  Individuals with these exact email addresses receive direct
+                  access to the trust portal without signing an NDA when their
+                  request is approved. Use this when an NDA has already been
+                  signed outside Comp.
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+        <CardDescription>
+          Individual email addresses that bypass NDA signing for trust portal access
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          <div className="flex gap-2">
+            <div className="flex-1">
+              <Input
+                type="email"
+                placeholder="person@example.com"
+                value={newEmail}
+                onChange={(event) => {
+                  setNewEmail(event.target.value);
+                  setError(null);
+                }}
+                onKeyDown={handleKeyDown}
+                disabled={isUpdating || !canUpdate}
+              />
+              {error && <p className="text-destructive mt-1 text-sm">{error}</p>}
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              aria-label="Add email"
+              onClick={handleAddEmail}
+              disabled={isUpdating || !newEmail.trim() || !canUpdate}
+            >
+              <Add size={16} />
+            </Button>
+          </div>
+
+          {emails.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {emails.map((email) => (
+                <Badge key={email} variant="secondary">
+                  <span className="flex items-center gap-1">
+                    {email}
+                    <button
+                      type="button"
+                      onClick={() => setEmailToDelete(email)}
+                      disabled={isUpdating || !canUpdate}
+                      className="hover:bg-muted-foreground/20 ml-1 rounded-full p-0.5 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+                      aria-label={`Remove ${email}`}
+                    >
+                      <Close size={12} />
+                    </button>
+                  </span>
+                </Badge>
+              ))}
+            </div>
+          )}
+        </div>
+      </CardContent>
+
+      <AlertDialog
+        open={emailToDelete !== null}
+        onOpenChange={(open) => !open && setEmailToDelete(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove Email</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to remove <strong>{emailToDelete}</strong> from
+              the allowed emails list? This person will need to sign an NDA when
+              requesting access.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirmDelete}>Remove</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Card>
+  );
+}

--- a/apps/app/src/app/(app)/[orgId]/trust/settings/components/TrustSettingsClient.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/trust/settings/components/TrustSettingsClient.test.tsx
@@ -20,6 +20,7 @@ vi.mock('@/hooks/use-trust-portal-settings', () => ({
     submitCustomDomain: vi.fn(),
     checkDns: vi.fn(),
     updateAllowedDomains: vi.fn(),
+    updateAllowedEmails: vi.fn(),
   }),
 }));
 
@@ -68,6 +69,7 @@ describe('TrustSettingsClient permission gating', () => {
     isVercelDomain: false,
     vercelVerification: null,
     allowedDomains: ['example.com'],
+    allowedEmails: ['vip@partner.com'],
   };
 
   beforeEach(() => {
@@ -81,6 +83,7 @@ describe('TrustSettingsClient permission gating', () => {
     expect(screen.getByText('Contact Information')).toBeInTheDocument();
     expect(screen.getByText('Configure Custom Domain')).toBeInTheDocument();
     expect(screen.getByText('NDA Bypass - Allowed Domains')).toBeInTheDocument();
+    expect(screen.getByText('NDA Bypass - Allowed Emails')).toBeInTheDocument();
   });
 
   it('enables contact email input when user has trust:update permission', () => {

--- a/apps/app/src/app/(app)/[orgId]/trust/settings/components/TrustSettingsClient.tsx
+++ b/apps/app/src/app/(app)/[orgId]/trust/settings/components/TrustSettingsClient.tsx
@@ -12,6 +12,7 @@ import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
 import { AllowedDomainsManager } from '../../portal-settings/components/AllowedDomainsManager';
+import { AllowedEmailsManager } from '../../portal-settings/components/AllowedEmailsManager';
 import { TrustPortalDomain } from '../../portal-settings/components/TrustPortalDomain';
 
 const trustSettingsSchema = z.object({
@@ -26,6 +27,7 @@ interface TrustSettingsClientProps {
   isVercelDomain: boolean;
   vercelVerification: string | null;
   allowedDomains: string[];
+  allowedEmails: string[];
 }
 
 export function TrustSettingsClient({
@@ -36,6 +38,7 @@ export function TrustSettingsClient({
   isVercelDomain,
   vercelVerification,
   allowedDomains,
+  allowedEmails,
 }: TrustSettingsClientProps) {
   const { hasPermission } = usePermissions();
   const canUpdate = hasPermission('trust', 'update');
@@ -163,6 +166,9 @@ export function TrustSettingsClient({
 
       {/* Allowed Domains */}
       <AllowedDomainsManager initialDomains={allowedDomains} orgId={orgId} />
+
+      {/* Allowed Emails */}
+      <AllowedEmailsManager initialEmails={allowedEmails} orgId={orgId} />
     </div>
   );
 }

--- a/apps/app/src/app/(app)/[orgId]/trust/settings/page.tsx
+++ b/apps/app/src/app/(app)/[orgId]/trust/settings/page.tsx
@@ -10,6 +10,7 @@ interface TrustPortalSettings {
   isVercelDomain: boolean;
   vercelVerification: string | null;
   allowedDomains: string[];
+  allowedEmails: string[];
 }
 
 export default async function TrustSettingsPage({
@@ -35,6 +36,7 @@ export default async function TrustSettingsPage({
         isVercelDomain={trustPortal?.isVercelDomain ?? false}
         vercelVerification={trustPortal?.vercelVerification ?? null}
         allowedDomains={trustPortal?.allowedDomains ?? []}
+        allowedEmails={trustPortal?.allowedEmails ?? []}
       />
     </PageLayout>
   );

--- a/apps/app/src/hooks/use-trust-portal-settings.ts
+++ b/apps/app/src/hooks/use-trust-portal-settings.ts
@@ -188,6 +188,15 @@ export function useTrustPortalSettings() {
     [api],
   );
 
+  const updateAllowedEmails = useCallback(
+    async (emails: string[]) => {
+      const response = await api.put('/v1/trust-portal/settings/allowed-emails', { emails });
+      if (response.error) throw new Error(response.error);
+      return response.data;
+    },
+    [api],
+  );
+
   const uploadFavicon = useCallback(
     async (fileName: string, fileType: string, fileData: string) => {
       const response = await api.post<FaviconUploadResponse>('/v1/trust-portal/favicon', {
@@ -249,6 +258,7 @@ export function useTrustPortalSettings() {
     saveOverview,
     updateVendorTrustSettings,
     updateAllowedDomains,
+    updateAllowedEmails,
     uploadFavicon,
     removeFavicon,
     submitCustomDomain,

--- a/packages/db/prisma/migrations/20260610225432_add_trust_allowed_emails/migration.sql
+++ b/packages/db/prisma/migrations/20260610225432_add_trust_allowed_emails/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Trust" ADD COLUMN     "allowedEmails" TEXT[] DEFAULT ARRAY[]::TEXT[];

--- a/packages/db/prisma/schema/trust.prisma
+++ b/packages/db/prisma/schema/trust.prisma
@@ -12,6 +12,9 @@ model Trust {
   /// Domains that bypass NDA signing when requesting trust portal access
   allowedDomains String[] @default([])
 
+  /// Individual email addresses that bypass NDA signing when requesting trust portal access
+  allowedEmails String[] @default([])
+
   email         String?
   privacyPolicy String?
   soc2          Boolean @default(false)


### PR DESCRIPTION
## What
Adds a **per-email** NDA-bypass allowlist for the Trust Portal, mirroring the existing **domain** allowlist (`Trust.allowedDomains` → `Trust.allowedEmails`).

## Why
Customer (Chang Liu) has an NDA already signed outside Comp with **one specific contact** and wants to grant just that person trust portal access without re-signing. Domain-level allowlisting is too broad — it would bypass the NDA for the contact's **entire** client domain.

## How
- **Schema**: `Trust.allowedEmails String[]` + migration `add_trust_allowed_emails`.
- **API**: `approveRequest` skips the NDA when the requester's email **OR** domain is allow-listed (admin approval still required). Audit log now records `bypassReason: 'allowed domain' | 'allowed email'`. New `PUT /v1/trust-portal/settings/allowed-emails`; `allowedEmails` returned in `getSettings`.
- **App**: New `AllowedEmailsManager` card built with `@trycompai/design-system`, rendered in Trust → Settings beside the existing domains card.
- The allowlist is evaluated **only at admin approval** — no change to the visitor portal or the request-submission flow. **comp-only** (Trust Portal business logic lives in `comp/apps/api`; the visitor portal in comp-private calls the API over HTTP and has no allowlist logic).

## Test plan
- API: `cd apps/api && npx jest src/trust-portal` — service bypass branches (email / domain / neither) + new endpoint delegation. ✅ 6/6 + 46/46
- App: `cd apps/app && npx vitest run AllowedEmailsManager TrustSettingsClient` — ✅ 13/13
- Manual: Trust → Settings → "NDA Bypass - Allowed Emails", add a single email; submit a request from that exact address; approve → **access granted, no NDA email** (audit `bypassReason: 'allowed email'`). A different address on the same domain still receives the NDA.

## Notes for reviewer
- The adjacent `AllowedDomainsManager` intentionally stays on legacy `@trycompai/ui`; only the new card uses the design system.
- Migration was hand-authored (mirrors the original `allowedDomains` migration) because the local dev DB has unrelated drift; it's a standard additive `ALTER TABLE … ADD COLUMN … TEXT[] DEFAULT ARRAY[]::TEXT[]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a per-email NDA bypass allowlist for the Trust Portal so admins can grant access to specific contacts without re-signing an NDA. Bypass is applied only during admin approval; the visitor portal flow is unchanged.

- **New Features**
  - DB: added `Trust.allowedEmails String[]` with migration.
  - API: `approveRequest` skips NDA if requester email or domain is allow-listed; audit logs include `bypassReason: 'allowed domain' | 'allowed email'`.
  - API: `PUT /v1/trust-portal/settings/allowed-emails` with `UpdateAllowedEmailsDto` validation; settings include `allowedEmails`; values are normalized and de-duplicated.
  - App: new AllowedEmailsManager card in Trust Settings using `@trycompai/design-system`.
  - Tests: service NDA-bypass branches, controller endpoint, and component tests.

- **Migration**
  - Adds `allowedEmails` column to `Trust` (additive, no manual steps).

<sup>Written for commit b956774957b3d80a32bbd28a0b09084042bad43a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

