### PR TITLE
fix(trust): resolve 4 cubic findings from the production deploy review

### DIFF
--- a/apps/api/src/trust-portal/trust-access.service.ts
+++ b/apps/api/src/trust-portal/trust-access.service.ts
@@ -1916,6 +1916,74 @@ export class TrustAccessService {
     return { faqs: Array.isArray(faqs) ? faqs : null };
   }
 
+  /**
+   * Shared certificate-download pipeline for trust-portal resources (native
+   * and custom frameworks): fetch the stored PDF from S3, watermark it for the
+   * requesting grant, re-upload the watermarked copy, and return a signed URL.
+   * The two callers differ only in the trustResource lookup and the doc/file
+   * naming, which they pass in.
+   */
+  private async watermarkAndSignTrustResource(params: {
+    s3Key: string;
+    fileName: string;
+    recipientName: string;
+    recipientEmail: string;
+    organizationId: string;
+    grantId: string;
+    docId: string;
+    downloadFileName: string;
+  }): Promise<{ signedUrl: string; fileName: string; fileSize: number }> {
+    if (!s3Client || !APP_AWS_ORG_ASSETS_BUCKET) {
+      throw new InternalServerErrorException(
+        'Organization assets bucket is not configured',
+      );
+    }
+
+    const response = await s3Client.send(
+      new GetObjectCommand({
+        Bucket: APP_AWS_ORG_ASSETS_BUCKET,
+        Key: params.s3Key,
+      }),
+    );
+    if (!response.Body) {
+      throw new InternalServerErrorException('No file data received from S3');
+    }
+
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of response.Body as Readable) {
+      chunks.push(chunk);
+    }
+    const originalPdfBuffer = Buffer.concat(chunks);
+
+    const watermarked = await this.ndaPdfService.watermarkExistingPdf(
+      originalPdfBuffer,
+      {
+        name: params.recipientName,
+        email: params.recipientEmail,
+        docId: params.docId,
+        watermarkText: 'Comp AI',
+      },
+    );
+
+    const key = await this.attachmentsService.uploadToS3(
+      watermarked,
+      params.downloadFileName,
+      'application/pdf',
+      params.organizationId,
+      'trust_compliance_downloads',
+      params.grantId,
+    );
+
+    const downloadUrl =
+      await this.attachmentsService.getPresignedDownloadUrl(key);
+
+    return {
+      signedUrl: downloadUrl,
+      fileName: params.fileName,
+      fileSize: watermarked.length,
+    };
+  }
+
   async getComplianceResourceUrlByAccessToken(
     token: string,
     framework: TrustFramework,
@@ -1993,56 +2061,17 @@ export class TrustAccessService {
       });
     }
 
-    // Download the original PDF from S3
-    const getCommand = new GetObjectCommand({
-      Bucket: APP_AWS_ORG_ASSETS_BUCKET,
-      Key: record.s3Key,
-    });
-
-    const response = await s3Client.send(getCommand);
-    const chunks: Uint8Array[] = [];
-
-    if (!response.Body) {
-      throw new InternalServerErrorException('No file data received from S3');
-    }
-
-    for await (const chunk of response.Body as any) {
-      chunks.push(chunk);
-    }
-
-    const originalPdfBuffer = Buffer.concat(chunks);
-
-    // Watermark the PDF
-    const docId = `compliance-${grant.id}-${framework}-${Date.now()}`;
-    const watermarked = await this.ndaPdfService.watermarkExistingPdf(
-      originalPdfBuffer,
-      {
-        name: grant.accessRequest.name,
-        email: grant.subjectEmail,
-        docId,
-        watermarkText: 'Comp AI',
-      },
-    );
-
-    // Upload watermarked PDF to S3
-    const key = await this.attachmentsService.uploadToS3(
-      watermarked,
-      `compliance-${framework}-grant-${grant.id}-${Date.now()}.pdf`,
-      'application/pdf',
-      grant.accessRequest.organizationId,
-      'trust_compliance_downloads',
-      `${grant.id}`,
-    );
-
-    // Generate signed URL for the watermarked PDF
-    const downloadUrl =
-      await this.attachmentsService.getPresignedDownloadUrl(key);
-
-    return {
-      signedUrl: downloadUrl,
+    // Download → watermark → re-upload → signed URL (shared pipeline).
+    return this.watermarkAndSignTrustResource({
+      s3Key: record.s3Key,
       fileName: record.fileName,
-      fileSize: watermarked.length,
-    };
+      recipientName: grant.accessRequest.name,
+      recipientEmail: grant.subjectEmail,
+      organizationId: grant.accessRequest.organizationId,
+      grantId: `${grant.id}`,
+      docId: `compliance-${grant.id}-${framework}-${Date.now()}`,
+      downloadFileName: `compliance-${framework}-grant-${grant.id}-${Date.now()}.pdf`,
+    });
   }
 
   /**
@@ -2078,52 +2107,17 @@ export class TrustAccessService {
       );
     }
 
-    const getCommand = new GetObjectCommand({
-      Bucket: APP_AWS_ORG_ASSETS_BUCKET,
-      Key: record.s3Key,
-    });
-
-    const response = await s3Client.send(getCommand);
-    const chunks: Uint8Array[] = [];
-
-    if (!response.Body) {
-      throw new InternalServerErrorException('No file data received from S3');
-    }
-
-    for await (const chunk of response.Body as Readable) {
-      chunks.push(chunk);
-    }
-
-    const originalPdfBuffer = Buffer.concat(chunks);
-
-    const docId = `compliance-${grant.id}-custom-${customFrameworkId}-${Date.now()}`;
-    const watermarked = await this.ndaPdfService.watermarkExistingPdf(
-      originalPdfBuffer,
-      {
-        name: grant.accessRequest.name,
-        email: grant.subjectEmail,
-        docId,
-        watermarkText: 'Comp AI',
-      },
-    );
-
-    const key = await this.attachmentsService.uploadToS3(
-      watermarked,
-      `compliance-custom-${customFrameworkId}-grant-${grant.id}-${Date.now()}.pdf`,
-      'application/pdf',
-      grant.accessRequest.organizationId,
-      'trust_compliance_downloads',
-      `${grant.id}`,
-    );
-
-    const downloadUrl =
-      await this.attachmentsService.getPresignedDownloadUrl(key);
-
-    return {
-      signedUrl: downloadUrl,
+    // Download → watermark → re-upload → signed URL (shared pipeline).
+    return this.watermarkAndSignTrustResource({
+      s3Key: record.s3Key,
       fileName: record.fileName,
-      fileSize: watermarked.length,
-    };
+      recipientName: grant.accessRequest.name,
+      recipientEmail: grant.subjectEmail,
+      organizationId: grant.accessRequest.organizationId,
+      grantId: `${grant.id}`,
+      docId: `compliance-${grant.id}-custom-${customFrameworkId}-${Date.now()}`,
+      downloadFileName: `compliance-custom-${customFrameworkId}-grant-${grant.id}-${Date.now()}.pdf`,
+    });
   }
 
   /** Custom frameworks shown on the public portal (delegates to the dedicated service). */

--- a/apps/api/src/trust-portal/trust-portal.controller.ts
+++ b/apps/api/src/trust-portal/trust-portal.controller.ts
@@ -418,6 +418,9 @@ export class TrustPortalController {
     schema: {
       type: 'object',
       required: ['customFrameworkId'],
+      // Mirrors UpdateTrustCustomFrameworkSchema's .refine(): the id is
+      // required and at least one mutable field must be present.
+      anyOf: [{ required: ['enabled'] }, { required: ['status'] }],
       properties: {
         customFrameworkId: { type: 'string', minLength: 1 },
         enabled: { type: 'boolean' },

--- a/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/ComplianceFramework.tsx
+++ b/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/ComplianceFramework.tsx
@@ -146,10 +146,12 @@ export function ComplianceFramework({
   // refreshes (SWR revalidation, another tab/user) — otherwise the row shows
   // stale enabled/status values forever. Single guarded sync: skipped while a
   // mutation is in flight so a concurrent revalidation can't clobber the
-  // optimistic value before the request settles.
-  const mutationInFlightRef = useRef(false);
+  // optimistic value before the request settles. A counter (not a boolean)
+  // so overlapping toggle + status mutations both keep resync gated until the
+  // last one settles.
+  const inFlightCountRef = useRef(0);
   useEffect(() => {
-    if (mutationInFlightRef.current) return;
+    if (inFlightCountRef.current > 0) return;
     setIsEnabled(isEnabledProp);
     setStatus(statusProp);
   }, [isEnabledProp, statusProp]);
@@ -249,13 +251,13 @@ export function ComplianceFramework({
                     if (!value) return;
                     const prev = status;
                     setStatus(value);
-                    mutationInFlightRef.current = true;
+                    inFlightCountRef.current += 1;
                     try {
                       await onStatusChange(value);
                     } catch {
                       setStatus(prev);
                     } finally {
-                      mutationInFlightRef.current = false;
+                      inFlightCountRef.current -= 1;
                     }
                   }}
                 >
@@ -304,13 +306,13 @@ export function ComplianceFramework({
                 checked={isEnabled}
                 onCheckedChange={async (checked) => {
                   setIsEnabled(checked);
-                  mutationInFlightRef.current = true;
+                  inFlightCountRef.current += 1;
                   try {
                     await onToggle(checked);
                   } catch {
                     setIsEnabled(!checked);
                   } finally {
-                    mutationInFlightRef.current = false;
+                    inFlightCountRef.current -= 1;
                   }
                 }}
               />

--- a/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/CustomFrameworksSection.tsx
+++ b/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/CustomFrameworksSection.tsx
@@ -99,6 +99,14 @@ export function CustomFrameworksSection({
   };
 
   const handleFileUpload = async (file: File, customFrameworkId: string) => {
+    // Defense-in-depth size cap at the API-call boundary: the raw file is
+    // limited to 100MB (server decodes and re-checks), and base64 inflates it
+    // ~33% — guarding here avoids building a ~133MB string and surfaces a clean
+    // error if this handler is ever invoked outside the validated row flow.
+    const MAX_FILE_SIZE = 100 * 1024 * 1024;
+    if (file.size > MAX_FILE_SIZE) {
+      throw new Error('File size must be less than 100MB');
+    }
     const fileData = await convertFileToBase64(file);
     const payload = await uploadCustomComplianceResource(
       orgId,


### PR DESCRIPTION
Investigated all 4 cubic findings on the production deploy PR. Verdicts and fixes:

| # | Finding | Verdict | Fix |
|---|---|---|---|
| 1 | `ComplianceFramework` shared `mutationInFlightRef` boolean unsafe for overlapping toggle/status | **Real, narrow race** — boolean cleared by whichever mutation finished first, re-opening resync while the other was still in flight | Counter (`inFlightCountRef`): resync stays gated until the last mutation settles |
| 2 | `CustomFrameworksSection` missing base64 size guard | **Partly real / defense-in-depth** — the row flow already checks raw `file.size ≤ 100MB` before this runs, and 100MB→~137MB encoded fits under the 150mb server body limit; but the team explicitly requested the cap and a guard avoids building a ~133MB string | 100MB guard at the top of `handleFileUpload` (throws → surfaced as a toast) |
| 3 | `@ApiBody` missing the "at least one of enabled/status" rule | **Real (doc accuracy)** — runtime zod `.refine()` enforces it; OpenAPI/MCP contract didn't | `anyOf: [{required:['enabled']},{required:['status']}]` (cubic's exact suggestion) |
| 4 | `trust-access.service` duplicated native vs custom download pipeline | **Real (maintainability)** — ~40 identical lines, drift risk | Extracted `watermarkAndSignTrustResource` (S3 get → watermark → re-upload → signed URL); both callers delegate, behavior identical |

## Verification
- API + app typecheck clean on all 4 touched files
- `trust-access.service.spec` passes (covers the extracted pipeline); 62 trust-portal tests pass. (`trust-portal.controller.spec` fails only at Prisma client init — a worktree DB-connection env issue, unrelated; the controller change is decorator metadata.)

Note on finding 2: honestly this is defense-in-depth rather than a live bug — the primary upload flow is already size-checked — but it's cheap, matches prior team feedback, and saves wasted base64 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four trust portal issues from the production deploy review: safe concurrent UI updates, an upload size guard, an accurate OpenAPI rule, and a deduped certificate download pipeline.

- **Bug Fixes**
  - ComplianceFramework: replaced a shared in-flight boolean with a counter so overlapping toggle/status mutations don’t clobber state; props resync only after the last mutation settles.
  - CustomFrameworksSection: added a 100MB file-size check before base64 encoding to avoid large strings and align with server limits; throws a clear error.
  - Controller: updated `@ApiBody` schema with `anyOf` to require at least one of `enabled` or `status`, matching runtime `zod` validation.

- **Refactors**
  - `trust-access.service`: extracted S3 download → watermark → re-upload → signed URL into `watermarkAndSignTrustResource`; used by native and custom frameworks; behavior unchanged and removes duplication.

<sup>Written for commit c2b91222c3f0c3dbce37433809426a37ef65657f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

