### PR TITLE
fix(trust): custom-frameworks feature sweep — drag-drop permission gate + 400-on-bad-body

### DIFF
--- a/apps/api/src/trust-portal/trust-portal.controller.ts
+++ b/apps/api/src/trust-portal/trust-portal.controller.ts
@@ -58,7 +58,11 @@ import type { UpdateTrustOverviewDto } from './dto/update-trust-overview.dto';
 import { UpdateTrustOverviewSchema } from './dto/update-trust-overview.dto';
 import type { UpdateVendorTrustSettingsDto } from './dto/trust-vendor.dto';
 import { UpdateVendorTrustSettingsSchema } from './dto/trust-vendor.dto';
-import { UpdateTrustCustomFrameworkSchema } from './dto/trust-custom-framework.dto';
+import {
+  UpdateTrustCustomFrameworkSchema,
+  type UpdateTrustCustomFrameworkDto,
+} from './dto/trust-custom-framework.dto';
+import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
 import { TrustPortalService } from './trust-portal.service';
 import { TrustCustomFrameworkService } from './trust-custom-framework.service';
 
@@ -433,9 +437,12 @@ export class TrustPortalController {
   })
   async updateCustomFramework(
     @OrganizationId() organizationId: string,
-    @Body() body: unknown,
+    // Validate via the pipe so a malformed body returns 400 (matching the
+    // @ApiBody/MCP contract) instead of an inline .parse() throwing a raw
+    // ZodError that surfaces as a 500.
+    @Body(new ZodValidationPipe(UpdateTrustCustomFrameworkSchema))
+    dto: UpdateTrustCustomFrameworkDto,
   ) {
-    const dto = UpdateTrustCustomFrameworkSchema.parse(body);
     return this.trustCustomFrameworkService.updateSelection(
       organizationId,
       dto,

--- a/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/ComplianceFramework.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/ComplianceFramework.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ComplianceFramework } from './ComplianceFramework';
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+function renderRow(overrides: { disabled?: boolean } = {}) {
+  const onFileUpload = vi.fn().mockResolvedValue(undefined);
+  render(
+    <ComplianceFramework
+      title="SOC 2"
+      description="Service Organization Control 2"
+      isEnabled
+      status="compliant"
+      onStatusChange={vi.fn().mockResolvedValue(undefined)}
+      onToggle={vi.fn().mockResolvedValue(undefined)}
+      onFileUpload={onFileUpload}
+      frameworkKey="soc2"
+      orgId="org_1"
+      {...overrides}
+    />,
+  );
+  return { onFileUpload };
+}
+
+function dropPdf() {
+  const dropZone = screen.getByText(/Drag & drop certificate/i);
+  const file = new File(['%PDF-1.4'], 'cert.pdf', { type: 'application/pdf' });
+  fireEvent.drop(dropZone, { dataTransfer: { files: [file] } });
+}
+
+describe('ComplianceFramework drag-and-drop permission gate', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('uploads a dropped certificate when editable', async () => {
+    const { onFileUpload } = renderRow({ disabled: false });
+    dropPdf();
+    expect(onFileUpload).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT upload a dropped certificate for read-only users (disabled)', () => {
+    const { onFileUpload } = renderRow({ disabled: true });
+    dropPdf();
+    expect(onFileUpload).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/ComplianceFramework.tsx
+++ b/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/ComplianceFramework.tsx
@@ -190,6 +190,9 @@ export function ComplianceFramework({
   const handleDragEnter = (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
+    // Read-only / mid-upload: no drag affordance, no drop (mirrors the
+    // disabled click path).
+    if (disabled || isUploading) return;
     dragCounterRef.current++;
     if (e.dataTransfer.items && e.dataTransfer.items.length > 0) {
       setIsDragging(true);
@@ -215,6 +218,10 @@ export function ComplianceFramework({
     e.stopPropagation();
     setIsDragging(false);
     dragCounterRef.current = 0;
+
+    // Gate uploads the same way the click path is gated — drag-and-drop must
+    // not bypass the read-only / uploading state.
+    if (disabled || isUploading) return;
 
     const files = e.dataTransfer.files;
     if (files && files.length > 0) {

--- a/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/CustomFrameworksSection.tsx
+++ b/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/CustomFrameworksSection.tsx
@@ -166,7 +166,7 @@ export function CustomFrameworksSection({
                 throw error;
               }
             }}
-            onFileUpload={handleFileUpload}
+            onFileUpload={canUpdate ? handleFileUpload : undefined}
             onFilePreview={handleFilePreview}
           />
         ))}


### PR DESCRIPTION
Proactive full-feature audit of the trust-portal **custom-frameworks** feature (#3088) — where every recent deploy-review finding has clustered — to stop the one-at-a-time cubic loop. 14 agents (6 dimension auditors + 8 adversarial verifiers) swept it across RBAC, IDOR/multi-tenancy, file safety, optimistic-UI races, API contract, and correctness.

## Result: the feature is solid

**8 candidate issues → 7 were false positives**, verified already-handled in code:
- Permission gating — server-side `@RequirePermission('trust','update')` on every mutation; frontend gating is defense-in-depth
- Multi-tenancy / IDOR — every custom-framework query is org-scoped; the token-gated download validates the grant
- File safety — size cap enforced server-side (decoded), org-scoped record lookup, no path traversal in the S3 key
- Optimistic-UI races — already fixed (in-flight counter)
- API contract — accurate after the `anyOf` fix

**2 real items, both included here:**

| Severity | Issue | Fix |
|---|---|---|
| **P1** | Drag-and-drop bypassed the read-only gate the click path had (read-only users could upload by dropping a file) | `handleDrop`/`handleDragEnter` early-return on `disabled \|\| isUploading`; custom section only passes the upload callback when `canUpdate`; new test asserts editable drops upload and read-only drops don't *(the unmerged P1 from #3099, folded in)* |
| **P3** | `PUT /custom-frameworks` inline `.parse()` → raw ZodError → **HTTP 500** instead of 400 on malformed input, contradicting the `@ApiBody`/MCP contract | Use the existing `ZodValidationPipe` → returns 400 |

## Note (out of scope, flagged not fixed)
The 500-on-bad-body pattern is app-wide — 5 sibling endpoints share the inline-`.parse()` shape. The consistent fix is a global `@Catch(ZodError)` filter (none registered today). Scoped this PR to the custom-frameworks endpoint; the global filter is a worthwhile separate cleanup.

## Verification
API typecheck clean; app tests pass (6, incl. the new drag-drop gate test). The controller jest spec fails only at Prisma TLS init in the worktree (env, not code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a permission bypass in Trust Portal custom frameworks. Drag-and-drop uploads now respect read-only state, and `PUT /custom-frameworks` returns 400 on malformed input.

- **Bug Fixes**
  - Frontend: gate `handleDragEnter`/`handleDrop` when `disabled` or uploading; pass `onFileUpload` only when `canUpdate`; added a test to ensure read-only drops do not upload.
  - Backend: use `ZodValidationPipe` for `UpdateTrustCustomFramework` so malformed bodies return 400 (not 500), matching the API contract.

<sup>Written for commit afc9c8f7f47843158b8ab696c9d3f819b4d9302e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

