### PR TITLE
fix(integrations): gate the Add-account CTA on integration:create RBAC

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/IntegrationProviderHero.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/IntegrationProviderHero.tsx
@@ -10,6 +10,7 @@ import { getConnectionDisplayLabel } from './connection-display';
 type HeroProps = {
   provider: IntegrationProvider;
   isConnected: boolean;
+  canCreateConnection: boolean;
   activeConnections: ConnectionListItem[];
   selectedConnection: ConnectionListItem | null;
   onSelectConnection: (id: string) => void;
@@ -20,6 +21,7 @@ type HeroProps = {
 export function IntegrationProviderHero({
   provider,
   isConnected,
+  canCreateConnection,
   activeConnections,
   selectedConnection,
   onSelectConnection,
@@ -142,7 +144,11 @@ export function IntegrationProviderHero({
                               connection, so a second OAuth connect silently
                               merges into the first — only offer "Add" where
                               the connect flow can actually create another. */}
-                          {provider.supportsMultipleConnections &&
+                          {/* Adding a connection is a create action — gate on
+                              RBAC, not just provider metadata, so users without
+                              integration:create aren't offered the flow. */}
+                          {canCreateConnection &&
+                            provider.supportsMultipleConnections &&
                             provider.authType !== 'oauth2' && (
                               <div className="flex shrink-0 items-center p-0.5">
                                 <Button

--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/ProviderDetailView.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/ProviderDetailView.tsx
@@ -8,6 +8,7 @@ import {
   type ConnectionListItem,
   type IntegrationProvider,
 } from '@/hooks/use-integration-platform';
+import { usePermissions } from '@/hooks/use-permissions';
 import { api } from '@/lib/api-client';
 import { CLOUD_RECONNECT_CUTOFF_LABEL, requiresCloudReconnect } from '@/lib/cloud-reconnect-policy';
 import { Breadcrumb, Button, Stack } from '@trycompai/design-system';
@@ -42,6 +43,8 @@ export function ProviderDetailView({
   const searchParams = useSearchParams();
   const { connections: allConnections, refresh: refreshConnections } = useIntegrationConnections();
   const { startOAuth } = useIntegrationMutations();
+  const { hasPermission } = usePermissions();
+  const canCreateConnection = hasPermission('integration', 'create');
   const [showAddAccount, setShowAddAccount] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [reconnectDialogOpen, setReconnectDialogOpen] = useState(false);
@@ -240,6 +243,7 @@ export function ProviderDetailView({
         <IntegrationProviderHero
           provider={provider}
           isConnected={isConnected}
+          canCreateConnection={canCreateConnection}
           activeConnections={activeConnections}
           selectedConnection={selectedConnection}
           onSelectConnection={(id) => setSelectedConnectionId(id)}


### PR DESCRIPTION
Fixes the cubic finding on the deploy review: the integration hero's **'Add' account CTA was gated only by provider metadata** (`supportsMultipleConnections && authType !== 'oauth2'`, which I added in the Azure multi-subscription PR), **not by RBAC** — so a user without `integration:create` was still offered the create-connection flow.

## Fix
Thread the same permission check the rest of the integrations UI already uses (`usePermissions().hasPermission('integration','create')` — see `PlatformIntegrations.tsx:124`, `ServiceDetailView.tsx:75`) from `ProviderDetailView` into `IntegrationProviderHero`, and add it to the Add-button condition.

## Notes
- Server-side connect endpoints already enforce `integration:create` (HybridAuthGuard + PermissionGuard) — this closes the **UI authorization-surface** gap (offering an action the user can't perform), consistent with the team's stated RBAC-on-Add-account rule.
- Hero stays presentational (permission passed as a prop, not hooked inside it).
- App typecheck clean; no tests render these components, so the new required prop breaks nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gated the “Add account” CTA in the integration provider hero behind `integration:create` RBAC so users without create permission no longer see the create-connection flow.

- **Bug Fixes**
  - Added `hasPermission('integration','create')` to the Add-button condition in `IntegrationProviderHero`.
  - Passed `canCreateConnection` from `ProviderDetailView` via `usePermissions()`; hero stays presentational.
  - Kept provider checks (`supportsMultipleConnections` and non-`oauth2`) and aligned UI with existing server-side guards.

<sup>Written for commit 6c35625d6dd38cd77b44322cf1c21ccedc3c37c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

