### PR TITLE
fix(integration-platform): skip GCP projects whose service API is disabled (false 'grant permission' findings)

### DIFF
--- a/packages/integration-platform/src/manifests/gcp/checks/__tests__/gcp-checks.test.ts
+++ b/packages/integration-platform/src/manifests/gcp/checks/__tests__/gcp-checks.test.ts
@@ -9,6 +9,7 @@ import { cloudSqlSslCheck } from '../cloud-sql-ssl';
 import { iamPrimitiveRolesCheck } from '../iam-primitive-roles';
 import { storagePublicAccessCheck } from '../storage-public-access';
 import { vpcOpenFirewallsCheck } from '../vpc-open-firewalls';
+import { isGcpApiDisabled } from '../shared';
 
 interface Captured {
   passed: Array<{ resourceId: string; title: string }>;
@@ -69,6 +70,60 @@ async function runCheck(
   await check.run(ctx);
   return { passed, failed };
 }
+
+describe('isGcpApiDisabled — service-not-enabled detection', () => {
+  const httpErr = (status: number, message: string) => {
+    const e = new Error(`HTTP ${status}: Forbidden - ${message}`);
+    (e as Error & { status: number }).status = status;
+    return e;
+  };
+  it('matches the real SERVICE_DISABLED 403 body', () => {
+    expect(
+      isGcpApiDisabled(
+        httpErr(403, '{"error":{"code":403,"message":"Cloud SQL Admin API has not been used in project gen-lang-client-0670714718 before or it is disabled.","status":"PERMISSION_DENIED","details":[{"reason":"SERVICE_DISABLED"}]}}'),
+      ),
+    ).toBe(true);
+  });
+  it('does NOT match a genuine permission denial', () => {
+    expect(
+      isGcpApiDisabled(
+        httpErr(403, '{"error":{"code":403,"message":"The caller does not have permission","status":"PERMISSION_DENIED"}}'),
+      ),
+    ).toBe(false);
+  });
+  it('does NOT match a transient 500', () => {
+    expect(isGcpApiDisabled(httpErr(500, 'Internal error'))).toBe(false);
+  });
+});
+
+describe('GCP checks skip projects whose service API is disabled', () => {
+  const apiDisabled = () => {
+    const e = new Error('HTTP 403: Forbidden - Cloud SQL Admin API has not been used in project p before or it is disabled. (SERVICE_DISABLED)');
+    (e as Error & { status: number }).status = 403;
+    return e;
+  };
+  it('cloud-sql-ssl emits NO finding when the API is disabled (vs a false "grant permission")', async () => {
+    const out = await runCheck(cloudSqlSslCheck, {
+      variables: { project_ids: ['p'] },
+      fetch: () => { throw apiDisabled(); },
+    });
+    expect(out.failed).toHaveLength(0);
+    expect(out.passed).toHaveLength(0);
+  });
+  it('still reports a finding for a genuine permission denial', async () => {
+    const denied = () => {
+      const e = new Error('HTTP 403: Forbidden - The caller does not have permission');
+      (e as Error & { status: number }).status = 403;
+      return e;
+    };
+    const out = await runCheck(cloudSqlSslCheck, {
+      variables: { project_ids: ['p'] },
+      fetch: () => { throw denied(); },
+    });
+    expect(out.failed).toHaveLength(1);
+    expect(out.failed[0]!.title).toMatch(/Could not verify Cloud SQL SSL/);
+  });
+});
 
 describe('GCP read-failure remediation gating', () => {
   const httpError = (status: number, message: string) => {

--- a/packages/integration-platform/src/manifests/gcp/checks/cloud-sql-backups.ts
+++ b/packages/integration-platform/src/manifests/gcp/checks/cloud-sql-backups.ts
@@ -4,7 +4,7 @@ import {
   remediationForReadFailure,
   toHttpReadFailure,
 } from '../../http-read-failure';
-import { gcpListItems, resolveGcpProjectIds } from './shared';
+import { gcpListItems, resolveGcpProjectIds, isGcpApiDisabled } from './shared';
 
 interface SqlInstance {
   name: string;
@@ -76,8 +76,14 @@ export const cloudSqlBackupsCheck: IntegrationCheck = {
           }
         }
       } catch (err) {
-        // Unverified project → emit a finding, not a warn-and-skip, so an
-        // all-projects-failed run doesn't leave the task stale (silent pass).
+        // The service's API simply isn't enabled on this project (403
+        // SERVICE_DISABLED) — nothing of this type exists here to evaluate,
+        // so skip it like a zero-resource project instead of emitting a
+        // false "grant permission" finding.
+        if (isGcpApiDisabled(err)) {
+          ctx.log(`GCP Cloud SQL: API not enabled in project "${projectId}" — no Cloud SQL instances to evaluate; skipping`);
+          continue;
+        }
         const failure = toHttpReadFailure(err);
         ctx.fail({
           title: `Could not verify Cloud SQL backups: ${projectId}`,

--- a/packages/integration-platform/src/manifests/gcp/checks/cloud-sql-ssl.ts
+++ b/packages/integration-platform/src/manifests/gcp/checks/cloud-sql-ssl.ts
@@ -4,7 +4,7 @@ import {
   remediationForReadFailure,
   toHttpReadFailure,
 } from '../../http-read-failure';
-import { gcpListItems, resolveGcpProjectIds } from './shared';
+import { gcpListItems, resolveGcpProjectIds, isGcpApiDisabled } from './shared';
 
 interface SqlInstance {
   name: string;
@@ -86,8 +86,14 @@ export const cloudSqlSslCheck: IntegrationCheck = {
           }
         }
       } catch (err) {
-        // Unverified project → emit a finding, not a warn-and-skip, so an
-        // all-projects-failed run doesn't leave the task stale (silent pass).
+        // The service's API simply isn't enabled on this project (403
+        // SERVICE_DISABLED) — nothing of this type exists here to evaluate,
+        // so skip it like a zero-resource project instead of emitting a
+        // false "grant permission" finding.
+        if (isGcpApiDisabled(err)) {
+          ctx.log(`GCP Cloud SQL: API not enabled in project "${projectId}" — no Cloud SQL instances to evaluate; skipping`);
+          continue;
+        }
         const failure = toHttpReadFailure(err);
         ctx.fail({
           title: `Could not verify Cloud SQL SSL: ${projectId}`,

--- a/packages/integration-platform/src/manifests/gcp/checks/shared.ts
+++ b/packages/integration-platform/src/manifests/gcp/checks/shared.ts
@@ -127,3 +127,25 @@ export function portsCover(
     return Number(spec) === target;
   });
 }
+
+/**
+ * True when a GCP API call failed only because the service's API is not
+ * enabled on the project (HTTP 403 with reason SERVICE_DISABLED, e.g. "Cloud
+ * SQL Admin API has not been used in project X ... or it is disabled").
+ *
+ * This is NOT a permission problem: a project that hasn't enabled the API has
+ * no resources of that type to evaluate, so the per-project check should skip
+ * it (like a project with zero instances) rather than emit a false "could not
+ * verify — grant <permission>" finding. A genuine PERMISSION_DENIED (API
+ * enabled, role missing) does NOT match and still surfaces as a finding.
+ */
+export function isGcpApiDisabled(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  // Match only Google's specific SERVICE_DISABLED signature, not any mention of
+  // "API"/"disabled" — over-broad matching could hide a genuine permission gap.
+  return (
+    /SERVICE_DISABLED/i.test(message) ||
+    /has not been used in project .* before or it is disabled/i.test(message) ||
+    /Enable it by visiting/i.test(message)
+  );
+}

--- a/packages/integration-platform/src/manifests/gcp/checks/storage-public-access.ts
+++ b/packages/integration-platform/src/manifests/gcp/checks/storage-public-access.ts
@@ -4,7 +4,7 @@ import {
   remediationForReadFailure,
   toHttpReadFailure,
 } from '../../http-read-failure';
-import { gcpListItems, resolveGcpProjectIds } from './shared';
+import { gcpListItems, resolveGcpProjectIds, isGcpApiDisabled } from './shared';
 
 interface Bucket {
   name: string;
@@ -56,8 +56,14 @@ export const storagePublicAccessCheck: IntegrationCheck = {
           await evaluateBucket(ctx, projectId, bucket);
         }
       } catch (err) {
-        // Unverified project → emit a finding, not a warn-and-skip, so an
-        // all-projects-failed run doesn't leave the task stale (silent pass).
+        // The service's API simply isn't enabled on this project (403
+        // SERVICE_DISABLED) — nothing of this type exists here to evaluate,
+        // so skip it like a zero-resource project instead of emitting a
+        // false "grant permission" finding.
+        if (isGcpApiDisabled(err)) {
+          ctx.log(`GCP Cloud Storage: API not enabled in project "${projectId}" — no buckets to evaluate; skipping`);
+          continue;
+        }
         const failure = toHttpReadFailure(err);
         ctx.fail({
           title: `Could not verify Cloud Storage: ${projectId}`,

--- a/packages/integration-platform/src/manifests/gcp/checks/vpc-open-firewalls.ts
+++ b/packages/integration-platform/src/manifests/gcp/checks/vpc-open-firewalls.ts
@@ -4,7 +4,7 @@ import {
   remediationForReadFailure,
   toHttpReadFailure,
 } from '../../http-read-failure';
-import { gcpListItems, portsCover, resolveGcpProjectIds } from './shared';
+import { gcpListItems, portsCover, resolveGcpProjectIds, isGcpApiDisabled } from './shared';
 
 interface FirewallRule {
   name: string;
@@ -114,9 +114,14 @@ export const vpcOpenFirewallsCheck: IntegrationCheck = {
           });
         }
       } catch (err) {
-        // A read failure for this project is unverified — emit a finding rather
-        // than warn-and-skip, otherwise an all-projects-failed run emits no
-        // outcomes and leaves the mapped task stale (a silent clean run).
+        // The service's API simply isn't enabled on this project (403
+        // SERVICE_DISABLED) — nothing of this type exists here to evaluate,
+        // so skip it like a zero-resource project instead of emitting a
+        // false "grant permission" finding.
+        if (isGcpApiDisabled(err)) {
+          ctx.log(`GCP Compute: API not enabled in project "${projectId}" — no firewall rules to evaluate; skipping`);
+          continue;
+        }
         const failure = toHttpReadFailure(err);
         ctx.fail({
           title: `Could not verify VPC firewall rules: ${projectId}`,


### PR DESCRIPTION
## Customer issue
A GCP customer saw 4 **medium** `Could not verify Cloud SQL SSL: <project>` findings — on projects like `gen-lang-client-0670714718`, `deploy-example-470517`, `psyflo-adk-agent-123` (Google's auto-created Gemini/sample/AI-agent projects) — each advising *"Grant cloudsql.instances.list"*.

## Is it a bug we introduced? No — but the message is a false alarm
The scan is working as designed (CS-534: never silently pass an unverified project). But those projects **don't use Cloud SQL** — the Cloud SQL Admin API is disabled, which Google returns as **HTTP 403, reason `SERVICE_DISABLED`**. Our classifier saw `403` → `denied` → "grant the IAM role" — which is **wrong**: granting `cloudsql.viewer` won't help; there's simply nothing to scan there. Same class as the AWS `OptInRequired`-is-a-403 nuance we already handle.

## Fix
`isGcpApiDisabled(err)` matches Google's specific SERVICE_DISABLED signature (not any mention of "API/disabled" — kept narrow so a real permission gap is never hidden). The per-project GCP checks (`cloud-sql-ssl`, `cloud-sql-backups`, `vpc-open-firewalls`, `storage-public-access`) now **skip** such a project — exactly like a project with zero resources — instead of emitting a finding. A genuine `PERMISSION_DENIED` (API enabled, role missing) **still surfaces**.

## Verification
33 GCP tests pass (5 new): the helper matches the real SERVICE_DISABLED body, does NOT match a genuine permission denial or a 500, the check skips (no finding) when the API is disabled, and still reports a finding for a real permission denial.

Note: I could not pull this customer's exact `readError` (prod tunnel was down), but the fix is safe by construction — it only changes the SERVICE_DISABLED sub-case and preserves genuine findings. Happy to confirm their 4 findings clear against prod with a fresh tunnel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip GCP projects where the service API is disabled to avoid false “grant permission” findings in Cloud SQL (SSL, backups), VPC firewall, and Storage checks. Genuine `PERMISSION_DENIED` cases still surface as findings.

- **Bug Fixes**
  - Added `isGcpApiDisabled` to detect 403 `SERVICE_DISABLED` and related service-disabled messages.
  - Updated `cloud-sql-ssl`, `cloud-sql-backups`, `vpc-open-firewalls`, and `storage-public-access` to skip (logged) instead of emitting findings.
  - Added tests covering detection, non-matching real denials and 500s, and per-check skip vs. report behavior.

<sup>Written for commit 8299423592e7db9f803e22b95e82b89fd64318cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

