### PR TITLE
fix(trust-portal): use NDA-free copy in access-granted email when NDA is bypassed

### DIFF
--- a/apps/api/src/email/templates/access-granted.spec.ts
+++ b/apps/api/src/email/templates/access-granted.spec.ts
@@ -1,0 +1,39 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { AccessGrantedEmail } from './access-granted';
+
+const baseProps = {
+  toName: 'Chang Liu',
+  organizationName: 'Acme Security',
+  expiresAt: new Date('2026-12-31T00:00:00Z'),
+  portalUrl: 'https://portal.example.com/access/token',
+};
+
+describe('AccessGrantedEmail', () => {
+  it('omits all NDA copy when access was granted via allow-list bypass', () => {
+    const html = renderToStaticMarkup(
+      AccessGrantedEmail({ ...baseProps, ndaBypassed: true }),
+    );
+
+    // No NDA was signed, so the email must not reference one.
+    expect(html).not.toContain('NDA');
+    expect(html).not.toContain('signed');
+    // The access confirmation itself is still present.
+    expect(html).toContain('is now active');
+    expect(html).toContain('Acme Security');
+  });
+
+  it('includes NDA copy for the standard NDA-signed flow', () => {
+    const html = renderToStaticMarkup(
+      AccessGrantedEmail({ ...baseProps, ndaBypassed: false }),
+    );
+
+    expect(html).toContain('Your NDA has been signed');
+    expect(html).toContain('download your signed NDA');
+  });
+
+  it('defaults to the NDA-signed copy when ndaBypassed is omitted', () => {
+    const html = renderToStaticMarkup(AccessGrantedEmail({ ...baseProps }));
+
+    expect(html).toContain('Your NDA has been signed');
+  });
+});

--- a/apps/api/src/email/templates/access-granted.tsx
+++ b/apps/api/src/email/templates/access-granted.tsx
@@ -18,6 +18,11 @@ interface Props {
   organizationName: string;
   expiresAt: Date;
   portalUrl: string;
+  /**
+   * When true, access was granted without an NDA (the requester's email or
+   * domain is on the trust portal allow list). NDA-specific copy is omitted.
+   */
+  ndaBypassed?: boolean;
 }
 
 export const AccessGrantedEmail = ({
@@ -25,6 +30,7 @@ export const AccessGrantedEmail = ({
   organizationName,
   expiresAt,
   portalUrl,
+  ndaBypassed = false,
 }: Props) => {
   return (
     <Html>
@@ -60,9 +66,18 @@ export const AccessGrantedEmail = ({
             </Text>
 
             <Text className="text-[14px] leading-[24px] text-[#121212]">
-              Your NDA has been signed and your access to{' '}
-              <strong>{organizationName}</strong>'s policy documentation is now
-              active.
+              {ndaBypassed ? (
+                <>
+                  Your access to <strong>{organizationName}</strong>'s policy
+                  documentation is now active.
+                </>
+              ) : (
+                <>
+                  Your NDA has been signed and your access to{' '}
+                  <strong>{organizationName}</strong>'s policy documentation is
+                  now active.
+                </>
+              )}
             </Text>
 
             <Text className="text-[14px] leading-[24px] text-[#121212]">
@@ -85,10 +100,12 @@ export const AccessGrantedEmail = ({
               </Button>
             </Section>
 
-            <Text className="text-[14px] leading-[24px] text-[#121212]">
-              You can download your signed NDA for your records from the
-              confirmation page or by accessing the portal above.
-            </Text>
+            {!ndaBypassed && (
+              <Text className="text-[14px] leading-[24px] text-[#121212]">
+                You can download your signed NDA for your records from the
+                confirmation page or by accessing the portal above.
+              </Text>
+            )}
 
             <Section
               className="mt-[30px] mb-[20px] rounded-[3px] border-l-4 p-[15px]"

--- a/apps/api/src/trust-portal/email.service.ts
+++ b/apps/api/src/trust-portal/email.service.ts
@@ -37,8 +37,16 @@ export class TrustEmailService {
     organizationName: string;
     expiresAt: Date;
     portalUrl: string;
+    ndaBypassed?: boolean;
   }): Promise<void> {
-    const { toEmail, toName, organizationName, expiresAt, portalUrl } = params;
+    const {
+      toEmail,
+      toName,
+      organizationName,
+      expiresAt,
+      portalUrl,
+      ndaBypassed,
+    } = params;
 
     const { id } = await triggerEmail({
       to: toEmail,
@@ -48,6 +56,7 @@ export class TrustEmailService {
         organizationName,
         expiresAt,
         portalUrl,
+        ndaBypassed,
       }),
       trustPortal: true,
     });

--- a/apps/api/src/trust-portal/trust-access.service.spec.ts
+++ b/apps/api/src/trust-portal/trust-access.service.spec.ts
@@ -14,6 +14,8 @@ jest.mock('@db', () => ({
     },
     trustAccessGrant: {
       findUnique: jest.fn(),
+      findFirst: jest.fn(),
+      update: jest.fn(),
     },
     trustAccessRequest: {
       findFirst: jest.fn(),
@@ -62,6 +64,8 @@ const mockDb = db as unknown as {
   };
   trustAccessGrant: {
     findUnique: jest.Mock;
+    findFirst: jest.Mock;
+    update: jest.Mock;
   };
   trustAccessRequest: {
     findFirst: jest.Mock;
@@ -262,6 +266,10 @@ describe('TrustAccessService approveRequest NDA bypass', () => {
     expect(txMock.trustAccessGrant.create).toHaveBeenCalledTimes(1);
     expect(txMock.trustNDAAgreement.create).not.toHaveBeenCalled();
     expect(emailService.sendAccessGrantedEmail).toHaveBeenCalledTimes(1);
+    // The granted email must omit NDA copy since no NDA was signed.
+    expect(emailService.sendAccessGrantedEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ ndaBypassed: true }),
+    );
     expect(emailService.sendNdaSigningEmail).not.toHaveBeenCalled();
     expect(txMock.auditLog.create).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -286,6 +294,9 @@ describe('TrustAccessService approveRequest NDA bypass', () => {
 
     expect(txMock.trustAccessGrant.create).toHaveBeenCalledTimes(1);
     expect(emailService.sendAccessGrantedEmail).toHaveBeenCalledTimes(1);
+    expect(emailService.sendAccessGrantedEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ ndaBypassed: true }),
+    );
     expect(txMock.auditLog.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
@@ -308,5 +319,129 @@ describe('TrustAccessService approveRequest NDA bypass', () => {
     expect(emailService.sendNdaSigningEmail).toHaveBeenCalledTimes(1);
     expect(emailService.sendAccessGrantedEmail).not.toHaveBeenCalled();
     expect(result.message).toBe('NDA signing email sent');
+  });
+});
+
+describe('TrustAccessService resendAccessGrantEmail NDA copy', () => {
+  const emailService = {
+    sendAccessGrantedEmail: jest.fn(),
+  };
+  const service = new TrustAccessService(
+    {} as any,
+    emailService as any,
+    {} as any,
+    {} as any,
+    {} as any,
+  );
+  jest
+    .spyOn(service as any, 'buildPortalAccessUrl')
+    .mockResolvedValue('https://portal.example.com/access/token');
+
+  const baseGrant = {
+    id: 'tag_1',
+    subjectEmail: 'chang.liu@client.com',
+    status: 'active',
+    expiresAt: new Date(Date.now() + 86_400_000),
+    accessToken: 'existing-token',
+    accessTokenExpiresAt: new Date(Date.now() + 86_400_000),
+    accessRequest: {
+      name: 'Chang Liu',
+      organization: { name: 'Acme Security' },
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('marks the resent email as bypassed when the grant has no NDA agreement', async () => {
+    mockDb.trustAccessGrant.findFirst.mockResolvedValue({
+      ...baseGrant,
+      ndaAgreement: null,
+    });
+
+    await service.resendAccessGrantEmail('org_1', 'tag_1');
+
+    expect(emailService.sendAccessGrantedEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ ndaBypassed: true }),
+    );
+  });
+
+  it('keeps NDA copy when the grant has a signed NDA agreement', async () => {
+    mockDb.trustAccessGrant.findFirst.mockResolvedValue({
+      ...baseGrant,
+      ndaAgreement: { status: 'signed' },
+    });
+
+    await service.resendAccessGrantEmail('org_1', 'tag_1');
+
+    expect(emailService.sendAccessGrantedEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ ndaBypassed: false }),
+    );
+  });
+});
+
+describe('TrustAccessService signNda NDA copy', () => {
+  const ndaPdfService = {
+    generateNdaPdf: jest.fn().mockResolvedValue(Buffer.from('pdf')),
+    uploadNdaPdf: jest.fn().mockResolvedValue('org_1/nda/nda_1.pdf'),
+    getSignedUrl: jest.fn().mockResolvedValue('https://s3.example.com/nda.pdf'),
+  };
+  const emailService = {
+    sendAccessGrantedEmail: jest.fn(),
+  };
+  const service = new TrustAccessService(
+    ndaPdfService as any,
+    emailService as any,
+    {} as any,
+    {} as any,
+    {} as any,
+  );
+  jest
+    .spyOn(service as any, 'buildPortalAccessUrl')
+    .mockResolvedValue('https://portal.example.com/access/token');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDb.trustNDAAgreement.findUnique.mockResolvedValue({
+      id: 'nda_1',
+      organizationId: 'org_1',
+      accessRequestId: 'tar_1',
+      status: 'pending',
+      signTokenExpiresAt: new Date(Date.now() + 86_400_000),
+      grant: null,
+      accessRequest: {
+        requestedDurationDays: 30,
+        organization: { name: 'Acme Security' },
+      },
+    });
+    mockDb.$transaction.mockImplementation(
+      (cb: (tx: unknown) => Promise<unknown>) =>
+        cb({
+          trustAccessGrant: {
+            create: jest
+              .fn()
+              .mockResolvedValue({ id: 'tag_1', expiresAt: new Date() }),
+          },
+          trustNDAAgreement: {
+            update: jest.fn().mockResolvedValue({ id: 'nda_1' }),
+          },
+        }),
+    );
+  });
+
+  it('sends the granted email with NDA copy (ndaBypassed: false) after signing', async () => {
+    await service.signNda(
+      'sign-token',
+      'Chang Liu',
+      'chang.liu@client.com',
+      '1.2.3.4',
+      'jest-agent',
+    );
+
+    expect(emailService.sendAccessGrantedEmail).toHaveBeenCalledTimes(1);
+    expect(emailService.sendAccessGrantedEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ ndaBypassed: false }),
+    );
   });
 });

--- a/apps/api/src/trust-portal/trust-access.service.ts
+++ b/apps/api/src/trust-portal/trust-access.service.ts
@@ -763,6 +763,7 @@ export class TrustAccessService {
       organizationName: request.organization.name,
       expiresAt: result.grant.expiresAt,
       portalUrl,
+      ndaBypassed: true,
     });
 
     return {
@@ -976,6 +977,9 @@ export class TrustAccessService {
             },
           },
         },
+        ndaAgreement: {
+          select: { status: true },
+        },
       },
     });
 
@@ -1028,6 +1032,9 @@ export class TrustAccessService {
       organizationName: grant.accessRequest.organization.name,
       expiresAt: grant.expiresAt,
       portalUrl,
+      // A bypassed grant has no NDA agreement; an NDA-signed grant links a
+      // 'signed' one. Mirror the original email's copy when resending.
+      ndaBypassed: grant.ndaAgreement?.status !== 'signed',
     });
 
     return { message: 'Access email resent successfully' };
@@ -1239,6 +1246,7 @@ export class TrustAccessService {
       organizationName: nda.accessRequest.organization.name,
       expiresAt: result.grant.expiresAt,
       portalUrl,
+      ndaBypassed: false,
     });
 
     const pdfUrl = await this.ndaPdfService.getSignedUrl(pdfKey);


### PR DESCRIPTION
## Bug

When Trust Portal access is auto-granted via the allow list (**Allowed Domains** / **Allowed Emails**), the NDA step is bypassed — but the **"Access Granted" confirmation email** still rendered NDA-signed copy:

> *"Your NDA has been signed and your access to … is now active."*
> *"You can download your signed NDA for your records …"*

So recipients who never signed an NDA were told one was signed.

## Root cause

`AccessGrantedEmail` (`apps/api/src/email/templates/access-granted.tsx`) hardcoded the NDA-signed wording, and **both** flows send the same email via `sendAccessGrantedEmail`:
- `approveWithoutNda` — allow-list bypass (no NDA)
- `signNda` — standard flow (NDA signed)

## Fix

Thread an optional `ndaBypassed` flag from each call site → `sendAccessGrantedEmail` → the template, which omits the two NDA sentences when set:

| Call site | `ndaBypassed` |
|---|---|
| `approveWithoutNda` (allow-list) | `true` |
| `signNda` (standard) | `false` |
| `resendAccessGrantEmail` | derived: `grant.ndaAgreement?.status !== 'signed'` |

Defaults to `false`, preserving existing NDA-signed behavior.

This covers both **Allowed Domains** and **Allowed Emails** (same `approveWithoutNda` path), plus resends.

## Scope notes

- Email logic is **comp-only** (`apps/api`) — no comp-private duplicate.
- The public Trust frontend already hides the NDA download UI for bypassed grants (`ndaPdfUrl` is `null`), so no frontend change was needed.

## Tests

- **New** `access-granted.spec.ts` — renders the template; asserts the bypassed variant contains no "NDA"/"signed", and the standard variant keeps both lines.
- Extended `trust-access.service.spec.ts` — asserts the flag on all three call sites (bypass, resend, `signNda`).
- ✅ 12/12 pass. `tsc` clean for all changed files.

## Verification

```
cd apps/api && npx jest src/trust-portal/trust-access.service.spec.ts src/email/templates/access-granted.spec.ts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Access Granted email to remove NDA wording when access is auto-granted via the allow list, so recipients aren’t told an NDA was signed when it wasn’t. Applies to initial sends and resends; standard flow keeps NDA-signed copy.

- **Bug Fixes**
  - Added an optional `ndaBypassed` flag threaded to the email template; omits NDA sentences when true.
  - Flag values: `approveWithoutNda` → true, `signNda` → false, `resendAccessGrantEmail` → derived via `grant.ndaAgreement?.status !== 'signed'`.
  - Added tests for both template variants and for all call sites to assert the correct flag.

<sup>Written for commit 99207602754943c41374f6bd9c0860bceed0e0ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

