### PR TITLE
fix(pentest): cap the composed additionalContext briefing at 20k chars

### DIFF
--- a/apps/api/src/security-penetration-tests/finding-context.util.spec.ts
+++ b/apps/api/src/security-penetration-tests/finding-context.util.spec.ts
@@ -1,5 +1,6 @@
 import {
   buildAdditionalContext,
+  MAX_ADDITIONAL_CONTEXT_LENGTH,
   normalizeTargetUrl,
 } from './finding-context.util';
 
@@ -91,5 +92,39 @@ describe('buildAdditionalContext', () => {
     const notesIndex = (result as string).indexOf('1. "Issue A": Fixed.');
     expect(userIndex).toBeGreaterThanOrEqual(0);
     expect(notesIndex).toBeGreaterThan(userIndex);
+  });
+
+  it('does not add an omission marker when everything fits', () => {
+    const result = buildAdditionalContext({
+      userProvidedContext: 'User intent.',
+      findingContexts: [{ issueTitle: 'Issue A', context: 'Fixed.' }],
+    });
+
+    expect(result).not.toContain('omitted for length');
+  });
+
+  it('caps the composed briefing, keeping user context and marking omitted notes', () => {
+    const findingContexts = Array.from({ length: 30 }, (_, i) => ({
+      issueTitle: `Finding ${i + 1}`,
+      context: 'x'.repeat(1900),
+    }));
+
+    const result = buildAdditionalContext({
+      userProvidedContext: 'User intent.',
+      findingContexts,
+    });
+
+    expect(result).toBeDefined();
+    expect((result as string).length).toBeLessThanOrEqual(
+      MAX_ADDITIONAL_CONTEXT_LENGTH,
+    );
+    expect(result).toContain('User intent.');
+    expect(result).toContain('1. "Finding 1"');
+    expect(result).toMatch(/\d+ more notes omitted for length/);
+    // Whole notes are dropped, never cut: every included note line ends
+    // with its full 1900-char body.
+    const includedBodies = (result as string).match(/x{1900}/g) ?? [];
+    expect(includedBodies.length).toBeGreaterThan(0);
+    expect(result).not.toMatch(/x{1901,}/);
   });
 });

--- a/apps/api/src/security-penetration-tests/finding-context.util.ts
+++ b/apps/api/src/security-penetration-tests/finding-context.util.ts
@@ -38,6 +38,21 @@ export function normalizeTargetUrl(value: string): string {
 }
 
 /**
+ * Budget for the composed briefing. The provider has no documented limit
+ * (verified against its OpenAPI spec and prompt-injection source), but an
+ * unbounded string composed from arbitrarily many notes shouldn't be sent
+ * to an external API or an agent prompt. When over budget, whole notes
+ * are dropped — never cut mid-sentence — and an explicit omission marker
+ * tells the agent the list is incomplete.
+ */
+export const MAX_ADDITIONAL_CONTEXT_LENGTH = 20_000;
+
+const NOTES_HEADER =
+  'Customer-provided context on findings reported in previous scans of this target. ' +
+  'Take it into account when validating and reporting findings (e.g. behavior that is ' +
+  'accepted by design, or issues the customer has since remediated):';
+
+/**
  * Composes the `additionalContext` string sent to the pentest provider on
  * run creation: the user's free-text context for this run (if any) followed
  * by the stored per-finding notes from previous scans of the same target.
@@ -47,24 +62,37 @@ export function buildAdditionalContext(params: {
   userProvidedContext?: string;
   findingContexts: FindingContextNote[];
 }): string | undefined {
-  const sections: string[] = [];
+  const userSection = params.userProvidedContext?.trim();
 
-  const userProvided = params.userProvidedContext?.trim();
-  if (userProvided) {
-    sections.push(userProvided);
+  if (params.findingContexts.length === 0) {
+    return userSection || undefined;
   }
 
-  if (params.findingContexts.length > 0) {
-    const header =
-      'Customer-provided context on findings reported in previous scans of this target. ' +
-      'Take it into account when validating and reporting findings (e.g. behavior that is ' +
-      'accepted by design, or issues the customer has since remediated):';
-    const lines = params.findingContexts.map(
-      (note, index) =>
-        `${index + 1}. "${note.issueTitle.trim()}": ${note.context.trim()}`,
-    );
-    sections.push([header, ...lines].join('\n'));
+  const noteLines = params.findingContexts.map(
+    (note, index) =>
+      `${index + 1}. "${note.issueTitle.trim()}": ${note.context.trim()}`,
+  );
+
+  const compose = (includedCount: number): string => {
+    const omitted = noteLines.length - includedCount;
+    const lines = noteLines.slice(0, includedCount);
+    if (omitted > 0) {
+      lines.push(
+        `(${omitted} more note${omitted === 1 ? '' : 's'} omitted for length — see the finding context notes in Comp AI)`,
+      );
+    }
+    const sections = userSection ? [userSection] : [];
+    sections.push([NOTES_HEADER, ...lines].join('\n'));
+    return sections.join('\n\n');
+  };
+
+  let included = noteLines.length;
+  while (
+    included > 0 &&
+    compose(included).length > MAX_ADDITIONAL_CONTEXT_LENGTH
+  ) {
+    included -= 1;
   }
 
-  return sections.length > 0 ? sections.join('\n\n') : undefined;
+  return compose(included);
 }


### PR DESCRIPTION
Addresses the remaining cubic finding on the production deploy PR (#3111).

The finding's premise was partially off — there is no 4000-character provider contract (verified against Maced's OpenAPI spec and prompt-injection source: no maxLength, no server-side cap; the 4000 limit is our own DTO validation on the user-typed field only). But the underlying point stands: the **composed** briefing (user context + all stored notes for a target) was unbounded.

This caps it at 20,000 chars:
- whole notes are dropped, never cut mid-sentence
- an explicit `(N more notes omitted for length — see the finding context notes in Comp AI)` marker tells the agent the list is incomplete (no silent truncation)
- user-typed context is always kept (already DTO-capped at 4000)
- the report appendix is deliberately NOT capped — auditors should always see every note

Tests: over-limit note set stays ≤ cap with correct omission marker and intact note bodies; fitting sets get no marker. Module suite: 102 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the composed pentest `additionalContext` briefing at 20,000 characters to prevent unbounded payloads to the provider. Keeps user context, drops whole notes only, and adds an explicit omission marker when notes are omitted.

- **Bug Fixes**
  - Added `MAX_ADDITIONAL_CONTEXT_LENGTH = 20_000` and updated `buildAdditionalContext` to include only whole notes within the cap.
  - Appends an omission marker `(N more notes omitted for length — see the finding context notes in Comp AI)` when truncation occurs.
  - Always includes user-provided context (already DTO-capped at 4000).
  - Added tests for fit/over-limit cases, omission marker behavior, and ensuring notes aren’t cut mid-sentence.

<sup>Written for commit 70057129442c80667d44939cfdc335d7650abac6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

