### PR TITLE
fix(frameworks): let unpinned instances adopt version updates (FRAME-6)

### DIFF
--- a/apps/api/src/frameworks/framework-versioning/framework-sync.service.spec.ts
+++ b/apps/api/src/frameworks/framework-versioning/framework-sync.service.spec.ts
@@ -5,12 +5,12 @@ import { FrameworkSyncService } from './framework-sync.service';
 jest.mock('@db', () => {
   const tx = {
     frameworkInstance: { findUnique: jest.fn() },
-    frameworkVersion: { findUnique: jest.fn() },
+    frameworkVersion: { findUnique: jest.fn(), findFirst: jest.fn() },
   };
   return {
     db: {
       frameworkInstance: { findUnique: jest.fn() },
-      frameworkVersion: { findUnique: jest.fn() },
+      frameworkVersion: { findUnique: jest.fn(), findFirst: jest.fn() },
       $transaction: jest.fn((cb: (t: typeof tx) => Promise<unknown>) => cb(tx)),
       __tx: tx,
     },
@@ -21,8 +21,20 @@ jest.mock('./org-advisory-lock', () => ({
   lockOrganizationForSync: jest.fn().mockResolvedValue(undefined),
 }));
 
+jest.mock('./framework-sync-apply', () => ({
+  applySync: jest.fn(),
+}));
+
 import { db } from '@db';
-const tx = (db as unknown as { __tx: { frameworkInstance: { findUnique: jest.Mock }; frameworkVersion: { findUnique: jest.Mock } } }).__tx;
+import { applySync } from './framework-sync-apply';
+const tx = (
+  db as unknown as {
+    __tx: {
+      frameworkInstance: { findUnique: jest.Mock };
+      frameworkVersion: { findUnique: jest.Mock; findFirst: jest.Mock };
+    };
+  }
+).__tx;
 
 describe('FrameworkSyncService preconditions', () => {
   let service: FrameworkSyncService;
@@ -60,5 +72,49 @@ describe('FrameworkSyncService preconditions', () => {
     const result = await service.sync({ organizationId: 'org_1', frameworkInstanceId: 'frm_1', targetVersionId: 'fvr_target', memberId: 'mem_1' });
     expect(result.kind).toBe('no-op');
     expect(db.$transaction).not.toHaveBeenCalled();
+  });
+});
+
+describe('FrameworkSyncService unpinned instances (FRAME-2)', () => {
+  let service: FrameworkSyncService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const mod = await Test.createTestingModule({ providers: [FrameworkSyncService] }).compile();
+    service = mod.get(FrameworkSyncService);
+  });
+
+  it('diffs from the earliest published version when the instance has no current version', async () => {
+    const unpinned = { id: 'frm_1', organizationId: 'org_1', frameworkId: 'frk_soc2', currentVersionId: null };
+    (db.frameworkInstance.findUnique as jest.Mock).mockResolvedValue(unpinned);
+    tx.frameworkInstance.findUnique.mockResolvedValue(unpinned);
+    tx.frameworkVersion.findUnique.mockResolvedValue({ id: 'fvr_target', frameworkId: 'frk_soc2' });
+    tx.frameworkVersion.findFirst.mockResolvedValue({ id: 'fvr_earliest', frameworkId: 'frk_soc2' });
+    (applySync as jest.Mock).mockResolvedValue({ syncOperationId: 'sync_1' });
+
+    const result = await service.sync({ organizationId: 'org_1', frameworkInstanceId: 'frm_1', targetVersionId: 'fvr_target', memberId: 'mem_1' });
+
+    // Falls back to the earliest version as the "from" instead of throwing.
+    expect(tx.frameworkVersion.findFirst).toHaveBeenCalled();
+    expect(applySync).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        currentVersion: expect.objectContaining({ id: 'fvr_earliest' }),
+        targetVersion: expect.objectContaining({ id: 'fvr_target' }),
+      }),
+    );
+    expect(result.kind).toBe('synced');
+  });
+
+  it('400s when an unpinned instance’s framework has no published version to diff from', async () => {
+    const unpinned = { id: 'frm_1', organizationId: 'org_1', frameworkId: 'frk_soc2', currentVersionId: null };
+    (db.frameworkInstance.findUnique as jest.Mock).mockResolvedValue(unpinned);
+    tx.frameworkInstance.findUnique.mockResolvedValue(unpinned);
+    tx.frameworkVersion.findUnique.mockResolvedValue({ id: 'fvr_target', frameworkId: 'frk_soc2' });
+    tx.frameworkVersion.findFirst.mockResolvedValue(null);
+
+    await expect(service.sync({ organizationId: 'org_1', frameworkInstanceId: 'frm_1', targetVersionId: 'fvr_target', memberId: 'mem_1' }))
+      .rejects.toBeInstanceOf(BadRequestException);
+    expect(applySync).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/frameworks/framework-versioning/framework-sync.service.ts
+++ b/apps/api/src/frameworks/framework-versioning/framework-sync.service.ts
@@ -48,15 +48,27 @@ export class FrameworkSyncService {
         return { syncOperationId: null, instanceId: instance.id };
       }
 
-      const [currentVersion, targetVersion] = await Promise.all([
+      const [pinnedVersion, targetVersion] = await Promise.all([
         instance.currentVersionId
           ? tx.frameworkVersion.findUnique({ where: { id: instance.currentVersionId } })
           : null,
         tx.frameworkVersion.findUnique({ where: { id: params.targetVersionId } }),
       ]);
       if (!targetVersion) throw new NotFoundException('Target version not found');
+
+      // Unpinned instances (no currentVersion) diff from the framework's
+      // earliest published version so they can still adopt updates. applySync
+      // sets currentVersionId at the end, healing the unpinned state.
+      const currentVersion =
+        pinnedVersion ??
+        (await tx.frameworkVersion.findFirst({
+          where: { frameworkId: instance.frameworkId! },
+          orderBy: { publishedAt: 'asc' },
+        }));
       if (!currentVersion) {
-        throw new BadRequestException('Instance is not on any version; backfill v1.0.0 first');
+        throw new BadRequestException(
+          'Framework has no published version to sync from',
+        );
       }
       if (currentVersion.frameworkId !== instance.frameworkId) {
         throw new BadRequestException('Version / framework mismatch');

--- a/apps/api/src/frameworks/frameworks.service.ts
+++ b/apps/api/src/frameworks/frameworks.service.ts
@@ -1022,9 +1022,6 @@ export class FrameworksService {
     if (!instance || instance.organizationId !== params.organizationId) {
       throw new NotFoundException('Framework instance not found');
     }
-    if (!instance.currentVersion) {
-      throw new BadRequestException('Instance is not on any version');
-    }
 
     const latest = await db.frameworkVersion.findFirst({
       where: { frameworkId: instance.frameworkId! },
@@ -1034,8 +1031,22 @@ export class FrameworksService {
       throw new NotFoundException('No update available');
     }
 
-    const fromManifest = instance.currentVersion
-      .manifest as unknown as FrameworkManifest;
+    // Instances that were never pinned to a version (e.g. created before
+    // versioning) have no currentVersion. Rather than dead-ending the update
+    // flow, diff from the framework's earliest published version so they can
+    // still adopt the latest — applying the sync pins currentVersionId, which
+    // heals the state for future updates.
+    const baseVersion =
+      instance.currentVersion ??
+      (await db.frameworkVersion.findFirst({
+        where: { frameworkId: instance.frameworkId! },
+        orderBy: { publishedAt: 'asc' },
+      }));
+    if (!baseVersion) {
+      throw new NotFoundException('No update available');
+    }
+
+    const fromManifest = baseVersion.manifest as unknown as FrameworkManifest;
     const toManifest = latest.manifest as unknown as FrameworkManifest;
     const templateControlIds = [
       ...new Set([
@@ -1109,8 +1120,8 @@ export class FrameworksService {
         status: p.status,
       })),
       fromVersionLabel: {
-        id: instance.currentVersion.id,
-        version: instance.currentVersion.version,
+        id: baseVersion.id,
+        version: baseVersion.version,
       },
       toVersionLabel: { id: latest.id, version: latest.version },
       releaseNotes: latest.releaseNotes,


### PR DESCRIPTION
## FRAME-2 — framework "Update available" won't apply

A CS admin published new NIST 800-53 versions, but clicking **Review update** flashed and bounced straight back — no **Apply** button, the banner never cleared, and editor changes never reached the org.

### Root cause (verified)
The org's framework **instance had no pinned `currentVersionId`** (instances created before versioning). That single fact broke the whole flow:
- `getUpdatePreview` threw `BadRequestException('Instance is not on any version')`.
- The `review-update` page does `if (!previewRes.data?.data) redirect(...)` → so the thrown preview made it **307 redirect back** (the flash, no Apply). Confirmed from the captured `NEXT_REDIRECT` response.
- `sync` also threw on the null version, so even via API it couldn't apply.
- `getUpdateStatus` returned `currentVersion: null` → the banner showed `v—` and `updateAvailable` stayed true forever.

### Fix
Both `getUpdatePreview` and `sync` now **fall back to the framework's earliest published version** as the diff baseline when the instance is unpinned, instead of throwing.

This is safe because `applySync` reconciles **additions against the target manifest, guarded by existing instance controls** (`if (ctlByTemplate.has(targetControl.id)) continue`) — it doesn't create from the diff — so:
- no duplicate controls/tasks,
- `removed`/`updated` are computed against the real baseline (earliest), not an empty one,
- requirement→control edges reconcile to the target (the AC-2x links Joe needs), and
- `applySync` sets `currentVersionId` to the target at the end → **self-heals** the unpinned state, so future updates work normally and the banner clears.

No schema change (the `SyncOperation.fromVersionId` FK is satisfied by a real version id).

### Testing
- New tests: sync resolves the earliest version for an unpinned instance and calls `applySync` with it (instead of throwing); 400s only when the framework has **no** published versions at all.
- `buildUpdatePreview` already covers the empty/earliest-from diff math.
- My two changed files typecheck clean. (The frameworks test dir has pre-existing failures in `findOne`/`applySync`/timeline/controller specs — confirmed identical on `origin/main`, unrelated to this change.)

### Out of scope
**FRAME-9** (publish ignoring framework title/description changes) is a separate bug Joe raised — not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the update flow for framework instances with no pinned version by diffing from the framework’s earliest published version. This stops the “Review update” bounce (no Apply button) and lets updates apply; the instance is pinned after apply.

- **Bug Fixes**
  - Preview: falls back to the earliest published version when `currentVersion` is null; returns “No update available” if none exist.
  - Sync: uses the same fallback; returns 400 if the framework has no published versions; `applySync` pins `currentVersionId` to heal the state.
  - Tests: added coverage for unpinned fallback and the no-published-versions error path.

<sup>Written for commit d4f1d49d07bf1aa3abe6290f30f9e833d357e2e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

