### PR TITLE
feat(api): stable download URLs for MCP server artifacts

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -48,6 +48,7 @@ import { AuditModule } from './audit/audit.module';
 import { ControlsModule } from './controls/controls.module';
 import { RolesModule } from './roles/roles.module';
 import { McpModule } from './mcp/mcp.module';
+import { McpDownloadModule } from './mcp-download/mcp-download.module';
 import { EmailModule } from './email/email.module';
 import { SecretsModule } from './secrets/secrets.module';
 import { SecurityPenetrationTestsModule } from './security-penetration-tests/security-penetration-tests.module';
@@ -128,6 +129,7 @@ import { OffboardingChecklistModule } from './offboarding-checklist/offboarding-
     TimelinesModule,
     OffboardingChecklistModule,
     McpModule,
+    McpDownloadModule,
   ],
   controllers: [AppController],
   providers: [

--- a/apps/api/src/mcp-download/mcp-download.controller.ts
+++ b/apps/api/src/mcp-download/mcp-download.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Get, Param, Res, VERSION_NEUTRAL } from '@nestjs/common';
+import { ApiExcludeController } from '@nestjs/swagger';
+import type { Response } from 'express';
+import { Public } from '../auth/public.decorator';
+import { McpDownloadService } from './mcp-download.service';
+
+/**
+ * Stable, never-stale download links for the MCP server artifacts.
+ *
+ * The `.mcpb` and the platform binaries are published as assets on the MCP
+ * release stream (`apps/mcp-server/vX.Y.Z`), which is buried among the frequent
+ * product releases — so a version-pinned link in the docs rots every release and
+ * is hard for customers to find. These endpoints 302-redirect to the asset on
+ * whatever the latest MCP release is, so the docs can link here once and forget.
+ *
+ * Public + unversioned on purpose (customer-facing download URLs). Excluded from
+ * the OpenAPI spec so it never becomes an MCP tool or a docs entry.
+ */
+@ApiExcludeController()
+@Controller({ path: 'mcp/download', version: VERSION_NEUTRAL })
+export class McpDownloadController {
+  constructor(private readonly mcpDownloadService: McpDownloadService) {}
+
+  @Get(':target')
+  @Public()
+  async download(
+    @Param('target') target: string,
+    @Res() res: Response,
+  ): Promise<void> {
+    const url = await this.mcpDownloadService.resolveDownloadUrl(target);
+    res.redirect(302, url);
+  }
+}

--- a/apps/api/src/mcp-download/mcp-download.module.ts
+++ b/apps/api/src/mcp-download/mcp-download.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { McpDownloadController } from './mcp-download.controller';
+import { McpDownloadService } from './mcp-download.service';
+
+@Module({
+  controllers: [McpDownloadController],
+  providers: [McpDownloadService],
+})
+export class McpDownloadModule {}

--- a/apps/api/src/mcp-download/mcp-download.service.spec.ts
+++ b/apps/api/src/mcp-download/mcp-download.service.spec.ts
@@ -1,0 +1,140 @@
+import { NotFoundException, ServiceUnavailableException } from '@nestjs/common';
+import { McpDownloadService } from './mcp-download.service';
+
+function releasesPayload() {
+  return [
+    // A product release with no MCP assets — must be skipped.
+    { tag_name: 'v3.79.1', draft: false, assets: [] },
+    // The latest MCP release.
+    {
+      tag_name: 'apps/mcp-server/v0.2.0',
+      draft: false,
+      assets: [
+        {
+          name: 'mcp-server.mcpb',
+          browser_download_url: 'https://gh/dl/v0.2.0/mcp-server.mcpb',
+        },
+        {
+          name: 'mcp-server-bun-darwin-arm64',
+          browser_download_url:
+            'https://gh/dl/v0.2.0/mcp-server-bun-darwin-arm64',
+        },
+      ],
+    },
+    // An older MCP release — must not win.
+    {
+      tag_name: 'apps/mcp-server/v0.1.0',
+      draft: false,
+      assets: [
+        {
+          name: 'mcp-server.mcpb',
+          browser_download_url: 'https://gh/dl/v0.1.0/mcp-server.mcpb',
+        },
+      ],
+    },
+  ];
+}
+
+describe('McpDownloadService', () => {
+  let service: McpDownloadService;
+  let fetchSpy: jest.SpyInstance<Promise<Response>, Parameters<typeof fetch>>;
+
+  beforeEach(() => {
+    service = new McpDownloadService();
+    fetchSpy = jest.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  function mockReleasesOnce(payload: unknown, status = 200) {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify(payload), {
+        status,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+  }
+
+  it('resolves a target to the asset URL on the latest MCP release', async () => {
+    mockReleasesOnce(releasesPayload());
+
+    const url = await service.resolveDownloadUrl('claude-desktop');
+
+    // Picked v0.2.0, not the older v0.1.0, and ignored the product release.
+    expect(url).toBe('https://gh/dl/v0.2.0/mcp-server.mcpb');
+  });
+
+  it('maps each platform target to its stable asset', async () => {
+    mockReleasesOnce(releasesPayload());
+
+    const macos = await service.resolveDownloadUrl('macos-arm64');
+
+    expect(macos).toBe('https://gh/dl/v0.2.0/mcp-server-bun-darwin-arm64');
+  });
+
+  it('rejects an unknown target without calling GitHub', async () => {
+    await expect(service.resolveDownloadUrl('bogus')).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('404s when the asset is missing on the latest release', async () => {
+    // Latest MCP release ships only the .mcpb, not the windows binary.
+    mockReleasesOnce([
+      {
+        tag_name: 'apps/mcp-server/v0.2.0',
+        draft: false,
+        assets: [
+          {
+            name: 'mcp-server.mcpb',
+            browser_download_url: 'https://gh/dl/v0.2.0/mcp-server.mcpb',
+          },
+        ],
+      },
+    ]);
+
+    await expect(
+      service.resolveDownloadUrl('windows-x64'),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('caches the release lookup across requests', async () => {
+    mockReleasesOnce(releasesPayload());
+
+    await service.resolveDownloadUrl('claude-desktop');
+    await service.resolveDownloadUrl('macos-arm64');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves a stale cached release if a later GitHub lookup fails', async () => {
+    mockReleasesOnce(releasesPayload());
+    await service.resolveDownloadUrl('claude-desktop'); // primes the cache
+
+    // Force the cache to look expired, then make the refresh fail.
+    (service as unknown as { cache: { fetchedAt: number } }).cache.fetchedAt = 0;
+    fetchSpy.mockRejectedValueOnce(new Error('network down'));
+
+    const url = await service.resolveDownloadUrl('claude-desktop');
+    expect(url).toBe('https://gh/dl/v0.2.0/mcp-server.mcpb');
+  });
+
+  it('throws ServiceUnavailable when GitHub fails and there is no cache', async () => {
+    fetchSpy.mockResolvedValueOnce(new Response(null, { status: 503 }));
+
+    await expect(
+      service.resolveDownloadUrl('claude-desktop'),
+    ).rejects.toBeInstanceOf(ServiceUnavailableException);
+  });
+
+  it('throws when no MCP-tagged release exists in the page', async () => {
+    mockReleasesOnce([{ tag_name: 'v3.79.1', draft: false, assets: [] }]);
+
+    await expect(
+      service.resolveDownloadUrl('claude-desktop'),
+    ).rejects.toBeInstanceOf(ServiceUnavailableException);
+  });
+});

--- a/apps/api/src/mcp-download/mcp-download.service.spec.ts
+++ b/apps/api/src/mcp-download/mcp-download.service.spec.ts
@@ -101,6 +101,42 @@ describe('McpDownloadService', () => {
     ).rejects.toBeInstanceOf(NotFoundException);
   });
 
+  it('paginates beyond the first 100 releases to find the MCP release', async () => {
+    // Page 1: a full page of product releases, no MCP release.
+    const page1 = Array.from({ length: 100 }, (_, i) => ({
+      tag_name: `v3.${i}.0`,
+      draft: false,
+      assets: [],
+    }));
+    mockReleasesOnce(page1);
+    // Page 2: contains the MCP release.
+    mockReleasesOnce(releasesPayload());
+
+    const url = await service.resolveDownloadUrl('claude-desktop');
+
+    expect(url).toBe('https://gh/dl/v0.2.0/mcp-server.mcpb');
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('bounds each GitHub request with an abort signal (no unbounded hang)', async () => {
+    mockReleasesOnce(releasesPayload());
+
+    await service.resolveDownloadUrl('claude-desktop');
+
+    const init = fetchSpy.mock.calls[0][1];
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('handles a GitHub timeout/abort without hanging', async () => {
+    const timeout = new Error('The operation timed out');
+    timeout.name = 'TimeoutError';
+    fetchSpy.mockRejectedValueOnce(timeout);
+
+    await expect(
+      service.resolveDownloadUrl('claude-desktop'),
+    ).rejects.toBeInstanceOf(ServiceUnavailableException);
+  });
+
   it('caches the release lookup across requests', async () => {
     mockReleasesOnce(releasesPayload());
 

--- a/apps/api/src/mcp-download/mcp-download.service.ts
+++ b/apps/api/src/mcp-download/mcp-download.service.ts
@@ -1,0 +1,138 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+
+/**
+ * Stable, human-friendly download target -> the (version-less) GitHub release
+ * asset name. The MCP server's release assets keep the same names across
+ * versions, so we can resolve them by name on whatever the latest release is.
+ */
+const ASSET_BY_TARGET: Record<string, string> = {
+  'claude-desktop': 'mcp-server.mcpb',
+  'macos-arm64': 'mcp-server-bun-darwin-arm64',
+  'linux-x64': 'mcp-server-bun-linux-x64-modern',
+  'windows-x64': 'mcp-server-bun-windows-x64-modern.exe',
+};
+
+// The MCP server ships its own release stream (tag `apps/mcp-server/vX.Y.Z`),
+// interleaved with the much more frequent product releases (`vX.Y.Z`). We page
+// through the newest releases and pick the first one on the MCP stream.
+const GITHUB_RELEASES_URL =
+  'https://api.github.com/repos/trycompai/comp/releases?per_page=100';
+const MCP_TAG_PREFIX = 'apps/mcp-server/';
+
+// Cache the resolved release so a burst of downloads can't exhaust GitHub's
+// unauthenticated API budget (60 req/hr/IP). 10 min keeps us at a handful of
+// API calls per hour regardless of download volume.
+const CACHE_TTL_MS = 10 * 60 * 1000;
+
+interface ResolvedRelease {
+  tag: string;
+  /** asset filename -> browser_download_url */
+  assets: Record<string, string>;
+  fetchedAt: number;
+}
+
+interface GitHubRelease {
+  tag_name: string;
+  draft: boolean;
+  assets: Array<{ name: string; browser_download_url: string }>;
+}
+
+@Injectable()
+export class McpDownloadService {
+  private readonly logger = new Logger(McpDownloadService.name);
+  private cache: ResolvedRelease | null = null;
+
+  static readonly TARGETS = Object.keys(ASSET_BY_TARGET);
+
+  /**
+   * Resolve a stable download target to the current GitHub CDN URL for that
+   * asset on the latest MCP release. Throws NotFoundException for unknown
+   * targets or missing assets.
+   */
+  async resolveDownloadUrl(target: string): Promise<string> {
+    const assetName = ASSET_BY_TARGET[target];
+    if (!assetName) {
+      throw new NotFoundException(
+        `Unknown download target '${target}'. Valid targets: ${McpDownloadService.TARGETS.join(
+          ', ',
+        )}.`,
+      );
+    }
+
+    const release = await this.getLatestMcpRelease();
+    const url = release.assets[assetName];
+    if (!url) {
+      throw new NotFoundException(
+        `Asset '${assetName}' is not present on the latest MCP release (${release.tag}).`,
+      );
+    }
+    return url;
+  }
+
+  private async getLatestMcpRelease(): Promise<ResolvedRelease> {
+    if (this.cache && Date.now() - this.cache.fetchedAt < CACHE_TTL_MS) {
+      return this.cache;
+    }
+
+    try {
+      this.cache = await this.fetchLatestMcpRelease();
+      return this.cache;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'unknown error';
+      // Prefer a slightly stale answer over a hard failure if GitHub blips.
+      if (this.cache) {
+        this.logger.warn(
+          `GitHub lookup failed; serving stale MCP release ${this.cache.tag}: ${message}`,
+        );
+        return this.cache;
+      }
+      this.logger.error(`Failed to resolve latest MCP release: ${message}`);
+      throw new ServiceUnavailableException(
+        'Could not resolve the latest MCP server release. Please try again shortly.',
+      );
+    }
+  }
+
+  private async fetchLatestMcpRelease(): Promise<ResolvedRelease> {
+    const response = await fetch(GITHUB_RELEASES_URL, {
+      headers: {
+        // GitHub rejects API requests without a User-Agent.
+        'User-Agent': 'comp-ai-mcp-download',
+        Accept: 'application/vnd.github+json',
+        // Optional: lifts the rate limit to 5000/hr if a token is configured.
+        ...(process.env.GITHUB_TOKEN && {
+          Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+        }),
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`GitHub releases API returned ${response.status}`);
+    }
+
+    const releases = (await response.json()) as GitHubRelease[];
+    // Releases are returned newest-first, so the first MCP-tagged, non-draft
+    // release is the latest one.
+    const latest = releases.find(
+      (release) => !release.draft && release.tag_name.startsWith(MCP_TAG_PREFIX),
+    );
+
+    if (!latest) {
+      throw new Error(
+        `No release with tag prefix '${MCP_TAG_PREFIX}' in the latest 100 releases.`,
+      );
+    }
+
+    const assets: Record<string, string> = {};
+    for (const asset of latest.assets) {
+      assets[asset.name] = asset.browser_download_url;
+    }
+
+    return { tag: latest.tag_name, assets, fetchedAt: Date.now() };
+  }
+}

--- a/apps/api/src/mcp-download/mcp-download.service.ts
+++ b/apps/api/src/mcp-download/mcp-download.service.ts
@@ -18,11 +18,21 @@ const ASSET_BY_TARGET: Record<string, string> = {
 };
 
 // The MCP server ships its own release stream (tag `apps/mcp-server/vX.Y.Z`),
-// interleaved with the much more frequent product releases (`vX.Y.Z`). We page
-// through the newest releases and pick the first one on the MCP stream.
+// interleaved with the much more frequent product releases (`vX.Y.Z`) — the repo
+// cuts several product releases a day, so the latest MCP release can sit well
+// past the first page. We page through newest-first and stop at the first MCP
+// release (which, because the list is newest-first, is the latest one).
 const GITHUB_RELEASES_URL =
-  'https://api.github.com/repos/trycompai/comp/releases?per_page=100';
+  'https://api.github.com/repos/trycompai/comp/releases';
+const RELEASES_PER_PAGE = 100;
+// Bounds the work (and the GitHub API budget) while covering many months of
+// product-release velocity, so a slow MCP release cadence can't make downloads
+// look unavailable.
+const MAX_RELEASE_PAGES = 5;
 const MCP_TAG_PREFIX = 'apps/mcp-server/';
+
+// Bound each GitHub call so a stalled upstream can't tie up the endpoint.
+const GITHUB_TIMEOUT_MS = 5_000;
 
 // Cache the resolved release so a burst of downloads can't exhaust GitHub's
 // unauthenticated API budget (60 req/hr/IP). 10 min keeps us at a handful of
@@ -99,7 +109,39 @@ export class McpDownloadService {
   }
 
   private async fetchLatestMcpRelease(): Promise<ResolvedRelease> {
-    const response = await fetch(GITHUB_RELEASES_URL, {
+    for (let page = 1; page <= MAX_RELEASE_PAGES; page++) {
+      const releases = await this.fetchReleasesPage(page);
+
+      // Releases come back newest-first, so the first MCP-tagged, non-draft
+      // release on any page is the latest one.
+      const latest = releases.find(
+        (release) =>
+          !release.draft && release.tag_name.startsWith(MCP_TAG_PREFIX),
+      );
+      if (latest) {
+        const assets: Record<string, string> = {};
+        for (const asset of latest.assets) {
+          assets[asset.name] = asset.browser_download_url;
+        }
+        return { tag: latest.tag_name, assets, fetchedAt: Date.now() };
+      }
+
+      // A short page means we've reached the end of the release history.
+      if (releases.length < RELEASES_PER_PAGE) break;
+    }
+
+    throw new Error(
+      `No release with tag prefix '${MCP_TAG_PREFIX}' in the latest ${
+        MAX_RELEASE_PAGES * RELEASES_PER_PAGE
+      } releases.`,
+    );
+  }
+
+  private async fetchReleasesPage(page: number): Promise<GitHubRelease[]> {
+    const url = `${GITHUB_RELEASES_URL}?per_page=${RELEASES_PER_PAGE}&page=${page}`;
+    const response = await fetch(url, {
+      // Abort a stalled GitHub call instead of hanging the endpoint.
+      signal: AbortSignal.timeout(GITHUB_TIMEOUT_MS),
       headers: {
         // GitHub rejects API requests without a User-Agent.
         'User-Agent': 'comp-ai-mcp-download',
@@ -115,24 +157,6 @@ export class McpDownloadService {
       throw new Error(`GitHub releases API returned ${response.status}`);
     }
 
-    const releases = (await response.json()) as GitHubRelease[];
-    // Releases are returned newest-first, so the first MCP-tagged, non-draft
-    // release is the latest one.
-    const latest = releases.find(
-      (release) => !release.draft && release.tag_name.startsWith(MCP_TAG_PREFIX),
-    );
-
-    if (!latest) {
-      throw new Error(
-        `No release with tag prefix '${MCP_TAG_PREFIX}' in the latest 100 releases.`,
-      );
-    }
-
-    const assets: Record<string, string> = {};
-    for (const asset of latest.assets) {
-      assets[asset.name] = asset.browser_download_url;
-    }
-
-    return { tag: latest.tag_name, assets, fetchedAt: Date.now() };
+    return (await response.json()) as GitHubRelease[];
   }
 }


### PR DESCRIPTION
## What & why

CX (Dustin) flagged that customers can't find the Claude Desktop `.mcpb` bundle — it's published on the MCP release stream (`apps/mcp-server/vX.Y.Z`), which is buried under the frequent product releases (`v3.x.x`), and our docs link is pinned to a stale `v0.0.2`. Version-pinned links rot on every release.

This adds **stable, never-stale download URLs** for all MCP artifacts (the `.mcpb` plus the three platform binaries), so the docs can link once and forget.

## How

A public, version-neutral redirect endpoint that resolves the **latest** `apps/mcp-server/*` release at request time and 302-redirects to the requested asset on GitHub's CDN:

| URL | Asset |
| --- | --- |
| `GET /mcp/download/claude-desktop` | `mcp-server.mcpb` |
| `GET /mcp/download/macos-arm64` | `mcp-server-bun-darwin-arm64` |
| `GET /mcp/download/linux-x64` | `mcp-server-bun-linux-x64-modern` |
| `GET /mcp/download/windows-x64` | `mcp-server-bun-windows-x64-modern.exe` |

→ Live URL shape: `https://api.trycomp.ai/mcp/download/{target}`

Why this is safe and low-maintenance:
- **Never goes stale** — resolves the newest MCP release each call, so no link touch-ups when a version ships.
- **No bandwidth cost** — the file still downloads from GitHub's CDN; we only issue the redirect. (Works because the repo is public, so asset URLs need no auth.)
- **No GitHub rate-limit risk** — the release lookup is cached ~10 min (caps API calls at a handful/hour regardless of download volume), and serves a slightly stale result rather than failing if GitHub blips.
- **Invisible to the API surface** — `@ApiExcludeController()` keeps it out of the OpenAPI spec, so it never becomes an MCP tool or a docs entry.
- Public by omission (no auth guards) + `@Public()` intent marker; throttled by the global `ThrottlerGuard`.

## Tests
`mcp-download.service.spec.ts` — 8 cases: resolves each target to the latest release's asset (ignores product releases + older MCP releases), unknown target → 404 without hitting GitHub, missing asset → 404, lookup cached across calls, serves stale cache on GitHub failure, `ServiceUnavailable` when GitHub fails with no cache, and when no MCP release is in the page. All pass; my files typecheck clean; `AppModule` boots with the new module.

## Follow-up (not in this PR)
Once this is **deployed**, point the docs (`packages/docs/mcp-server.mdx` — currently links `v0.0.2`) at these stable URLs and add a "Download for Claude Desktop" button. Sequencing matters: the docs links 404 until the endpoint is live, so docs come after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds stable, version-neutral download URLs for MCP server artifacts via a public redirect endpoint. Adds pagination and timeouts to keep lookups reliable as releases grow.

- **New Features**
  - Add `GET /mcp/download/:target` → 302 to the latest `apps/mcp-server/*` release asset on GitHub.
  - Targets: `claude-desktop`, `macos-arm64`, `linux-x64`, `windows-x64`.
  - Paginates newest-first up to 500 releases to find the latest MCP release.
  - 10-minute cache with stale-on-error; 5s timeout per GitHub request; 503 if no cache and lookup fails.
  - Public and version-neutral; excluded from OpenAPI.

- **Migration**
  - After deploy, point docs to `https://api.trycomp.ai/mcp/download/{target}`.

<sup>Written for commit 760ef2f6c8b20c5cf04ba3425d61ce2dc45add54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

