### PR TITLE
feat(framework-editor): raise requirement description limit to 10,000 chars (FRAME-2)

### DIFF
--- a/apps/api/src/framework-editor/requirement/dto/batch-update-requirements.dto.spec.ts
+++ b/apps/api/src/framework-editor/requirement/dto/batch-update-requirements.dto.spec.ts
@@ -1,0 +1,49 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { BatchUpdateRequirementsDto } from './batch-update-requirements.dto';
+
+/**
+ * Mirrors the global ValidationPipe config from main.ts:
+ *   whitelist: true, transform: true, enableImplicitConversion: true
+ */
+function toDto(plain: Record<string, unknown>): BatchUpdateRequirementsDto {
+  return plainToInstance(BatchUpdateRequirementsDto, plain, {
+    enableImplicitConversion: true,
+  });
+}
+
+describe('BatchUpdateRequirementsDto', () => {
+  it('accepts a valid batch payload', async () => {
+    const dto = toDto({
+      updates: [{ id: 'frq_1', description: 'Updated description' }],
+    });
+    const errors = await validate(dto, {
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    });
+    expect(errors).toHaveLength(0);
+  });
+
+  // ── nested description length (FRAME-2: limit raised 5,000 → 10,000) ─
+  it('accepts a nested description at the 10,000-char limit', async () => {
+    const dto = toDto({
+      updates: [{ id: 'frq_1', description: 'x'.repeat(10_000) }],
+    });
+    const errors = await validate(dto, {
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects a nested description longer than 10,000 chars', async () => {
+    const dto = toDto({
+      updates: [{ id: 'frq_1', description: 'x'.repeat(10_001) }],
+    });
+    const errors = await validate(dto, {
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    });
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/api/src/framework-editor/requirement/dto/batch-update-requirements.dto.ts
+++ b/apps/api/src/framework-editor/requirement/dto/batch-update-requirements.dto.ts
@@ -30,7 +30,7 @@ class BatchUpdateRequirementItem {
   @ApiProperty()
   @IsString()
   @IsOptional()
-  @MaxLength(5000)
+  @MaxLength(10000)
   description?: string;
 
   @ApiProperty()

--- a/apps/api/src/framework-editor/requirement/dto/create-requirement.dto.spec.ts
+++ b/apps/api/src/framework-editor/requirement/dto/create-requirement.dto.spec.ts
@@ -1,0 +1,50 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { CreateRequirementDto } from './create-requirement.dto';
+
+/**
+ * Mirrors the global ValidationPipe config from main.ts:
+ *   whitelist: true, transform: true, enableImplicitConversion: true
+ */
+function toDto(plain: Record<string, unknown>): CreateRequirementDto {
+  return plainToInstance(CreateRequirementDto, plain, {
+    enableImplicitConversion: true,
+  });
+}
+
+const VALID_BASE = {
+  frameworkId: 'frk_abc123',
+  name: 'AC-1',
+  description: 'Access control policy and procedures',
+};
+
+describe('CreateRequirementDto', () => {
+  it('accepts a valid payload', async () => {
+    const dto = toDto(VALID_BASE);
+    const errors = await validate(dto, {
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    });
+    expect(errors).toHaveLength(0);
+  });
+
+  // ── description length (FRAME-2: limit raised 5,000 → 10,000) ──────
+  it('accepts a description at the 10,000-char limit', async () => {
+    const dto = toDto({ ...VALID_BASE, description: 'x'.repeat(10_000) });
+    const errors = await validate(dto, {
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects a description longer than 10,000 chars', async () => {
+    const dto = toDto({ ...VALID_BASE, description: 'x'.repeat(10_001) });
+    const errors = await validate(dto, {
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    });
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe('description');
+  });
+});

--- a/apps/api/src/framework-editor/requirement/dto/create-requirement.dto.ts
+++ b/apps/api/src/framework-editor/requirement/dto/create-requirement.dto.ts
@@ -22,7 +22,7 @@ export class CreateRequirementDto {
 
   @ApiProperty({ example: 'Control environment requirements' })
   @IsString()
-  @MaxLength(5000)
+  @MaxLength(10000)
   description: string;
 
   @ApiPropertyOptional({ example: 'Access Control' })

--- a/apps/api/src/framework-editor/requirement/dto/update-requirement.dto.spec.ts
+++ b/apps/api/src/framework-editor/requirement/dto/update-requirement.dto.spec.ts
@@ -1,0 +1,44 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { UpdateRequirementDto } from './update-requirement.dto';
+
+/**
+ * Mirrors the global ValidationPipe config from main.ts:
+ *   whitelist: true, transform: true, enableImplicitConversion: true
+ */
+function toDto(plain: Record<string, unknown>): UpdateRequirementDto {
+  return plainToInstance(UpdateRequirementDto, plain, {
+    enableImplicitConversion: true,
+  });
+}
+
+describe('UpdateRequirementDto', () => {
+  it('accepts a partial update (single field)', async () => {
+    const dto = toDto({ name: 'AC-2' });
+    const errors = await validate(dto, {
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    });
+    expect(errors).toHaveLength(0);
+  });
+
+  // ── description length (FRAME-2: limit raised 5,000 → 10,000) ──────
+  it('accepts a description at the 10,000-char limit', async () => {
+    const dto = toDto({ description: 'x'.repeat(10_000) });
+    const errors = await validate(dto, {
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects a description longer than 10,000 chars', async () => {
+    const dto = toDto({ description: 'x'.repeat(10_001) });
+    const errors = await validate(dto, {
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    });
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe('description');
+  });
+});

--- a/apps/api/src/framework-editor/requirement/dto/update-requirement.dto.ts
+++ b/apps/api/src/framework-editor/requirement/dto/update-requirement.dto.ts
@@ -17,7 +17,7 @@ export class UpdateRequirementDto {
   @ApiPropertyOptional()
   @IsString()
   @IsOptional()
-  @MaxLength(5000)
+  @MaxLength(10000)
   description?: string;
 
   @ApiPropertyOptional()


### PR DESCRIPTION
## What

Raises the **requirement description** character limit from **5,000 → 10,000** in the Framework Editor API.

## Why

NIST-style requirement text routinely exceeds 5,000 characters. The API rejected those edits with a validation error, so editors couldn't save full requirement descriptions. Requested in **FRAME-2**.

## Changes

`@MaxLength(5000)` → `@MaxLength(10000)` on the `description` field of all three requirement DTOs:

- `requirement/dto/create-requirement.dto.ts`
- `requirement/dto/update-requirement.dto.ts`
- `requirement/dto/batch-update-requirements.dto.ts` (nested item)

Adds DTO validation specs for each, asserting the new boundary (10,000 passes, 10,001 rejected). 9 tests, all green.

## Scope notes

- **Requirements only.** Other resources (control/policy/task templates, framework import) keep their own `@MaxLength(5000)` — out of scope for this ticket. Happy to bump those in a follow-up if desired.
- No DB schema change: requirement `description` is already an unbounded Postgres `text` column; the 5,000 cap was purely the DTO validator.
- No frontend cap to change: the Framework Editor requirement description input has no client-side length limit, so the DTO was the only gate.

## Testing

- `npx jest src/framework-editor/requirement` → 3 suites, 9 tests passing.
- `npx turbo run typecheck --filter=@trycompai/api`: the only errors are the pre-existing AI-SDK `LanguageModelV3`/`EmbeddingModelV3` mismatches on `main` (in `trigger/vendor` and `vector-store`) — none in the changed files. A `@MaxLength` literal change cannot introduce those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised the Framework Editor requirement description limit from 5,000 to 10,000 characters so editors can save full NIST-style text without validation errors. Addresses Linear FRAME-2 and unblocks publishing of entries like SP800-53 PL-2 (>6k chars).

- **Bug Fixes**
  - Increased `@MaxLength` to 10,000 on `description` in create, update, and batch-update requirement DTOs.
  - Added DTO validation tests to enforce the new boundary (10,000 passes; 10,001 rejected).
  - No DB or frontend changes; the previous cap was API validation-only.

<sup>Written for commit baebbcdb8365c4d82f347056863474ab18baf08e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

