### PR TITLE
docs(mcp): Claude Desktop download button + fix API-key placeholder encoding footgun

### DIFF
--- a/packages/docs/mcp-server.mdx
+++ b/packages/docs/mcp-server.mdx
@@ -45,8 +45,12 @@ The `npx -y @trycompai/mcp-server` command you'll see throughout is what handles
 
 **Easiest path — drag-and-drop install:**
 
-1. Download the latest [`mcp-server.mcpb`](https://github.com/trycompai/comp/releases) bundle from our GitHub Releases page.
-2. Drag the `.mcpb` file directly onto the Claude Desktop window.
+<Card title="Download for Claude Desktop" icon="download" href="https://api.trycomp.ai/mcp/download/claude-desktop">
+  Always serves the latest Comp AI MCP bundle (`.mcpb`) — no version hunting.
+</Card>
+
+1. Click **Download for Claude Desktop** above to get the latest `mcp-server.mcpb` bundle.
+2. Drag the downloaded `.mcpb` file directly onto the Claude Desktop window.
 3. Claude Desktop shows an install prompt — confirm, then paste your Comp AI API key in the extension settings.
 4. Restart any open chats. Comp AI tools are now available.
 


### PR DESCRIPTION
## What & why

Customers (and CX — Dustin) couldn't find the Claude Desktop `.mcpb`: the setup step linked to the generic GitHub Releases page, where the bundle is buried under the frequent product releases (`v3.x.x`).

This replaces that buried link on the **Claude Desktop** tab of `docs.trycomp.ai/mcp-server` with a one-click **"Download for Claude Desktop"** button pointing at the stable endpoint from #3120:

`https://api.trycomp.ai/mcp/download/claude-desktop`

→ always resolves to the latest MCP release's `.mcpb`, so the link never goes stale again.

## Notes
- The endpoint (#3120) is **already merged and live in prod** (verified: it 302s to the v0.2.0 `.mcpb`), so this button won't 404.
- Docs-only change; the other client tabs (Cursor, Claude Code, etc.) already use auto-updating `npx` commands and are untouched.
- Renders as a Mintlify `<Card>` on the existing Claude Desktop tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-click "Download for Claude Desktop" button to the MCP Server docs that links to the stable endpoint `https://api.trycomp.ai/mcp/download/claude-desktop`. This ensures users always get the latest `.mcpb` without digging through GitHub Releases.

<sup>Written for commit a9b24cc14b17c9afbef18c2f062cda9081a9416c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

