### PR TITLE
feat(framework-editor): requirement edit dialog context + row highlight (FRAME-7)

### DIFF
--- a/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/FrameworkRequirementsClientPage.expandable.test.tsx
+++ b/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/FrameworkRequirementsClientPage.expandable.test.tsx
@@ -71,7 +71,11 @@ describe('FrameworkRequirementsClientPage — Description column', () => {
 
     const description = editableCellProps.find((p) => p.columnId === 'description');
     expect(description?.expandable).toBe(true);
-    expect(description?.expandTitle).toBe('Edit Requirement Description');
+    // Identifier + name are appended so the editor dialog says which requirement
+    // is being edited (FRAME-7), e.g. "… - AC-2 - Account Management".
+    expect(description?.expandTitle).toBe(
+      'Edit Requirement Description - AC-2 - Account Management',
+    );
 
     // The short single-line columns stay as plain inline edits.
     for (const columnId of ['identifier', 'name']) {

--- a/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/FrameworkRequirementsClientPage.tsx
+++ b/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/FrameworkRequirementsClientPage.tsx
@@ -73,6 +73,9 @@ export function FrameworkRequirementsClientPage({
   const router = useRouter();
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  // Row whose large description editor is currently open — highlighted so the
+  // edited row is obvious behind the (semi-transparent) editor dialog.
+  const [expandedRowId, setExpandedRowId] = useState<string | null>(null);
 
   const initialGridData: RequirementGridRow[] = useMemo(
     () =>
@@ -155,16 +158,27 @@ export function FrameworkRequirementsClientPage({
         header: 'Description',
         size: 300,
         maxSize: 300,
-        cell: ({ row, getValue }) => (
-          <EditableCell
-            value={getValue()}
-            rowId={row.original.id}
-            columnId="description"
-            onUpdate={updateCell}
-            expandable
-            expandTitle="Edit Requirement Description"
-          />
-        ),
+        cell: ({ row, getValue }) => {
+          const { identifier, name } = row.original;
+          const titleSuffix = [identifier, name].filter(Boolean).join(' - ');
+          return (
+            <EditableCell
+              value={getValue()}
+              rowId={row.original.id}
+              columnId="description"
+              onUpdate={updateCell}
+              expandable
+              expandTitle={
+                titleSuffix
+                  ? `Edit Requirement Description - ${titleSuffix}`
+                  : 'Edit Requirement Description'
+              }
+              onExpandedChange={(open) =>
+                setExpandedRowId(open ? row.original.id : null)
+              }
+            />
+          );
+        },
       }),
       columnHelper.accessor('controlTemplates', {
         header: 'Linked Controls',
@@ -369,7 +383,11 @@ export function FrameworkRequirementsClientPage({
             {table.getRowModel().rows.map((row) => (
               <tr
                 key={row.id}
-                className={`border-border hover:bg-muted/30 border-b transition-colors ${getRowClassName(row.original.id)}`}
+                className={`border-border hover:bg-muted/30 border-b transition-colors ${getRowClassName(row.original.id)} ${
+                  expandedRowId === row.original.id
+                    ? 'ring-primary !bg-primary/15 ring-2 ring-inset'
+                    : ''
+                }`}
               >
                 {row.getVisibleCells().map((cell) => (
                   <td

--- a/apps/framework-editor/app/components/table/EditableCell.test.tsx
+++ b/apps/framework-editor/app/components/table/EditableCell.test.tsx
@@ -120,4 +120,23 @@ describe('EditableCell — expandable', () => {
     setup({ expandable: true, disabled: true });
     expect(screen.queryByRole('button', { name: /large editor/i })).toBeNull();
   });
+
+  it('notifies onExpandedChange when the editor opens and on Save', () => {
+    const onExpandedChange = vi.fn();
+    setup({ expandable: true, onExpandedChange });
+    fireEvent.click(screen.getByRole('button', { name: /large editor/i }));
+    expect(onExpandedChange).toHaveBeenLastCalledWith(true);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'changed' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(onExpandedChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('notifies onExpandedChange(false) on Cancel', () => {
+    const onExpandedChange = vi.fn();
+    setup({ expandable: true, onExpandedChange });
+    fireEvent.contextMenu(screen.getByText(/assign account managers/i));
+    expect(onExpandedChange).toHaveBeenLastCalledWith(true);
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onExpandedChange).toHaveBeenLastCalledWith(false);
+  });
 });

--- a/apps/framework-editor/app/components/table/EditableCell.tsx
+++ b/apps/framework-editor/app/components/table/EditableCell.tsx
@@ -24,6 +24,9 @@ interface EditableCellProps {
   // values like control descriptions.
   expandable?: boolean;
   expandTitle?: string;
+  // Notified when the large editor opens/closes so the parent can highlight
+  // the row currently being edited.
+  onExpandedChange?: (open: boolean) => void;
 }
 
 export function EditableCell({
@@ -35,11 +38,20 @@ export function EditableCell({
   placeholder = 'Click to edit',
   expandable = false,
   expandTitle = 'Edit',
+  onExpandedChange,
 }: EditableCellProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState(value ?? '');
   const [isExpanded, setIsExpanded] = useState(false);
   const [expandValue, setExpandValue] = useState(value ?? '');
+
+  // Keep local open state and the parent notification in lockstep so the row
+  // highlight tracks the dialog exactly (open icon, right-click, save, cancel,
+  // Esc, and overlay click all route through here).
+  const setExpanded = (open: boolean) => {
+    setIsExpanded(open);
+    onExpandedChange?.(open);
+  };
 
   const handleBlur = () => {
     setIsEditing(false);
@@ -66,14 +78,14 @@ export function EditableCell({
   const handleOpenExpanded = () => {
     if (disabled) return;
     setExpandValue(value ?? '');
-    setIsExpanded(true);
+    setExpanded(true);
   };
 
   const handleExpandSave = () => {
     if (expandValue !== (value ?? '')) {
       onUpdate(rowId, columnId, expandValue);
     }
-    setIsExpanded(false);
+    setExpanded(false);
   };
 
   if (disabled) {
@@ -136,7 +148,7 @@ export function EditableCell({
         <Maximize2 className="h-3.5 w-3.5" />
       </button>
 
-      <Dialog open={isExpanded} onOpenChange={setIsExpanded}>
+      <Dialog open={isExpanded} onOpenChange={setExpanded}>
         <DialogContent className="sm:max-w-[760px]">
           <DialogHeader>
             <DialogTitle>{expandTitle}</DialogTitle>
@@ -148,7 +160,7 @@ export function EditableCell({
             className="min-h-[260px] font-mono text-sm"
           />
           <DialogFooter>
-            <Button variant="outline" onClick={() => setIsExpanded(false)}>
+            <Button variant="outline" onClick={() => setExpanded(false)}>
               Cancel
             </Button>
             <Button onClick={handleExpandSave} disabled={expandValue === (value ?? '')}>


### PR DESCRIPTION
## What

Two small UX fixes for the requirement **description** multi-line editor in the Framework Editor.

## Why (FRAME-7)

When you open the large editor for a requirement description:
1. The dialog title was just "Edit Requirement Description" — no indication of *which* requirement you're editing.
2. The row being edited wasn't highlighted, so it was easy to lose context.

## Changes

- **Dialog title now includes identifier + name**, e.g. `Edit Requirement Description - SC-13 - Cryptographic Protection` (exactly the format Joe asked for). Falls back to plain `Edit Requirement Description` if both are empty.
- **`EditableCell` reports open/close via a new `onExpandedChange` callback**, so `FrameworkRequirementsClientPage` highlights the active row. The editor dialog overlay is `bg-black/50`, so the row stays visible behind it — the highlight (`ring` + tint) makes it obvious.

## Testing

- `EditableCell.test.tsx`: added 2 tests — `onExpandedChange(true)` on open, `(false)` on Save and on Cancel. 12 tests pass.
- `FrameworkRequirementsClientPage.expandable.test.tsx`: updated the title assertion to the new dynamic value. Passes.
- `npx turbo run typecheck --filter=@trycompai/framework-editor`: clean.

Frontend-only; no API or DB changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds requirement context to the multi-line description editor and highlights the active row while the dialog is open. Satisfies FRAME-7 by making it clear which requirement you’re editing.

- **New Features**
  - Dialog title now includes identifier and name, e.g. "Edit Requirement Description - SC-13 - Cryptographic Protection" (falls back to the default if missing).
  - `EditableCell` exposes `onExpandedChange`; the page highlights the active row (ring + tint) while the large editor is open, visible through the `bg-black/50` overlay.

<sup>Written for commit f04e60d44289d2bda2323b6fbbf297922ce9d6fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

