### PR TITLE
fix(framework-editor): flip Linked Controls panel up when clipped (FRAME-8)

### DIFF
--- a/apps/framework-editor/app/components/table/RelationalCell.test.tsx
+++ b/apps/framework-editor/app/components/table/RelationalCell.test.tsx
@@ -86,3 +86,35 @@ describe('RelationalCell on uncommitted rows', () => {
     );
   });
 });
+
+describe('RelationalCell panel placement (FRAME-8)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('opens downward when there is room below', () => {
+    renderCell();
+    fireEvent.click(screen.getByText('None'));
+    const panel = screen.getByText('Linked Controls').closest('.bg-popover');
+    expect(panel?.className).toContain('top-0');
+    expect(panel?.className).not.toContain('bottom-0');
+  });
+
+  it('flips upward when the cell is near the viewport bottom', () => {
+    renderCell();
+    const trigger = screen.getByText('None').closest('div') as HTMLDivElement;
+    // window.innerHeight is 768 in jsdom; a cell ending at 760 leaves 8px below.
+    vi.spyOn(trigger, 'getBoundingClientRect').mockReturnValue({
+      bottom: 760,
+      top: 740,
+      left: 0,
+      right: 100,
+      width: 100,
+      height: 20,
+      x: 0,
+      y: 740,
+      toJSON: () => ({}),
+    } as DOMRect);
+    fireEvent.click(trigger);
+    const panel = screen.getByText('Linked Controls').closest('.bg-popover');
+    expect(panel?.className).toContain('bottom-0');
+  });
+});

--- a/apps/framework-editor/app/components/table/RelationalCell.tsx
+++ b/apps/framework-editor/app/components/table/RelationalCell.tsx
@@ -42,6 +42,7 @@ export function RelationalCell({
   const [search, setSearch] = useState('');
   const [allItems, setAllItems] = useState<RelationalItem[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [dropUp, setDropUp] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
   // Close when clicking outside
@@ -118,7 +119,13 @@ export function RelationalCell({
     return (
       <div
         className="hover:bg-muted/50 flex h-full cursor-pointer items-center px-2 py-1.5"
-        onClick={() => setIsExpanded(true)}
+        onClick={(e) => {
+          // Flip the panel upward when there isn't room below the cell, so it
+          // isn't clipped by the table's overflow-auto scroll container.
+          const rect = e.currentTarget.getBoundingClientRect();
+          setDropUp(window.innerHeight - rect.bottom < 340);
+          setIsExpanded(true);
+        }}
       >
         {items.length === 0 ? (
           <span className="text-muted-foreground text-sm italic">None</span>
@@ -134,7 +141,9 @@ export function RelationalCell({
   // Expanded view - show all items with controls
   return (
     <div
-      className="bg-popover border-border absolute left-0 top-0 z-50 min-w-[280px] rounded-xs border shadow-lg"
+      className={`bg-popover border-border absolute left-0 ${
+        dropUp ? 'bottom-0' : 'top-0'
+      } z-50 min-w-[280px] rounded-xs border shadow-lg`}
       ref={containerRef}
     >
       {/* Header */}


### PR DESCRIPTION
## What

Stops the **Linked Controls** panel from being clipped at the bottom of a framework.

## Why (FRAME-8)

The panel always opened downward (`absolute top-0`). On rows near the bottom of the table it extended past the `overflow-auto` scroll container and was cut off — "you cannot see any more."

Joe suggested adding whitespace at the bottom. That's a workaround; the robust fix is to open the panel **upward** when there isn't room below — the same heuristic `ComboboxCell` already uses in this table.

## Changes

`RelationalCell`:
- On open, measure space below the cell (`window.innerHeight - rect.bottom`).
- If under ~340px (the panel's max height), anchor the panel to `bottom-0` (grows up) instead of `top-0` (grows down).

3-line behavioral change, no layout/structure churn, no permanent empty whitespace.

## Testing

- `RelationalCell.test.tsx`: added 2 tests — opens down with room below, flips up when the cell sits near the viewport bottom. 5 tests pass.
- `npx turbo run typecheck --filter=@trycompai/framework-editor`: clean.

Frontend-only. Worth a quick visual check on the preview (open Linked Controls on the last row of a long framework).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Linked Controls panel being cut off at the bottom of the Framework Editor by flipping it upward when there isn’t enough space below, matching `ComboboxCell` behavior. Addresses Linear FRAME-8 without adding whitespace to the table.

- **Bug Fixes**
  - In `RelationalCell`, measure space below the trigger on open and anchor the panel to `bottom-0` when space is < ~340px; otherwise use `top-0`.
  - Adds tests to verify opening downward with room and flipping upward near the viewport bottom.

<sup>Written for commit 3d123881b960f1c2e71c136120d2c7138ac3be86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

