### PR TITLE
fix(framework-editor): publish detects name/description-only changes (FRAME-9)

### DIFF
--- a/apps/api/src/frameworks/framework-versioning/framework-diff.spec.ts
+++ b/apps/api/src/frameworks/framework-versioning/framework-diff.spec.ts
@@ -65,6 +65,29 @@ describe('diffManifests', () => {
     expect(diff.requirementMapEdges.removed).toContainEqual({ controlTemplateId: 'c1', requirementTemplateId: 'r1' });
   });
 
+  it('reports no framework-metadata change for identical manifests', () => {
+    const m = emptyManifest();
+    expect(diffManifests(m, m).framework.changed).toBe(false);
+  });
+
+  it('detects a framework name change (FRAME-9)', () => {
+    const from = emptyManifest();
+    const to = { ...emptyManifest(), framework: { ...from.framework, name: 'New Name' } };
+    const diff = diffManifests(from, to);
+    expect(diff.framework.changed).toBe(true);
+    expect(diff.framework.name).toEqual({ from: 'n', to: 'New Name' });
+    expect(diff.framework.description).toBeUndefined();
+  });
+
+  it('detects a framework description change (FRAME-9)', () => {
+    const from = { ...emptyManifest(), framework: { id: 'f', name: 'n', catalogVersion: '1', description: 'old' } };
+    const to = { ...emptyManifest(), framework: { id: 'f', name: 'n', catalogVersion: '1', description: 'new' } };
+    const diff = diffManifests(from, to);
+    expect(diff.framework.changed).toBe(true);
+    expect(diff.framework.description).toEqual({ from: 'old', to: 'new' });
+    expect(diff.framework.name).toBeUndefined();
+  });
+
   it('drops phantom edges that reference entities missing from the manifest', () => {
     // Older snapshots sometimes stored cross-framework requirement IDs in
     // control.requirementIds. Those IDs are not in manifest.requirements, so

--- a/apps/api/src/frameworks/framework-versioning/framework-diff.ts
+++ b/apps/api/src/frameworks/framework-versioning/framework-diff.ts
@@ -38,7 +38,19 @@ export interface ControlDocumentTypeEdge {
   formType: string;
 }
 
+/**
+ * Changes to the framework's own metadata (name / description). These don't
+ * live in any entity list, so without this the diff treats a name- or
+ * description-only edit as "no changes" and the Publish button stays disabled.
+ */
+export interface FrameworkMetaDiff {
+  changed: boolean;
+  name?: { from: string; to: string };
+  description?: { from: string | null; to: string | null };
+}
+
 export interface ManifestDiff {
+  framework: FrameworkMetaDiff;
   controls: EntityDiff<ManifestControl>;
   requirements: EntityDiff<ManifestRequirement>;
   policies: EntityDiff<ManifestPolicy>;
@@ -85,6 +97,7 @@ export function diffManifests(fromRaw: FrameworkManifest, toRaw: FrameworkManife
   const from = sanitizeManifestEdges(fromRaw);
   const to = sanitizeManifestEdges(toRaw);
   return {
+    framework: diffFrameworkMeta(from.framework, to.framework),
     controls: diffEntities(from.controls, to.controls, controlEqual),
     requirements: diffEntities(from.requirements, to.requirements, requirementEqual),
     policies: diffEntities(from.policies, to.policies, policyEqual),
@@ -166,6 +179,23 @@ function edgesFromControls<E>(
   extract: (c: ManifestControl) => E[],
 ): E[] {
   return controls.flatMap(extract);
+}
+
+function diffFrameworkMeta(
+  from: FrameworkManifest['framework'],
+  to: FrameworkManifest['framework'],
+): FrameworkMetaDiff {
+  const nameChanged = from.name !== to.name;
+  const fromDescription = from.description ?? null;
+  const toDescription = to.description ?? null;
+  const descriptionChanged = fromDescription !== toDescription;
+  return {
+    changed: nameChanged || descriptionChanged,
+    ...(nameChanged ? { name: { from: from.name, to: to.name } } : {}),
+    ...(descriptionChanged
+      ? { description: { from: fromDescription, to: toDescription } }
+      : {}),
+  };
 }
 
 function controlEqual(a: ManifestControl, b: ManifestControl): boolean {

--- a/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/versions/components/VersionDiffView.test.tsx
+++ b/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/versions/components/VersionDiffView.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import type { DraftDiff } from '../hooks/useFrameworkDraftDiff';
+import { hasAnyChanges } from './VersionDiffView';
+
+function emptyDiff(): DraftDiff['diff'] {
+  const entity = { added: [], removed: [], updated: [] };
+  const edge = { added: [], removed: [] };
+  return {
+    controls: entity,
+    requirements: entity,
+    policies: entity,
+    tasks: entity,
+    requirementMapEdges: edge,
+    controlPolicyEdges: edge,
+    controlTaskEdges: edge,
+    controlDocumentTypeEdges: edge,
+  };
+}
+
+describe('hasAnyChanges', () => {
+  it('is false for an empty diff', () => {
+    expect(hasAnyChanges(emptyDiff())).toBe(false);
+  });
+
+  // FRAME-9: a name/description-only edit must count as a change so Publish
+  // doesn't stay greyed out with "no changes detected".
+  it('is true when only the framework name changed', () => {
+    const diff = { ...emptyDiff(), framework: { changed: true, name: { from: 'A', to: 'B' } } };
+    expect(hasAnyChanges(diff)).toBe(true);
+  });
+
+  it('is true when only the framework description changed', () => {
+    const diff = {
+      ...emptyDiff(),
+      framework: { changed: true, description: { from: 'old', to: 'new' } },
+    };
+    expect(hasAnyChanges(diff)).toBe(true);
+  });
+
+  it('is false when framework.changed is false', () => {
+    const diff = { ...emptyDiff(), framework: { changed: false } };
+    expect(hasAnyChanges(diff)).toBe(false);
+  });
+
+  it('still detects entity changes (sanity)', () => {
+    const diff = emptyDiff();
+    diff.controls = { added: [{ id: 'c1', name: 'C1' }], removed: [], updated: [] };
+    expect(hasAnyChanges(diff)).toBe(true);
+  });
+});

--- a/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/versions/components/VersionDiffView.tsx
+++ b/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/versions/components/VersionDiffView.tsx
@@ -32,6 +32,7 @@ export function hasAnyChanges(diff: DraftDiff['diff']): boolean {
   } = diff;
   const docTypeEdges = controlDocumentTypeEdges ?? { added: [], removed: [] };
   return (
+    (diff.framework?.changed ?? false) ||
     controls.added.length > 0 ||
     controls.removed.length > 0 ||
     controls.updated.length > 0 ||
@@ -58,6 +59,7 @@ export function hasAnyChanges(diff: DraftDiff['diff']): boolean {
 export function VersionDiffView({ diff, linkChanges }: VersionDiffViewProps) {
   return (
     <>
+      <FrameworkMetaSection framework={diff.framework} />
       <DiffDetailSection
         title="Requirements"
         added={diff.requirements.added}
@@ -169,6 +171,37 @@ export function VersionDiffView({ diff, linkChanges }: VersionDiffViewProps) {
         fallbackRemoved={diff.controlDocumentTypeEdges?.removed.length ?? 0}
       />
     </>
+  );
+}
+
+function FrameworkMetaSection({
+  framework,
+}: {
+  framework: DraftDiff['diff']['framework'];
+}) {
+  if (!framework?.changed) return null;
+  return (
+    <div className="border-b last:border-b-0 px-4 py-3">
+      <p className="text-muted-foreground mb-2 text-xs font-semibold uppercase tracking-wide">
+        Framework
+      </p>
+      <div className="flex flex-col gap-1">
+        {framework.name && (
+          <DiffRow kind="modified">
+            <span>
+              Name:{' '}
+              <span className="text-muted-foreground line-through">{framework.name.from}</span>{' '}
+              → <span className="font-medium">{framework.name.to}</span>
+            </span>
+          </DiffRow>
+        )}
+        {framework.description && (
+          <DiffRow kind="modified">
+            <span>Description updated</span>
+          </DiffRow>
+        )}
+      </div>
+    </div>
   );
 }
 

--- a/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/versions/hooks/useFrameworkDraftDiff.ts
+++ b/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/versions/hooks/useFrameworkDraftDiff.ts
@@ -44,6 +44,13 @@ export interface EdgeDiffCounts {
 export interface DraftDiff {
   latestVersion: { id: string; version: string } | null;
   diff: {
+    // Optional for older API responses / historical diffs that predate the
+    // framework-metadata diff (FRAME-9).
+    framework?: {
+      changed: boolean;
+      name?: { from: string; to: string };
+      description?: { from: string | null; to: string | null };
+    };
     controls: EntityDiffCounts<DiffControl>;
     requirements: EntityDiffCounts<DiffRequirement>;
     policies: EntityDiffCounts<DiffPolicy>;


### PR DESCRIPTION
## What

The Publish Version button no longer stays greyed out ("no changes detected since the last published version") when you change **only** the framework's name and/or description.

## Why (FRAME-9)

Reported on NIST SP800-53 v5.2 Low Impact: editing just the framework title/description via "Edit Framework" left Publish disabled, claiming no changes — the reporter had to make a throwaway edit to a requirement to force it.

Root cause: the manifest **stores** `framework.name`/`description`, but `diffManifests` only compared controls/requirements/policies/tasks and their links — never the framework's own metadata. So `hasAnyChanges` returned false and the Publish button stayed disabled.

## Changes

**API** (`framework-diff.ts`):
- Added a `framework` meta-diff (`{ changed, name?, description? }`) to `ManifestDiff`, computed by comparing `from.framework` vs `to.framework`. Purely additive — no existing consumer constructs a `ManifestDiff` literal, so nothing else changes.

**Frontend** (`VersionDiffView.tsx`, `useFrameworkDraftDiff.ts`):
- `hasAnyChanges()` now counts a framework metadata change → Publish enables.
- The diff renders a "Framework" section showing the name (`from → to`) / description-updated change. Field is optional on the client type for backward-compat with older/historical diffs.

## Testing

- API `framework-diff.spec.ts`: +3 tests (identical → no change; name change; description change). 29 API version tests pass, none of the existing ones regressed by the added field.
- Frontend `VersionDiffView.test.tsx`: +5 tests for `hasAnyChanges` (empty, name-only, description-only, changed:false, entity sanity).
- `turbo typecheck` clean for both `@trycompai/framework-editor` and the changed API files.

Both publish-time (draft vs latest) and historical (v_n vs v_n-1) diffs go through the same function, so both now reflect metadata changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables Publish when only the framework name or description changes, and shows those edits in the diff. Addresses FRAME-9.

- **Bug Fixes**
  - API: added a `framework` meta-diff (name/description) to `ManifestDiff` and compute it in `diffManifests`.
  - UI: `hasAnyChanges()` now includes framework metadata; the diff shows a “Framework” section with name (from → to) and “Description updated”.
  - Backward-compat: `framework` field is optional in client types for older/historical diffs.
  - Tests added for metadata-only changes in both API and UI.

<sup>Written for commit b6e824070d5283673cb429bdf818dbdfaee48812. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

