### PR TITLE
feat(framework-editor): Save as Draft / Save and Commit (FRAME-4)

### DIFF
--- a/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/FrameworkRequirementsClientPage.expandable.test.tsx
+++ b/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/FrameworkRequirementsClientPage.expandable.test.tsx
@@ -22,6 +22,12 @@ vi.mock('../../../components/table', () => ({
 
 vi.mock('./components/EditFrameworkDialog', () => ({ EditFrameworkDialog: () => null }));
 vi.mock('./components/DeleteFrameworkDialog', () => ({ DeleteFrameworkDialog: () => null }));
+vi.mock('./versions/components/PublishVersionDialog', () => ({
+  PublishVersionDialog: () => null,
+}));
+vi.mock('./versions/hooks/useFrameworkVersions', () => ({
+  useFrameworkVersions: () => ({ data: [], refetch: vi.fn() }),
+}));
 vi.mock('@/app/lib/api-client', () => ({ apiClient: vi.fn() }));
 vi.mock('next/navigation', () => ({ useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }) }));
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));

--- a/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/FrameworkRequirementsClientPage.toolbar.test.tsx
+++ b/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/FrameworkRequirementsClientPage.toolbar.test.tsx
@@ -1,0 +1,101 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Shared, hoisted handles so the mock factory and the assertions see the same
+// references. publishProps records each render's `open` value.
+const { handleCommit, handleCancel, publishProps } = vi.hoisted(() => ({
+  handleCommit: vi.fn(async () => true),
+  handleCancel: vi.fn(),
+  publishProps: [] as Array<{ open: boolean }>,
+}));
+
+vi.mock('../../../components/table', () => ({
+  ComboboxCell: () => null,
+  DateCell: () => null,
+  RelationalCell: () => null,
+  EditableCell: () => null,
+}));
+vi.mock('./components/EditFrameworkDialog', () => ({ EditFrameworkDialog: () => null }));
+vi.mock('./components/DeleteFrameworkDialog', () => ({ DeleteFrameworkDialog: () => null }));
+vi.mock('./versions/components/PublishVersionDialog', () => ({
+  PublishVersionDialog: (props: { open: boolean }) => {
+    publishProps.push({ open: props.open });
+    return null;
+  },
+}));
+vi.mock('./versions/hooks/useFrameworkVersions', () => ({
+  useFrameworkVersions: () => ({ data: [{ version: '1.0.0' }], refetch: vi.fn() }),
+}));
+vi.mock('@/app/lib/api-client', () => ({ apiClient: vi.fn() }));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }) }));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('@trycompai/ui', () => ({
+  Button: ({ children, variant: _v, size: _s, ...props }: any) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock('./hooks/useRequirementChangeTracking', () => ({
+  simpleUUID: () => 'temp-id',
+  useRequirementChangeTracking: () => ({
+    data: [],
+    updateCell: vi.fn(),
+    updateRelational: vi.fn(),
+    addRow: vi.fn(),
+    deleteRow: vi.fn(),
+    getRowClassName: () => '',
+    handleCommit,
+    handleCancel,
+    isDirty: true,
+    createdIds: new Set<string>(),
+    changesSummary: '(2 changes)',
+  }),
+}));
+
+import { FrameworkRequirementsClientPage } from './FrameworkRequirementsClientPage';
+
+function renderPage() {
+  render(
+    <FrameworkRequirementsClientPage
+      frameworkDetails={{ id: 'frk_1', name: 'NIST', version: '1', description: '', visible: true }}
+      initialRequirements={[]}
+    />,
+  );
+}
+
+describe('FrameworkRequirementsClientPage — Save as Draft / Save and Commit (FRAME-4)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handleCommit.mockImplementation(async () => true);
+    publishProps.length = 0;
+  });
+
+  it('shows all three buttons when there are uncommitted changes', () => {
+    renderPage();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Save as Draft' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Save and Commit' })).toBeTruthy();
+  });
+
+  it('Save as Draft commits without opening the publish dialog', () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: 'Save as Draft' }));
+    expect(handleCommit).toHaveBeenCalledTimes(1);
+    expect(publishProps.every((p) => p.open === false)).toBe(true);
+  });
+
+  it('Save and Commit saves then opens the publish dialog', async () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: 'Save and Commit' }));
+    expect(handleCommit).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(publishProps.some((p) => p.open === true)).toBe(true));
+  });
+
+  it('does not open the publish dialog when the save fails', async () => {
+    handleCommit.mockImplementation(async () => false);
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: 'Save and Commit' }));
+    await waitFor(() => expect(handleCommit).toHaveBeenCalled());
+    expect(publishProps.every((p) => p.open === false)).toBe(true);
+  });
+});

--- a/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/FrameworkRequirementsClientPage.tsx
+++ b/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/FrameworkRequirementsClientPage.tsx
@@ -22,6 +22,8 @@ import {
   useRequirementChangeTracking,
   type RequirementGridRow,
 } from './hooks/useRequirementChangeTracking';
+import { PublishVersionDialog } from './versions/components/PublishVersionDialog';
+import { useFrameworkVersions } from './versions/hooks/useFrameworkVersions';
 
 interface FrameworkDetails {
   id: string;
@@ -76,6 +78,12 @@ export function FrameworkRequirementsClientPage({
   // Row whose large description editor is currently open — highlighted so the
   // edited row is obvious behind the (semi-transparent) editor dialog.
   const [expandedRowId, setExpandedRowId] = useState<string | null>(null);
+  // "Save and Commit" saves the edits then opens the publish flow (FRAME-4).
+  const [isPublishOpen, setIsPublishOpen] = useState(false);
+  const { data: publishedVersions, refetch: refetchVersions } = useFrameworkVersions(
+    frameworkDetails.id,
+  );
+  const latestPublishedVersion = publishedVersions?.[0]?.version;
 
   const initialGridData: RequirementGridRow[] = useMemo(
     () =>
@@ -106,6 +114,13 @@ export function FrameworkRequirementsClientPage({
     createdIds,
     changesSummary,
   } = useRequirementChangeTracking(initialGridData, frameworkDetails.id);
+
+  // Save edits, then (only if they all persisted) open the publish dialog so
+  // the accumulated changes can be committed as a new version.
+  const handleSaveAndCommit = useCallback(async () => {
+    const ok = await handleCommit();
+    if (ok) setIsPublishOpen(true);
+  }, [handleCommit]);
 
   const uniqueFamilies = useMemo(() => {
     const families = new Set<string>();
@@ -304,8 +319,11 @@ export function FrameworkRequirementsClientPage({
               <Button variant="outline" onClick={handleCancel} size="sm" className="rounded-xs">
                 Cancel
               </Button>
-              <Button onClick={handleCommit} size="sm" className="rounded-xs">
-                Commit Changes
+              <Button variant="outline" onClick={handleCommit} size="sm" className="rounded-xs">
+                Save as Draft
+              </Button>
+              <Button onClick={handleSaveAndCommit} size="sm" className="rounded-xs">
+                Save and Commit
               </Button>
             </>
           )}
@@ -430,6 +448,17 @@ export function FrameworkRequirementsClientPage({
           frameworkName={frameworkDetails.name}
         />
       )}
+      <PublishVersionDialog
+        frameworkId={frameworkDetails.id}
+        open={isPublishOpen}
+        onClose={() => setIsPublishOpen(false)}
+        latestVersion={latestPublishedVersion}
+        onPublished={() => {
+          setIsPublishOpen(false);
+          void refetchVersions();
+          router.refresh();
+        }}
+      />
     </div>
   );
 }

--- a/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/hooks/useRequirementChangeTracking.ts
+++ b/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/hooks/useRequirementChangeTracking.ts
@@ -256,6 +256,10 @@ export function useRequirementChangeTracking(
       // Re-sync the grid with server truth (ids, timestamps, links).
       router.refresh();
     }
+
+    // Report success so callers (e.g. "Save and Commit") can chain a publish
+    // only when every edit persisted cleanly.
+    return results.errors.length === 0;
   }, [data, createdIds, updatedIds, deletedIds, frameworkId, router]);
 
   const handleCancel = useCallback(() => {


### PR DESCRIPTION
## What

Replaces the single **Commit Changes** button on the requirements editor with the three buttons Joe asked for: **Cancel**, **Save as Draft**, **Save and Commit**.

## Why (FRAME-4, interpretation A)

Per Joe's confirmation of interpretation **A**:
- **Cancel** — discard the uncommitted grid edits (unchanged behaviour).
- **Save as Draft** — persist edits to the live framework templates *without* publishing. This is exactly what "Commit Changes" did before — your edits are saved but not yet released to customers.
- **Save and Commit** — persist edits, then open the **Publish Version** dialog so the accumulated changes go out as a new published version.

This matches Joe's "5 drafts then commit = 6 changes committed": each Save-as-Draft persists edits as you go, and the final Save-and-Commit publishes a version containing everything.

## Changes

- `FrameworkRequirementsClientPage`: three-button toolbar; **Save and Commit** runs the save then opens `PublishVersionDialog` — but only if the save succeeded (so we never publish a half-saved state). Reuses `useFrameworkVersions` for the next-version suggestion (same as the Versions tab).
- `useRequirementChangeTracking.handleCommit` now returns `boolean` (true when every edit persisted) so the publish step can be chained safely. Existing callers (`onClick={handleCommit}`) are unaffected.

No API or DB changes — reuses the existing publish endpoint + dialog.

## Testing

- New `FrameworkRequirementsClientPage.toolbar.test.tsx` (4 tests): all three buttons render when dirty; Save-as-Draft commits without opening publish; Save-and-Commit commits then opens publish; publish stays closed when the save fails.
- Updated `…expandable.test.tsx` with mocks for the new imports.
- `turbo typecheck --filter=@trycompai/framework-editor`: clean.

Worth a quick click-through on the preview (Save as Draft, then Save and Commit → publish dialog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Cancel, Save as Draft, and Save and Commit to the requirements editor to match FRAME-4 (interpretation A). Save as Draft saves edits without publishing; Save and Commit saves then opens the publish dialog to release a new version.

- New Features
  - Three-button toolbar: Cancel discards local edits.
  - Save as Draft: persists edits to live templates without publishing.
  - Save and Commit: saves, then opens `PublishVersionDialog` only on success; uses `useFrameworkVersions` for next-version suggestion.
  - `handleCommit` now returns a boolean to signal save success; existing callers remain compatible.
  - No API or DB changes.

<sup>Written for commit bb7064b8f8d0ac14855b4afc85ff61ccc1043a31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

