### PR TITLE
fix(sentry): only report errors from the production environment

### DIFF
--- a/apps/app/sentry.edge.config.ts
+++ b/apps/app/sentry.edge.config.ts
@@ -10,6 +10,11 @@ Sentry.init({
     process.env.SENTRY_DSN ??
     'https://331f1c3d4b08e9352dd1a2621e1ae845@o4509214247813120.ingest.us.sentry.io/4511304630927360',
 
+  // Only report from production. On Vercel, VERCEL_ENV is 'production' | 'preview'
+  // | 'development'; on any non-production deployment (or if the var is missing)
+  // Sentry stays disabled — a no-op, never an error — to avoid noise and quota burn.
+  enabled: process.env.VERCEL_ENV === 'production',
+
   tracesSampleRate: process.env.NODE_ENV === 'development' ? 1.0 : 0.1,
 
   enableLogs: true,

--- a/apps/app/sentry.server.config.ts
+++ b/apps/app/sentry.server.config.ts
@@ -9,6 +9,11 @@ Sentry.init({
     process.env.SENTRY_DSN ??
     'https://331f1c3d4b08e9352dd1a2621e1ae845@o4509214247813120.ingest.us.sentry.io/4511304630927360',
 
+  // Only report from production. On Vercel, VERCEL_ENV is 'production' | 'preview'
+  // | 'development'; on any non-production deployment (or if the var is missing)
+  // Sentry stays disabled — a no-op, never an error — to avoid noise and quota burn.
+  enabled: process.env.VERCEL_ENV === 'production',
+
   tracesSampleRate: process.env.NODE_ENV === 'development' ? 1.0 : 0.1,
 
   // Off in production: local variables in stack frames can expose request-scoped

--- a/apps/app/src/instrumentation-client.ts
+++ b/apps/app/src/instrumentation-client.ts
@@ -14,6 +14,11 @@ Sentry.init({
     process.env.NEXT_PUBLIC_SENTRY_DSN ??
     'https://331f1c3d4b08e9352dd1a2621e1ae845@o4509214247813120.ingest.us.sentry.io/4511304630927360',
 
+  // Only report from production. NEXT_PUBLIC_VERCEL_ENV is inlined at build time
+  // per Vercel deployment; preview/dev builds (or a missing var) keep Sentry
+  // disabled — a no-op, never an error — to avoid noise and quota burn.
+  enabled: process.env.NEXT_PUBLIC_VERCEL_ENV === 'production',
+
   integrations: [
     // Add `data-sentry-mask` (or `.sentry-mask`) to any element rendering
     // customer-confidential data; `data-sentry-block` to drop whole sections.

--- a/apps/portal/sentry.edge.config.ts
+++ b/apps/portal/sentry.edge.config.ts
@@ -10,6 +10,11 @@ Sentry.init({
     process.env.SENTRY_DSN ??
     'https://331f1c3d4b08e9352dd1a2621e1ae845@o4509214247813120.ingest.us.sentry.io/4511304630927360',
 
+  // Only report from production. On Vercel, VERCEL_ENV is 'production' | 'preview'
+  // | 'development'; on any non-production deployment (or if the var is missing)
+  // Sentry stays disabled — a no-op, never an error — to avoid noise and quota burn.
+  enabled: process.env.VERCEL_ENV === 'production',
+
   tracesSampleRate: process.env.NODE_ENV === 'development' ? 1.0 : 0.1,
 
   enableLogs: true,

--- a/apps/portal/sentry.server.config.ts
+++ b/apps/portal/sentry.server.config.ts
@@ -9,6 +9,11 @@ Sentry.init({
     process.env.SENTRY_DSN ??
     'https://331f1c3d4b08e9352dd1a2621e1ae845@o4509214247813120.ingest.us.sentry.io/4511304630927360',
 
+  // Only report from production. On Vercel, VERCEL_ENV is 'production' | 'preview'
+  // | 'development'; on any non-production deployment (or if the var is missing)
+  // Sentry stays disabled — a no-op, never an error — to avoid noise and quota burn.
+  enabled: process.env.VERCEL_ENV === 'production',
+
   tracesSampleRate: process.env.NODE_ENV === 'development' ? 1.0 : 0.1,
 
   // Off in production: local variables in stack frames can expose request-scoped

--- a/apps/portal/src/instrumentation-client.ts
+++ b/apps/portal/src/instrumentation-client.ts
@@ -9,6 +9,11 @@ Sentry.init({
     process.env.NEXT_PUBLIC_SENTRY_DSN ??
     'https://331f1c3d4b08e9352dd1a2621e1ae845@o4509214247813120.ingest.us.sentry.io/4511304630927360',
 
+  // Only report from production. NEXT_PUBLIC_VERCEL_ENV is inlined at build time
+  // per Vercel deployment; preview/dev builds (or a missing var) keep Sentry
+  // disabled — a no-op, never an error — to avoid noise and quota burn.
+  enabled: process.env.NEXT_PUBLIC_VERCEL_ENV === 'production',
+
   integrations: [
     // Add `data-sentry-mask` (or `.sentry-mask`) to any element rendering
     // customer-confidential data; `data-sentry-block` to drop whole sections.


### PR DESCRIPTION
## What

Restrict Sentry error reporting to the **production** environment only. Today it reports from every environment.

## Why

Sentry is wired into `apps/app` and `apps/portal` (both Vercel-hosted) across the server, edge, and client runtimes. In all six `Sentry.init()` calls:

- the DSN has a **hardcoded fallback**, so Sentry initializes even without env vars — it's always on;
- there is **no `enabled` flag, no `beforeSend`, no environment gating**.

Result: every Vercel deployment — production **and every preview/branch deploy from PRs** — reports into the same Sentry project. That's the noise/spam we've been seeing.

## Change

Gate ingestion on the Vercel environment via Sentry's built-in `enabled` option:

| File | Gate |
|------|------|
| `apps/app/sentry.server.config.ts` | `VERCEL_ENV === 'production'` |
| `apps/app/sentry.edge.config.ts` | `VERCEL_ENV === 'production'` |
| `apps/app/src/instrumentation-client.ts` | `NEXT_PUBLIC_VERCEL_ENV === 'production'` |
| `apps/portal/sentry.server.config.ts` | `VERCEL_ENV === 'production'` |
| `apps/portal/sentry.edge.config.ts` | `VERCEL_ENV === 'production'` |
| `apps/portal/src/instrumentation-client.ts` | `NEXT_PUBLIC_VERCEL_ENV === 'production'` |

Server/edge runtimes read `VERCEL_ENV` (always injected server-side by Vercel — no config needed). The client reads `NEXT_PUBLIC_VERCEL_ENV`, the browser-exposed version.

## ⚠️ Required Vercel step (for the client-side gate)

`NEXT_PUBLIC_VERCEL_ENV` only exists if **"Automatically expose System Environment Variables"** is enabled on the project. Before/after merge:

1. In **both** Vercel projects (`app` and `portal`): **Settings → Environment Variables → enable "Automatically expose System Environment Variables"**.
2. **Redeploy** both (env changes only apply to new builds).

Note: this is a *system* variable — it is injected at build time and will **not** appear in the Environment Variables list. That's expected.

Server/edge reporting works regardless of this toggle. If the toggle is off, the only effect is that **client/browser** errors stay off even in prod (still safe — never an error).

## Safety

Worst case is Sentry being **off**, never an error:

- `enabled` is a documented, typed Sentry option. `enabled: false` makes the SDK a silent no-op — `captureException`, replay, router-transition, and request-error hooks all just do nothing. It **never throws**.
- A **missing** env var resolves the comparison to `false` → Sentry off. So even in an unexpected environment, the failure mode is "no reporting," not a crash.
- Purely additive: 6 files, 30 lines, one option per init.

## Verification

- ✅ `enabled?: boolean` is a supported option in the installed SDK (`@sentry/nextjs@10.51.0` → `@sentry/core` `_isEnabled()` returns `enabled !== false && transport`).
- ✅ Typecheck: none of the 6 changed files produce errors (app + portal). Unrelated pre-existing test-file errors on `main` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)