### PR TITLE
fix(framework-editor-cli): scope task/policy/doc-type links to a framework

### DIFF
--- a/packages/framework-editor-cli/src/commands/control-relations.ts
+++ b/packages/framework-editor-cli/src/commands/control-relations.ts
@@ -1,8 +1,7 @@
 import type { Command } from 'commander';
 import { apiRequest } from '../lib/api-client.js';
 import { handleError, CliError } from '../lib/errors.js';
-import { outputResult, outputSuccess } from '../lib/output.js';
-import type { ControlTemplate } from '../types.js';
+import { outputSuccess } from '../lib/output.js';
 import { EVIDENCE_FORM_TYPE_VALUES } from '../types.js';
 
 export function registerControlRelationCommands(ctl: Command): void {
@@ -48,12 +47,14 @@ export function registerControlRelationCommands(ctl: Command): void {
     .command('link-policy')
     .argument('<control-id>', 'Control template ID')
     .argument('<policy-id>', 'Policy template ID to link')
-    .description('Link a policy template to this control (many-to-many relationship).')
-    .action(async (controlId: string, policyId: string, _opts, cmd) => {
+    .requiredOption('--framework-id <id>', 'Framework the link is scoped to (required by the API)')
+    .description('Link a policy template to this control, scoped to a framework.')
+    .action(async (controlId: string, policyId: string, opts, cmd) => {
       const json = cmd.optsWithGlobals().json as boolean;
       try {
         await apiRequest(`/control-template/${controlId}/policy-templates/${policyId}`, {
           method: 'POST',
+          query: { frameworkId: opts.frameworkId },
           apiUrl: cmd.optsWithGlobals().apiUrl,
         });
         outputSuccess(`Policy ${policyId} linked to control ${controlId}.`, { json });
@@ -66,12 +67,14 @@ export function registerControlRelationCommands(ctl: Command): void {
     .command('unlink-policy')
     .argument('<control-id>', 'Control template ID')
     .argument('<policy-id>', 'Policy template ID to unlink')
-    .description('Remove the link between a policy template and this control.')
-    .action(async (controlId: string, policyId: string, _opts, cmd) => {
+    .requiredOption('--framework-id <id>', 'Framework the link is scoped to (required by the API)')
+    .description('Remove the framework-scoped link between a policy template and this control.')
+    .action(async (controlId: string, policyId: string, opts, cmd) => {
       const json = cmd.optsWithGlobals().json as boolean;
       try {
         await apiRequest(`/control-template/${controlId}/policy-templates/${policyId}`, {
           method: 'DELETE',
+          query: { frameworkId: opts.frameworkId },
           apiUrl: cmd.optsWithGlobals().apiUrl,
         });
         outputSuccess(`Policy ${policyId} unlinked from control ${controlId}.`, { json });
@@ -84,12 +87,14 @@ export function registerControlRelationCommands(ctl: Command): void {
     .command('link-task')
     .argument('<control-id>', 'Control template ID')
     .argument('<task-id>', 'Task template ID to link')
-    .description('Link a task template to this control (many-to-many relationship).')
-    .action(async (controlId: string, taskId: string, _opts, cmd) => {
+    .requiredOption('--framework-id <id>', 'Framework the link is scoped to (required by the API)')
+    .description('Link a task template to this control, scoped to a framework.')
+    .action(async (controlId: string, taskId: string, opts, cmd) => {
       const json = cmd.optsWithGlobals().json as boolean;
       try {
         await apiRequest(`/control-template/${controlId}/task-templates/${taskId}`, {
           method: 'POST',
+          query: { frameworkId: opts.frameworkId },
           apiUrl: cmd.optsWithGlobals().apiUrl,
         });
         outputSuccess(`Task ${taskId} linked to control ${controlId}.`, { json });
@@ -102,12 +107,14 @@ export function registerControlRelationCommands(ctl: Command): void {
     .command('unlink-task')
     .argument('<control-id>', 'Control template ID')
     .argument('<task-id>', 'Task template ID to unlink')
-    .description('Remove the link between a task template and this control.')
-    .action(async (controlId: string, taskId: string, _opts, cmd) => {
+    .requiredOption('--framework-id <id>', 'Framework the link is scoped to (required by the API)')
+    .description('Remove the framework-scoped link between a task template and this control.')
+    .action(async (controlId: string, taskId: string, opts, cmd) => {
       const json = cmd.optsWithGlobals().json as boolean;
       try {
         await apiRequest(`/control-template/${controlId}/task-templates/${taskId}`, {
           method: 'DELETE',
+          query: { frameworkId: opts.frameworkId },
           apiUrl: cmd.optsWithGlobals().apiUrl,
         });
         outputSuccess(`Task ${taskId} unlinked from control ${controlId}.`, { json });
@@ -120,12 +127,12 @@ export function registerControlRelationCommands(ctl: Command): void {
     .command('add-document-type')
     .argument('<control-id>', 'Control template ID')
     .argument('<document-type>', `Document type to add (${EVIDENCE_FORM_TYPE_VALUES.join(', ')})`)
+    .requiredOption('--framework-id <id>', 'Framework the document-type link is scoped to (required by the API)')
     .description(
-      'Add an evidence document type to a control template. This is an atomic operation ' +
-        'that appends to the existing list without replacing it. ' +
-        'Use "framework documents <id>" to see the current matrix.',
+      'Add an evidence document type to a control template, scoped to a framework. ' +
+        'Idempotent: the API skips duplicates. Use "framework documents <id>" to see the matrix.',
     )
-    .action(async (controlId: string, documentType: string, _opts, cmd) => {
+    .action(async (controlId: string, documentType: string, opts, cmd) => {
       const json = cmd.optsWithGlobals().json as boolean;
       try {
         if (!EVIDENCE_FORM_TYPE_VALUES.includes(documentType as never)) {
@@ -133,20 +140,12 @@ export function registerControlRelationCommands(ctl: Command): void {
             `Invalid document type: "${documentType}". Must be one of: ${EVIDENCE_FORM_TYPE_VALUES.join(', ')}`,
           );
         }
-        const current = await apiRequest<ControlTemplate>(`/control-template/${controlId}`, {
+        await apiRequest(`/control-template/${controlId}/document-types/${documentType}`, {
+          method: 'POST',
+          query: { frameworkId: opts.frameworkId },
           apiUrl: cmd.optsWithGlobals().apiUrl,
         });
-        const types = Array.isArray(current.documentTypes) ? current.documentTypes : [];
-        if (types.includes(documentType)) {
-          outputSuccess(`Document type "${documentType}" already exists on control ${controlId}.`, { json });
-          return;
-        }
-        const data = await apiRequest<ControlTemplate>(`/control-template/${controlId}`, {
-          method: 'PATCH',
-          body: { documentTypes: [...types, documentType] },
-          apiUrl: cmd.optsWithGlobals().apiUrl,
-        });
-        outputResult(data, { json });
+        outputSuccess(`Document type "${documentType}" linked to control ${controlId}.`, { json });
       } catch (error) {
         handleError(error, json);
       }
@@ -156,27 +155,17 @@ export function registerControlRelationCommands(ctl: Command): void {
     .command('remove-document-type')
     .argument('<control-id>', 'Control template ID')
     .argument('<document-type>', `Document type to remove (${EVIDENCE_FORM_TYPE_VALUES.join(', ')})`)
-    .description(
-      'Remove an evidence document type from a control template. This is an atomic ' +
-        'operation that removes only the specified type without affecting others.',
-    )
-    .action(async (controlId: string, documentType: string, _opts, cmd) => {
+    .requiredOption('--framework-id <id>', 'Framework the document-type link is scoped to (required by the API)')
+    .description('Remove a framework-scoped evidence document type from a control template.')
+    .action(async (controlId: string, documentType: string, opts, cmd) => {
       const json = cmd.optsWithGlobals().json as boolean;
       try {
-        const current = await apiRequest<ControlTemplate>(`/control-template/${controlId}`, {
+        await apiRequest(`/control-template/${controlId}/document-types/${documentType}`, {
+          method: 'DELETE',
+          query: { frameworkId: opts.frameworkId },
           apiUrl: cmd.optsWithGlobals().apiUrl,
         });
-        const types = Array.isArray(current.documentTypes) ? current.documentTypes : [];
-        if (!types.includes(documentType)) {
-          outputSuccess(`Document type "${documentType}" not found on control ${controlId}.`, { json });
-          return;
-        }
-        const data = await apiRequest<ControlTemplate>(`/control-template/${controlId}`, {
-          method: 'PATCH',
-          body: { documentTypes: types.filter((t) => t !== documentType) },
-          apiUrl: cmd.optsWithGlobals().apiUrl,
-        });
-        outputResult(data, { json });
+        outputSuccess(`Document type "${documentType}" unlinked from control ${controlId}.`, { json });
       } catch (error) {
         handleError(error, json);
       }


### PR DESCRIPTION
## What

The API now requires a `frameworkId` for **task**, **policy**, and **document-type** link endpoints on a control template (`control-template.service.ts: ensureFramework`). Without it the request is rejected with `400 "frameworkId is required for policy, task, and document links"`. The framework-editor CLI predates this change, so its `link-task` / `link-policy` / `add-document-type` commands no longer work.

## Changes

- Add a required `--framework-id` option to `link-task`/`unlink-task` and `link-policy`/`unlink-policy`, forwarded as the `frameworkId` query param.
- Rewrite `add-document-type`/`remove-document-type` to use the scoped `POST`/`DELETE :id/document-types/:formType?frameworkId=` endpoints, replacing the obsolete `GET` + `PATCH documentTypes` flow (`update` also now requires `frameworkId` when `documentTypes` is provided).
- Drop the now-unused `ControlTemplate` type and `outputResult` imports.

## Why now

Surfaced while building the **NIST SP 800-53 Rev 5.2 Moderate baseline** (287 requirements) via the CLI: phase-5 task→control linking failed against staging until the CLI was updated to pass `frameworkId`. Note that because links are now framework-scoped, callers must also avoid deduping links against the cross-framework `control list`/`task list` snapshots (which return links across all frameworks).

## Testing

- Rebuilt the CLI (`bun run build`).
- Verified end-to-end against `https://api.staging.trycomp.ai`: created 287 requirements, 508 control→requirement links, 256 framework-scoped task→control links, and 22 framework-scoped doc-type tags on the Moderate framework with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes task, policy, and document-type links in `framework-editor-cli` to a specific framework to match API changes, fixing 400 errors. Adds a required `--framework-id` flag to link/unlink commands and moves document-type operations to scoped endpoints.

- **Migration**
  - Pass `--framework-id <id>` to: `link-task`/`unlink-task`, `link-policy`/`unlink-policy`, and `add-document-type`/`remove-document-type`.
  - If you dedupe links locally, do it per framework (not across all frameworks).

<sup>Written for commit b3f5c4a01c399c41276ada4f807c89a86f7a53ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

