### PR TITLE
fix(integration-platform): force Google account chooser on connect/reconnect

### DIFF
--- a/packages/integration-platform/src/manifests/gcp/index.ts
+++ b/packages/integration-platform/src/manifests/gcp/index.ts
@@ -34,7 +34,10 @@ export const gcpManifest: IntegrationManifest = {
       supportsRefreshToken: true,
       authorizationParams: {
         access_type: 'offline',
-        prompt: 'consent',
+        // select_account forces Google's account chooser so a user can switch
+        // from a wrong account when connecting/reconnecting; consent keeps the
+        // consent screen so a refresh token is always issued.
+        prompt: 'select_account consent',
       },
       setupInstructions: `## Platform Admin: Enable GCP OAuth
 

--- a/packages/integration-platform/src/manifests/google-workspace/index.ts
+++ b/packages/integration-platform/src/manifests/google-workspace/index.ts
@@ -31,7 +31,10 @@ export const googleWorkspaceManifest: IntegrationManifest = {
       supportsRefreshToken: true,
       authorizationParams: {
         access_type: 'offline',
-        prompt: 'consent',
+        // select_account forces Google's account chooser so an admin can switch
+        // from a wrong (e.g. non-admin) account when connecting/reconnecting;
+        // consent keeps the consent screen so a refresh token is always issued.
+        prompt: 'select_account consent',
       },
       setupInstructions: `To enable Google Workspace Admin SDK:
 1. Go to Google Cloud Console (console.cloud.google.com)


### PR DESCRIPTION
## Problem (customer report)

A customer connected **Google Workspace** with a **non-admin** user account. Google Workspace's Admin SDK Directory scopes (`admin.directory.*`) require a Workspace **admin**, so the integration can't function. They can disconnect, but **can't get a working connection back** — the reconnect flow never lets them choose a different (admin) Google account; re-authenticating keeps binding the same wrong account.

## Root cause

The Google Workspace and GCP OAuth flows send `prompt=consent`. That forces the **consent** screen but **not** the **account chooser**, so Google silently reuses whatever Google account the browser is already signed into. There's no way for the user to switch to an admin account during connect/reconnect.

(The connection record side is fine — disconnect → reconnect creates a fresh connection — but it re-binds the same browser-signed-in account.)

## Fix

Add `select_account` to the prompt on both Google manifests:

```ts
prompt: 'select_account consent'
```

`select_account` always shows Google's account chooser; `consent` is retained so a refresh token is still issued (`access_type=offline` + `consent`).

## Why this is safe ("won't break anything")

- **Refresh tokens unaffected** — `select_account` only applies to the interactive authorize step; token refresh (`grant_type=refresh_token`) doesn't use this URL. `access_type=offline` + `consent` are kept.
- **Existing connected customers unaffected** — they don't re-run authorize; their stored tokens keep working.
- **Encoding is already proven** — the `scope` param is already sent space-separated through the same `searchParams.set(...)` path and works in prod, so `'select_account consent'` (also space-separated) encodes identically.
- **Scope is limited** — only the two Google manifests change; other providers untouched. `comp` is canonical (no comp-private copy).
- **Verified** — `@trycompai/integration-platform` builds + typechecks; all 308 package tests pass; no test pinned the prompt value.

## Effect

- New connects and reconnects now show the account chooser, so a customer can pick the correct (admin) Google account.
- Removes the need for the incognito/sign-out workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force the Google account chooser during connect/reconnect for Google Workspace and GCP by sending `prompt: 'select_account consent'`. This lets users switch to the correct (admin) account and fixes reconnects that kept binding to a non-admin.

- **Bug Fixes**
  - Set `prompt: 'select_account consent'` in the Google Workspace and GCP OAuth manifests to always show the account chooser.
  - Retain `consent` with `access_type: 'offline'` so refresh tokens are issued; token refresh and existing connections are unaffected.
  - Changes are limited to `packages/integration-platform/src/manifests/google-workspace` and `packages/integration-platform/src/manifests/gcp`.

<sup>Written for commit 13fe965d226f7c9879de908b883c70d6466536a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

