### PR TITLE
fix(framework-editor): allow deleting a framework with versions/instances (FRAME-13)

### DIFF
--- a/apps/api/src/framework-editor/framework/framework.service.spec.ts
+++ b/apps/api/src/framework-editor/framework/framework.service.spec.ts
@@ -2,19 +2,28 @@ jest.mock('@db', () => {
   const dbMock = {
     frameworkEditorFramework: {
       findUnique: jest.fn(),
+      delete: jest.fn(),
     },
     frameworkEditorRequirement: {
       findMany: jest.fn(),
+      deleteMany: jest.fn(),
     },
     frameworkEditorControlTemplate: {
       update: jest.fn(),
     },
+    frameworkInstance: {
+      deleteMany: jest.fn(),
+    },
+    frameworkVersion: {
+      deleteMany: jest.fn(),
+    },
+    $transaction: jest.fn((ops: unknown[]) => Promise.all(ops)),
   };
   return { db: dbMock, Prisma: { PrismaClientKnownRequestError: class {} } };
 });
 
 import { BadRequestException, ConflictException } from '@nestjs/common';
-import { db } from '@db';
+import { db, Prisma } from '@db';
 import { FrameworkEditorFrameworkService } from './framework.service';
 
 const mockDb = db as jest.Mocked<typeof db>;
@@ -85,5 +94,61 @@ describe('FrameworkEditorFrameworkService.linkControl', () => {
       ConflictException,
     );
     expect(mockDb.frameworkEditorControlTemplate.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('FrameworkEditorFrameworkService.delete (FRAME-13)', () => {
+  let service: FrameworkEditorFrameworkService;
+
+  beforeEach(() => {
+    service = new FrameworkEditorFrameworkService();
+    jest.clearAllMocks();
+    (mockDb.frameworkEditorFramework.findUnique as jest.Mock).mockResolvedValue({
+      id: 'frk_1',
+    });
+  });
+
+  it('deletes instances, versions, requirements, then the framework — in that order', async () => {
+    const result = await service.delete('frk_1');
+
+    expect(result).toEqual({ message: 'Framework deleted successfully' });
+    expect(mockDb.frameworkInstance.deleteMany).toHaveBeenCalledWith({
+      where: { frameworkId: 'frk_1' },
+    });
+    expect(mockDb.frameworkVersion.deleteMany).toHaveBeenCalledWith({
+      where: { frameworkId: 'frk_1' },
+    });
+    expect(mockDb.frameworkEditorRequirement.deleteMany).toHaveBeenCalledWith({
+      where: { frameworkId: 'frk_1' },
+    });
+    expect(mockDb.frameworkEditorFramework.delete).toHaveBeenCalledWith({
+      where: { id: 'frk_1' },
+    });
+
+    // Order matters: instances free the currentVersion Restrict FK before
+    // versions are removed, and requirements before the framework itself.
+    const order = [
+      (mockDb.frameworkInstance.deleteMany as jest.Mock).mock.invocationCallOrder[0],
+      (mockDb.frameworkVersion.deleteMany as jest.Mock).mock.invocationCallOrder[0],
+      (mockDb.frameworkEditorRequirement.deleteMany as jest.Mock).mock
+        .invocationCallOrder[0],
+      (mockDb.frameworkEditorFramework.delete as jest.Mock).mock.invocationCallOrder[0],
+    ];
+    expect(order).toEqual([...order].sort((a, b) => a - b));
+  });
+
+  it('maps a residual FK conflict (P2003) to a ConflictException', async () => {
+    // Runtime uses the mocked class (ignores ctor args); the args satisfy the
+    // real Prisma type, and Object.assign sets the code the catch checks.
+    const fkError = Object.assign(
+      new Prisma.PrismaClientKnownRequestError('FK constraint', {
+        code: 'P2003',
+        clientVersion: '0',
+      }),
+      { code: 'P2003' },
+    );
+    (mockDb.$transaction as jest.Mock).mockRejectedValueOnce(fkError);
+
+    await expect(service.delete('frk_1')).rejects.toBeInstanceOf(ConflictException);
   });
 });

--- a/apps/api/src/framework-editor/framework/framework.service.ts
+++ b/apps/api/src/framework-editor/framework/framework.service.ts
@@ -102,8 +102,22 @@ export class FrameworkEditorFrameworkService {
   async delete(id: string) {
     await this.findById(id);
 
+    // A framework may have published versions and org-level instances that
+    // reference it. Delete the dependency graph in order inside one transaction:
+    //   1. instances   — cascades their org controls/maps/links/sync-operations
+    //                    AND frees the Restrict FK on
+    //                    FrameworkInstance.currentVersionId -> FrameworkVersion
+    //   2. versions     — now unreferenced by instances or sync-operations
+    //   3. requirements — Restrict FK back to the framework
+    //   4. the framework — cascades the editor-side control/policy/task/document
+    //                    links + ISMS docs
+    // Deleting the framework directly would cascade versions and instances
+    // together, which trips the currentVersionId Restrict (P2003) depending on
+    // cascade order; the explicit ordering avoids that.
     try {
       await db.$transaction([
+        db.frameworkInstance.deleteMany({ where: { frameworkId: id } }),
+        db.frameworkVersion.deleteMany({ where: { frameworkId: id } }),
         db.frameworkEditorRequirement.deleteMany({
           where: { frameworkId: id },
         }),
@@ -115,7 +129,7 @@ export class FrameworkEditorFrameworkService {
         error.code === 'P2003'
       ) {
         throw new ConflictException(
-          'Cannot delete framework: it is referenced by existing framework instances',
+          'Could not delete framework: it still has references that could not be removed automatically',
         );
       }
       throw error;

--- a/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/components/DeleteFrameworkDialog.tsx
+++ b/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/components/DeleteFrameworkDialog.tsx
@@ -65,8 +65,9 @@ export function DeleteFrameworkDialog({
             Are you sure you want to delete {`"${frameworkName}"`}?
           </AlertDialogTitle>
           <AlertDialogDescription>
-            This action cannot be undone. This will permanently delete the framework and all of its
-            associated requirements.
+            This action cannot be undone. This will permanently delete the framework, all of its
+            requirements and published versions, and remove it from any organizations currently
+            tracking it.
             {error && <p className="text-destructive mt-2 text-sm font-medium">Error: {error}</p>}
           </AlertDialogDescription>
         </AlertDialogHeader>


### PR DESCRIPTION
## Context (FRAME-13)

Joe couldn't delete the stale, hidden, empty `NIST SP800-53 r5.2 Low Impact v1.0.0 (hidden)` framework — both the confirm dialog and the toast showed:

> `{"message":"Cannot delete framework: it is referenced by existing framework instances","error":"Conflict","statusCode":409}`

## Root cause

`FrameworkEditorFrameworkService.delete()` only removed the framework's **requirements** then the **framework** row. But the framework also had:
- `FrameworkVersion` rows (the published v1.0.0), and
- `FrameworkInstance` rows (orgs tracking it).

Both `FrameworkVersion.frameworkId` and `FrameworkInstance.frameworkId` are `onDelete: Cascade`, **but** `FrameworkInstance.currentVersionId → FrameworkVersion` is `onDelete: Restrict`. Deleting the framework cascades versions and instances *together*, and depending on cascade order the `currentVersionId` Restrict fires → Prisma `P2003` → the 409. (The old error message blamed "instances", but the real blocker was the version/instance FK ordering.)

## Fix

Delete the dependency graph in **explicit order** inside the transaction:
1. **instances** — cascades their org controls/maps/links/sync-operations *and* frees the `currentVersionId` Restrict FK
2. **versions** — now unreferenced by instances or sync-operations
3. **requirements** — Restrict FK back to the framework
4. **the framework** — cascades the editor-side control/policy/task/document links + ISMS docs

(Verified every `FrameworkInstance` child — RequirementMap, TimelineInstance, sync-operations, control/policy/task/document links, CustomRequirement, FrameworkControlFamily — is `onDelete: Cascade`, so deleting instances is clean.)

The editor delete confirmation now states the real blast radius (also removes published versions + any org instances). The controller is `@UseGuards(PlatformAdminGuard)` — internal-admin only — so this is an admin cleanup operation, not customer-reachable.

## Testing

- `framework.service.spec.ts`: +2 tests — asserts the four deletes run in the right order; and that a residual `P2003` still maps to a `ConflictException`. 7 tests pass.
- `turbo typecheck`: clean for `@trycompai/api` (changed files) and `@trycompai/framework-editor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow deleting frameworks that have published versions and org instances by removing dependencies in order within a single transaction. Satisfies FRAME-13 and fixes the 409 caused by the `currentVersionId` restrict FK.

- **Bug Fixes**
  - Explicit delete order: instances → versions → requirements → framework to avoid Prisma `P2003`.
  - Clearer error when residual references remain.
  - Dialog copy now states versions and org instances will also be removed.
  - Tests added for delete order and P2003 → `ConflictException` mapping.

<sup>Written for commit 5f64e5f183839ac2091a3efad923b37b6f5c749a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

