### PR TITLE
fix(framework-editor): also delete timeline templates on framework delete (FRAME-13 follow-up)

### DIFF
--- a/apps/api/src/framework-editor/framework/framework.service.spec.ts
+++ b/apps/api/src/framework-editor/framework/framework.service.spec.ts
@@ -14,6 +14,9 @@ jest.mock('@db', () => {
     frameworkInstance: {
       deleteMany: jest.fn(),
     },
+    timelineTemplate: {
+      deleteMany: jest.fn(),
+    },
     frameworkVersion: {
       deleteMany: jest.fn(),
     },
@@ -108,11 +111,14 @@ describe('FrameworkEditorFrameworkService.delete (FRAME-13)', () => {
     });
   });
 
-  it('deletes instances, versions, requirements, then the framework — in that order', async () => {
+  it('deletes instances, timeline templates, versions, requirements, then the framework — in that order', async () => {
     const result = await service.delete('frk_1');
 
     expect(result).toEqual({ message: 'Framework deleted successfully' });
     expect(mockDb.frameworkInstance.deleteMany).toHaveBeenCalledWith({
+      where: { frameworkId: 'frk_1' },
+    });
+    expect(mockDb.timelineTemplate.deleteMany).toHaveBeenCalledWith({
       where: { frameworkId: 'frk_1' },
     });
     expect(mockDb.frameworkVersion.deleteMany).toHaveBeenCalledWith({
@@ -125,16 +131,26 @@ describe('FrameworkEditorFrameworkService.delete (FRAME-13)', () => {
       where: { id: 'frk_1' },
     });
 
-    // Order matters: instances free the currentVersion Restrict FK before
-    // versions are removed, and requirements before the framework itself.
+    // Order matters: instances must go first (they cascade TimelineInstances,
+    // freeing the Restrict FK TimelineInstance.templateId -> TimelineTemplate and
+    // FrameworkInstance.currentVersionId -> FrameworkVersion); then timeline
+    // templates and versions; requirements before the framework itself.
     const order = [
       (mockDb.frameworkInstance.deleteMany as jest.Mock).mock.invocationCallOrder[0],
+      (mockDb.timelineTemplate.deleteMany as jest.Mock).mock.invocationCallOrder[0],
       (mockDb.frameworkVersion.deleteMany as jest.Mock).mock.invocationCallOrder[0],
       (mockDb.frameworkEditorRequirement.deleteMany as jest.Mock).mock
         .invocationCallOrder[0],
       (mockDb.frameworkEditorFramework.delete as jest.Mock).mock.invocationCallOrder[0],
     ];
     expect(order).toEqual([...order].sort((a, b) => a - b));
+    // Timeline templates must be removed AFTER instances (their TimelineInstances
+    // cascade-delete with the instance, freeing the templateId Restrict FK).
+    expect(
+      (mockDb.timelineTemplate.deleteMany as jest.Mock).mock.invocationCallOrder[0],
+    ).toBeGreaterThan(
+      (mockDb.frameworkInstance.deleteMany as jest.Mock).mock.invocationCallOrder[0],
+    );
   });
 
   it('maps a residual FK conflict (P2003) to a ConflictException', async () => {

--- a/apps/api/src/framework-editor/framework/framework.service.ts
+++ b/apps/api/src/framework-editor/framework/framework.service.ts
@@ -102,21 +102,27 @@ export class FrameworkEditorFrameworkService {
   async delete(id: string) {
     await this.findById(id);
 
-    // A framework may have published versions and org-level instances that
-    // reference it. Delete the dependency graph in order inside one transaction:
-    //   1. instances   — cascades their org controls/maps/links/sync-operations
-    //                    AND frees the Restrict FK on
-    //                    FrameworkInstance.currentVersionId -> FrameworkVersion
-    //   2. versions     — now unreferenced by instances or sync-operations
-    //   3. requirements — Restrict FK back to the framework
-    //   4. the framework — cascades the editor-side control/policy/task/document
-    //                    links + ISMS docs
+    // A framework may have published versions, org-level instances, and timeline
+    // templates that reference it. Delete the dependency graph in order inside one
+    // transaction:
+    //   1. instances        — cascades their org controls/maps/links/sync-ops AND
+    //                         their TimelineInstances+phases, and frees the Restrict
+    //                         FK on FrameworkInstance.currentVersionId -> Version
+    //   2. timeline templates — TimelineTemplate.frameworkId is a Restrict FK back
+    //                         to the framework; its TimelineInstances are already
+    //                         gone via step 1, so it (and its phase templates) can
+    //                         now be removed
+    //   3. versions         — now unreferenced by instances or sync-operations
+    //   4. requirements     — Restrict FK back to the framework
+    //   5. the framework    — cascades the editor-side control/policy/task/document
+    //                         links + ISMS docs
     // Deleting the framework directly would cascade versions and instances
     // together, which trips the currentVersionId Restrict (P2003) depending on
     // cascade order; the explicit ordering avoids that.
     try {
       await db.$transaction([
         db.frameworkInstance.deleteMany({ where: { frameworkId: id } }),
+        db.timelineTemplate.deleteMany({ where: { frameworkId: id } }),
         db.frameworkVersion.deleteMany({ where: { frameworkId: id } }),
         db.frameworkEditorRequirement.deleteMany({
           where: { frameworkId: id },


### PR DESCRIPTION
## Context

Follow-up to #3154. After that shipped to prod, Joe **still** got a 409 deleting the empty hidden `NIST SP800-53 r5.2 Low Impact v1.0.0` — now with #3154's own message: *"Could not delete framework: it still has references that could not be removed automatically."* So the fix was live but the cascade missed a reference.

## Root cause (the missed FK)

An **exhaustive** scan of every FK into `FrameworkEditorFramework` shows all are `onDelete: Cascade` **except two** defaulting to `Restrict`:
- `FrameworkEditorRequirement.frameworkId` — already handled, and
- **`TimelineTemplate.frameworkId`** (`timeline.prisma:34`) — **missed.** A `TimelineTemplate` is created per framework, so it blocked the delete.

## Fix

Add `db.timelineTemplate.deleteMany({ where: { frameworkId: id } })` to the transaction, **right after instances** — by then each instance's `TimelineInstance`s (and their phases) have cascade-deleted, freeing the Restrict FK `TimelineInstance.templateId → TimelineTemplate`, so the templates (and their `TimelinePhaseTemplate` children, which cascade) can be removed. Then versions → requirements → framework, as before.

Final order: **instances → timeline templates → versions → requirements → framework.**

Verified requirements + timeline templates are now the *only* non-cascade FKs into the framework, and the version/instance graph is fully handled (instances cascade their org data + sync-ops + timelines, and free `currentVersionId`).

## Testing

- `framework.service.spec.ts`: updated the delete test to assert `timelineTemplate.deleteMany` is called, the full 5-step order, and specifically that timeline templates are deleted **after** instances. 7 tests pass.
- `turbo typecheck --filter=@trycompai/api`: clean for the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix framework deletion by also removing timeline templates in the delete transaction to prevent FK conflicts. Addresses FRAME-13 and stops 409 errors when deleting empty/hidden frameworks.

- **Bug Fixes**
  - Delete timeline templates right after instances in the transaction to clear the Restrict FK.
  - Enforce deletion order: instances → timeline templates → versions → requirements → framework.
  - Updated tests to assert the new step and ensure templates are deleted after instances.

<sup>Written for commit 59aa455c677eae04d5c70f5baf5314a264f5c136. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

