### PR TITLE
docs(mcp): fix API-key placeholder encoding footgun (ellipsis in header)

### DIFF
--- a/packages/docs/mcp-server.mdx
+++ b/packages/docs/mcp-server.mdx
@@ -25,7 +25,7 @@ The AI assistant figures out which tools to call. Your team types the request an
 1. Sign in to [Comp AI](https://app.trycomp.ai).
 2. Open **Settings → API Keys**.
 3. Click **Create new key**. Scope it to the actions the AI assistant should be allowed to take.
-4. Copy the key (it starts with `comp_…`) — you will paste it into your AI client's config once.
+4. Copy the key (it starts with `comp_`) — you will paste it into your AI client's config once. Copy the full string exactly, with no extra characters, spaces, or line breaks.
 
 The API key carries your existing RBAC and permissions. The AI assistant can only do what *your* role can do in the dashboard.
 
@@ -69,7 +69,7 @@ If you prefer to manage `claude_desktop_config.json` yourself, open **Settings �
         "@trycompai/mcp-server",
         "start",
         "--apikey",
-        "comp_…your_key_here…"
+        "comp_your_api_key_here"
       ]
     }
   }
@@ -100,7 +100,7 @@ Open **Cursor → Settings → Tools and Integrations → New MCP Server** and p
     "@trycompai/mcp-server",
     "start",
     "--apikey",
-    "comp_…your_key_here…"
+    "comp_your_api_key_here"
   ]
 }
 ```
@@ -129,7 +129,7 @@ Open the **Command Palette → MCP: Open User Configuration** and paste:
     "@trycompai/mcp-server",
     "start",
     "--apikey",
-    "comp_…your_key_here…"
+    "comp_your_api_key_here"
   ]
 }
 ```
@@ -142,7 +142,7 @@ Open the **Command Palette → MCP: Open User Configuration** and paste:
 Install with one command:
 
 ```bash
-claude mcp add CompAI -- npx -y @trycompai/mcp-server start --apikey comp_…your_key_here…
+claude mcp add CompAI -- npx -y @trycompai/mcp-server start --apikey comp_your_api_key_here
 ```
 
 Claude Code registers the server immediately — Comp AI tools become available in your next session.
@@ -154,7 +154,7 @@ Claude Code registers the server immediately — Comp AI tools become available 
 Install with one command:
 
 ```bash
-codex mcp add comp-ai -- npx -y @trycompai/mcp-server start --apikey comp_…your_key_here…
+codex mcp add comp-ai -- npx -y @trycompai/mcp-server start --apikey comp_your_api_key_here
 ```
 
 Codex registers the server immediately — Comp AI tools become available in your next session.
@@ -168,7 +168,7 @@ For ChatGPT desktop / web with MCP support, follow OpenAI's MCP integration docs
 Install with one command:
 
 ```bash
-gemini mcp add CompAI -- npx -y @trycompai/mcp-server start --apikey comp_…your_key_here…
+gemini mcp add CompAI -- npx -y @trycompai/mcp-server start --apikey comp_your_api_key_here
 ```
 
 </Tab>
@@ -187,7 +187,7 @@ Open **Windsurf → Settings → Cascade → Manage MCPs → View raw config** a
         "@trycompai/mcp-server",
         "start",
         "--apikey",
-        "comp_…your_key_here…"
+        "comp_your_api_key_here"
       ]
     }
   }
@@ -222,9 +222,18 @@ Most common causes:
 </Accordion>
 
 <Accordion title="401 / authentication error">
-- Confirm your API key starts with `comp_…` and you copied the full string (these keys are long).
+- Confirm your API key starts with `comp_` and you copied the full string (these keys are long).
 - Confirm the key hasn't been revoked in **Comp AI → Settings → API Keys**.
 - Confirm the key's role has permission for the action you're asking the AI to take.
+</Accordion>
+
+<Accordion title="Every tool call fails with an encoding error (e.g. “character … value 8230”)">
+This means the API key in your config contains a stray non-standard character — most often an ellipsis (`…`) accidentally pasted in place of the real key. HTTP headers only allow plain characters, so the request can't be sent.
+
+Fix it by re-entering the key cleanly:
+1. In **Comp AI → Settings → API Keys**, copy your key again (or create a new one).
+2. In your config, replace the entire `--apikey` value so it's just your real key — `comp_` followed by letters and numbers, with **no `…`, spaces, or line breaks**.
+3. Fully quit and reopen your AI client.
 </Accordion>
 
 <Accordion title="`npx` or `command not found`">


### PR DESCRIPTION
## What & why

A customer (James) hit **every MCP tool call failing** with an encoding error: *"character at index 5 has a value of 8230 which is greater than 255."*

`8230` is U+2026 `…` (ellipsis), and index 5 lands right after `comp_`. Root cause: our setup docs showed the API-key placeholder as **`comp_…your_key_here…`** using literal ellipsis characters. The customer copied it and left the `…` in, so the MCP server tried to send an `x-api-key` HTTP header containing an ellipsis — Node/undici rejects any header character > 255, so the request dies during serialization, before it ever reaches our API. Every tool call carries the same bad header, so they all fail identically (matching the report).

It's our docs, not the API or the customer's data.

## Fix
- Replace every copy-paste API-key placeholder (`comp_…your_key_here…` → `comp_your_api_key_here`) — plain ASCII, no non-standard characters.
- Drop the ellipsis from the surrounding prose (`comp_…` → `comp_`) and add a "copy the full key with no extra characters" note.
- Add a troubleshooting accordion for the encoding error so customers (and CX) can self-diagnose it instantly.

Docs-only; renders on `docs.trycomp.ai/mcp-server`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a docs footgun that caused MCP tool calls to fail by replacing the ellipsis in the API key placeholder with plain ASCII. Adds clear copy instructions and a troubleshooting note to help users resolve the header-encoding error.

- **Bug Fixes**
  - Replaced `comp_…your_key_here…` with `comp_your_api_key_here` in all `@trycompai/mcp-server` snippets and one-command installs; removed ellipsis from prose and the 401 auth note (`comp_`).
  - Added a note to copy the full key exactly, with no extra characters, spaces, or line breaks.
  - Added a troubleshooting accordion for the “character … value 8230” header-encoding error with quick fix steps.

<sup>Written for commit 1c6d2d752921b079f2aa99ff99c8953359b0db25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

