### PR TITLE
fix(integration-platform): run dynamic integration checks on the daily schedule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,6 @@ scripts/sync-release-branch.sh
 apps/mcp-server/.github/
 
 # Ad-hoc read-only prod ops scripts (contain DB creds) + any exported customer data.
-# These must never be committed.
-/dbq_*.js
-/*.csv
+# These must never be committed. Unanchored so nested paths are covered too.
+dbq_*.js
+*.csv

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,8 @@ scripts/sync-release-branch.sh
 # from .github/workflows/ at the repo root. We move them up. See
 # .github/workflows/sdk_generation.yaml + sdk_publish.yaml (the real ones).
 apps/mcp-server/.github/
+
+# Ad-hoc read-only prod ops scripts (contain DB creds) + any exported customer data.
+# These must never be committed.
+/dbq_*.js
+/*.csv

--- a/apps/api/src/trigger/integration-platform/dynamic-provider.spec.ts
+++ b/apps/api/src/trigger/integration-platform/dynamic-provider.spec.ts
@@ -1,0 +1,62 @@
+// Mock @db so importing the helper doesn't open a Postgres connection.
+const findUnique = jest.fn();
+jest.mock('@db', () => ({
+  db: { dynamicIntegration: { findUnique: (...args: unknown[]) => findUnique(...args) } },
+}));
+
+import { isActiveDynamicProvider, shouldRunOnServer } from './dynamic-provider';
+
+describe('shouldRunOnServer', () => {
+  it('always delegates AWS (VPC egress), with or without a manifest', () => {
+    expect(
+      shouldRunOnServer({ providerSlug: 'aws', hasManifest: true, isActiveDynamic: false }),
+    ).toBe(true);
+    expect(
+      shouldRunOnServer({ providerSlug: 'aws', hasManifest: false, isActiveDynamic: false }),
+    ).toBe(true);
+  });
+
+  it('runs static providers (manifest present) in-process', () => {
+    expect(
+      shouldRunOnServer({ providerSlug: 'github', hasManifest: true, isActiveDynamic: false }),
+    ).toBe(false);
+    // Even if a dynamic row somehow also exists, a present manifest wins (static).
+    expect(
+      shouldRunOnServer({ providerSlug: 'vercel', hasManifest: true, isActiveDynamic: true }),
+    ).toBe(false);
+  });
+
+  it('delegates active dynamic providers (no local manifest) to the server', () => {
+    expect(
+      shouldRunOnServer({ providerSlug: 'keeper-security', hasManifest: false, isActiveDynamic: true }),
+    ).toBe(true);
+    expect(
+      shouldRunOnServer({ providerSlug: 'supabase', hasManifest: false, isActiveDynamic: true }),
+    ).toBe(true);
+  });
+
+  it('does NOT delegate an unknown provider (no manifest, not dynamic)', () => {
+    expect(
+      shouldRunOnServer({ providerSlug: 'deleted-thing', hasManifest: false, isActiveDynamic: false }),
+    ).toBe(false);
+  });
+});
+
+describe('isActiveDynamicProvider', () => {
+  beforeEach(() => findUnique.mockReset());
+
+  it('is true only for an active dynamic integration row', async () => {
+    findUnique.mockResolvedValue({ isActive: true });
+    await expect(isActiveDynamicProvider('keeper-security')).resolves.toBe(true);
+  });
+
+  it('is false for an inactive dynamic integration', async () => {
+    findUnique.mockResolvedValue({ isActive: false });
+    await expect(isActiveDynamicProvider('paused-thing')).resolves.toBe(false);
+  });
+
+  it('is false when no dynamic row exists (static or unknown slug)', async () => {
+    findUnique.mockResolvedValue(null);
+    await expect(isActiveDynamicProvider('github')).resolves.toBe(false);
+  });
+});

--- a/apps/api/src/trigger/integration-platform/dynamic-provider.ts
+++ b/apps/api/src/trigger/integration-platform/dynamic-provider.ts
@@ -1,0 +1,48 @@
+import { db } from '@db';
+
+/**
+ * Dynamic (DB-backed) integrations are NOT present in the Trigger.dev runtime's
+ * manifest registry: the registry singleton is seeded only with the static code
+ * manifests, and the loader that merges DB-backed manifests in
+ * (`DynamicManifestLoaderService`) is a NestJS lifecycle service that never runs
+ * in the Trigger.dev process. So `getManifest(slug)` returns `undefined` here
+ * for dynamic providers, and their checks cannot execute in-process.
+ *
+ * The fix (mirroring AWS) is to run those checks ON OUR SERVER, where the loader
+ * HAS populated the registry — see `runChecksOnServer` and the internal endpoint
+ * it calls. These helpers decide when to delegate.
+ */
+
+/** True when `slug` is an active DB-backed (dynamic) integration. */
+export async function isActiveDynamicProvider(slug: string): Promise<boolean> {
+  const row = await db.dynamicIntegration.findUnique({
+    where: { slug },
+    select: { isActive: true },
+  });
+  return row?.isActive === true;
+}
+
+/**
+ * Whether a provider's checks must run on the API server instead of in the
+ * Trigger.dev runtime.
+ *
+ * - AWS → always on the server (its S3 calls must egress our VPC, not
+ *   Trigger.dev's, whose endpoint policy blocks the cross-account read).
+ * - Has a manifest here → static code integration → run in-process (unchanged).
+ * - No manifest but an active dynamic integration → on the server (the manifest
+ *   only exists in the API process).
+ * - No manifest and not dynamic → unknown provider → do NOT delegate (the caller
+ *   surfaces "manifest not found" instead of sending a doomed request).
+ *
+ * Pure so it can be unit-tested without the DB.
+ */
+export function shouldRunOnServer(params: {
+  providerSlug: string;
+  hasManifest: boolean;
+  isActiveDynamic: boolean;
+}): boolean {
+  const { providerSlug, hasManifest, isActiveDynamic } = params;
+  if (providerSlug === 'aws') return true;
+  if (hasManifest) return false;
+  return isActiveDynamic;
+}

--- a/apps/api/src/trigger/integration-platform/run-connection-checks.ts
+++ b/apps/api/src/trigger/integration-platform/run-connection-checks.ts
@@ -6,7 +6,14 @@ import {
   requestValidCredentials,
   type IntegrationCredentialValues,
 } from './ensure-valid-credentials';
-import { runChecksOnServer } from './run-checks-on-server';
+import {
+  runChecksOnServer,
+  type RunAllChecksResult,
+} from './run-checks-on-server';
+import {
+  isActiveDynamicProvider,
+  shouldRunOnServer,
+} from './dynamic-provider';
 
 /**
  * Trigger task that runs all checks for a connection.
@@ -37,12 +44,24 @@ export const runConnectionChecks = task({
 
     const manifest = getManifest(providerSlug);
 
-    if (!manifest) {
+    // Dynamic (DB-backed) providers have no manifest in the Trigger.dev runtime,
+    // so run their checks ON OUR SERVER (like AWS), where the dynamic-manifest
+    // loader has populated the registry. Static providers keep running here.
+    const isDynamic = manifest
+      ? false
+      : await isActiveDynamicProvider(providerSlug);
+    const runOnServer = shouldRunOnServer({
+      providerSlug,
+      hasManifest: !!manifest,
+      isActiveDynamic: isDynamic,
+    });
+
+    if (!manifest && !runOnServer) {
       logger.error(`Manifest not found for provider: ${providerSlug}`);
       return { success: false, error: `Manifest not found: ${providerSlug}` };
     }
 
-    if (!manifest.checks || manifest.checks.length === 0) {
+    if (manifest && (!manifest.checks || manifest.checks.length === 0)) {
       logger.info(`No checks defined for provider: ${providerSlug}`);
       return { success: true, reason: 'No checks defined' };
     }
@@ -57,53 +76,59 @@ export const runConnectionChecks = task({
       return { success: false, error: 'Connection not found or inactive' };
     }
 
-    // Check if all required variables are configured
-    const requiredVariables = new Set<string>();
-    for (const check of manifest.checks) {
-      if (check.variables) {
-        for (const variable of check.variables) {
-          if (variable.required) {
-            requiredVariables.add(variable.id);
+    // Check if all required variables are configured. Only possible for
+    // in-process (static) providers — for server-delegated dynamic providers the
+    // manifest (and thus its variable definitions) isn't available here, so the
+    // server runs every check and reports any that are unconfigured as results.
+    if (manifest) {
+      const requiredVariables = new Set<string>();
+      for (const check of manifest.checks ?? []) {
+        if (check.variables) {
+          for (const variable of check.variables) {
+            if (variable.required) {
+              requiredVariables.add(variable.id);
+            }
           }
         }
       }
-    }
 
-    const configuredVariables =
-      (connection.variables as Record<string, unknown>) || {};
-    const missingVariables: string[] = [];
+      const configuredVariables =
+        (connection.variables as Record<string, unknown>) || {};
+      const missingVariables: string[] = [];
 
-    for (const requiredVar of requiredVariables) {
-      const value = configuredVariables[requiredVar];
-      if (value === undefined || value === null || value === '') {
-        missingVariables.push(requiredVar);
+      for (const requiredVar of requiredVariables) {
+        const value = configuredVariables[requiredVar];
+        if (value === undefined || value === null || value === '') {
+          missingVariables.push(requiredVar);
+        }
+        if (Array.isArray(value) && value.length === 0) {
+          missingVariables.push(requiredVar);
+        }
       }
-      if (Array.isArray(value) && value.length === 0) {
-        missingVariables.push(requiredVar);
-      }
-    }
 
-    if (missingVariables.length > 0) {
-      logger.info(
-        `Skipping auto-run: missing required variables: ${missingVariables.join(', ')}`,
-      );
-      return {
-        success: true,
-        reason: `Missing required variables: ${missingVariables.join(', ')}`,
-      };
+      if (missingVariables.length > 0) {
+        logger.info(
+          `Skipping auto-run: missing required variables: ${missingVariables.join(', ')}`,
+        );
+        return {
+          success: true,
+          reason: `Missing required variables: ${missingVariables.join(', ')}`,
+        };
+      }
     }
 
     const apiUrl = process.env.BASE_URL || 'http://localhost:3333';
 
-    // AWS checks run ON OUR SERVER (see below), which decrypts the credentials
-    // and assumes the cross-account role there. Skip the Trigger-side credential
-    // preflight for AWS — running it would add redundant failure points (a
-    // transient preflight error would falsely fail an AWS run that
-    // `runChecksOnServer` could have completed).
+    // Server-delegated checks (AWS + dynamic providers) decrypt credentials and
+    // run ON OUR SERVER, so the Trigger-side credential preflight is skipped for
+    // them — running it would add redundant failure points (a transient
+    // preflight error would falsely fail a run that `runChecksOnServer` could
+    // have completed). The `&& manifest` is a no-op at runtime (a non-delegated
+    // provider always has a manifest by here) that narrows the type below.
     let credentials: IntegrationCredentialValues = {};
     let handleTokenRefresh: (() => Promise<string | null>) | undefined;
 
-    if (providerSlug !== 'aws') {
+    if (!runOnServer && manifest) {
       logger.info('Ensuring valid credentials...');
       const credentialsResult = await requestValidCredentials({
         apiUrl,
@@ -177,30 +202,37 @@ export const runConnectionChecks = task({
     let totalPassing = 0;
 
     try {
-      // AWS checks run ON OUR SERVER so their S3 calls egress our VPC (allowed)
-      // instead of Trigger.dev's (blocked). Every other provider keeps running
-      // here in the Trigger.dev runtime, unchanged. Same result shape either
-      // way, so the persistence below is shared.
-      const result =
-        providerSlug === 'aws'
-          ? await runChecksOnServer({ apiUrl, connectionId, organizationId })
-          : await runAllChecks({
-              manifest,
-              accessToken: getAccessToken(credentials),
-              credentials,
-              variables,
-              connectionId,
-              organizationId,
-              onTokenRefresh:
-                manifest.auth.type === 'oauth2'
-                  ? handleTokenRefresh
-                  : undefined,
-              logger: {
-                info: (msg, data) => logger.info(msg, data),
-                warn: (msg, data) => logger.warn(msg, data),
-                error: (msg, data) => logger.error(msg, data),
-              },
-            });
+      // Server-delegated providers (AWS + dynamic) run ON OUR SERVER so their
+      // checks egress our VPC / resolve their DB-backed manifest there. Static
+      // providers keep running here in the Trigger.dev runtime, unchanged. Same
+      // result shape either way, so the persistence below is shared.
+      let result: RunAllChecksResult;
+      if (runOnServer) {
+        result = await runChecksOnServer({
+          apiUrl,
+          connectionId,
+          organizationId,
+        });
+      } else if (manifest) {
+        result = await runAllChecks({
+          manifest,
+          accessToken: getAccessToken(credentials),
+          credentials,
+          variables,
+          connectionId,
+          organizationId,
+          onTokenRefresh:
+            manifest.auth.type === 'oauth2' ? handleTokenRefresh : undefined,
+          logger: {
+            info: (msg, data) => logger.info(msg, data),
+            warn: (msg, data) => logger.warn(msg, data),
+            error: (msg, data) => logger.error(msg, data),
+          },
+        });
+      } else {
+        // Unreachable: guarded at the top (no manifest ⇒ runOnServer).
+        throw new Error(`Manifest not found: ${providerSlug}`);
+      }
 
       totalFindings = result.totalFindings;
       totalPassing = result.totalPassing;

--- a/apps/api/src/trigger/integration-platform/run-integration-checks-schedule.spec.ts
+++ b/apps/api/src/trigger/integration-platform/run-integration-checks-schedule.spec.ts
@@ -1,5 +1,8 @@
 import { TaskFrequency } from '@trycompai/db';
-import { filterDueTasks } from './run-integration-checks-schedule';
+import {
+  filterDueTasks,
+  resolveProviderChecks,
+} from './run-integration-checks-schedule';
 
 // Mock @db at the module boundary so importing the orchestrator does not try
 // to connect to Postgres. We never call the scheduled `run` function itself
@@ -9,6 +12,7 @@ jest.mock('@db', () => ({
   db: {
     integrationConnection: { findMany: jest.fn() },
     task: { findMany: jest.fn(), update: jest.fn() },
+    dynamicIntegration: { findMany: jest.fn() },
   },
   TaskFrequency: {
     daily: 'daily',
@@ -117,5 +121,54 @@ describe('filterDueTasks (integration orchestrator)', () => {
     const dueTasks = filterDueTasks({ tasks: candidateTasks, now });
 
     expect(dueTasks).toEqual([]);
+  });
+});
+
+describe('resolveProviderChecks (static vs dynamic)', () => {
+  it('uses the static code manifest when present (and ignores any dynamic map)', () => {
+    const checks = resolveProviderChecks({
+      manifest: {
+        checks: [
+          { id: 'two_factor_auth', taskMapping: 'tpl_mfa' },
+          { id: 'branch_protection', taskMapping: null },
+        ],
+      },
+      dynamicChecks: [{ id: 'should_not_be_used', taskMapping: 'tpl_x' }],
+    });
+
+    expect(checks).toEqual([
+      { id: 'two_factor_auth', taskMapping: 'tpl_mfa' },
+      { id: 'branch_protection', taskMapping: null },
+    ]);
+  });
+
+  it('falls back to the dynamic DB map when there is no manifest (the fix)', () => {
+    const checks = resolveProviderChecks({
+      manifest: undefined,
+      dynamicChecks: [
+        { id: 'mfa_enforcement', taskMapping: 'frk_tt_mfa' },
+        { id: 'supabase_mfa', taskMapping: 'frk_tt_mfa' },
+      ],
+    });
+
+    expect(checks).toEqual([
+      { id: 'mfa_enforcement', taskMapping: 'frk_tt_mfa' },
+      { id: 'supabase_mfa', taskMapping: 'frk_tt_mfa' },
+    ]);
+  });
+
+  it('returns [] for an unknown provider (no manifest, no dynamic entry)', () => {
+    expect(
+      resolveProviderChecks({ manifest: undefined, dynamicChecks: undefined }),
+    ).toEqual([]);
+  });
+
+  it('normalizes an undefined manifest taskMapping to null', () => {
+    const checks = resolveProviderChecks({
+      manifest: { checks: [{ id: 'c1', taskMapping: undefined }] },
+      dynamicChecks: undefined,
+    });
+
+    expect(checks).toEqual([{ id: 'c1', taskMapping: null }]);
   });
 });

--- a/apps/api/src/trigger/integration-platform/run-integration-checks-schedule.ts
+++ b/apps/api/src/trigger/integration-platform/run-integration-checks-schedule.ts
@@ -28,6 +28,44 @@ export function filterDueTasks<
   );
 }
 
+/** A provider's check reduced to what the orchestrator needs to schedule it. */
+export interface ProviderCheck {
+  id: string;
+  taskMapping: string | null;
+}
+
+/**
+ * Resolve a connection's checks from EITHER the static code manifest (the 8
+ * built-in integrations, present in the Trigger.dev registry) OR the dynamic
+ * (DB-backed) check map for that provider slug.
+ *
+ * Dynamic integrations are absent from the Trigger.dev manifest registry, so
+ * `getManifest` returns undefined for them here and they were silently skipped —
+ * the entire reason scheduled checks never ran for them. Falling back to the DB
+ * map lets the orchestrator discover their due tasks too. Static manifests win
+ * when both exist (matching the registry, which never lets a dynamic manifest
+ * override a code one).
+ */
+export function resolveProviderChecks({
+  manifest,
+  dynamicChecks,
+}: {
+  // Loose check shape so a real `IntegrationManifest` (whose `taskMapping` is a
+  // literal-union-or-undefined) is accepted; `.map` below normalizes it.
+  manifest:
+    | { checks?: Array<{ id: string; taskMapping?: string | null }> }
+    | undefined;
+  dynamicChecks: ProviderCheck[] | undefined;
+}): ProviderCheck[] {
+  if (manifest?.checks) {
+    return manifest.checks.map((c) => ({
+      id: c.id,
+      taskMapping: c.taskMapping ?? null,
+    }));
+  }
+  return dynamicChecks ?? [];
+}
+
 /**
  * Daily scheduled task (orchestrator) that finds all tasks with integration checks
  * and triggers individual check runs for each.
@@ -57,6 +95,28 @@ export const integrationChecksSchedule = schedules.task({
 
     logger.info(`Found ${activeConnections.length} active connections`);
 
+    // Dynamic (DB-backed) integrations are NOT in the Trigger.dev manifest
+    // registry, so getManifest() returns undefined for them below. Load their
+    // enabled check → task mappings straight from the DB so this orchestrator
+    // can discover their due tasks too (their checks are then run on the API
+    // server by the worker — see runOnServer in run-task-integration-checks).
+    const dynamicIntegrations = await db.dynamicIntegration.findMany({
+      where: { isActive: true },
+      select: {
+        slug: true,
+        checks: {
+          where: { isEnabled: true },
+          select: { checkSlug: true, taskMapping: true },
+        },
+      },
+    });
+    const dynamicChecksBySlug = new Map<string, ProviderCheck[]>(
+      dynamicIntegrations.map((d) => [
+        d.slug,
+        d.checks.map((c) => ({ id: c.checkSlug, taskMapping: c.taskMapping })),
+      ]),
+    );
+
     // For each connection, find tasks that have checks mapped to them
     const tasksToRun: Array<{
       taskId: string;
@@ -68,16 +128,22 @@ export const integrationChecksSchedule = schedules.task({
     }> = [];
 
     for (const connection of activeConnections) {
+      // Static providers resolve from the code manifest; dynamic ones from the
+      // DB map loaded above. Both reduce to the same { id, taskMapping } shape.
       const manifest = getManifest(connection.provider.slug);
+      const checks = resolveProviderChecks({
+        manifest,
+        dynamicChecks: dynamicChecksBySlug.get(connection.provider.slug),
+      });
 
-      if (!manifest?.checks || manifest.checks.length === 0) {
+      if (checks.length === 0) {
         continue;
       }
 
       // Get task template IDs that this integration's checks map to
-      const taskTemplateIds = manifest.checks
+      const taskTemplateIds = checks
         .map((c) => c.taskMapping)
-        .filter((id): id is NonNullable<typeof id> => !!id);
+        .filter((id): id is string => !!id);
 
       if (taskTemplateIds.length === 0) {
         continue;
@@ -118,7 +184,7 @@ export const integrationChecksSchedule = schedules.task({
         const disabledForThisTask = new Set(disabledByTask[t.id] ?? []);
 
         // Find which checks apply to this task, minus any the user disabled
-        const checksForTask = manifest.checks
+        const checksForTask = checks
           .filter(
             (c) =>
               c.taskMapping === t.taskTemplateId &&

--- a/apps/api/src/trigger/integration-platform/run-task-integration-checks.ts
+++ b/apps/api/src/trigger/integration-platform/run-task-integration-checks.ts
@@ -14,6 +14,10 @@ import {
   runChecksOnServer,
   type RunAllChecksResult,
 } from './run-checks-on-server';
+import {
+  isActiveDynamicProvider,
+  shouldRunOnServer,
+} from './dynamic-provider';
 import { loadActiveExceptionSet } from '../../cloud-security/finding-exceptions';
 import {
   countEffectiveFailures,
@@ -212,7 +216,21 @@ export const runTaskIntegrationChecks = task({
 
     const manifest = getManifest(providerSlug);
 
-    if (!manifest) {
+    // Dynamic (DB-backed) providers have no manifest in the Trigger.dev runtime,
+    // so run their checks ON OUR SERVER (like AWS), where the dynamic-manifest
+    // loader has populated the registry. Static providers keep running here.
+    const isDynamic = manifest
+      ? false
+      : await isActiveDynamicProvider(providerSlug);
+    const runOnServer = shouldRunOnServer({
+      providerSlug,
+      hasManifest: !!manifest,
+      isActiveDynamic: isDynamic,
+    });
+
+    // Only a truly unknown provider (no manifest AND not delegated) is a dead
+    // end; dynamic providers are delegated below instead of failing here.
+    if (!manifest && !runOnServer) {
       logger.error(`Manifest not found for provider: ${providerSlug}`);
       return { success: false, error: `Manifest not found: ${providerSlug}` };
     }
@@ -229,15 +247,17 @@ export const runTaskIntegrationChecks = task({
 
     const apiUrl = process.env.BASE_URL || 'http://localhost:3333';
 
-    // AWS checks run ON OUR SERVER (see the loop below), which decrypts the
-    // credentials and assumes the cross-account role there. So the Trigger-side
-    // credential/session preflight is skipped for AWS — running it would add
-    // redundant failure points (a transient preflight error would falsely fail
-    // an AWS run that `runChecksOnServer` could have completed).
+    // Server-delegated checks (AWS + dynamic providers) decrypt credentials and
+    // run ON OUR SERVER, so the Trigger-side credential/session preflight is
+    // skipped for them — running it would add redundant failure points (a
+    // transient preflight error would falsely fail a run that
+    // `runChecksOnServer` could have completed). The `&& manifest` is a no-op at
+    // runtime (a non-delegated provider always has a manifest by here) that lets
+    // TypeScript narrow `manifest` for the in-process branch below.
     let credentials: IntegrationCredentialValues = {};
     let handleTokenRefresh: (() => Promise<string | null>) | undefined;
 
-    if (providerSlug !== 'aws') {
+    if (!runOnServer && manifest) {
       logger.info('Ensuring valid credentials (refreshing if needed)...');
       const credentialsResult = await requestValidCredentials({
         apiUrl,
@@ -347,58 +367,64 @@ export const runTaskIntegrationChecks = task({
     // Run only the checks that apply to this task
     try {
       for (const checkId of effectiveCheckIds) {
-        // AWS checks run ON OUR SERVER so their S3 calls egress our VPC (whose
-        // endpoint allows the read) instead of Trigger.dev's (which blocks it).
-        // Every other provider keeps executing here in the Trigger.dev runtime,
+        // Server-delegated providers (AWS + dynamic) run ON OUR SERVER so their
+        // checks egress our VPC / resolve their DB-backed manifest there.
+        // Static providers keep executing here in the Trigger.dev runtime,
         // unchanged. The result shape is identical either way, so all the
         // persistence / status / email logic below is shared.
         let result: RunAllChecksResult;
         try {
-          result =
-            providerSlug === 'aws'
-              ? await runChecksOnServer({
-                  apiUrl,
-                  connectionId,
-                  organizationId,
-                  checkId,
-                })
-              : await runAllChecks({
-                  manifest,
-                  accessToken: getAccessToken(credentials),
-                  credentials,
-                  variables,
-                  connectionId,
-                  organizationId,
-                  checkId, // Run specific check
-                  onTokenRefresh:
-                    manifest.auth.type === 'oauth2'
-                      ? handleTokenRefresh
-                      : undefined,
-                  logger: {
-                    info: (msg, data) => logger.info(msg, data),
-                    warn: (msg, data) => logger.warn(msg, data),
-                    error: (msg, data) => logger.error(msg, data),
-                  },
-                });
+          if (runOnServer) {
+            result = await runChecksOnServer({
+              apiUrl,
+              connectionId,
+              organizationId,
+              checkId,
+            });
+          } else if (manifest) {
+            result = await runAllChecks({
+              manifest,
+              accessToken: getAccessToken(credentials),
+              credentials,
+              variables,
+              connectionId,
+              organizationId,
+              checkId, // Run specific check
+              onTokenRefresh:
+                manifest.auth.type === 'oauth2'
+                  ? handleTokenRefresh
+                  : undefined,
+              logger: {
+                info: (msg, data) => logger.info(msg, data),
+                warn: (msg, data) => logger.warn(msg, data),
+                error: (msg, data) => logger.error(msg, data),
+              },
+            });
+          } else {
+            // Unreachable: guarded at the top (no manifest ⇒ runOnServer). Kept
+            // so the type checker knows `result` is always assigned.
+            throw new Error(`Manifest not found: ${providerSlug}`);
+          }
         } catch (error) {
-          // Only the AWS server-run path is degraded here. Non-AWS providers run
-          // in-process via runAllChecks, which catches per-check failures and
-          // returns status:'error' rather than throwing — so a throw on the
-          // non-AWS branch is unexpected and must NOT be silently downgraded.
-          // Re-throw it to preserve the pre-change behavior (it propagates to the
-          // outer catch and fails the task).
-          if (providerSlug !== 'aws') throw error;
+          // Only the server-run path is degraded here. In-process providers run
+          // via runAllChecks, which catches per-check failures and returns
+          // status:'error' rather than throwing — so a throw on the in-process
+          // branch is unexpected and must NOT be silently downgraded. Re-throw
+          // it to preserve the pre-change behavior (it propagates to the outer
+          // catch and fails the task).
+          if (!runOnServer) throw error;
 
-          // AWS server-run threw, and only on a transport blip (network/non-2xx)
-          // — per-check AWS execution errors come back inside the result, not
-          // thrown. Record THIS check as errored and keep going so one blip
-          // doesn't abort its sibling checks (multiple AWS checks share a task)
-          // or skip the lastSyncAt/status updates, mirroring runAllChecks'
-          // per-check resilience. hasExecutionErrors keeps integrationLastRunAt
-          // unwritten, so the next orchestrator tick retries.
+          // Server-run threw, and only on a transport blip (network/non-2xx) —
+          // per-check execution errors come back inside the result, not thrown.
+          // Record THIS check as errored and keep going so one blip doesn't abort
+          // its sibling checks (multiple checks share a task) or skip the
+          // lastSyncAt/status updates, mirroring runAllChecks' per-check
+          // resilience. hasExecutionErrors keeps integrationLastRunAt unwritten,
+          // so the next orchestrator tick retries. `manifest` is undefined for
+          // dynamic providers, so resolve the check name defensively.
           const message =
             error instanceof Error ? error.message : String(error);
-          const checkDef = manifest.checks?.find((c) => c.id === checkId);
+          const checkDef = manifest?.checks?.find((c) => c.id === checkId);
           // A transport blip is indeterminate, not a finding: it gates
           // integrationLastRunAt (retry next tick) but must not fail the task.
           hasExecutionErrors = true;


### PR DESCRIPTION
## Problem
Dynamic (DB-backed) integrations — **Keeper, Supabase, and ~575 others** — never ran on the daily schedule. They only ran when a user clicked **Run** manually, so their task "last run" sat stale for days. **1,167 active dynamic connections across 282 orgs** are affected (verified in prod).

## Root cause
The daily orchestrator (`integration-checks-schedule`) and worker (`run-task-integration-checks`) run in the **Trigger.dev runtime**, whose manifest registry is seeded with only the **8 static code manifests**. The dynamic-manifest loader is a NestJS `OnModuleInit` service that **never runs in Trigger.dev**, so `getManifest(dynamicSlug)` returns `undefined` and the orchestrator silently skipped those connections (`continue`). Manual runs work because they execute in the **API process**, where the loader has populated the registry.

Confirmed in prod on an example task: github/google-workspace (static) get the 06:00 UTC scheduled runs; Keeper ran once (manual), Supabase ran once (manual).

## Fix (mirrors the existing AWS server-delegation)
- **Discovery** — the orchestrator now reads dynamic task-mappings straight from the DB (`DynamicCheck.taskMapping` / `isEnabled`) via `resolveProviderChecks`. Static providers still resolve from the code manifest and win when both exist.
- **Execution** — the worker and auto-run-on-connect delegate dynamic providers to the API server (`runChecksOnServer` → the already provider-agnostic `ConnectionCheckRunnerService`), where the dynamic manifest is loaded. `shouldRunOnServer = aws || (no local manifest && active dynamic)`. A truly unknown provider still early-returns instead of crashing.

**Static integrations and AWS are unchanged** — the in-process path only runs when a manifest is present. Also fixes scheduled auto-run-on-connect for dynamic providers.

## Why it's safe (no regression to working behavior)
- Static + AWS paths are byte-identical no-ops (`runOnServer` only adds a branch).
- Manual-run path is untouched.
- Risk audit of every `api_key`/`basic` dynamic integration platform-wide: only `coda`/`pinecone` have ever run successfully — both provably safe (a successful run proves the credential resolves under the same lookup the server runner uses). Everything else has never run. `custom`/`oauth2` (incl. Keeper/Supabase) are byte-identical to the proven manual path.
- Load when enabled: ~2,775 server check-calls/day — trivial; no concurrency cap added (a task-level cap would have throttled AWS, which shares the worker).

## Tests
- New `dynamic-provider.spec.ts` (`shouldRunOnServer` + `isActiveDynamicProvider`) and `resolveProviderChecks` cases.
- `cd apps/api && npx jest src/trigger/integration-platform` → 5 suites / 21 tests pass.
- API typecheck: changed files clean (pre-existing `main`-RED errors unrelated: smithy dedup + framework-editor spec drift).

## Follow-up (not in this PR)
Scheduled employee sync (`sync-employees-schedule.ts:64`) has the identical `getManifest` gate for dynamic providers — separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missed daily runs for dynamic (DB-backed) integrations by reading their checks from the DB and delegating execution to the API server when no local manifest exists. Static integrations and AWS are unchanged; manual runs are unaffected.

- **Bug Fixes**
  - Discovery: Orchestrator uses `resolveProviderChecks` to fall back to DB-backed `dynamicIntegration.checks` (enabled only) when `getManifest` is missing; static manifests win.
  - Routing: Worker and auto-run use `shouldRunOnServer` to delegate when `aws` or (no manifest + active dynamic) and call `runChecksOnServer`; unknown providers no-op.
  - Credentials/vars: Skip Trigger-side credential preflight only for delegated runs; in-process path keeps token refresh and required-variable checks.
  - Error handling: Server-run transport failures are recorded as per-check errors (with retry gating) instead of aborting the task; in-process behavior unchanged.
  - Tests/hygiene: Added `dynamic-provider.spec.ts` and `resolveProviderChecks` tests; unanchored `.gitignore` rules for `dbq_*.js` and `*.csv`.

<sup>Written for commit c4f56a19cdd250903cc1d012c4d19944b9d39de6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

