### PR TITLE
fix(auth): grant admin role portal permission to submit evidence forms (CS-550)

### DIFF
--- a/apps/api/src/training/permissions-regression.spec.ts
+++ b/apps/api/src/training/permissions-regression.spec.ts
@@ -195,8 +195,10 @@ describe('Built-in role permissions — regression', () => {
       );
     });
 
-    it('should NOT have portal permissions', () => {
-      expect(perms.portal).toBeUndefined();
+    it('should have portal read/update', () => {
+      expect(perms.portal).toEqual(
+        expect.arrayContaining(['read', 'update']),
+      );
     });
 
     it('should have pentest create/read/delete', () => {

--- a/apps/api/src/training/portal-access.spec.ts
+++ b/apps/api/src/training/portal-access.spec.ts
@@ -93,7 +93,10 @@ describe('Portal access matrix', () => {
       ['employee'],
       ['contractor'],
       ['owner'],
+      ['admin'],
       ['admin,employee'],
+      ['admin,member'],
+      ['admin,auditor'],
       ['owner,employee'],
       ['employee,contractor'],
     ])('%s → ALLOW', (roleString) => {
@@ -102,24 +105,24 @@ describe('Portal access matrix', () => {
   });
 
   describe('roles that should NOT have portal access', () => {
-    it.each([
-      ['admin'],
-      ['auditor'],
-      ['member'],
-      ['admin,member'],
-      ['admin,auditor'],
-      [''],
-    ])('%s → DENY', (roleString) => {
-      expect(hasPortalAccessForBuiltInRoles(roleString)).toBe(false);
-    });
+    it.each([['auditor'], ['member'], ['']])(
+      '%s → DENY',
+      (roleString) => {
+        expect(hasPortalAccessForBuiltInRoles(roleString)).toBe(false);
+      },
+    );
   });
 
   describe('portal access relies on RBAC, not role names', () => {
-    it('admin gets portal access only through the employee role', () => {
-      expect(BUILT_IN_ROLE_PERMISSIONS.admin?.portal).toBeUndefined();
-      expect(BUILT_IN_ROLE_PERMISSIONS.employee?.portal).toEqual(
+    it('admin has portal access through its own permissions', () => {
+      expect(BUILT_IN_ROLE_PERMISSIONS.admin?.portal).toEqual(
         expect.arrayContaining(['read', 'update']),
       );
+    });
+
+    it('auditor is denied portal access by RBAC, not by role name', () => {
+      expect(BUILT_IN_ROLE_PERMISSIONS.auditor?.portal).toBeUndefined();
+      expect(BUILT_IN_ROLE_OBLIGATIONS.auditor?.compliance).toBeFalsy();
     });
 
     it('admin does not have compliance obligation', () => {

--- a/packages/auth/src/permissions.ts
+++ b/packages/auth/src/permissions.ts
@@ -125,6 +125,9 @@ export const admin = ac.newRole({
   pentest: ['create', 'read', 'update', 'delete'],
   // Training management
   training: ['read', 'update'],
+  // Portal self-service — admins manage GRC evidence, so they need to submit
+  // evidence forms (portal:update) just like owners do.
+  portal: ['read', 'update'],
   // Secrets manager — admin can fully manage decrypted credentials
   secret: ['create', 'read', 'update', 'delete'],
 });


### PR DESCRIPTION
## CS-550 — Admin "Access Denied" submitting evidence forms

**Customer:** Andy (Admin role), org `org_69f4840d4ad2bbaf04849942`. Workaround applied (granted Employee role) — can be removed after this ships.

### Problem
An Admin-role user gets **"Access Denied"** submitting an evidence form (e.g. Risk Committee Meeting at `/documents/risk-committee-meeting/new`). An Owner submits the same form fine. Granting the **Employee** role also fixed it.

### Root cause
The evidence-form submit/upload/my-submissions endpoints are gated on **`portal:update`** (`apps/api/src/evidence-forms/evidence-forms.controller.ts` lines 98, 117, 200, 272) — deliberately, so **employees can self-submit evidence from the portal** (`apps/portal` calls these exact endpoints; commit `3c96a1d4b`).

But the built-in **`admin` role had no `portal` statement at all** (`packages/auth/src/permissions.ts`). `owner`, `employee`, and `contractor` all had `portal:['read','update']`; `admin` and `auditor` did not. The `PermissionGuard` authorizes session users via better-auth's in-memory role definitions, so a missing statement → `authorize()` fails → 403.

That precisely matches the symptom: Owner (has `portal`) works; adding Employee (has `portal`) works; Admin alone → denied.

### Why not re-gate the endpoint to `evidence`?
Employees only have `portal` permissions, not `evidence`. Re-gating to `evidence` would **break the employee self-service submission flow**. The correct fix is at the role layer: give Admin `portal`, mirroring Owner (Admin = Owner minus `organization:delete`).

### Change
- `packages/auth/src/permissions.ts` — add `portal: ['read', 'update']` to the **admin** role.
- **Auditor intentionally left unchanged** (read-only by design — auditors shouldn't submit evidence).
- Updated the two specs that encoded the old "admins get portal only via the employee role" policy (`permissions-regression.spec.ts`, `portal-access.spec.ts`).

### ⚠️ Intended side effect
A pure-admin user can now **log into the employee portal** (`apps/portal/src/utils/portal-access.ts` keys off `portal?.length`) — same capability Owner already had. **Invite-email behavior is unchanged** (it keys off the compliance *obligation*, which admin still lacks → admin obligation stays `{}`).

### Verification
Proven against the **built `@trycompai/auth` dist running real better-auth** (the exact mechanism the guard uses):
- `admin.authorize({ portal: ['update'] }).success === true` ✅ (admin can now submit)
- `auditor.authorize({ portal: ['update'] }).success === false` ✅ (still blocked)
- owner / employee unchanged ✅
- `@trycompai/auth` typecheck clean; `apps/api` typecheck adds **no new errors** in touched files.

> **Reviewer note — pre-existing test infra:** the two guarding specs currently **fail to *load* on `main` too** (`SyntaxError: Cannot use import statement outside a module` from `better-auth/.../access/index.mjs` — a jest/ESM mock-resolution issue, unrelated to this change). I verified behavior via the built dist instead, which exercises real `authorize()` rather than a mocked stub. Worth a separate fix to the jest `better-auth` ESM handling.

### Deploy notes
- `@trycompai/auth` is a tsc-built package consumed by `apps/api` at runtime — needs a rebuild + API restart (CI/turbo builds deps first, so the prod artifact picks it up automatically).
- **No DB migration / re-seed / re-login** — built-in role permissions are evaluated in-memory.
- After deploy, the Employee-role workaround on Andy's account can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes “Access Denied” for Admins submitting evidence forms by giving the `admin` role `portal: ['read','update']`. Aligns Admin with Owner while keeping Auditor read-only (CS-550).

- **Bug Fixes**
  - Added `portal: ['read','update']` to `admin` in `packages/auth/src/permissions.ts` so Admins can use endpoints gated by `portal:update`.
  - Updated expectations in `apps/api/src/training/permissions-regression.spec.ts` and `apps/api/src/training/portal-access.spec.ts`.
  - Impact: Admins can now access the employee portal; invite emails remain unchanged (no compliance obligation). No DB changes. Rebuild `@trycompai/auth` and restart API. Remove the Employee-role workaround for Andy (`org_69f4840d4ad2bbaf04849942`).

<sup>Written for commit 3386bb260a232b7c830d141935299fa6c0cb26d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

