### PR TITLE
fix(risk): stop AI mitigation from reopening user-closed risks

### DIFF
--- a/apps/app/src/trigger/tasks/onboarding/generate-risk-mitigation.test.ts
+++ b/apps/app/src/trigger/tasks/onboarding/generate-risk-mitigation.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// generate-risk-mitigation.ts calls task()/queue() at import time and pulls in
+// the Prisma client, axios, and onboarding helpers. Mock those so we can import
+// and unit-test the pure buildMitigationDefaultWrites helper in isolation.
+vi.mock('@trigger.dev/sdk', () => ({
+  task: vi.fn((config) => config),
+  queue: vi.fn((config) => config),
+  tags: { add: vi.fn() },
+  metadata: { set: vi.fn(), increment: vi.fn(), decrement: vi.fn() },
+  tasks: { trigger: vi.fn(), batchTriggerAndWait: vi.fn() },
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock('@db/server', () => ({
+  db: {},
+  Prisma: {},
+  RiskStatus: { open: 'open', pending: 'pending', closed: 'closed', archived: 'archived' },
+}));
+vi.mock('axios', () => ({ default: { post: vi.fn() } }));
+vi.mock('./onboard-organization-helpers', () => ({
+  createRiskMitigationComment: vi.fn(),
+  findCommentAuthor: vi.fn(),
+}));
+
+import { buildMitigationDefaultWrites } from './generate-risk-mitigation';
+
+describe('buildMitigationDefaultWrites', () => {
+  const riskId = 'rsk_1';
+  const organizationId = 'org_1';
+
+  it('promotes a still-open risk to pending, scoped to status: open', () => {
+    const writes = buildMitigationDefaultWrites({ riskId, organizationId });
+
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toEqual({
+      where: { id: riskId, organizationId, status: 'open' },
+      data: { status: 'pending' },
+    });
+  });
+
+  it('never issues an unconditional status write — the where-clause must constrain status to open so an async re-run (Regenerate / task-unlink) cannot reopen a user-closed risk', () => {
+    const writes = buildMitigationDefaultWrites({ riskId, organizationId, authorId: 'mem_1' });
+
+    for (const write of writes) {
+      const data = write.data as { status?: string };
+      if (data.status === 'pending') {
+        expect(write.where).toMatchObject({ status: 'open' });
+      }
+    }
+  });
+
+  it('assigns the author only when the risk is still unassigned', () => {
+    const writes = buildMitigationDefaultWrites({ riskId, organizationId, authorId: 'mem_1' });
+
+    expect(writes).toHaveLength(2);
+    expect(writes[1]).toEqual({
+      where: { id: riskId, organizationId, assigneeId: null },
+      data: { assigneeId: 'mem_1' },
+    });
+  });
+
+  it('skips the assignee write entirely on the task-unlink path (no author)', () => {
+    const writes = buildMitigationDefaultWrites({ riskId, organizationId });
+
+    expect(writes.some((w) => 'assigneeId' in (w.data as object))).toBe(false);
+  });
+});

--- a/apps/app/src/trigger/tasks/onboarding/generate-risk-mitigation.ts
+++ b/apps/app/src/trigger/tasks/onboarding/generate-risk-mitigation.ts
@@ -1,4 +1,4 @@
-import { RiskStatus, db } from '@db/server';
+import { Prisma, RiskStatus, db } from '@db/server';
 import { logger, metadata, queue, tags, task, tasks } from '@trigger.dev/sdk';
 import axios from 'axios';
 import {
@@ -10,6 +10,48 @@ import {
 // Queues
 const riskMitigationQueue = queue({ name: 'risk-mitigations', concurrencyLimit: 50 });
 const riskMitigationFanoutQueue = queue({ name: 'risk-mitigations-fanout', concurrencyLimit: 50 });
+
+/**
+ * Builds the "apply onboarding defaults" writes for a risk after a mitigation
+ * plan is drafted, WITHOUT clobbering a user-managed risk.
+ *
+ * generateRiskMitigation re-runs on EXISTING risks — via the "Regenerate"
+ * button and via task-unlink (refreshTreatmentPlan) — and those runs land
+ * asynchronously AFTER the user may have changed the risk. An unconditional
+ * write here silently reopened risks the user had closed ("I mark a risk
+ * closed and it comes back as pending"). So each write is scoped:
+ *  - status: promote only a still-default `open` risk to `pending` (the AI
+ *    drafted a plan that needs review). Never downgrade a user-set
+ *    pending/closed/archived.
+ *  - assigneeId: assign the author only when the risk is still unassigned —
+ *    don't reassign a risk the user has already given an owner.
+ *
+ * The status/assignee where-clauses also keep this correct against a race
+ * where the user edits the risk while this async job is in flight.
+ */
+export function buildMitigationDefaultWrites(params: {
+  riskId: string;
+  organizationId: string;
+  authorId?: string;
+}): Prisma.RiskUpdateManyArgs[] {
+  const { riskId, organizationId, authorId } = params;
+
+  const writes: Prisma.RiskUpdateManyArgs[] = [
+    {
+      where: { id: riskId, organizationId, status: RiskStatus.open },
+      data: { status: RiskStatus.pending },
+    },
+  ];
+
+  if (authorId) {
+    writes.push({
+      where: { id: riskId, organizationId, assigneeId: null },
+      data: { assigneeId: authorId },
+    });
+  }
+
+  return writes;
+}
 
 export const generateRiskMitigation = task({
   id: 'generate-risk-mitigation',
@@ -42,17 +84,16 @@ export const generateRiskMitigation = task({
 
     await createRiskMitigationComment(risk, policies, organizationId, authorId ?? '');
 
-    // Mark risk as PENDING (not closed) — the AI drafted a plan but the
-    // user still needs to review it. Closing on the user's behalf would
-    // skip review and feel automated-away. Reassign to owner/admin only
-    // if we have one.
-    await db.risk.update({
-      where: { id: risk.id, organizationId },
-      data: {
-        status: RiskStatus.pending,
-        ...(authorId ? { assigneeId: authorId } : {}),
-      },
-    });
+    // Apply onboarding defaults without clobbering a user-managed risk — the
+    // AI drafted a plan, but the user owns the status/assignee. See
+    // buildMitigationDefaultWrites for why each write is scoped.
+    for (const write of buildMitigationDefaultWrites({
+      riskId: risk.id,
+      organizationId,
+      authorId,
+    })) {
+      await db.risk.updateMany(write);
+    }
 
     // Mark as completed after mitigation is done
     // Update root onboarding task metadata if available


### PR DESCRIPTION
## Problem
A user sets a Risk's **Status = Closed** and Saves, but it reverts to **Pending** (it reappears under the "Pending" filter in the Risks list). Reported via CS (customer: Joe Farrell's org).

## Root cause
The `generate-risk-mitigation` Trigger.dev task (`apps/app/src/trigger/tasks/onboarding/generate-risk-mitigation.ts`) **unconditionally wrote `status: pending`** (and reassigned `assigneeId`) on the risk every time it ran — the comment even said *"Mark risk as PENDING (not closed)"*.

That's correct for **onboarding** (fresh AI-drafted plan → pending review), but the same task **re-runs against existing, user-managed risks** via two paths:
1. **"Regenerate" mitigation button** → `POST /api/risks/[riskId]/regenerate-mitigation`
2. **Unlinking a task from a risk** → `DELETE /api/risks/[riskId]/tasks/[taskId]` fires fire-and-forget `refreshTreatmentPlan()`

Both run **asynchronously** through Trigger.dev, so they land **after** the user's synchronous PATCH save and silently overwrite `Closed → Pending` (and, on the Regenerate path, reassign the risk away from the user's chosen owner).

### How this was confirmed (4 parallel investigations)
- The PATCH save path itself is fully correct (DTO validates `status`, service persists it, `resolveStrategyDescriptionUpdate` returns `{}`). ✅
- The list filter queries the real DB `status` column, so a risk under "Pending" genuinely has `status='pending'` in the DB — i.e. the close was overwritten, not a stale cache. ✅
- No cron/scheduled job and no raw SQL resets risk status; the only writer of `pending` to an existing risk is this task. ✅
- Current code is deployed (v3.83.8); not a regression-needs-deploy and not a display/derivation bug. ✅

## Fix
Extract `buildMitigationDefaultWrites`, which scopes each write so the task only applies onboarding **defaults** and never clobbers a user-managed risk:
- **status**: promote only a still-default `open` risk to `pending` (`where: { status: open }`). Never downgrade a user-set `pending`/`closed`/`archived`.
- **assigneeId**: assign the author only when the risk is still unassigned (`where: { assigneeId: null }`).

The status/assignee `where`-clauses also make this **race-safe** if the user edits the risk while the async job is in flight. **Onboarding behavior is unchanged** — baseline risks are created `open`/unassigned, so they still become `pending` and get the author. Adds unit tests for the helper.

## Testing
- `apps/app/src/trigger/tasks/onboarding/generate-risk-mitigation.test.ts` — 4 passing tests (promote-open-only, never-unconditional-status-write, assign-only-if-unassigned, skip-assignee-without-author).
- `@trycompai/app` typecheck: no new errors in touched files (pre-existing unrelated errors remain).

## Customer remediation after deploy
No data migration needed. Risks that already reverted are currently `pending` in the DB — the customer just **re-closes** them once this ships, and now it sticks (even if they later Regenerate or unlink a task).
**Pre-deploy workaround:** avoid clicking "Regenerate" or unlinking tasks on a risk you've closed.

## Note (not fixed here)
Minor UX foot-gun: after Save, `UpdateRiskOverview` doesn't `reset()` the RHF form or refetch the single risk in place, so the dropdown keeps showing the just-picked value until the next 5s poll/navigation. Separate, low-priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop mitigation generation from reopening user-closed risks. The task now applies onboarding defaults only when the risk is still open and unassigned.

- **Bug Fixes**
  - Introduced `buildMitigationDefaultWrites` to scope updates via `updateMany` with precise `where` clauses.
  - Status: promote `open` → `pending` only; never change `pending`, `closed`, or `archived`.
  - Assignee: set to author only when `assigneeId` is `null`. Added unit tests; onboarding behavior unchanged.

<sup>Written for commit 9c16aaaf33f1eb74eeb9de438a2b4ae4dff0bd0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

