### PR TITLE
feat(integrations): Separation of Environments checks for GCP, AWS & Azure

### DIFF
--- a/packages/integration-platform/src/manifests/__tests__/environment-classification.test.ts
+++ b/packages/integration-platform/src/manifests/__tests__/environment-classification.test.ts
@@ -51,7 +51,15 @@ describe('classifyEnvironment — token-exact matching', () => {
 describe('envTagValues — only env-key tags, case-insensitive', () => {
   it('reads environment-indicating keys regardless of case', () => {
     expect(envTagValues({ Environment: 'production' })).toEqual(['production']);
-    expect(envTagValues({ env: 'prod', stage: 'dev' }).sort()).toEqual(['dev', 'prod']);
+  });
+
+  it('returns values in env-key PRIORITY order, not tag insertion order', () => {
+    // `environment` outranks `stage` even though `stage` is inserted first.
+    expect(envTagValues({ stage: 'dev', environment: 'prod' })).toEqual(['prod', 'dev']);
+    // so the authoritative key wins classification
+    expect(classifyEnvironment(envTagValues({ stage: 'dev', environment: 'prod' }))).toBe(
+      'production',
+    );
   });
 
   it('ignores non-environment tags (false-positive guard)', () => {

--- a/packages/integration-platform/src/manifests/__tests__/environment-classification.test.ts
+++ b/packages/integration-platform/src/manifests/__tests__/environment-classification.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  classifyEnvironment,
+  envTagValues,
+} from '../environment-classification';
+
+describe('classifyEnvironment — token-exact matching', () => {
+  it('classifies common environment tokens', () => {
+    expect(classifyEnvironment(['myapp-prod'])).toBe('production');
+    expect(classifyEnvironment(['web-staging'])).toBe('staging');
+    expect(classifyEnvironment(['svc-dev'])).toBe('development');
+    expect(classifyEnvironment(['api-qa'])).toBe('test');
+    expect(classifyEnvironment(['demo'])).toBe('sandbox');
+  });
+
+  it('handles ANY separator including underscore (the bug the reviewer caught)', () => {
+    expect(classifyEnvironment(['myapp_prod'])).toBe('production');
+    expect(classifyEnvironment(['prod_network'])).toBe('production');
+    expect(classifyEnvironment(['dev_network'])).toBe('development');
+    expect(classifyEnvironment(['myapp.prod'])).toBe('production');
+    expect(classifyEnvironment(['rg/staging'])).toBe('staging');
+  });
+
+  it('does NOT false-match substrings (product/developer/etc.)', () => {
+    expect(classifyEnvironment(['product-catalog'])).toBeNull();
+    expect(classifyEnvironment(['developer-portal'])).toBeNull();
+    expect(classifyEnvironment(['data-warehouse'])).toBeNull();
+    expect(classifyEnvironment(['prod123'])).toBeNull(); // not a clean token
+  });
+
+  it('treats preprod as staging, not production', () => {
+    expect(classifyEnvironment(['app-preprod'])).toBe('staging');
+    expect(classifyEnvironment(['preprod'])).toBe('staging');
+  });
+
+  it('is case-insensitive and skips empty/undefined candidates', () => {
+    expect(classifyEnvironment(['PROD'])).toBe('production');
+    expect(classifyEnvironment([undefined, '', 'svc-dev'])).toBe('development');
+  });
+
+  it('returns the first matching candidate (authoritative source first)', () => {
+    // an explicit env value passed first wins over a later name
+    expect(classifyEnvironment(['production', 'thing-dev'])).toBe('production');
+  });
+
+  it('returns null when nothing matches', () => {
+    expect(classifyEnvironment(['backend', 'frontend', 'vpc-0abc'])).toBeNull();
+  });
+});
+
+describe('envTagValues — only env-key tags, case-insensitive', () => {
+  it('reads environment-indicating keys regardless of case', () => {
+    expect(envTagValues({ Environment: 'production' })).toEqual(['production']);
+    expect(envTagValues({ env: 'prod', stage: 'dev' }).sort()).toEqual(['dev', 'prod']);
+  });
+
+  it('ignores non-environment tags (false-positive guard)', () => {
+    expect(envTagValues({ team: 'dev-team', costCenter: 'prod-123' })).toEqual([]);
+  });
+
+  it('returns [] for undefined tags', () => {
+    expect(envTagValues(undefined)).toEqual([]);
+  });
+});

--- a/packages/integration-platform/src/manifests/aws/checks/__tests__/aws-checks.test.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/__tests__/aws-checks.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from 'bun:test';
 import { evaluateCloudTrail } from '../cloudtrail';
 import { evaluateSecurityGroups } from '../ec2';
 import {
+  classifyVpcEnv,
+  evaluateEnvironmentSeparation,
+} from '../environment-separation';
+import {
   evaluateAccountSummary,
   evaluateIamAccount,
   evaluatePasswordPolicy,
@@ -951,5 +955,54 @@ describe('account-level findings carry AWS account attribution (cubic finding on
       error: 'assume failed for test',
     });
     expect(failed[0]!.description).toContain('AWS account 123456789012');
+  });
+});
+
+describe('AWS environment separation', () => {
+  it('classifyVpcEnv: env tag wins, then Name tag, incl. underscore', () => {
+    expect(classifyVpcEnv([{ Key: 'Environment', Value: 'production' }])).toBe('production');
+    expect(classifyVpcEnv([{ Key: 'Name', Value: 'prod-vpc' }])).toBe('production');
+    expect(classifyVpcEnv([{ Key: 'Name', Value: 'vpc_dev' }])).toBe('development');
+  });
+
+  it('classifyVpcEnv: ignores non-env tags (no fabricated environment)', () => {
+    expect(classifyVpcEnv([{ Key: 'team', Value: 'dev-team' }])).toBeNull();
+    expect(classifyVpcEnv(undefined)).toBeNull();
+  });
+
+  it('passes when >=2 environments are found, without claiming cross-account isolation', () => {
+    const out = evaluateEnvironmentSeparation([
+      { vpcId: 'vpc-1', region: 'us-east-1', environment: 'production' },
+      { vpcId: 'vpc-2', region: 'us-east-1', environment: 'development' },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.kind).toBe('pass');
+    expect(out[0]!.description).toMatch(/not cross-account isolation/);
+  });
+
+  it('fails (low) with guidance when only one environment is detected', () => {
+    const out = evaluateEnvironmentSeparation([
+      { vpcId: 'vpc-1', region: 'us-east-1', environment: 'production' },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.kind).toBe('fail');
+    expect(out[0]!.severity).toBe('low');
+    expect(out[0]!.remediation).toMatch(/separate AWS account per environment/);
+  });
+
+  it('fails when no VPC can be classified', () => {
+    const out = evaluateEnvironmentSeparation([
+      { vpcId: 'vpc-1', region: 'us-east-1', environment: null },
+      { vpcId: 'vpc-2', region: 'us-east-1', environment: null },
+    ]);
+    expect(out[0]!.kind).toBe('fail');
+  });
+
+  it('fails (low) with guidance when there are no non-default VPCs', () => {
+    const out = evaluateEnvironmentSeparation([]);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.kind).toBe('fail');
+    expect(out[0]!.severity).toBe('low');
+    expect(out[0]!.evidence).toMatchObject({ vpcCount: 0 });
   });
 });

--- a/packages/integration-platform/src/manifests/aws/checks/environment-separation.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/environment-separation.ts
@@ -1,0 +1,217 @@
+import { DescribeVpcsCommand, EC2Client } from '@aws-sdk/client-ec2';
+import { TASK_TEMPLATES } from '../../../task-mappings';
+import type { CheckContext, IntegrationCheck } from '../../../types';
+import {
+  classifyEnvironment,
+  envTagValues,
+} from '../../environment-classification';
+import {
+  combineReadFailures,
+  emitOutcomes,
+  remediationForReadFailure,
+  resolveAwsSessionOrFail,
+  toReadFailure,
+  type CheckOutcome,
+  type ReadFailure,
+} from './shared';
+
+export interface VpcInfo {
+  vpcId: string;
+  region: string;
+  environment: string | null;
+}
+
+// Shown on every "could not confirm" outcome. AWS's recommended separation is a
+// separate ACCOUNT per environment, which is invisible from one connection (one
+// account's role), so a single-account result is the EXPECTED shape for those
+// customers — guide, never accuse.
+const ACCOUNT_GUIDANCE =
+  'If you separate environments using a separate AWS account per environment (the recommended pattern), connect each environment account as its own connection — this check evaluates one account at a time. Otherwise separate prod/non-prod into distinct VPCs and tag each (Environment=production / Environment=staging), or upload an architecture diagram as evidence.';
+
+/**
+ * Classify a VPC into an environment from its tags: an explicit `environment`
+ * tag value first, then the `Name` tag value. Only env-key tag values and the
+ * Name tag are considered — arbitrary tag values are NOT scanned, so a stray
+ * `team=dev-team` tag can't fabricate a second environment.
+ */
+export function classifyVpcEnv(
+  tags: ReadonlyArray<{ Key?: string; Value?: string }> | undefined,
+): string | null {
+  const tagMap: Record<string, string> = {};
+  for (const t of tags ?? []) {
+    if (typeof t.Key === 'string' && typeof t.Value === 'string') {
+      tagMap[t.Key] = t.Value;
+    }
+  }
+  const nameTag = Object.entries(tagMap).find(
+    ([k]) => k.toLowerCase() === 'name',
+  )?.[1];
+  return classifyEnvironment([...envTagValues(tagMap), nameTag]);
+}
+
+/**
+ * Pure verdict from the account's non-default VPCs. PASS only when >=2 distinct
+ * environments are positively observed; otherwise fail-with-guidance (never a
+ * silent pass). The PASS wording is deliberately scoped to "within a single
+ * AWS account" — two environment-labeled VPCs prove network labeling, not
+ * cross-account isolation (they can be peered / share the account boundary).
+ */
+export function evaluateEnvironmentSeparation(vpcs: VpcInfo[]): CheckOutcome[] {
+  const sample = vpcs.slice(0, 50).map((v) => ({
+    vpcId: v.vpcId,
+    region: v.region,
+    environment: v.environment ?? 'unclassified',
+  }));
+
+  if (vpcs.length === 0) {
+    return [
+      {
+        kind: 'fail',
+        title: 'Could not confirm environment separation',
+        description:
+          'No non-default VPCs were found in this AWS account, so environment separation could not be evaluated here.',
+        resourceType: 'aws-environment-separation',
+        resourceId: 'vpcs',
+        severity: 'low',
+        remediation: ACCOUNT_GUIDANCE,
+        evidence: { vpcCount: 0 },
+      },
+    ];
+  }
+
+  const detected = [
+    ...new Set(
+      vpcs.map((v) => v.environment).filter((e): e is string => e !== null),
+    ),
+  ];
+
+  if (detected.length >= 2) {
+    return [
+      {
+        kind: 'pass',
+        title: 'Distinct environment-labeled VPCs found',
+        description: `Detected ${detected.length} distinct environments across non-default VPCs in this AWS account: ${detected.join(', ')}. This evidences environment-labeled network separation within a single account (not cross-account isolation).`,
+        resourceType: 'aws-environment-separation',
+        resourceId: 'vpcs',
+        evidence: {
+          detectedEnvironments: detected,
+          vpcCount: vpcs.length,
+          vpcs: sample,
+        },
+      },
+    ];
+  }
+
+  return [
+    {
+      kind: 'fail',
+      title: 'Could not confirm environment separation',
+      description:
+        detected.length === 1
+          ? `Only one environment ("${detected[0]}") was detected among this account's VPCs; this connection evaluates a single AWS account.`
+          : "No VPC in this account could be classified by environment, so environment separation could not be confirmed.",
+      resourceType: 'aws-environment-separation',
+      resourceId: 'vpcs',
+      severity: 'low',
+      remediation: ACCOUNT_GUIDANCE,
+      evidence: {
+        detectedEnvironments: detected,
+        vpcCount: vpcs.length,
+        vpcs: sample,
+      },
+    },
+  ];
+}
+
+/**
+ * Separation of Environments check (heuristic, within-account). Lists every
+ * non-default VPC across the account's regions, classifies each by its
+ * Environment/Name tag, and passes when >=2 distinct environments are found.
+ * Account-per-environment separation is invisible from one connection (no
+ * Organizations access), so a single-environment account fails with guidance to
+ * connect each env account or upload a diagram — the task accepts manual
+ * evidence either way.
+ */
+export const environmentSeparationCheck: IntegrationCheck = {
+  id: 'aws-environment-separation',
+  name: 'Separation of environments — production isolated from non-production',
+  description:
+    'Verify production and non-production workloads run in distinct VPCs within the AWS account.',
+  service: 'ec2-vpc',
+  taskMapping: TASK_TEMPLATES.separationOfEnvironments,
+  run: async (ctx: CheckContext) => {
+    const session = await resolveAwsSessionOrFail(ctx);
+    if (!session) {
+      ctx.log(
+        'AWS environment-separation check: connection not configured — skipping',
+      );
+      return;
+    }
+
+    const vpcs: VpcInfo[] = [];
+    const regionFailures: Array<{ region: string; failure: ReadFailure }> = [];
+
+    for (const region of session.regions) {
+      try {
+        const ec2 = new EC2Client({
+          region,
+          credentials: session.credentials,
+          maxAttempts: 5,
+        });
+        let token: string | undefined;
+        do {
+          const resp = await ec2.send(
+            new DescribeVpcsCommand({ NextToken: token, MaxResults: 1000 }),
+          );
+          for (const v of resp.Vpcs ?? []) {
+            // Default VPCs ship in every region (usually untagged) and would
+            // pollute the signal; only evaluate available, non-default VPCs.
+            if (v.IsDefault === true) continue;
+            if (v.State && v.State !== 'available') continue;
+            vpcs.push({
+              vpcId: v.VpcId ?? 'unknown',
+              region,
+              environment: classifyVpcEnv(v.Tags),
+            });
+          }
+          token = resp.NextToken;
+        } while (token);
+      } catch (err) {
+        const failure = toReadFailure(err);
+        regionFailures.push({ region, failure });
+        ctx.log(`VPC: could not list VPCs in ${region}: ${failure.error}`);
+      }
+    }
+
+    // A region we couldn't read is unverified — surface it instead of letting a
+    // partial read failure end as a silent verdict.
+    if (regionFailures.length > 0) {
+      const regions = regionFailures.map((r) => r.region);
+      emitOutcomes(ctx, [
+        {
+          kind: 'fail',
+          title: 'Could not verify VPCs in some regions',
+          description: `VPCs could not be listed in: ${regions.join(', ')}, so environment separation is unverified in those regions.`,
+          resourceType: 'aws-environment-separation',
+          resourceId: `regions:${regions.join(',')}`,
+          severity: 'medium',
+          remediation: remediationForReadFailure(
+            combineReadFailures(regionFailures.map((r) => r.failure)),
+            'Grant ec2:DescribeVpcs to the integration role in all enabled regions, then re-run the check.',
+          ),
+          evidence: {
+            failedRegions: regionFailures.map((r) => ({
+              region: r.region,
+              error: r.failure.error,
+            })),
+          },
+        },
+      ]);
+      // If we also found zero VPCs, the unverified-region finding already tells
+      // the story — don't add a misleading "no VPCs" verdict on unread data.
+      if (vpcs.length === 0) return;
+    }
+
+    emitOutcomes(ctx, evaluateEnvironmentSeparation(vpcs));
+  },
+};

--- a/packages/integration-platform/src/manifests/aws/checks/index.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/index.ts
@@ -4,3 +4,4 @@ export { ec2SecurityGroupsCheck } from './ec2';
 export { rdsEncryptionCheck, rdsBackupsCheck } from './rds';
 export { kmsKeyRotationCheck } from './kms';
 export { cloudTrailEnabledCheck } from './cloudtrail';
+export { environmentSeparationCheck } from './environment-separation';

--- a/packages/integration-platform/src/manifests/aws/index.ts
+++ b/packages/integration-platform/src/manifests/aws/index.ts
@@ -2,6 +2,7 @@ import type { IntegrationManifest } from '../../types';
 import {
   cloudTrailEnabledCheck,
   ec2SecurityGroupsCheck,
+  environmentSeparationCheck,
   iamAccountSecurityCheck,
   kmsKeyRotationCheck,
   rdsBackupsCheck,
@@ -100,5 +101,6 @@ export const awsManifest: IntegrationManifest = {
     rdsBackupsCheck,
     kmsKeyRotationCheck,
     cloudTrailEnabledCheck,
+    environmentSeparationCheck,
   ],
 };

--- a/packages/integration-platform/src/manifests/azure/checks/__tests__/azure-checks.test.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/__tests__/azure-checks.test.ts
@@ -996,4 +996,26 @@ describe('Azure environment separation', () => {
     expect(passed).toHaveLength(0);
     expect(failed.some((f) => /Could not verify environment separation/.test(f.title))).toBe(true);
   });
+
+  it('surfaces the subscription scan cap as explicit coverage info (no silent truncation)', async () => {
+    // 60 enabled subscriptions, none env-named, no classifiable resource groups
+    // → unconfirmed, and the >50 RG-scan cap must be disclosed.
+    const subs = Array.from({ length: 60 }, (_, i) => ({
+      subscriptionId: `s${i}`,
+      state: 'Enabled',
+      displayName: `Company-${i}`,
+    }));
+    const { passed, failed } = await run(
+      environmentSeparationCheck,
+      envSepFetch({ subs, rgs: {} }),
+    );
+    expect(passed).toHaveLength(0);
+    expect(failed).toHaveLength(1);
+    expect(failed[0]!.title).toMatch(/Could not verify environment separation/);
+    expect(failed[0]!.remediation).toMatch(/Reduce to at most 50 enabled subscriptions/);
+    expect(failed[0]!.evidence).toMatchObject({
+      enabledSubscriptions: 60,
+      subscriptionsScannedForResourceGroups: 50,
+    });
+  });
 });

--- a/packages/integration-platform/src/manifests/azure/checks/__tests__/azure-checks.test.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/__tests__/azure-checks.test.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../../../types';
 import { azureManifest } from '../../index';
 import { rbacLeastPrivilegeCheck } from '../entra-id';
+import { environmentSeparationCheck } from '../environment-separation';
 import { keyVaultProtectionCheck, keyVaultRbacCheck } from '../key-vault';
 import { monitorLoggingAlertingCheck } from '../monitor';
 import {
@@ -894,5 +895,105 @@ describe('azure subscription picker fetchOptions', () => {
     } as unknown as Parameters<NonNullable<typeof variable.fetchOptions>>[0];
     const options = await variable!.fetchOptions!(ctx);
     expect(options).toEqual([]);
+  });
+});
+
+describe('Azure environment separation', () => {
+  const envSepFetch =
+    (opts: { subs: unknown[]; rgs?: Record<string, unknown[]> }) =>
+    (url: string) => {
+      if (url.includes('/subscriptions?api-version')) return { value: opts.subs };
+      const m = url.match(/\/subscriptions\/([^/]+)\/resourcegroups/);
+      if (m) return { value: opts.rgs?.[m[1]!] ?? [] };
+      return {};
+    };
+
+  it('passes (strong) when >=2 subscriptions classify to distinct environments', async () => {
+    const { passed, failed } = await run(
+      environmentSeparationCheck,
+      envSepFetch({
+        subs: [
+          { subscriptionId: 's1', state: 'Enabled', displayName: 'Production' },
+          { subscriptionId: 's2', state: 'Enabled', displayName: 'Development' },
+        ],
+      }),
+    );
+    expect(failed).toHaveLength(0);
+    expect(passed).toContain('Environments separated across subscriptions');
+  });
+
+  it('passes (weak) on resource-group separation, disclosed as logical', async () => {
+    const { passed, failed } = await run(
+      environmentSeparationCheck,
+      envSepFetch({
+        subs: [{ subscriptionId: 's1', state: 'Enabled', displayName: 'MyCompany' }],
+        rgs: {
+          s1: [
+            { id: 'a', name: 'rg-prod' },
+            { id: 'b', name: 'rg-dev' },
+          ],
+        },
+      }),
+    );
+    expect(failed).toHaveLength(0);
+    expect(passed).toContain('Environments separated across resource groups');
+  });
+
+  it('passes on resource-group tags (case-insensitive key)', async () => {
+    const { passed } = await run(
+      environmentSeparationCheck,
+      envSepFetch({
+        subs: [{ subscriptionId: 's1', state: 'Enabled', displayName: 'Company' }],
+        rgs: {
+          s1: [
+            { id: 'a', name: 'a', tags: { environment: 'production' } },
+            { id: 'b', name: 'b', tags: { Environment: 'staging' } },
+          ],
+        },
+      }),
+    );
+    expect(passed).toContain('Environments separated across resource groups');
+  });
+
+  it('does NOT union tiers: a prod subscription with an rg-dev inside fails', async () => {
+    const { passed, failed } = await run(
+      environmentSeparationCheck,
+      envSepFetch({
+        subs: [{ subscriptionId: 's1', state: 'Enabled', displayName: 'Production' }],
+        rgs: { s1: [{ id: 'a', name: 'rg-dev' }] },
+      }),
+    );
+    expect(passed).toHaveLength(0);
+    expect(failed.some((f) => /Could not confirm environment separation/.test(f.title))).toBe(true);
+  });
+
+  it('fails with guidance when nothing classifies', async () => {
+    const { passed, failed } = await run(
+      environmentSeparationCheck,
+      envSepFetch({
+        subs: [{ subscriptionId: 's1', state: 'Enabled', displayName: 'Company' }],
+        rgs: { s1: [{ id: 'a', name: 'backend' }] },
+      }),
+    );
+    expect(passed).toHaveLength(0);
+    expect(failed).toHaveLength(1);
+    expect(failed[0]!.remediation).toMatch(/distinct subscriptions/);
+  });
+
+  it('fails when no enabled subscriptions are visible', async () => {
+    const { failed } = await run(
+      environmentSeparationCheck,
+      envSepFetch({ subs: [{ subscriptionId: 's1', state: 'Disabled', displayName: 'Old' }] }),
+    );
+    expect(failed.some((f) => /No Azure subscriptions detected/.test(f.title))).toBe(true);
+  });
+
+  it('fails "could not verify" when the subscription list read fails', async () => {
+    const { passed, failed } = await run(environmentSeparationCheck, (url) => {
+      if (url.includes('/subscriptions?api-version')) throw new Error('HTTP 403: Forbidden');
+      return {};
+    });
+    expect(passed).toHaveLength(0);
+    expect(failed.some((f) => /Could not verify environment separation/.test(f.title))).toBe(true);
   });
 });

--- a/packages/integration-platform/src/manifests/azure/checks/environment-separation.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/environment-separation.ts
@@ -124,8 +124,12 @@ export const environmentSeparationCheck: IntegrationCheck = {
       return;
     }
 
-    // Tier 2 (weak, logical): resource-group-level separation across the footprint.
+    // Tier 2 (weak, logical): resource-group-level separation across the
+    // footprint. The RG fan-out is bounded (one list call per subscription);
+    // a footprint larger than the cap is surfaced as incomplete coverage below,
+    // never silently dropped.
     const boundedSubs = subscriptions.slice(0, MAX_SUBSCRIPTIONS);
+    const truncated = subscriptions.length > boundedSubs.length;
     const rgEnvSet = new Set<string>();
     const rgSamples: Array<{ name: string; environment: string }> = [];
     let anyRgReadFailed = false;
@@ -152,6 +156,10 @@ export const environmentSeparationCheck: IntegrationCheck = {
       }
     }
     const resourceGroupEnvs = [...rgEnvSet];
+    // A PASS means >=2 environments were positively found; scanning the
+    // remaining subscriptions could only ADD environments, never remove the two
+    // we already have, so truncation cannot invalidate a pass. The scanned count
+    // is still recorded in evidence for transparency.
     if (resourceGroupEnvs.length >= 2) {
       ctx.pass({
         title: 'Environments separated across resource groups',
@@ -161,32 +169,51 @@ export const environmentSeparationCheck: IntegrationCheck = {
         evidence: {
           boundary: 'resource-group',
           detectedEnvironments: resourceGroupEnvs,
-          subscriptionCount: boundedSubs.length,
+          enabledSubscriptions: subscriptions.length,
+          subscriptionsScannedForResourceGroups: boundedSubs.length,
           resourceGroups: rgSamples,
         },
       });
       return;
     }
 
-    // Neither tier confirmed separation.
+    // Neither tier confirmed separation. Surface any incomplete coverage (read
+    // failures and/or the subscription scan cap) so the verdict is never
+    // presented as if it covered the whole footprint.
     const detectedAll = [...new Set([...subscriptionEnvs, ...resourceGroupEnvs])];
+    const coverageGaps: string[] = [];
+    if (truncated) {
+      coverageGaps.push(
+        `only ${boundedSubs.length} of ${subscriptions.length} enabled subscriptions were scanned for resource groups`,
+      );
+    }
+    if (anyRgReadFailed) {
+      coverageGaps.push('some resource groups could not be read');
+    }
+    const base =
+      detectedAll.length === 0
+        ? `No Azure subscription or resource group could be classified by environment across ${subscriptions.length} subscription(s)`
+        : `Environment(s) detected (${detectedAll.join(', ')}) but not 2+ distinct environments at a single boundary (subscriptions, or resource groups)`;
     ctx.fail({
+      // Incomplete coverage that leaves us short of a verdict is "could not
+      // verify"; a complete scan that simply found no separation is "could not
+      // confirm".
       title:
-        anyRgReadFailed && detectedAll.length < 2
+        coverageGaps.length > 0 && detectedAll.length < 2
           ? 'Could not verify environment separation'
           : 'Could not confirm environment separation',
-      description:
-        detectedAll.length === 0
-          ? `No Azure subscription or resource group could be classified by environment across ${subscriptions.length} subscription(s)${anyRgReadFailed ? ' (some resource groups could not be read)' : ''}, so environment separation could not be confirmed.`
-          : `Environment(s) detected (${detectedAll.join(', ')}) but not 2+ distinct environments at a single boundary (subscriptions, or resource groups), so environment separation could not be confirmed.`,
+      description: `${base}${coverageGaps.length ? ` (${coverageGaps.join('; ')})` : ''}, so environment separation could not be confirmed.`,
       resourceType: 'azure-environment-separation',
       resourceId: 'subscriptions',
       severity: 'medium',
-      remediation: GUIDANCE,
+      remediation: truncated
+        ? `Reduce to at most ${MAX_SUBSCRIPTIONS} enabled subscriptions (or contact support to raise the limit). ${GUIDANCE}`
+        : GUIDANCE,
       evidence: {
         subscriptionEnvironments: subscriptionEnvs,
         resourceGroupEnvironments: resourceGroupEnvs,
-        subscriptionCount: subscriptions.length,
+        enabledSubscriptions: subscriptions.length,
+        subscriptionsScannedForResourceGroups: boundedSubs.length,
         resourceGroupsClassified: rgSamples.length,
       },
     });

--- a/packages/integration-platform/src/manifests/azure/checks/environment-separation.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/environment-separation.ts
@@ -1,0 +1,194 @@
+import { TASK_TEMPLATES } from '../../../task-mappings';
+import type { CheckContext, IntegrationCheck } from '../../../types';
+import {
+  classifyEnvironment,
+  envTagValues,
+} from '../../environment-classification';
+import { remediationForReadFailure, toHttpReadFailure } from '../../http-read-failure';
+import { ARM_BASE, armListAll } from './shared';
+
+const SUBSCRIPTIONS_API_VERSION = '2020-01-01';
+const RESOURCE_GROUPS_API_VERSION = '2021-04-01';
+// Bound the resource-group fan-out (one list call per subscription).
+const MAX_SUBSCRIPTIONS = 50;
+
+interface Subscription {
+  subscriptionId: string;
+  displayName?: string;
+  state?: string;
+}
+
+interface ResourceGroup {
+  id: string;
+  name: string;
+  location?: string;
+  tags?: Record<string, string>;
+}
+
+/**
+ * Classify a resource group into an environment: an explicit `environment` tag
+ * value first, then the RG name. Only env-key tag values and the name are
+ * considered (never arbitrary tag values).
+ */
+export function classifyResourceGroupEnv(rg: {
+  name: string;
+  tags?: Record<string, string>;
+}): string | null {
+  return classifyEnvironment([...envTagValues(rg.tags), rg.name]);
+}
+
+const GUIDANCE =
+  'Separate production and non-production into distinct subscriptions (strongest), or tag each resource group with an `environment` tag (e.g. environment=production / environment=staging). If you separate environments another way, upload a console screenshot or architecture diagram as evidence.';
+
+/**
+ * Separation of Environments check (heuristic). Evaluates the whole footprint in
+ * two tiers, in safety order:
+ *  1) Subscriptions — a real isolation/RBAC/billing boundary. If >=2 enabled
+ *     subscriptions classify into distinct environments → PASS (strong).
+ *  2) Resource groups — the most commonly env-named primitive, but only a
+ *     LOGICAL container (shares the subscription's access/network). If >=2
+ *     distinct environments across RGs → PASS, explicitly disclosed as logical.
+ * Tiers are NOT unioned: a single prod subscription containing an `rg-dev`
+ * resource group must not be mistaken for separation. Anything else fails with
+ * guidance; the task accepts manual evidence.
+ */
+export const environmentSeparationCheck: IntegrationCheck = {
+  id: 'azure-environment-separation',
+  name: 'Separation of environments — production isolated from non-production',
+  description:
+    'Verify production and non-production are separated across Azure subscriptions or resource groups.',
+  service: 'policy',
+  taskMapping: TASK_TEMPLATES.separationOfEnvironments,
+  run: async (ctx: CheckContext) => {
+    // Footprint-wide: list ALL enabled subscriptions directly (separation is a
+    // whole-footprint property, so this intentionally ignores subscription
+    // scoping the way the GCP check ignores project scoping).
+    let subscriptions: Subscription[];
+    try {
+      const data = await ctx.fetch<{ value?: Subscription[] }>(
+        `${ARM_BASE}/subscriptions?api-version=${SUBSCRIPTIONS_API_VERSION}`,
+      );
+      subscriptions = (data.value ?? []).filter((s) => s.state === 'Enabled');
+    } catch (err) {
+      const failure = toHttpReadFailure(err);
+      ctx.fail({
+        title: 'Could not verify environment separation',
+        description: `Azure subscriptions could not be listed (${failure.error}), so environment separation could not be evaluated.`,
+        resourceType: 'azure-environment-separation',
+        resourceId: 'subscriptions',
+        severity: 'medium',
+        remediation: remediationForReadFailure(
+          failure,
+          'Grant the connection Reader access to the subscription(s), then re-run the check.',
+        ),
+        evidence: { readError: failure.error },
+      });
+      return;
+    }
+
+    if (subscriptions.length === 0) {
+      ctx.fail({
+        title: 'No Azure subscriptions detected',
+        description:
+          'No enabled Azure subscriptions were accessible, so environment separation could not be evaluated.',
+        resourceType: 'azure-environment-separation',
+        resourceId: 'subscriptions',
+        severity: 'medium',
+        remediation:
+          'Grant the connection Reader access to your subscriptions, then re-run — or upload a console screenshot / architecture diagram as evidence.',
+        evidence: { subscriptionCount: 0 },
+      });
+      return;
+    }
+
+    // Tier 1 (strong): subscription-level separation.
+    const subscriptionEnvs = [
+      ...new Set(
+        subscriptions
+          .map((s) => classifyEnvironment([s.displayName]))
+          .filter((e): e is string => e !== null),
+      ),
+    ];
+    if (subscriptionEnvs.length >= 2) {
+      ctx.pass({
+        title: 'Environments separated across subscriptions',
+        description: `Detected ${subscriptionEnvs.length} distinct environments across ${subscriptions.length} Azure subscriptions: ${subscriptionEnvs.join(', ')} (subscription-level boundary).`,
+        resourceType: 'azure-environment-separation',
+        resourceId: 'subscriptions',
+        evidence: {
+          boundary: 'subscription',
+          detectedEnvironments: subscriptionEnvs,
+          subscriptionCount: subscriptions.length,
+        },
+      });
+      return;
+    }
+
+    // Tier 2 (weak, logical): resource-group-level separation across the footprint.
+    const boundedSubs = subscriptions.slice(0, MAX_SUBSCRIPTIONS);
+    const rgEnvSet = new Set<string>();
+    const rgSamples: Array<{ name: string; environment: string }> = [];
+    let anyRgReadFailed = false;
+    for (const sub of boundedSubs) {
+      let resourceGroups: ResourceGroup[];
+      try {
+        resourceGroups = await armListAll<ResourceGroup>(
+          ctx,
+          `${ARM_BASE}/subscriptions/${sub.subscriptionId}/resourcegroups?api-version=${RESOURCE_GROUPS_API_VERSION}`,
+        );
+      } catch (err) {
+        anyRgReadFailed = true;
+        ctx.log(
+          `Azure env-separation: could not list resource groups in ${sub.subscriptionId} — ${toHttpReadFailure(err).error}`,
+        );
+        continue;
+      }
+      for (const rg of resourceGroups) {
+        const env = classifyResourceGroupEnv(rg);
+        if (env) {
+          rgEnvSet.add(env);
+          if (rgSamples.length < 50) rgSamples.push({ name: rg.name, environment: env });
+        }
+      }
+    }
+    const resourceGroupEnvs = [...rgEnvSet];
+    if (resourceGroupEnvs.length >= 2) {
+      ctx.pass({
+        title: 'Environments separated across resource groups',
+        description: `Detected ${resourceGroupEnvs.length} distinct environments across resource groups in ${boundedSubs.length} subscription(s): ${resourceGroupEnvs.join(', ')}. Resource-group separation is logical — RGs share the subscription's access and network boundary — not full isolation.`,
+        resourceType: 'azure-environment-separation',
+        resourceId: 'resource-groups',
+        evidence: {
+          boundary: 'resource-group',
+          detectedEnvironments: resourceGroupEnvs,
+          subscriptionCount: boundedSubs.length,
+          resourceGroups: rgSamples,
+        },
+      });
+      return;
+    }
+
+    // Neither tier confirmed separation.
+    const detectedAll = [...new Set([...subscriptionEnvs, ...resourceGroupEnvs])];
+    ctx.fail({
+      title:
+        anyRgReadFailed && detectedAll.length < 2
+          ? 'Could not verify environment separation'
+          : 'Could not confirm environment separation',
+      description:
+        detectedAll.length === 0
+          ? `No Azure subscription or resource group could be classified by environment across ${subscriptions.length} subscription(s)${anyRgReadFailed ? ' (some resource groups could not be read)' : ''}, so environment separation could not be confirmed.`
+          : `Environment(s) detected (${detectedAll.join(', ')}) but not 2+ distinct environments at a single boundary (subscriptions, or resource groups), so environment separation could not be confirmed.`,
+      resourceType: 'azure-environment-separation',
+      resourceId: 'subscriptions',
+      severity: 'medium',
+      remediation: GUIDANCE,
+      evidence: {
+        subscriptionEnvironments: subscriptionEnvs,
+        resourceGroupEnvironments: resourceGroupEnvs,
+        subscriptionCount: subscriptions.length,
+        resourceGroupsClassified: rgSamples.length,
+      },
+    });
+  },
+};

--- a/packages/integration-platform/src/manifests/azure/checks/index.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/index.ts
@@ -10,3 +10,4 @@ export { keyVaultProtectionCheck, keyVaultRbacCheck } from './key-vault';
 export { nsgNoOpenPortsCheck } from './network';
 export { rbacLeastPrivilegeCheck } from './entra-id';
 export { monitorLoggingAlertingCheck } from './monitor';
+export { environmentSeparationCheck } from './environment-separation';

--- a/packages/integration-platform/src/manifests/azure/index.ts
+++ b/packages/integration-platform/src/manifests/azure/index.ts
@@ -1,5 +1,6 @@
 import type { IntegrationManifest } from '../../types';
 import {
+  environmentSeparationCheck,
   keyVaultProtectionCheck,
   keyVaultRbacCheck,
   monitorLoggingAlertingCheck,
@@ -176,5 +177,6 @@ Our integration only makes read-only API calls for security scanning.`,
     nsgNoOpenPortsCheck,
     rbacLeastPrivilegeCheck,
     monitorLoggingAlertingCheck,
+    environmentSeparationCheck,
   ],
 };

--- a/packages/integration-platform/src/manifests/environment-classification.ts
+++ b/packages/integration-platform/src/manifests/environment-classification.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared environment classification for "Separation of Environments" checks
+ * across cloud manifests (GCP projects, AWS VPCs, Azure subscriptions/resource
+ * groups). Kept here — alongside `http-read-failure` — because all three cloud
+ * manifests need the identical, well-tested logic.
+ *
+ * Matching is TOKEN-EXACT, not substring: a candidate string is split on any
+ * run of non-alphanumeric characters (`-`, `_`, `.`, `/`, spaces) and each
+ * token is compared exactly to a set of environment keywords. This is why
+ * "production"/"product" and "dev"/"developer" never collide, and why separator
+ * style doesn't matter (`myapp-prod`, `myapp_prod`, `myapp.prod` all classify).
+ */
+
+const ENV_TOKEN_SETS: ReadonlyArray<{ env: string; tokens: ReadonlySet<string> }> = [
+  // Production is first so it wins ties when a string carries multiple tokens.
+  { env: 'production', tokens: new Set(['prod', 'production', 'prd', 'live']) },
+  { env: 'staging', tokens: new Set(['staging', 'stage', 'stg', 'preprod', 'uat']) },
+  { env: 'development', tokens: new Set(['dev', 'develop', 'development']) },
+  { env: 'test', tokens: new Set(['test', 'testing', 'qa']) },
+  { env: 'sandbox', tokens: new Set(['sandbox', 'sbx', 'demo']) },
+];
+
+/** Default tag/label keys that conventionally carry the environment. */
+export const ENV_TAG_KEYS = ['environment', 'env', 'stage', 'tier'] as const;
+
+/** Split on any run of non-alphanumeric chars; lowercased, empties removed. */
+function tokenize(value: string): string[] {
+  return value
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length > 0);
+}
+
+/**
+ * Classify a list of candidate strings (e.g. an environment tag/label value,
+ * then a resource name) into a canonical environment, or null if none match.
+ * Candidates are tried in order, so callers should pass the most authoritative
+ * source (explicit env tag/label value) before the resource name.
+ */
+export function classifyEnvironment(
+  candidates: ReadonlyArray<string | undefined>,
+): string | null {
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const tokens = tokenize(candidate);
+    for (const { env, tokens: keywords } of ENV_TOKEN_SETS) {
+      if (tokens.some((t) => keywords.has(t))) return env;
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract the values of environment-indicating tag/label keys from a tag map.
+ * Key matching is case-insensitive (Azure/AWS tag keys vary in casing). Only
+ * the configured env keys are read — arbitrary tag values are deliberately NOT
+ * scanned, so a stray `team=dev-team` tag can't fabricate an environment.
+ */
+export function envTagValues(
+  tags: Record<string, string> | undefined,
+  keys: ReadonlyArray<string> = ENV_TAG_KEYS,
+): string[] {
+  if (!tags) return [];
+  const wanted = new Set(keys.map((k) => k.toLowerCase()));
+  return Object.entries(tags)
+    .filter(([k]) => wanted.has(k.toLowerCase()))
+    .map(([, v]) => v)
+    .filter((v): v is string => typeof v === 'string' && v.length > 0);
+}

--- a/packages/integration-platform/src/manifests/environment-classification.ts
+++ b/packages/integration-platform/src/manifests/environment-classification.ts
@@ -61,9 +61,13 @@ export function envTagValues(
   keys: ReadonlyArray<string> = ENV_TAG_KEYS,
 ): string[] {
   if (!tags) return [];
-  const wanted = new Set(keys.map((k) => k.toLowerCase()));
-  return Object.entries(tags)
-    .filter(([k]) => wanted.has(k.toLowerCase()))
-    .map(([, v]) => v)
+  // Iterate the configured keys in PRIORITY order (not the tag map's insertion
+  // order) so a more authoritative key (`environment`) is returned before a
+  // less authoritative one (`stage`) — `classifyEnvironment` trusts order.
+  const normalized = new Map(
+    Object.entries(tags).map(([k, v]) => [k.toLowerCase(), v]),
+  );
+  return keys
+    .map((k) => normalized.get(k.toLowerCase()))
     .filter((v): v is string => typeof v === 'string' && v.length > 0);
 }

--- a/packages/integration-platform/src/manifests/gcp/checks/__tests__/gcp-checks.test.ts
+++ b/packages/integration-platform/src/manifests/gcp/checks/__tests__/gcp-checks.test.ts
@@ -8,6 +8,10 @@ import { cloudMonitoringAlertingCheck } from '../cloud-monitoring-alerting';
 import { cloudSqlBackupsCheck } from '../cloud-sql-backups';
 import { cloudSqlEncryptionCheck } from '../cloud-sql-encryption';
 import { cloudSqlSslCheck } from '../cloud-sql-ssl';
+import {
+  classifyProjectEnv,
+  environmentSeparationCheck,
+} from '../environment-separation';
 import { iamPrimitiveRolesCheck } from '../iam-primitive-roles';
 import { storageEncryptionCheck } from '../storage-encryption';
 import { storagePublicAccessCheck } from '../storage-public-access';
@@ -881,5 +885,120 @@ describe('GCP Cloud SQL encryption check', () => {
     expect(out.passed).toHaveLength(0);
     expect(out.failed).toHaveLength(1);
     expect(out.failed[0]!.title).toMatch(/Could not verify Cloud SQL encryption/);
+  });
+});
+
+describe('classifyProjectEnv — token matching', () => {
+  it('classifies by name token', () => {
+    expect(classifyProjectEnv({ projectId: 'myapp-prod' })).toBe('production');
+    expect(classifyProjectEnv({ projectId: 'myapp-dev-123' })).toBe('development');
+    expect(classifyProjectEnv({ projectId: 'web-staging' })).toBe('staging');
+  });
+
+  it('prefers an explicit environment label over the name', () => {
+    expect(
+      classifyProjectEnv({ projectId: 'proj-001', labels: { environment: 'production' } }),
+    ).toBe('production');
+    expect(
+      classifyProjectEnv({ projectId: 'proj-002', labels: { env: 'qa' } }),
+    ).toBe('test');
+  });
+
+  it('does NOT false-match substrings like product/developer', () => {
+    expect(classifyProjectEnv({ projectId: 'product-catalog' })).toBeNull();
+    expect(classifyProjectEnv({ projectId: 'developer-portal' })).toBeNull();
+    expect(classifyProjectEnv({ projectId: 'data-warehouse' })).toBeNull();
+  });
+
+  it('treats preprod as staging, not production', () => {
+    expect(classifyProjectEnv({ projectId: 'app-preprod' })).toBe('staging');
+  });
+});
+
+describe('GCP environment-separation check', () => {
+  const status = (err: Error, code: number) => {
+    (err as Error & { status: number }).status = code;
+    return err;
+  };
+
+  it('passes when ≥2 distinct environments are detected by name', async () => {
+    const out = await runCheck(environmentSeparationCheck, {
+      fetch: () => ({
+        projects: [{ projectId: 'myapp-prod' }, { projectId: 'myapp-dev' }],
+      }),
+    });
+    expect(out.failed).toHaveLength(0);
+    expect(out.passed).toHaveLength(1);
+    expect(out.passed[0]!.title).toMatch(/Environments separated/);
+    expect(out.passed[0]!.evidence).toMatchObject({
+      detectedEnvironments: expect.arrayContaining(['production', 'development']),
+    });
+  });
+
+  it('passes when environments are distinguished by labels', async () => {
+    const out = await runCheck(environmentSeparationCheck, {
+      fetch: () => ({
+        projects: [
+          { projectId: 'a', labels: { environment: 'production' } },
+          { projectId: 'b', labels: { environment: 'staging' } },
+        ],
+      }),
+    });
+    expect(out.failed).toHaveLength(0);
+    expect(out.passed).toHaveLength(1);
+  });
+
+  it('evaluates projects across multiple pages', async () => {
+    const out = await runCheck(environmentSeparationCheck, {
+      fetch: (url) => {
+        if (url.includes('pageToken=tok2')) {
+          return { projects: [{ projectId: 'app-dev' }] };
+        }
+        return { projects: [{ projectId: 'app-prod' }], nextPageToken: 'tok2' };
+      },
+    });
+    expect(out.failed).toHaveLength(0);
+    expect(out.passed).toHaveLength(1);
+  });
+
+  it('fails with guidance when only one environment is present', async () => {
+    const out = await runCheck(environmentSeparationCheck, {
+      fetch: () => ({ projects: [{ projectId: 'myapp-prod' }] }),
+    });
+    expect(out.passed).toHaveLength(0);
+    expect(out.failed).toHaveLength(1);
+    expect(out.failed[0]!.title).toMatch(/Could not confirm environment separation/);
+    expect(out.failed[0]!.remediation).toMatch(/distinct GCP projects/);
+  });
+
+  it('fails with guidance when no project can be classified', async () => {
+    const out = await runCheck(environmentSeparationCheck, {
+      fetch: () => ({
+        projects: [{ projectId: 'product-catalog' }, { projectId: 'backend' }],
+      }),
+    });
+    expect(out.passed).toHaveLength(0);
+    expect(out.failed).toHaveLength(1);
+    expect(out.failed[0]!.title).toMatch(/Could not confirm environment separation/);
+  });
+
+  it('fails when no projects are accessible', async () => {
+    const out = await runCheck(environmentSeparationCheck, {
+      fetch: () => ({ projects: [] }),
+    });
+    expect(out.passed).toHaveLength(0);
+    expect(out.failed).toHaveLength(1);
+    expect(out.failed[0]!.title).toMatch(/No GCP projects detected/);
+  });
+
+  it('fails "could not verify" when the project list read fails', async () => {
+    const out = await runCheck(environmentSeparationCheck, {
+      fetch: () => {
+        throw status(new Error('HTTP 403: Forbidden'), 403);
+      },
+    });
+    expect(out.passed).toHaveLength(0);
+    expect(out.failed).toHaveLength(1);
+    expect(out.failed[0]!.title).toMatch(/Could not verify environment separation/);
   });
 });

--- a/packages/integration-platform/src/manifests/gcp/checks/__tests__/gcp-checks.test.ts
+++ b/packages/integration-platform/src/manifests/gcp/checks/__tests__/gcp-checks.test.ts
@@ -889,10 +889,11 @@ describe('GCP Cloud SQL encryption check', () => {
 });
 
 describe('classifyProjectEnv — token matching', () => {
-  it('classifies by name token', () => {
+  it('classifies by name token (any separator, incl. underscore)', () => {
     expect(classifyProjectEnv({ projectId: 'myapp-prod' })).toBe('production');
     expect(classifyProjectEnv({ projectId: 'myapp-dev-123' })).toBe('development');
     expect(classifyProjectEnv({ projectId: 'web-staging' })).toBe('staging');
+    expect(classifyProjectEnv({ projectId: 'myapp_prod' })).toBe('production');
   });
 
   it('prefers an explicit environment label over the name', () => {

--- a/packages/integration-platform/src/manifests/gcp/checks/environment-separation.ts
+++ b/packages/integration-platform/src/manifests/gcp/checks/environment-separation.ts
@@ -1,6 +1,10 @@
 import { TASK_TEMPLATES } from '../../../task-mappings';
 import type { CheckContext, IntegrationCheck } from '../../../types';
 import {
+  classifyEnvironment,
+  envTagValues,
+} from '../../environment-classification';
+import {
   remediationForReadFailure,
   toHttpReadFailure,
 } from '../../http-read-failure';
@@ -12,35 +16,18 @@ interface GcpProject {
 }
 
 /**
- * Environment classification by token. Production is listed first so it wins
- * when a string could match more than one bucket. Tokens are matched with word
- * boundaries (so "product"/"developer" do NOT match "prod"/"dev").
+ * Classify a project into an environment bucket, or null if undetermined.
+ * Explicit `environment`/`env` label values are most authoritative, then the
+ * project id / display name. Token matching (shared classifier) means
+ * "product"/"developer" do NOT match "prod"/"dev" and separator style
+ * (`-`/`_`/`.`) doesn't matter.
  */
-const ENV_PATTERNS: ReadonlyArray<{ env: string; re: RegExp }> = [
-  { env: 'production', re: /\b(prod|production|prd|live)\b/i },
-  { env: 'staging', re: /\b(staging|stage|stg|preprod|uat)\b/i },
-  { env: 'development', re: /\b(dev|develop|development)\b/i },
-  { env: 'test', re: /\b(test|testing|qa)\b/i },
-  { env: 'sandbox', re: /\b(sandbox|sbx|demo)\b/i },
-];
-
-// Label keys that conventionally carry the environment, checked before falling
-// back to the project name/id — an explicit label is more authoritative.
-const ENV_LABEL_KEYS = ['environment', 'env', 'stage', 'tier'] as const;
-
-/** Classify a project into an environment bucket, or null if undetermined. */
 export function classifyProjectEnv(project: GcpProject): string | null {
-  const labelValues = ENV_LABEL_KEYS.map((k) => project.labels?.[k]).filter(
-    (v): v is string => typeof v === 'string' && v.length > 0,
-  );
-  // Explicit env labels first, then the project id / display name.
-  const haystacks = [...labelValues, project.projectId, project.name ?? ''];
-  for (const haystack of haystacks) {
-    for (const { env, re } of ENV_PATTERNS) {
-      if (re.test(haystack)) return env;
-    }
-  }
-  return null;
+  return classifyEnvironment([
+    ...envTagValues(project.labels),
+    project.projectId,
+    project.name,
+  ]);
 }
 
 /** List every active project the connection can see (bounded pagination). */

--- a/packages/integration-platform/src/manifests/gcp/checks/environment-separation.ts
+++ b/packages/integration-platform/src/manifests/gcp/checks/environment-separation.ts
@@ -1,0 +1,188 @@
+import { TASK_TEMPLATES } from '../../../task-mappings';
+import type { CheckContext, IntegrationCheck } from '../../../types';
+import {
+  remediationForReadFailure,
+  toHttpReadFailure,
+} from '../../http-read-failure';
+
+interface GcpProject {
+  projectId: string;
+  name?: string;
+  labels?: Record<string, string>;
+}
+
+/**
+ * Environment classification by token. Production is listed first so it wins
+ * when a string could match more than one bucket. Tokens are matched with word
+ * boundaries (so "product"/"developer" do NOT match "prod"/"dev").
+ */
+const ENV_PATTERNS: ReadonlyArray<{ env: string; re: RegExp }> = [
+  { env: 'production', re: /\b(prod|production|prd|live)\b/i },
+  { env: 'staging', re: /\b(staging|stage|stg|preprod|uat)\b/i },
+  { env: 'development', re: /\b(dev|develop|development)\b/i },
+  { env: 'test', re: /\b(test|testing|qa)\b/i },
+  { env: 'sandbox', re: /\b(sandbox|sbx|demo)\b/i },
+];
+
+// Label keys that conventionally carry the environment, checked before falling
+// back to the project name/id — an explicit label is more authoritative.
+const ENV_LABEL_KEYS = ['environment', 'env', 'stage', 'tier'] as const;
+
+/** Classify a project into an environment bucket, or null if undetermined. */
+export function classifyProjectEnv(project: GcpProject): string | null {
+  const labelValues = ENV_LABEL_KEYS.map((k) => project.labels?.[k]).filter(
+    (v): v is string => typeof v === 'string' && v.length > 0,
+  );
+  // Explicit env labels first, then the project id / display name.
+  const haystacks = [...labelValues, project.projectId, project.name ?? ''];
+  for (const haystack of haystacks) {
+    for (const { env, re } of ENV_PATTERNS) {
+      if (re.test(haystack)) return env;
+    }
+  }
+  return null;
+}
+
+/** List every active project the connection can see (bounded pagination). */
+async function listActiveProjects(ctx: CheckContext): Promise<GcpProject[]> {
+  const projects: GcpProject[] = [];
+  let pageToken: string | undefined;
+  let pages = 0;
+  do {
+    const tokenParam = pageToken
+      ? `&pageToken=${encodeURIComponent(pageToken)}`
+      : '';
+    const data = await ctx.fetch<{
+      projects?: GcpProject[];
+      nextPageToken?: string;
+    }>(
+      `/v1/projects?filter=${encodeURIComponent('lifecycleState:ACTIVE')}&pageSize=100${tokenParam}`,
+    );
+    for (const p of data.projects ?? []) projects.push(p);
+    pageToken =
+      typeof data.nextPageToken === 'string' ? data.nextPageToken : undefined;
+    pages++;
+  } while (pageToken && pages < 20);
+  if (pageToken) {
+    ctx.warn(
+      'GCP project discovery hit the page cap; some projects may not be evaluated for environment separation',
+      { pages, discovered: projects.length },
+    );
+  }
+  return projects;
+}
+
+/**
+ * Separation of Environments check (heuristic). GCP's recommended pattern is a
+ * separate project per environment, so this infers separation from the project
+ * footprint: it classifies each accessible project into an environment (by
+ * `environment`/`env` label, else name/id token) and passes when TWO OR MORE
+ * distinct environments are present.
+ *
+ * It is intentionally evidence-first, not a hard gate: separation is an
+ * architectural property with no single API field, so when it cannot confirm
+ * separation it emits actionable guidance (label projects, or upload a diagram)
+ * rather than a silent pass. It evaluates ALL accessible projects regardless of
+ * the `project_ids` scoping variable, since separation is about the whole
+ * footprint.
+ */
+export const environmentSeparationCheck: IntegrationCheck = {
+  id: 'gcp-environment-separation',
+  name: 'Separation of environments — production isolated from non-production',
+  description:
+    'Verify production and non-production workloads are separated across distinct GCP projects.',
+  service: 'iam',
+  taskMapping: TASK_TEMPLATES.separationOfEnvironments,
+
+  run: async (ctx: CheckContext) => {
+    let projects: GcpProject[];
+    try {
+      projects = await listActiveProjects(ctx);
+    } catch (err) {
+      const failure = toHttpReadFailure(err);
+      ctx.fail({
+        title: 'Could not verify environment separation',
+        description: `GCP projects could not be listed (${failure.error}), so environment separation could not be evaluated.`,
+        resourceType: 'gcp-environment-separation',
+        resourceId: 'projects',
+        severity: 'medium',
+        remediation: remediationForReadFailure(
+          failure,
+          'Grant resourcemanager.projects.list (e.g. roles/viewer) to the connection, then re-run the check.',
+        ),
+        evidence: { readError: failure.error },
+      });
+      return;
+    }
+
+    if (projects.length === 0) {
+      ctx.fail({
+        title: 'No GCP projects detected',
+        description:
+          'No active GCP projects were accessible, so environment separation could not be evaluated.',
+        resourceType: 'gcp-environment-separation',
+        resourceId: 'projects',
+        severity: 'medium',
+        remediation:
+          'Grant resourcemanager.projects.list to the connection (or select projects in the integration settings), then re-run — or upload a console screenshot / architecture diagram as evidence of environment separation.',
+        evidence: { projectCount: 0 },
+      });
+      return;
+    }
+
+    const classified = projects.map((p) => ({
+      projectId: p.projectId,
+      environment: classifyProjectEnv(p),
+    }));
+    const detected = [
+      ...new Set(
+        classified
+          .map((c) => c.environment)
+          .filter((e): e is string => e !== null),
+      ),
+    ];
+
+    if (detected.length >= 2) {
+      ctx.pass({
+        title: 'Environments separated across projects',
+        description: `Detected ${detected.length} distinct environments across ${projects.length} GCP project(s): ${detected.join(', ')}.`,
+        resourceType: 'gcp-environment-separation',
+        resourceId: 'projects',
+        evidence: {
+          detectedEnvironments: detected,
+          projectCount: projects.length,
+          projects: classified
+            .slice(0, 50)
+            .map((c) => ({
+              projectId: c.projectId,
+              environment: c.environment ?? 'unclassified',
+            })),
+        },
+      });
+      return;
+    }
+
+    ctx.fail({
+      title: 'Could not confirm environment separation',
+      description:
+        detected.length === 1
+          ? `Only one environment ("${detected[0]}") was detected across ${projects.length} project(s); production and non-production do not appear to be separated into distinct projects.`
+          : `No GCP project could be classified by environment across ${projects.length} project(s), so environment separation could not be confirmed.`,
+      resourceType: 'gcp-environment-separation',
+      resourceId: 'projects',
+      severity: 'medium',
+      remediation:
+        'Separate production and non-production workloads into distinct GCP projects and label each with an `environment` label (e.g. environment=production, environment=staging). If you separate environments another way (e.g. VPCs or folders), upload a console screenshot or architecture diagram as evidence.',
+      evidence: {
+        detectedEnvironments: detected,
+        projectCount: projects.length,
+        projects: classified
+          .slice(0, 50)
+          .map((c) => ({
+            projectId: c.projectId,
+            environment: c.environment ?? 'unclassified',
+          })),
+      },
+    });
+  },
+};

--- a/packages/integration-platform/src/manifests/gcp/checks/index.ts
+++ b/packages/integration-platform/src/manifests/gcp/checks/index.ts
@@ -6,3 +6,4 @@ export { cloudSqlBackupsCheck } from './cloud-sql-backups';
 export { cloudMonitoringAlertingCheck } from './cloud-monitoring-alerting';
 export { storageEncryptionCheck } from './storage-encryption';
 export { cloudSqlEncryptionCheck } from './cloud-sql-encryption';
+export { environmentSeparationCheck } from './environment-separation';

--- a/packages/integration-platform/src/manifests/gcp/index.ts
+++ b/packages/integration-platform/src/manifests/gcp/index.ts
@@ -4,6 +4,7 @@ import {
   cloudSqlBackupsCheck,
   cloudSqlEncryptionCheck,
   cloudSqlSslCheck,
+  environmentSeparationCheck,
   iamPrimitiveRolesCheck,
   storageEncryptionCheck,
   storagePublicAccessCheck,
@@ -168,5 +169,6 @@ This is industry standard - all GCP security monitoring tools use the same scope
     cloudMonitoringAlertingCheck,
     storageEncryptionCheck,
     cloudSqlEncryptionCheck,
+    environmentSeparationCheck,
   ],
 };


### PR DESCRIPTION
## What & why

The **Separation of Environments** evidence task had **no check for any cloud provider**, so its integration picker was empty — a customer reported "can't even connect to any cloud provider (AWS, GCP, Azure)." This adds a check for all three so the task is automatable, plus a shared, well-tested environment classifier.

> Builds on the GCP Monitoring & Alerting + Encryption at Rest checks already merged to `main`. This PR is **only** the Separation of Environments work (clean branch off latest `main` — no unrelated/CHANGELOG churn).

## Approach (honest)

"Environments are separated" is an **architectural property**, not a single API field, so each check is a **heuristic** over the cloud's separation primitive. All checks are **evidence-first**: they PASS only on positive evidence of ≥2 environments, otherwise **fail with actionable guidance** (never a silent pass), and the task always accepts manual evidence (screenshot/diagram).

| Cloud | Primitive | Pass bar | Honesty constraint |
|---|---|---|---|
| **GCP** (`iam`) | Projects | ≥2 envs by `environment` label / name token | — |
| **AWS** (`ec2-vpc`) | Non-default VPCs across regions | ≥2 envs by Environment/Name tag | PASS scoped to "within a single account, **not** cross-account isolation"; account-per-env is invisible from one connection → single-account fails at **severity `low`** with guidance |
| **Azure** (`policy`) | Subscriptions, then resource groups | ≥2 envs **per tier (never unioned)** | RG-tier pass disclosed as "logical, not isolation"; subscription scan cap surfaced as explicit coverage info |

**Shared `manifests/environment-classification.ts`** — token-exact classification (split on any separator incl. `_`): `production`≠`product`, `dev`≠`developer`, and only env-key tag values are read (a stray `team=dev-team` can't fabricate an environment). Env-key values are returned in priority order so `environment` outranks `stage`.

## Safety (adversarially reviewed before coding)
Built via a research + adversarial-safety workflow, then two rounds of automated-review fixes: no substring false-matches, no arbitrary-tag scanning, no cross-tier union, no "isolation" overclaiming, read failures → "could not verify", and incomplete coverage (Azure subscription cap) surfaced rather than silently truncated.

## Runs on both paths
Same engine as the other cloud checks — verified to run identically on the **manual run-check** path and the **scheduled orchestrator** (GCP/Azure in-process on Trigger.dev calling public APIs; AWS via the existing session resolver).

## Tests
373 package tests pass (incl. shared-classifier underscore/preprod/product cases, AWS pure evaluators, Azure `run()` incl. the no-cross-tier-union + scan-cap cases). Typecheck + build green.

⚠️ Heuristic, **not yet live-tested against real AWS/Azure/GCP accounts** — mock-tested now; customer live run is the final validation. AWS's signal is the weakest (single-account limitation), hence it fails quietly (low severity) with guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Separation of Environments checks for GCP, AWS, and Azure, plus a shared, token-exact environment classifier, so the task is now automatable across all three clouds. Passes only on clear evidence of 2+ environments; otherwise fails with concise guidance.

- **New Features**
  - GCP: evaluates all active projects; classifies by `environment`/`env` labels or name tokens; passes on 2+ environments.
  - AWS: scans non-default, available VPCs across regions; classifies by `Environment`/`Name` tags; result scoped to a single account (not cross-account isolation).
  - Azure: two-tier evaluation — subscriptions (strong boundary) then resource groups (logical, disclosed); no cross-tier union.
  - Shared `manifests/environment-classification.ts`: token-exact matching with any separator (`-`, `_`, `.`, `/`); reads only env-key tags (`environment`, `env`, `stage`, `tier`) in priority order.

- **Bug Fixes**
  - Fixed underscore tokenization bug and removed substring false matches (e.g., “product” vs “prod”, “developer” vs “dev”).
  - Ensured env-tag priority so `environment` outranks `stage`/`tier`.
  - Surfaced Azure RG scan cap (50 subscriptions) and partial reads as “could not verify” with clear coverage evidence.

<sup>Written for commit 11696f9624111e2845d2c487ecee797f5232b124. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

