### PR TITLE
fix(integrations): env-separation review fixes — subscription scope, prod+non-prod pass bar, truncation

### DIFF
--- a/packages/integration-platform/src/manifests/__tests__/environment-classification.test.ts
+++ b/packages/integration-platform/src/manifests/__tests__/environment-classification.test.ts
@@ -1,8 +1,26 @@
 import { describe, expect, it } from 'bun:test';
 import {
   classifyEnvironment,
+  confirmsEnvironmentSeparation,
   envTagValues,
 } from '../environment-classification';
+
+describe('confirmsEnvironmentSeparation — requires prod + non-prod', () => {
+  it('passes only with production AND a non-production environment', () => {
+    expect(confirmsEnvironmentSeparation(['production', 'development'])).toBe(true);
+    expect(confirmsEnvironmentSeparation(['production', 'staging', 'test'])).toBe(true);
+  });
+
+  it('fails on two non-production environments (no production)', () => {
+    expect(confirmsEnvironmentSeparation(['development', 'staging'])).toBe(false);
+  });
+
+  it('fails on production alone, or a single environment, or none', () => {
+    expect(confirmsEnvironmentSeparation(['production'])).toBe(false);
+    expect(confirmsEnvironmentSeparation(['development'])).toBe(false);
+    expect(confirmsEnvironmentSeparation([])).toBe(false);
+  });
+});
 
 describe('classifyEnvironment — token-exact matching', () => {
   it('classifies common environment tokens', () => {

--- a/packages/integration-platform/src/manifests/aws/checks/__tests__/aws-checks.test.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/__tests__/aws-checks.test.ts
@@ -970,7 +970,7 @@ describe('AWS environment separation', () => {
     expect(classifyVpcEnv(undefined)).toBeNull();
   });
 
-  it('passes when >=2 environments are found, without claiming cross-account isolation', () => {
+  it('passes on production + non-production, without claiming cross-account isolation', () => {
     const out = evaluateEnvironmentSeparation([
       { vpcId: 'vpc-1', region: 'us-east-1', environment: 'production' },
       { vpcId: 'vpc-2', region: 'us-east-1', environment: 'development' },
@@ -978,6 +978,15 @@ describe('AWS environment separation', () => {
     expect(out).toHaveLength(1);
     expect(out[0]!.kind).toBe('pass');
     expect(out[0]!.description).toMatch(/not cross-account isolation/);
+  });
+
+  it('fails when only non-production environments are present (no production)', () => {
+    const out = evaluateEnvironmentSeparation([
+      { vpcId: 'vpc-1', region: 'us-east-1', environment: 'development' },
+      { vpcId: 'vpc-2', region: 'us-east-1', environment: 'staging' },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.kind).toBe('fail');
   });
 
   it('fails (low) with guidance when only one environment is detected', () => {

--- a/packages/integration-platform/src/manifests/aws/checks/environment-separation.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/environment-separation.ts
@@ -3,6 +3,7 @@ import { TASK_TEMPLATES } from '../../../task-mappings';
 import type { CheckContext, IntegrationCheck } from '../../../types';
 import {
   classifyEnvironment,
+  confirmsEnvironmentSeparation,
   envTagValues,
 } from '../../environment-classification';
 import {
@@ -50,11 +51,12 @@ export function classifyVpcEnv(
 }
 
 /**
- * Pure verdict from the account's non-default VPCs. PASS only when >=2 distinct
- * environments are positively observed; otherwise fail-with-guidance (never a
- * silent pass). The PASS wording is deliberately scoped to "within a single
- * AWS account" — two environment-labeled VPCs prove network labeling, not
- * cross-account isolation (they can be peered / share the account boundary).
+ * Pure verdict from the account's non-default VPCs. PASS only when a PRODUCTION
+ * environment is positively observed alongside at least one NON-PRODUCTION
+ * environment; otherwise fail-with-guidance (never a silent pass). The PASS
+ * wording is deliberately scoped to "within a single AWS account" — environment-
+ * labeled VPCs prove network labeling, not cross-account isolation (they can be
+ * peered / share the account boundary).
  */
 export function evaluateEnvironmentSeparation(vpcs: VpcInfo[]): CheckOutcome[] {
   const sample = vpcs.slice(0, 50).map((v) => ({
@@ -85,12 +87,15 @@ export function evaluateEnvironmentSeparation(vpcs: VpcInfo[]): CheckOutcome[] {
     ),
   ];
 
-  if (detected.length >= 2) {
+  // A confirmed pass requires a production environment separated from a
+  // non-production one — two non-production VPCs alone do not demonstrate that
+  // production is segregated.
+  if (confirmsEnvironmentSeparation(detected)) {
     return [
       {
         kind: 'pass',
         title: 'Distinct environment-labeled VPCs found',
-        description: `Detected ${detected.length} distinct environments across non-default VPCs in this AWS account: ${detected.join(', ')}. This evidences environment-labeled network separation within a single account (not cross-account isolation).`,
+        description: `Detected production separated from non-production across non-default VPCs in this AWS account: ${detected.join(', ')}. This evidences environment-labeled network separation within a single account (not cross-account isolation).`,
         resourceType: 'aws-environment-separation',
         resourceId: 'vpcs',
         evidence: {
@@ -107,9 +112,9 @@ export function evaluateEnvironmentSeparation(vpcs: VpcInfo[]): CheckOutcome[] {
       kind: 'fail',
       title: 'Could not confirm environment separation',
       description:
-        detected.length === 1
-          ? `Only one environment ("${detected[0]}") was detected among this account's VPCs; this connection evaluates a single AWS account.`
-          : "No VPC in this account could be classified by environment, so environment separation could not be confirmed.",
+        detected.length === 0
+          ? "No VPC in this account could be classified by environment, so environment separation could not be confirmed."
+          : `Detected environment(s) ${detected.join(', ')} among this account's VPCs, but could not confirm a production environment separated from a non-production one; this connection evaluates a single AWS account.`,
       resourceType: 'aws-environment-separation',
       resourceId: 'vpcs',
       severity: 'low',
@@ -126,7 +131,8 @@ export function evaluateEnvironmentSeparation(vpcs: VpcInfo[]): CheckOutcome[] {
 /**
  * Separation of Environments check (heuristic, within-account). Lists every
  * non-default VPC across the account's regions, classifies each by its
- * Environment/Name tag, and passes when >=2 distinct environments are found.
+ * Environment/Name tag, and passes when a production environment is found
+ * alongside at least one non-production environment.
  * Account-per-environment separation is invisible from one connection (no
  * Organizations access), so a single-environment account fails with guidance to
  * connect each env account or upload a diagram — the task accepts manual

--- a/packages/integration-platform/src/manifests/azure/checks/__tests__/azure-checks.test.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/__tests__/azure-checks.test.ts
@@ -899,24 +899,24 @@ describe('azure subscription picker fetchOptions', () => {
 });
 
 describe('Azure environment separation', () => {
-  const envSepFetch =
-    (opts: { subs: unknown[]; rgs?: Record<string, unknown[]> }) =>
+  // Mocks the IN-SCOPE per-subscription name GET and the per-subscription
+  // resource-group list. Scope is driven by the `variables` arg (subscription_id
+  // / subscription_ids) via resolveAzureSubscriptionIds — there is NO list-all.
+  const azFetch =
+    (opts: { names?: Record<string, string>; rgs?: Record<string, unknown[]> }) =>
     (url: string) => {
-      if (url.includes('/subscriptions?api-version')) return { value: opts.subs };
-      const m = url.match(/\/subscriptions\/([^/]+)\/resourcegroups/);
-      if (m) return { value: opts.rgs?.[m[1]!] ?? [] };
+      const subM = url.match(/\/subscriptions\/([^/?]+)\?api-version/);
+      if (subM) return { displayName: opts.names?.[subM[1]!] ?? subM[1]! };
+      const rgM = url.match(/\/subscriptions\/([^/]+)\/resourcegroups/);
+      if (rgM) return { value: opts.rgs?.[rgM[1]!] ?? [] };
       return {};
     };
 
-  it('passes (strong) when >=2 subscriptions classify to distinct environments', async () => {
+  it('passes (strong) when scoped subscriptions classify to prod + non-prod', async () => {
     const { passed, failed } = await run(
       environmentSeparationCheck,
-      envSepFetch({
-        subs: [
-          { subscriptionId: 's1', state: 'Enabled', displayName: 'Production' },
-          { subscriptionId: 's2', state: 'Enabled', displayName: 'Development' },
-        ],
-      }),
+      azFetch({ names: { s1: 'Production', s2: 'Development' } }),
+      { subscription_ids: ['s1', 's2'] },
     );
     expect(failed).toHaveLength(0);
     expect(passed).toContain('Environments separated across subscriptions');
@@ -925,14 +925,9 @@ describe('Azure environment separation', () => {
   it('passes (weak) on resource-group separation, disclosed as logical', async () => {
     const { passed, failed } = await run(
       environmentSeparationCheck,
-      envSepFetch({
-        subs: [{ subscriptionId: 's1', state: 'Enabled', displayName: 'MyCompany' }],
-        rgs: {
-          s1: [
-            { id: 'a', name: 'rg-prod' },
-            { id: 'b', name: 'rg-dev' },
-          ],
-        },
+      azFetch({
+        names: { 'sub-1': 'MyCompany' },
+        rgs: { 'sub-1': [{ id: 'a', name: 'rg-prod' }, { id: 'b', name: 'rg-dev' }] },
       }),
     );
     expect(failed).toHaveLength(0);
@@ -942,10 +937,10 @@ describe('Azure environment separation', () => {
   it('passes on resource-group tags (case-insensitive key)', async () => {
     const { passed } = await run(
       environmentSeparationCheck,
-      envSepFetch({
-        subs: [{ subscriptionId: 's1', state: 'Enabled', displayName: 'Company' }],
+      azFetch({
+        names: { 'sub-1': 'Company' },
         rgs: {
-          s1: [
+          'sub-1': [
             { id: 'a', name: 'a', tags: { environment: 'production' } },
             { id: 'b', name: 'b', tags: { Environment: 'staging' } },
           ],
@@ -955,67 +950,84 @@ describe('Azure environment separation', () => {
     expect(passed).toContain('Environments separated across resource groups');
   });
 
-  it('does NOT union tiers: a prod subscription with an rg-dev inside fails', async () => {
+  it('fails on two non-production environments (no production)', async () => {
     const { passed, failed } = await run(
       environmentSeparationCheck,
-      envSepFetch({
-        subs: [{ subscriptionId: 's1', state: 'Enabled', displayName: 'Production' }],
-        rgs: { s1: [{ id: 'a', name: 'rg-dev' }] },
+      azFetch({
+        names: { 'sub-1': 'Company' },
+        rgs: { 'sub-1': [{ id: 'a', name: 'rg-dev' }, { id: 'b', name: 'rg-staging' }] },
       }),
     );
     expect(passed).toHaveLength(0);
     expect(failed.some((f) => /Could not confirm environment separation/.test(f.title))).toBe(true);
   });
 
+  it('does NOT union tiers: prod subscription + an rg-dev inside fails', async () => {
+    const { passed, failed } = await run(
+      environmentSeparationCheck,
+      azFetch({ names: { s1: 'Production' }, rgs: { s1: [{ id: 'a', name: 'rg-dev' }] } }),
+      { subscription_ids: ['s1'] },
+    );
+    expect(passed).toHaveLength(0);
+    expect(failed.some((f) => /Could not confirm environment separation/.test(f.title))).toBe(true);
+  });
+
+  it('only scans the configured subscription scope', async () => {
+    // Scope is ['s1']; touching any other subscription must throw.
+    const { passed, failed } = await run(
+      environmentSeparationCheck,
+      (url) => {
+        if (!url.includes('/subscriptions/s1')) {
+          throw new Error(`out-of-scope access: ${url}`);
+        }
+        const subM = url.match(/\/subscriptions\/([^/?]+)\?api-version/);
+        if (subM) return { displayName: 'Company' };
+        if (url.includes('/resourcegroups')) {
+          return { value: [{ id: 'a', name: 'rg-prod' }, { id: 'b', name: 'rg-dev' }] };
+        }
+        return {};
+      },
+      { subscription_ids: ['s1'] },
+    );
+    expect(failed).toHaveLength(0);
+    expect(passed).toContain('Environments separated across resource groups');
+  });
+
   it('fails with guidance when nothing classifies', async () => {
     const { passed, failed } = await run(
       environmentSeparationCheck,
-      envSepFetch({
-        subs: [{ subscriptionId: 's1', state: 'Enabled', displayName: 'Company' }],
-        rgs: { s1: [{ id: 'a', name: 'backend' }] },
-      }),
+      azFetch({ names: { 'sub-1': 'Company' }, rgs: { 'sub-1': [{ id: 'a', name: 'backend' }] } }),
     );
     expect(passed).toHaveLength(0);
     expect(failed).toHaveLength(1);
     expect(failed[0]!.remediation).toMatch(/distinct subscriptions/);
   });
 
-  it('fails when no enabled subscriptions are visible', async () => {
-    const { failed } = await run(
-      environmentSeparationCheck,
-      envSepFetch({ subs: [{ subscriptionId: 's1', state: 'Disabled', displayName: 'Old' }] }),
-    );
-    expect(failed.some((f) => /No Azure subscriptions detected/.test(f.title))).toBe(true);
-  });
-
-  it('fails "could not verify" when the subscription list read fails', async () => {
+  it('fails "could not verify" when a resource-group read fails', async () => {
     const { passed, failed } = await run(environmentSeparationCheck, (url) => {
-      if (url.includes('/subscriptions?api-version')) throw new Error('HTTP 403: Forbidden');
+      if (url.includes('/resourcegroups')) throw new Error('HTTP 403: Forbidden');
+      const subM = url.match(/\/subscriptions\/([^/?]+)\?api-version/);
+      if (subM) return { displayName: 'Company' };
       return {};
     });
     expect(passed).toHaveLength(0);
     expect(failed.some((f) => /Could not verify environment separation/.test(f.title))).toBe(true);
   });
 
-  it('surfaces the subscription scan cap as explicit coverage info (no silent truncation)', async () => {
-    // 60 enabled subscriptions, none env-named, no classifiable resource groups
-    // → unconfirmed, and the >50 RG-scan cap must be disclosed.
-    const subs = Array.from({ length: 60 }, (_, i) => ({
-      subscriptionId: `s${i}`,
-      state: 'Enabled',
-      displayName: `Company-${i}`,
-    }));
+  it('defers to the scope resolver when no subscription is in scope', async () => {
+    // variables {} → discovery; no enabled subscription → resolveAzureSubscriptionIds
+    // emits its own scope finding and the check early-returns (no double fail).
     const { passed, failed } = await run(
       environmentSeparationCheck,
-      envSepFetch({ subs, rgs: {} }),
+      (url) => {
+        if (url.includes('/subscriptions?api-version')) {
+          return { value: [{ subscriptionId: 's1', state: 'Disabled' }] };
+        }
+        return {};
+      },
+      {},
     );
     expect(passed).toHaveLength(0);
-    expect(failed).toHaveLength(1);
-    expect(failed[0]!.title).toMatch(/Could not verify environment separation/);
-    expect(failed[0]!.remediation).toMatch(/Reduce to at most 50 enabled subscriptions/);
-    expect(failed[0]!.evidence).toMatchObject({
-      enabledSubscriptions: 60,
-      subscriptionsScannedForResourceGroups: 50,
-    });
+    expect(failed.some((f) => /Could not verify Azure subscription scope/.test(f.title))).toBe(true);
   });
 });

--- a/packages/integration-platform/src/manifests/azure/checks/environment-separation.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/environment-separation.ts
@@ -2,21 +2,14 @@ import { TASK_TEMPLATES } from '../../../task-mappings';
 import type { CheckContext, IntegrationCheck } from '../../../types';
 import {
   classifyEnvironment,
+  confirmsEnvironmentSeparation,
   envTagValues,
 } from '../../environment-classification';
-import { remediationForReadFailure, toHttpReadFailure } from '../../http-read-failure';
-import { ARM_BASE, armListAll } from './shared';
+import { toHttpReadFailure } from '../../http-read-failure';
+import { ARM_BASE, armListAll, resolveAzureSubscriptionIds } from './shared';
 
-const SUBSCRIPTIONS_API_VERSION = '2020-01-01';
+const SUBSCRIPTION_API_VERSION = '2020-01-01';
 const RESOURCE_GROUPS_API_VERSION = '2021-04-01';
-// Bound the resource-group fan-out (one list call per subscription).
-const MAX_SUBSCRIPTIONS = 50;
-
-interface Subscription {
-  subscriptionId: string;
-  displayName?: string;
-  state?: string;
-}
 
 interface ResourceGroup {
   id: string;
@@ -41,16 +34,18 @@ const GUIDANCE =
   'Separate production and non-production into distinct subscriptions (strongest), or tag each resource group with an `environment` tag (e.g. environment=production / environment=staging). If you separate environments another way, upload a console screenshot or architecture diagram as evidence.';
 
 /**
- * Separation of Environments check (heuristic). Evaluates the whole footprint in
- * two tiers, in safety order:
- *  1) Subscriptions — a real isolation/RBAC/billing boundary. If >=2 enabled
- *     subscriptions classify into distinct environments → PASS (strong).
+ * Separation of Environments check (heuristic). Evaluates ONLY the subscriptions
+ * the connection is scoped to via `resolveAzureSubscriptionIds` — the same
+ * opt-in scope every Azure check honors (selection → legacy single → first
+ * enabled). That helper also bounds the fan-out and surfaces an over-limit
+ * selection or an unresolvable scope as its own finding, and returns [] when
+ * nothing is in scope. Two tiers, in safety order:
+ *  1) Subscriptions — a real isolation/RBAC/billing boundary.
  *  2) Resource groups — the most commonly env-named primitive, but only a
- *     LOGICAL container (shares the subscription's access/network). If >=2
- *     distinct environments across RGs → PASS, explicitly disclosed as logical.
- * Tiers are NOT unioned: a single prod subscription containing an `rg-dev`
- * resource group must not be mistaken for separation. Anything else fails with
- * guidance; the task accepts manual evidence.
+ *     LOGICAL container (shares the subscription's access/network).
+ * A pass requires a PRODUCTION environment separated from a NON-PRODUCTION one
+ * (not merely two non-production environments). Tiers are not unioned; anything
+ * else fails with guidance and the task accepts manual evidence.
  */
 export const environmentSeparationCheck: IntegrationCheck = {
   id: 'azure-environment-separation',
@@ -60,90 +55,59 @@ export const environmentSeparationCheck: IntegrationCheck = {
   service: 'policy',
   taskMapping: TASK_TEMPLATES.separationOfEnvironments,
   run: async (ctx: CheckContext) => {
-    // Footprint-wide: list ALL enabled subscriptions directly (separation is a
-    // whole-footprint property, so this intentionally ignores subscription
-    // scoping the way the GCP check ignores project scoping).
-    let subscriptions: Subscription[];
-    try {
-      const data = await ctx.fetch<{ value?: Subscription[] }>(
-        `${ARM_BASE}/subscriptions?api-version=${SUBSCRIPTIONS_API_VERSION}`,
-      );
-      subscriptions = (data.value ?? []).filter((s) => s.state === 'Enabled');
-    } catch (err) {
-      const failure = toHttpReadFailure(err);
-      ctx.fail({
-        title: 'Could not verify environment separation',
-        description: `Azure subscriptions could not be listed (${failure.error}), so environment separation could not be evaluated.`,
-        resourceType: 'azure-environment-separation',
-        resourceId: 'subscriptions',
-        severity: 'medium',
-        remediation: remediationForReadFailure(
-          failure,
-          'Grant the connection Reader access to the subscription(s), then re-run the check.',
-        ),
-        evidence: { readError: failure.error },
-      });
-      return;
-    }
+    const subscriptionIds = await resolveAzureSubscriptionIds(ctx);
+    // resolveAzureSubscriptionIds already emitted a finding when scope is empty.
+    if (subscriptionIds.length === 0) return;
 
-    if (subscriptions.length === 0) {
-      ctx.fail({
-        title: 'No Azure subscriptions detected',
-        description:
-          'No enabled Azure subscriptions were accessible, so environment separation could not be evaluated.',
-        resourceType: 'azure-environment-separation',
-        resourceId: 'subscriptions',
-        severity: 'medium',
-        remediation:
-          'Grant the connection Reader access to your subscriptions, then re-run — or upload a console screenshot / architecture diagram as evidence.',
-        evidence: { subscriptionCount: 0 },
-      });
-      return;
+    // Tier 1 (strong): subscription-level separation. Read each IN-SCOPE
+    // subscription's display name only — we never touch subscriptions outside
+    // the configured selection.
+    const subscriptionEnvSet = new Set<string>();
+    for (const id of subscriptionIds) {
+      try {
+        const sub = await ctx.fetch<{ displayName?: string }>(
+          `${ARM_BASE}/subscriptions/${id}?api-version=${SUBSCRIPTION_API_VERSION}`,
+        );
+        const env = classifyEnvironment([sub.displayName]);
+        if (env) subscriptionEnvSet.add(env);
+      } catch (err) {
+        ctx.log(
+          `Azure env-separation: could not read subscription ${id} — ${toHttpReadFailure(err).error}`,
+        );
+      }
     }
-
-    // Tier 1 (strong): subscription-level separation.
-    const subscriptionEnvs = [
-      ...new Set(
-        subscriptions
-          .map((s) => classifyEnvironment([s.displayName]))
-          .filter((e): e is string => e !== null),
-      ),
-    ];
-    if (subscriptionEnvs.length >= 2) {
+    const subscriptionEnvs = [...subscriptionEnvSet];
+    if (confirmsEnvironmentSeparation(subscriptionEnvs)) {
       ctx.pass({
         title: 'Environments separated across subscriptions',
-        description: `Detected ${subscriptionEnvs.length} distinct environments across ${subscriptions.length} Azure subscriptions: ${subscriptionEnvs.join(', ')} (subscription-level boundary).`,
+        description: `Detected production separated from non-production across ${subscriptionIds.length} in-scope Azure subscription(s): ${subscriptionEnvs.join(', ')} (subscription-level boundary).`,
         resourceType: 'azure-environment-separation',
         resourceId: 'subscriptions',
         evidence: {
           boundary: 'subscription',
           detectedEnvironments: subscriptionEnvs,
-          subscriptionCount: subscriptions.length,
+          subscriptionsScanned: subscriptionIds.length,
         },
       });
       return;
     }
 
-    // Tier 2 (weak, logical): resource-group-level separation across the
-    // footprint. The RG fan-out is bounded (one list call per subscription);
-    // a footprint larger than the cap is surfaced as incomplete coverage below,
-    // never silently dropped.
-    const boundedSubs = subscriptions.slice(0, MAX_SUBSCRIPTIONS);
-    const truncated = subscriptions.length > boundedSubs.length;
+    // Tier 2 (weak, logical): resource-group-level separation within the
+    // IN-SCOPE subscriptions only.
     const rgEnvSet = new Set<string>();
     const rgSamples: Array<{ name: string; environment: string }> = [];
     let anyRgReadFailed = false;
-    for (const sub of boundedSubs) {
+    for (const id of subscriptionIds) {
       let resourceGroups: ResourceGroup[];
       try {
         resourceGroups = await armListAll<ResourceGroup>(
           ctx,
-          `${ARM_BASE}/subscriptions/${sub.subscriptionId}/resourcegroups?api-version=${RESOURCE_GROUPS_API_VERSION}`,
+          `${ARM_BASE}/subscriptions/${id}/resourcegroups?api-version=${RESOURCE_GROUPS_API_VERSION}`,
         );
       } catch (err) {
         anyRgReadFailed = true;
         ctx.log(
-          `Azure env-separation: could not list resource groups in ${sub.subscriptionId} — ${toHttpReadFailure(err).error}`,
+          `Azure env-separation: could not list resource groups in ${id} — ${toHttpReadFailure(err).error}`,
         );
         continue;
       }
@@ -156,64 +120,43 @@ export const environmentSeparationCheck: IntegrationCheck = {
       }
     }
     const resourceGroupEnvs = [...rgEnvSet];
-    // A PASS means >=2 environments were positively found; scanning the
-    // remaining subscriptions could only ADD environments, never remove the two
-    // we already have, so truncation cannot invalidate a pass. The scanned count
-    // is still recorded in evidence for transparency.
-    if (resourceGroupEnvs.length >= 2) {
+    if (confirmsEnvironmentSeparation(resourceGroupEnvs)) {
       ctx.pass({
         title: 'Environments separated across resource groups',
-        description: `Detected ${resourceGroupEnvs.length} distinct environments across resource groups in ${boundedSubs.length} subscription(s): ${resourceGroupEnvs.join(', ')}. Resource-group separation is logical — RGs share the subscription's access and network boundary — not full isolation.`,
+        description: `Detected production separated from non-production across resource groups in ${subscriptionIds.length} in-scope subscription(s): ${resourceGroupEnvs.join(', ')}. Resource-group separation is logical — RGs share the subscription's access and network boundary — not full isolation.`,
         resourceType: 'azure-environment-separation',
         resourceId: 'resource-groups',
         evidence: {
           boundary: 'resource-group',
           detectedEnvironments: resourceGroupEnvs,
-          enabledSubscriptions: subscriptions.length,
-          subscriptionsScannedForResourceGroups: boundedSubs.length,
+          subscriptionsScanned: subscriptionIds.length,
           resourceGroups: rgSamples,
         },
       });
       return;
     }
 
-    // Neither tier confirmed separation. Surface any incomplete coverage (read
-    // failures and/or the subscription scan cap) so the verdict is never
-    // presented as if it covered the whole footprint.
+    // Could not confirm. A read failure leaves coverage incomplete ("could not
+    // verify"); a complete scan that simply found no prod/non-prod split is
+    // "could not confirm".
     const detectedAll = [...new Set([...subscriptionEnvs, ...resourceGroupEnvs])];
-    const coverageGaps: string[] = [];
-    if (truncated) {
-      coverageGaps.push(
-        `only ${boundedSubs.length} of ${subscriptions.length} enabled subscriptions were scanned for resource groups`,
-      );
-    }
-    if (anyRgReadFailed) {
-      coverageGaps.push('some resource groups could not be read');
-    }
     const base =
       detectedAll.length === 0
-        ? `No Azure subscription or resource group could be classified by environment across ${subscriptions.length} subscription(s)`
-        : `Environment(s) detected (${detectedAll.join(', ')}) but not 2+ distinct environments at a single boundary (subscriptions, or resource groups)`;
+        ? `No in-scope Azure subscription or resource group could be classified by environment across ${subscriptionIds.length} subscription(s)`
+        : `Detected environment(s) ${detectedAll.join(', ')}, but could not confirm a production environment separated from a non-production one across ${subscriptionIds.length} in-scope subscription(s)`;
     ctx.fail({
-      // Incomplete coverage that leaves us short of a verdict is "could not
-      // verify"; a complete scan that simply found no separation is "could not
-      // confirm".
-      title:
-        coverageGaps.length > 0 && detectedAll.length < 2
-          ? 'Could not verify environment separation'
-          : 'Could not confirm environment separation',
-      description: `${base}${coverageGaps.length ? ` (${coverageGaps.join('; ')})` : ''}, so environment separation could not be confirmed.`,
+      title: anyRgReadFailed
+        ? 'Could not verify environment separation'
+        : 'Could not confirm environment separation',
+      description: `${base}${anyRgReadFailed ? ' (some resource groups could not be read)' : ''}.`,
       resourceType: 'azure-environment-separation',
       resourceId: 'subscriptions',
       severity: 'medium',
-      remediation: truncated
-        ? `Reduce to at most ${MAX_SUBSCRIPTIONS} enabled subscriptions (or contact support to raise the limit). ${GUIDANCE}`
-        : GUIDANCE,
+      remediation: GUIDANCE,
       evidence: {
         subscriptionEnvironments: subscriptionEnvs,
         resourceGroupEnvironments: resourceGroupEnvs,
-        enabledSubscriptions: subscriptions.length,
-        subscriptionsScannedForResourceGroups: boundedSubs.length,
+        subscriptionsScanned: subscriptionIds.length,
         resourceGroupsClassified: rgSamples.length,
       },
     });

--- a/packages/integration-platform/src/manifests/environment-classification.ts
+++ b/packages/integration-platform/src/manifests/environment-classification.ts
@@ -23,6 +23,24 @@ const ENV_TOKEN_SETS: ReadonlyArray<{ env: string; tokens: ReadonlySet<string> }
 /** Default tag/label keys that conventionally carry the environment. */
 export const ENV_TAG_KEYS = ['environment', 'env', 'stage', 'tier'] as const;
 
+/** The single production bucket; every other bucket is non-production. */
+const PRODUCTION_ENV = 'production';
+
+/**
+ * Whether a set of detected environments confirms environment SEPARATION as the
+ * control intends: production must be present AND at least one non-production
+ * environment (staging/development/test/sandbox). Two non-production
+ * environments alone (e.g. dev + staging) do NOT demonstrate that production is
+ * segregated, so they must not pass.
+ */
+export function confirmsEnvironmentSeparation(
+  envs: ReadonlyArray<string>,
+): boolean {
+  return (
+    envs.includes(PRODUCTION_ENV) && envs.some((e) => e !== PRODUCTION_ENV)
+  );
+}
+
 /** Split on any run of non-alphanumeric chars; lowercased, empties removed. */
 function tokenize(value: string): string[] {
   return value

--- a/packages/integration-platform/src/manifests/gcp/checks/__tests__/gcp-checks.test.ts
+++ b/packages/integration-platform/src/manifests/gcp/checks/__tests__/gcp-checks.test.ts
@@ -921,9 +921,13 @@ describe('GCP environment-separation check', () => {
     (err as Error & { status: number }).status = code;
     return err;
   };
+  // `variables: {}` forces unscoped discovery (the project_ids-less default),
+  // so the mock can return the `/v1/projects` list shape.
+  const UNSCOPED = {};
 
-  it('passes when ≥2 distinct environments are detected by name', async () => {
+  it('passes when production is separated from a non-production env (by name)', async () => {
     const out = await runCheck(environmentSeparationCheck, {
+      variables: UNSCOPED,
       fetch: () => ({
         projects: [{ projectId: 'myapp-prod' }, { projectId: 'myapp-dev' }],
       }),
@@ -936,8 +940,9 @@ describe('GCP environment-separation check', () => {
     });
   });
 
-  it('passes when environments are distinguished by labels', async () => {
+  it('passes when environments are distinguished by labels (prod + staging)', async () => {
     const out = await runCheck(environmentSeparationCheck, {
+      variables: UNSCOPED,
       fetch: () => ({
         projects: [
           { projectId: 'a', labels: { environment: 'production' } },
@@ -949,8 +954,9 @@ describe('GCP environment-separation check', () => {
     expect(out.passed).toHaveLength(1);
   });
 
-  it('evaluates projects across multiple pages', async () => {
+  it('evaluates projects across multiple pages (unscoped discovery)', async () => {
     const out = await runCheck(environmentSeparationCheck, {
+      variables: UNSCOPED,
       fetch: (url) => {
         if (url.includes('pageToken=tok2')) {
           return { projects: [{ projectId: 'app-dev' }] };
@@ -962,8 +968,39 @@ describe('GCP environment-separation check', () => {
     expect(out.passed).toHaveLength(1);
   });
 
-  it('fails with guidance when only one environment is present', async () => {
+  it('honors project_ids scope: fetches selected projects, never lists all', async () => {
     const out = await runCheck(environmentSeparationCheck, {
+      variables: { project_ids: ['p-prod', 'p-dev'] },
+      fetch: (url) => {
+        if (url.includes('/v1/projects/p-prod')) {
+          return { projectId: 'p-prod', labels: { environment: 'production' } };
+        }
+        if (url.includes('/v1/projects/p-dev')) {
+          return { projectId: 'p-dev', labels: { environment: 'development' } };
+        }
+        // The list endpoint must NOT be called when projects are selected.
+        throw new Error(`unexpected list call: ${url}`);
+      },
+    });
+    expect(out.failed).toHaveLength(0);
+    expect(out.passed).toHaveLength(1);
+  });
+
+  it('fails when only non-production environments are present (no production)', async () => {
+    const out = await runCheck(environmentSeparationCheck, {
+      variables: UNSCOPED,
+      fetch: () => ({
+        projects: [{ projectId: 'app-dev' }, { projectId: 'app-staging' }],
+      }),
+    });
+    expect(out.passed).toHaveLength(0);
+    expect(out.failed).toHaveLength(1);
+    expect(out.failed[0]!.title).toMatch(/Could not confirm environment separation/);
+  });
+
+  it('fails when only production is present (no non-production)', async () => {
+    const out = await runCheck(environmentSeparationCheck, {
+      variables: UNSCOPED,
       fetch: () => ({ projects: [{ projectId: 'myapp-prod' }] }),
     });
     expect(out.passed).toHaveLength(0);
@@ -972,8 +1009,9 @@ describe('GCP environment-separation check', () => {
     expect(out.failed[0]!.remediation).toMatch(/distinct GCP projects/);
   });
 
-  it('fails with guidance when no project can be classified', async () => {
+  it('fails when no project can be classified', async () => {
     const out = await runCheck(environmentSeparationCheck, {
+      variables: UNSCOPED,
       fetch: () => ({
         projects: [{ projectId: 'product-catalog' }, { projectId: 'backend' }],
       }),
@@ -983,8 +1021,25 @@ describe('GCP environment-separation check', () => {
     expect(out.failed[0]!.title).toMatch(/Could not confirm environment separation/);
   });
 
-  it('fails when no projects are accessible', async () => {
+  it('surfaces truncation as "could not verify" when discovery is capped', async () => {
+    // Every page returns more pages → the 20-page cap trips; classify only
+    // non-prod so the verdict is a fail that must disclose the partial scan.
     const out = await runCheck(environmentSeparationCheck, {
+      variables: UNSCOPED,
+      fetch: () => ({
+        projects: [{ projectId: 'app-dev' }],
+        nextPageToken: 'next',
+      }),
+    });
+    expect(out.passed).toHaveLength(0);
+    expect(out.failed).toHaveLength(1);
+    expect(out.failed[0]!.title).toMatch(/Could not verify environment separation/);
+    expect(out.failed[0]!.evidence).toMatchObject({ discoveryTruncated: true });
+  });
+
+  it('fails when no projects are accessible (unscoped)', async () => {
+    const out = await runCheck(environmentSeparationCheck, {
+      variables: UNSCOPED,
       fetch: () => ({ projects: [] }),
     });
     expect(out.passed).toHaveLength(0);
@@ -992,8 +1047,21 @@ describe('GCP environment-separation check', () => {
     expect(out.failed[0]!.title).toMatch(/No GCP projects detected/);
   });
 
-  it('fails "could not verify" when the project list read fails', async () => {
+  it('fails "could not verify" when unscoped discovery read fails', async () => {
     const out = await runCheck(environmentSeparationCheck, {
+      variables: UNSCOPED,
+      fetch: () => {
+        throw status(new Error('HTTP 403: Forbidden'), 403);
+      },
+    });
+    expect(out.passed).toHaveLength(0);
+    expect(out.failed).toHaveLength(1);
+    expect(out.failed[0]!.title).toMatch(/Could not verify environment separation/);
+  });
+
+  it('fails "could not verify" when a selected (scoped) project cannot be read', async () => {
+    const out = await runCheck(environmentSeparationCheck, {
+      variables: { project_ids: ['p1'] },
       fetch: () => {
         throw status(new Error('HTTP 403: Forbidden'), 403);
       },

--- a/packages/integration-platform/src/manifests/gcp/checks/environment-separation.ts
+++ b/packages/integration-platform/src/manifests/gcp/checks/environment-separation.ts
@@ -2,6 +2,7 @@ import { TASK_TEMPLATES } from '../../../task-mappings';
 import type { CheckContext, IntegrationCheck } from '../../../types';
 import {
   classifyEnvironment,
+  confirmsEnvironmentSeparation,
   envTagValues,
 } from '../../environment-classification';
 import {
@@ -13,6 +14,14 @@ interface GcpProject {
   projectId: string;
   name?: string;
   labels?: Record<string, string>;
+}
+
+interface ResolvedProjects {
+  projects: GcpProject[];
+  /** True when UNSCOPED discovery hit the page cap (a scoped fetch is exact). */
+  truncated: boolean;
+  /** Set when a selected project could not be read (scoped path). */
+  readError?: string;
 }
 
 /**
@@ -30,8 +39,44 @@ export function classifyProjectEnv(project: GcpProject): string | null {
   ]);
 }
 
-/** List every active project the connection can see (bounded pagination). */
-async function listActiveProjects(ctx: CheckContext): Promise<GcpProject[]> {
+/** The user-selected project scope (`project_ids` variable), trimmed. */
+function selectedProjectIds(ctx: CheckContext): string[] {
+  const selected = ctx.variables.project_ids;
+  if (!Array.isArray(selected)) return [];
+  return selected
+    .filter((s): s is string => typeof s === 'string')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Resolve the projects to evaluate, HONORING the `project_ids` opt-in scope:
+ * when projects are selected we fetch exactly those (no truncation possible);
+ * otherwise we discover all active projects with a bounded page walk and report
+ * `truncated` so a partial footprint is never presented as a complete verdict.
+ */
+async function resolveProjects(ctx: CheckContext): Promise<ResolvedProjects> {
+  const selected = selectedProjectIds(ctx);
+
+  if (selected.length > 0) {
+    const projects: GcpProject[] = [];
+    let readError: string | undefined;
+    for (const id of selected) {
+      try {
+        const project = await ctx.fetch<GcpProject>(
+          `/v1/projects/${encodeURIComponent(id)}`,
+        );
+        if (project && typeof project.projectId === 'string') {
+          projects.push(project);
+        }
+      } catch (err) {
+        readError = toHttpReadFailure(err).error;
+        ctx.log(`GCP env-separation: could not read project ${id} — ${readError}`);
+      }
+    }
+    return { projects, truncated: false, readError };
+  }
+
   const projects: GcpProject[] = [];
   let pageToken: string | undefined;
   let pages = 0;
@@ -50,28 +95,25 @@ async function listActiveProjects(ctx: CheckContext): Promise<GcpProject[]> {
       typeof data.nextPageToken === 'string' ? data.nextPageToken : undefined;
     pages++;
   } while (pageToken && pages < 20);
-  if (pageToken) {
-    ctx.warn(
-      'GCP project discovery hit the page cap; some projects may not be evaluated for environment separation',
-      { pages, discovered: projects.length },
-    );
-  }
-  return projects;
+
+  return { projects, truncated: Boolean(pageToken) };
 }
+
+const GUIDANCE =
+  'Separate production and non-production workloads into distinct GCP projects and label each with an `environment` label (e.g. environment=production, environment=staging). If you separate environments another way (e.g. VPCs or folders), upload a console screenshot or architecture diagram as evidence.';
 
 /**
  * Separation of Environments check (heuristic). GCP's recommended pattern is a
  * separate project per environment, so this infers separation from the project
- * footprint: it classifies each accessible project into an environment (by
- * `environment`/`env` label, else name/id token) and passes when TWO OR MORE
- * distinct environments are present.
+ * footprint: it classifies each in-scope project into an environment (by
+ * `environment`/`env` label, else name/id token) and passes only when it can
+ * confirm a PRODUCTION environment is separated from at least one
+ * NON-PRODUCTION environment.
  *
- * It is intentionally evidence-first, not a hard gate: separation is an
- * architectural property with no single API field, so when it cannot confirm
+ * It honors the `project_ids` opt-in scope, never presents a truncated
+ * discovery as complete, and is evidence-first: when it cannot confirm
  * separation it emits actionable guidance (label projects, or upload a diagram)
- * rather than a silent pass. It evaluates ALL accessible projects regardless of
- * the `project_ids` scoping variable, since separation is about the whole
- * footprint.
+ * rather than a silent pass.
  */
 export const environmentSeparationCheck: IntegrationCheck = {
   id: 'gcp-environment-separation',
@@ -82,9 +124,9 @@ export const environmentSeparationCheck: IntegrationCheck = {
   taskMapping: TASK_TEMPLATES.separationOfEnvironments,
 
   run: async (ctx: CheckContext) => {
-    let projects: GcpProject[];
+    let resolved: ResolvedProjects;
     try {
-      projects = await listActiveProjects(ctx);
+      resolved = await resolveProjects(ctx);
     } catch (err) {
       const failure = toHttpReadFailure(err);
       ctx.fail({
@@ -102,17 +144,25 @@ export const environmentSeparationCheck: IntegrationCheck = {
       return;
     }
 
+    const { projects, truncated, readError } = resolved;
+
     if (projects.length === 0) {
+      // A read failure (scoped projects unreadable) is "could not verify"; a
+      // genuinely empty footprint is "no projects".
       ctx.fail({
-        title: 'No GCP projects detected',
-        description:
-          'No active GCP projects were accessible, so environment separation could not be evaluated.',
+        title: readError
+          ? 'Could not verify environment separation'
+          : 'No GCP projects detected',
+        description: readError
+          ? `Selected GCP projects could not be read (${readError}), so environment separation could not be evaluated.`
+          : 'No GCP projects were in scope, so environment separation could not be evaluated.',
         resourceType: 'gcp-environment-separation',
         resourceId: 'projects',
         severity: 'medium',
-        remediation:
-          'Grant resourcemanager.projects.list to the connection (or select projects in the integration settings), then re-run — or upload a console screenshot / architecture diagram as evidence of environment separation.',
-        evidence: { projectCount: 0 },
+        remediation: readError
+          ? `Grant resourcemanager.projects.get (e.g. roles/viewer) for the selected projects, then re-run. ${GUIDANCE}`
+          : `Grant resourcemanager.projects.list to the connection (or select projects in the integration settings), then re-run. ${GUIDANCE}`,
+        evidence: { projectCount: 0, ...(readError ? { readError } : {}) },
       });
       return;
     }
@@ -128,47 +178,59 @@ export const environmentSeparationCheck: IntegrationCheck = {
           .filter((e): e is string => e !== null),
       ),
     ];
+    const sample = classified.slice(0, 50).map((c) => ({
+      projectId: c.projectId,
+      environment: c.environment ?? 'unclassified',
+    }));
 
-    if (detected.length >= 2) {
+    // A confirmed pass requires production + a non-production environment.
+    // Truncation/read gaps cannot turn a confirmed pass into a wrong one
+    // (scanning more projects only ADDS environments), so a pass stands.
+    if (confirmsEnvironmentSeparation(detected)) {
       ctx.pass({
         title: 'Environments separated across projects',
-        description: `Detected ${detected.length} distinct environments across ${projects.length} GCP project(s): ${detected.join(', ')}.`,
+        description: `Detected production separated from non-production across ${projects.length} GCP project(s): ${detected.join(', ')}.`,
         resourceType: 'gcp-environment-separation',
         resourceId: 'projects',
         evidence: {
           detectedEnvironments: detected,
           projectCount: projects.length,
-          projects: classified
-            .slice(0, 50)
-            .map((c) => ({
-              projectId: c.projectId,
-              environment: c.environment ?? 'unclassified',
-            })),
+          projects: sample,
         },
       });
       return;
     }
 
+    // Could not confirm. Surface any incomplete coverage so a partial footprint
+    // is never presented as a complete "not separated" verdict.
+    const coverageGaps: string[] = [];
+    if (truncated) {
+      coverageGaps.push(
+        'project discovery hit the page cap, so not all projects were evaluated',
+      );
+    }
+    if (readError) {
+      coverageGaps.push('some selected projects could not be read');
+    }
+    const base =
+      detected.length === 0
+        ? `No GCP project could be classified by environment across ${projects.length} project(s)`
+        : `Detected environment(s) ${detected.join(', ')}, but could not confirm a production environment separated from a non-production one across ${projects.length} project(s)`;
     ctx.fail({
-      title: 'Could not confirm environment separation',
-      description:
-        detected.length === 1
-          ? `Only one environment ("${detected[0]}") was detected across ${projects.length} project(s); production and non-production do not appear to be separated into distinct projects.`
-          : `No GCP project could be classified by environment across ${projects.length} project(s), so environment separation could not be confirmed.`,
+      title:
+        coverageGaps.length > 0
+          ? 'Could not verify environment separation'
+          : 'Could not confirm environment separation',
+      description: `${base}${coverageGaps.length ? ` (${coverageGaps.join('; ')})` : ''}.`,
       resourceType: 'gcp-environment-separation',
       resourceId: 'projects',
       severity: 'medium',
-      remediation:
-        'Separate production and non-production workloads into distinct GCP projects and label each with an `environment` label (e.g. environment=production, environment=staging). If you separate environments another way (e.g. VPCs or folders), upload a console screenshot or architecture diagram as evidence.',
+      remediation: GUIDANCE,
       evidence: {
         detectedEnvironments: detected,
         projectCount: projects.length,
-        projects: classified
-          .slice(0, 50)
-          .map((c) => ({
-            projectId: c.projectId,
-            environment: c.environment ?? 'unclassified',
-          })),
+        ...(truncated ? { discoveryTruncated: true } : {}),
+        projects: sample,
       },
     });
   },


### PR DESCRIPTION
## What

Addresses the 3 issues the automated review (cubic) flagged on the release PR for the Separation of Environments checks (merged in #3182). **I verified each against the actual code — all three are real** — and added one related consistency fix. Each fix was then re-verified by an adversarial review pass (no new false-pass, no regressions).

| # | Issue | Fix |
|---|---|---|
| 1 | **Azure ignored subscription scope** — scanned all enabled subscriptions, breaking the opt-in scan contract every other Azure check honors | Scope via `resolveAzureSubscriptionIds` (selection → legacy → first enabled; bounds the fan-out + surfaces over-limit/empty scope as its own finding). The per-subscription name read **and** the resource-group list now touch **only in-scope** subscriptions. |
| 2 | **Pass condition too weak** — `≥2 of any environments` could pass on `dev`+`staging` without confirming production is separated | New shared `confirmsEnvironmentSeparation` requires **production + ≥1 non-production**. Applied to GCP, AWS, **and** Azure. |
| 3 | **GCP pagination cap → silent partial verdict** — capped discovery still returned a normal verdict | Truncation now propagates: a non-confirmed verdict under truncation becomes **"could not verify"** (`evidence.discoveryTruncated`). A *confirmed* pass still stands — scanning more projects can only **add** environments, never remove the prod/non-prod already found. |
| 4 | *(consistency, same class as #1 — not flagged)* GCP also ignored `project_ids` | GCP now **honors the `project_ids` opt-in scope** — fetches selected projects directly instead of always listing all. |

## Why these are correct

- **False-pass is the worst outcome** (it would mark the evidence task compliant). The new bar is *strictly stricter* than before — `['production']` alone or `['dev','staging']` no longer pass — so it can only reduce false-passes.
- Every branch **fails-with-guidance, never silent-passes**; read failures and incomplete coverage surface as **"could not verify"**; the task still accepts manual evidence.
- The Azure scope change errs toward FAIL, not PASS (a multi-subscription customer who hasn't selected their subscriptions sees "could not confirm" + guidance to select them — never a false compliance claim). This matches all other Azure checks' opt-in contract.

## Tests
**382 package tests pass**, typecheck + build green. New/updated coverage: `confirmsEnvironmentSeparation` (prod+nonprod, two-non-prod→fail, prod-alone→fail), Azure scope (only-scoped-subscriptions-touched, defers to scope resolver), GCP `project_ids` scope + truncation→"could not verify", AWS two-non-prod→fail.

## Notes
- Branch is off the latest `main` (which already has #3182), so the diff is **only these fixes**.
- Still a heuristic, not yet live-tested against real cloud accounts (mock-tested; customer live run is the final validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens environment-separation checks across Azure, GCP, and AWS: require production + non‑production to pass, honor scoping for Azure subscriptions and GCP `project_ids`, and surface GCP discovery truncation. Reduces false passes and aligns Azure behavior with the opt‑in scope contract.

- **Bug Fixes**
  - Azure: Scope via `resolveAzureSubscriptionIds`; read subscription names and list resource groups only for in-scope subscriptions; does not union subscription and RG tiers; defers to the scope resolver when scope is empty.
  - GCP: Honor `project_ids` by fetching selected projects; when unscoped discovery hits the page cap, a non-confirmed verdict becomes “could not verify” with `evidence.discoveryTruncated`; guidance and evidence clarified.
  - AWS: Pass only when production is found alongside at least one non-production VPC; updated wording to avoid implying cross-account isolation.
  - Shared: Added `confirmsEnvironmentSeparation` helper and updated tests across clouds.

<sup>Written for commit adc2634f9b8b4bc398ef90b1a2b7574e7b696c2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

