### PR TITLE
fix(integrations): env-separation classifier negation + read-failure verdicts

### DIFF
--- a/packages/integration-platform/src/manifests/__tests__/environment-classification.test.ts
+++ b/packages/integration-platform/src/manifests/__tests__/environment-classification.test.ts
@@ -66,6 +66,63 @@ describe('classifyEnvironment — token-exact matching', () => {
   });
 });
 
+describe('classifyEnvironment — negated/qualified production (cubic finding)', () => {
+  it('classifies separated negated production as NON-production, not production', () => {
+    expect(classifyEnvironment(['non-prod'])).toBe('non-production');
+    expect(classifyEnvironment(['non_prod'])).toBe('non-production');
+    expect(classifyEnvironment(['non.prod'])).toBe('non-production');
+    expect(classifyEnvironment(['not-prod'])).toBe('non-production');
+    expect(classifyEnvironment(['myapp-non-prod'])).toBe('non-production');
+    expect(classifyEnvironment(['non-production'])).toBe('non-production');
+    expect(classifyEnvironment(['NON-PROD'])).toBe('non-production'); // case-insensitive
+  });
+
+  it('classifies joined non-production spellings as NON-production', () => {
+    expect(classifyEnvironment(['nonprod'])).toBe('non-production');
+    expect(classifyEnvironment(['notprod'])).toBe('non-production');
+    expect(classifyEnvironment(['nonprd'])).toBe('non-production');
+    expect(classifyEnvironment(['notprd'])).toBe('non-production');
+    expect(classifyEnvironment(['nonproduction'])).toBe('non-production');
+    expect(classifyEnvironment(['notproduction'])).toBe('non-production');
+    expect(classifyEnvironment(['app-nonprod'])).toBe('non-production');
+  });
+
+  it('classifies pre-prod as staging (consistent with joined "preprod")', () => {
+    expect(classifyEnvironment(['pre-prod'])).toBe('staging');
+    expect(classifyEnvironment(['pre_prod'])).toBe('staging');
+    expect(classifyEnvironment(['app-pre-prod'])).toBe('staging');
+    expect(classifyEnvironment(['preprod'])).toBe('staging');
+  });
+
+  it('still classifies plain production (negation needs an ADJACENT qualifier)', () => {
+    expect(classifyEnvironment(['prod'])).toBe('production');
+    expect(classifyEnvironment(['myapp-prod'])).toBe('production');
+    // a "non" that does not immediately precede a prod token must NOT negate
+    expect(classifyEnvironment(['prod-non-critical'])).toBe('production');
+  });
+
+  it('end-to-end: prod + non-prod now CONFIRMS separation (was a false fail)', () => {
+    // Pre-fix, "non-prod" classified as production, so detected={production}
+    // and separation failed despite a real prod/non-prod split.
+    const detected = [
+      ...new Set(['prod-vpc', 'non-prod-vpc'].map((n) => classifyEnvironment([n]))),
+    ].filter((e): e is string => e !== null);
+    expect(detected).toContain('production');
+    expect(detected).toContain('non-production');
+    expect(confirmsEnvironmentSeparation(detected)).toBe(true);
+  });
+
+  it('end-to-end: a non-prod-only footprint does NOT fabricate production (was a false pass)', () => {
+    // Pre-fix, "non-prod-staging" classified as production, so dev + that string
+    // passed as if production existed.
+    const detected = [
+      ...new Set(['dev', 'non-prod-staging'].map((n) => classifyEnvironment([n]))),
+    ].filter((e): e is string => e !== null);
+    expect(detected).not.toContain('production');
+    expect(confirmsEnvironmentSeparation(detected)).toBe(false);
+  });
+});
+
 describe('envTagValues — only env-key tags, case-insensitive', () => {
   it('reads environment-indicating keys regardless of case', () => {
     expect(envTagValues({ Environment: 'production' })).toEqual(['production']);

--- a/packages/integration-platform/src/manifests/aws/checks/__tests__/aws-checks.test.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/__tests__/aws-checks.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test';
 import { evaluateCloudTrail } from '../cloudtrail';
 import { evaluateSecurityGroups } from '../ec2';
 import {
+  buildEnvironmentSeparationOutcomes,
   classifyVpcEnv,
   evaluateEnvironmentSeparation,
 } from '../environment-separation';
@@ -1013,5 +1014,53 @@ describe('AWS environment separation', () => {
     expect(out[0]!.kind).toBe('fail');
     expect(out[0]!.severity).toBe('low');
     expect(out[0]!.evidence).toMatchObject({ vpcCount: 0 });
+  });
+});
+
+describe('buildEnvironmentSeparationOutcomes — region failures vs verdict (cubic finding)', () => {
+  const failure = { error: 'AccessDenied: ec2:DescribeVpcs', denied: true };
+  const regionFailures = [{ region: 'eu-west-1', failure }];
+
+  it('does NOT pair a region-failure fail with a confirmed pass', () => {
+    const out = buildEnvironmentSeparationOutcomes(
+      [
+        { vpcId: 'vpc-1', region: 'us-east-1', environment: 'production' },
+        { vpcId: 'vpc-2', region: 'us-east-1', environment: 'development' },
+      ],
+      regionFailures,
+    );
+    // A confirmed pass stands alone — more regions can only ADD environments, so
+    // the unread region can't un-confirm it; emitting a fail too would be a
+    // contradictory pass+fail in one run.
+    expect(out).toHaveLength(1);
+    expect(out[0]!.kind).toBe('pass');
+  });
+
+  it('surfaces the region failure alongside an UNconfirmed verdict (both negative)', () => {
+    const out = buildEnvironmentSeparationOutcomes(
+      [{ vpcId: 'vpc-1', region: 'us-east-1', environment: 'production' }],
+      regionFailures,
+    );
+    expect(out.length).toBeGreaterThanOrEqual(2);
+    expect(out.every((o) => o.kind === 'fail')).toBe(true);
+    expect(out.some((o) => /Could not verify VPCs in some regions/.test(o.title))).toBe(true);
+  });
+
+  it('returns only the region-failure finding when zero VPCs were read', () => {
+    const out = buildEnvironmentSeparationOutcomes([], regionFailures);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.title).toMatch(/Could not verify VPCs in some regions/);
+  });
+
+  it('with no region failures, returns the separation verdict unchanged', () => {
+    const out = buildEnvironmentSeparationOutcomes(
+      [
+        { vpcId: 'vpc-1', region: 'us-east-1', environment: 'production' },
+        { vpcId: 'vpc-2', region: 'us-east-1', environment: 'staging' },
+      ],
+      [],
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]!.kind).toBe('pass');
   });
 });

--- a/packages/integration-platform/src/manifests/aws/checks/environment-separation.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/environment-separation.ts
@@ -129,6 +129,55 @@ export function evaluateEnvironmentSeparation(vpcs: VpcInfo[]): CheckOutcome[] {
 }
 
 /**
+ * Combine the VPCs we read with any per-region read failures into the outcomes
+ * to emit. A region we couldn't read leaves coverage incomplete and is surfaced
+ * as its own "could not verify" finding — UNLESS the VPCs we DID read already
+ * confirm separation. Reading more regions can only ADD environments, so it can
+ * never un-confirm a positive result; pairing a confirmed pass with a
+ * verification-failure would only emit a contradictory pass+fail in one run.
+ * When zero VPCs were read AND a region failed, only the region-failure finding
+ * is returned — a "no VPCs" verdict layered on unread data would mislead.
+ */
+export function buildEnvironmentSeparationOutcomes(
+  vpcs: VpcInfo[],
+  regionFailures: ReadonlyArray<{ region: string; failure: ReadFailure }>,
+): CheckOutcome[] {
+  const separation = evaluateEnvironmentSeparation(vpcs);
+  const confirmed = separation.some((o) => o.kind === 'pass');
+
+  // No coverage gap, or separation already proven → the verdict stands alone.
+  if (regionFailures.length === 0 || confirmed) return separation;
+
+  const regions = regionFailures.map((r) => r.region);
+  const regionFailure: CheckOutcome = {
+    kind: 'fail',
+    title: 'Could not verify VPCs in some regions',
+    description: `VPCs could not be listed in: ${regions.join(', ')}, so environment separation is unverified in those regions.`,
+    resourceType: 'aws-environment-separation',
+    resourceId: `regions:${regions.join(',')}`,
+    severity: 'medium',
+    remediation: remediationForReadFailure(
+      combineReadFailures(regionFailures.map((r) => r.failure)),
+      'Grant ec2:DescribeVpcs to the integration role in all enabled regions, then re-run the check.',
+    ),
+    evidence: {
+      failedRegions: regionFailures.map((r) => ({
+        region: r.region,
+        error: r.failure.error,
+      })),
+    },
+  };
+
+  // Zero VPCs read + a region failure: the unverified-region finding already
+  // tells the story on its own.
+  if (vpcs.length === 0) return [regionFailure];
+
+  // Coverage gap AND we couldn't confirm from what we read: surface both —
+  // they're consistent (both negative).
+  return [regionFailure, ...separation];
+}
+
+/**
  * Separation of Environments check (heuristic, within-account). Lists every
  * non-default VPC across the account's regions, classifies each by its
  * Environment/Name tag, and passes when a production environment is found
@@ -189,35 +238,6 @@ export const environmentSeparationCheck: IntegrationCheck = {
       }
     }
 
-    // A region we couldn't read is unverified — surface it instead of letting a
-    // partial read failure end as a silent verdict.
-    if (regionFailures.length > 0) {
-      const regions = regionFailures.map((r) => r.region);
-      emitOutcomes(ctx, [
-        {
-          kind: 'fail',
-          title: 'Could not verify VPCs in some regions',
-          description: `VPCs could not be listed in: ${regions.join(', ')}, so environment separation is unverified in those regions.`,
-          resourceType: 'aws-environment-separation',
-          resourceId: `regions:${regions.join(',')}`,
-          severity: 'medium',
-          remediation: remediationForReadFailure(
-            combineReadFailures(regionFailures.map((r) => r.failure)),
-            'Grant ec2:DescribeVpcs to the integration role in all enabled regions, then re-run the check.',
-          ),
-          evidence: {
-            failedRegions: regionFailures.map((r) => ({
-              region: r.region,
-              error: r.failure.error,
-            })),
-          },
-        },
-      ]);
-      // If we also found zero VPCs, the unverified-region finding already tells
-      // the story — don't add a misleading "no VPCs" verdict on unread data.
-      if (vpcs.length === 0) return;
-    }
-
-    emitOutcomes(ctx, evaluateEnvironmentSeparation(vpcs));
+    emitOutcomes(ctx, buildEnvironmentSeparationOutcomes(vpcs, regionFailures));
   },
 };

--- a/packages/integration-platform/src/manifests/azure/checks/__tests__/azure-checks.test.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/__tests__/azure-checks.test.ts
@@ -1014,6 +1014,27 @@ describe('Azure environment separation', () => {
     expect(failed.some((f) => /Could not verify environment separation/.test(f.title))).toBe(true);
   });
 
+  it('fails "could not verify" when a SUBSCRIPTION name read fails (cubic finding)', async () => {
+    // Tier-1 displayName read fails while resource-group listing succeeds but
+    // classifies nothing. Coverage is incomplete, so the verdict must be the
+    // retry-signalling "could not verify", not the confident "could not confirm".
+    const { passed, failed } = await run(
+      environmentSeparationCheck,
+      (url) => {
+        const subM = url.match(/\/subscriptions\/([^/?]+)\?api-version/);
+        if (subM) throw new Error('HTTP 403: Forbidden');
+        if (url.includes('/resourcegroups')) {
+          return { value: [{ id: 'a', name: 'backend' }] };
+        }
+        return {};
+      },
+      { subscription_ids: ['s1'] },
+    );
+    expect(passed).toHaveLength(0);
+    expect(failed.some((f) => /Could not verify environment separation/.test(f.title))).toBe(true);
+    expect(failed.some((f) => /Could not confirm environment separation/.test(f.title))).toBe(false);
+  });
+
   it('defers to the scope resolver when no subscription is in scope', async () => {
     // variables {} → discovery; no enabled subscription → resolveAzureSubscriptionIds
     // emits its own scope finding and the check early-returns (no double fail).

--- a/packages/integration-platform/src/manifests/azure/checks/environment-separation.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/environment-separation.ts
@@ -63,6 +63,7 @@ export const environmentSeparationCheck: IntegrationCheck = {
     // subscription's display name only — we never touch subscriptions outside
     // the configured selection.
     const subscriptionEnvSet = new Set<string>();
+    let anySubscriptionReadFailed = false;
     for (const id of subscriptionIds) {
       try {
         const sub = await ctx.fetch<{ displayName?: string }>(
@@ -71,6 +72,7 @@ export const environmentSeparationCheck: IntegrationCheck = {
         const env = classifyEnvironment([sub.displayName]);
         if (env) subscriptionEnvSet.add(env);
       } catch (err) {
+        anySubscriptionReadFailed = true;
         ctx.log(
           `Azure env-separation: could not read subscription ${id} — ${toHttpReadFailure(err).error}`,
         );
@@ -136,19 +138,24 @@ export const environmentSeparationCheck: IntegrationCheck = {
       return;
     }
 
-    // Could not confirm. A read failure leaves coverage incomplete ("could not
-    // verify"); a complete scan that simply found no prod/non-prod split is
-    // "could not confirm".
+    // Could not confirm. A read failure in EITHER tier (a subscription name we
+    // couldn't read, or resource groups we couldn't list) leaves coverage
+    // incomplete, so the verdict is "could not verify" (retry/permissions) — not
+    // the confident "could not confirm" (a complete scan that found no split).
     const detectedAll = [...new Set([...subscriptionEnvs, ...resourceGroupEnvs])];
+    const readGaps: string[] = [];
+    if (anySubscriptionReadFailed) readGaps.push('subscriptions');
+    if (anyRgReadFailed) readGaps.push('resource groups');
+    const coverageIncomplete = readGaps.length > 0;
     const base =
       detectedAll.length === 0
         ? `No in-scope Azure subscription or resource group could be classified by environment across ${subscriptionIds.length} subscription(s)`
         : `Detected environment(s) ${detectedAll.join(', ')}, but could not confirm a production environment separated from a non-production one across ${subscriptionIds.length} in-scope subscription(s)`;
     ctx.fail({
-      title: anyRgReadFailed
+      title: coverageIncomplete
         ? 'Could not verify environment separation'
         : 'Could not confirm environment separation',
-      description: `${base}${anyRgReadFailed ? ' (some resource groups could not be read)' : ''}.`,
+      description: `${base}${coverageIncomplete ? ` (some ${readGaps.join(' and ')} could not be read)` : ''}.`,
       resourceType: 'azure-environment-separation',
       resourceId: 'subscriptions',
       severity: 'medium',
@@ -158,6 +165,7 @@ export const environmentSeparationCheck: IntegrationCheck = {
         resourceGroupEnvironments: resourceGroupEnvs,
         subscriptionsScanned: subscriptionIds.length,
         resourceGroupsClassified: rgSamples.length,
+        ...(coverageIncomplete ? { coverageIncomplete: true } : {}),
       },
     });
   },

--- a/packages/integration-platform/src/manifests/environment-classification.ts
+++ b/packages/integration-platform/src/manifests/environment-classification.ts
@@ -9,11 +9,25 @@
  * token is compared exactly to a set of environment keywords. This is why
  * "production"/"product" and "dev"/"developer" never collide, and why separator
  * style doesn't matter (`myapp-prod`, `myapp_prod`, `myapp.prod` all classify).
+ *
+ * Qualifiers are honored: a production keyword that is negated ("non-prod",
+ * "not-prod", or the joined "nonprod") classifies as NON-PRODUCTION, and a
+ * pre-production keyword ("pre-prod", matching the joined "preprod") classifies
+ * as STAGING — never as plain production. Without this a `non-prod` label would
+ * read as production and corrupt the prod-vs-non-prod separation verdict.
  */
+
+/** Production keywords — defined once so the qualifier pass below can reuse them. */
+const PRODUCTION_TOKENS: ReadonlySet<string> = new Set([
+  'prod',
+  'production',
+  'prd',
+  'live',
+]);
 
 const ENV_TOKEN_SETS: ReadonlyArray<{ env: string; tokens: ReadonlySet<string> }> = [
   // Production is first so it wins ties when a string carries multiple tokens.
-  { env: 'production', tokens: new Set(['prod', 'production', 'prd', 'live']) },
+  { env: 'production', tokens: PRODUCTION_TOKENS },
   { env: 'staging', tokens: new Set(['staging', 'stage', 'stg', 'preprod', 'uat']) },
   { env: 'development', tokens: new Set(['dev', 'develop', 'development']) },
   { env: 'test', tokens: new Set(['test', 'testing', 'qa']) },
@@ -25,6 +39,40 @@ export const ENV_TAG_KEYS = ['environment', 'env', 'stage', 'tier'] as const;
 
 /** The single production bucket; every other bucket is non-production. */
 const PRODUCTION_ENV = 'production';
+
+/** The staging bucket — also where pre-production ("pre-prod") classifies. */
+const STAGING_ENV = 'staging';
+
+/**
+ * Canonical bucket for an explicitly non-production label ("non-prod",
+ * "nonprod"). It says only "not production" — which is exactly what the
+ * separation control needs: it counts as a non-production environment.
+ */
+const NON_PRODUCTION_ENV = 'non-production';
+
+/**
+ * Joined non-production spellings: the qualifier and production word run
+ * together with no separator ("nonprod"), so they survive `tokenize` as a single
+ * token and are matched whole. Separated forms ("non-prod") are caught by the
+ * adjacency check in `classifyTokens`.
+ */
+const NON_PRODUCTION_TOKENS: ReadonlySet<string> = new Set([
+  'nonprod',
+  'nonprd',
+  'nonproduction',
+  'notprod',
+  'notprd',
+  'notproduction',
+]);
+
+/**
+ * Qualifier tokens checked against the token IMMEDIATELY before a production
+ * token. Only production is qualified — it's the one bucket where a missed
+ * qualifier flips the prod-vs-non-prod verdict — so a stray "non"/"pre"
+ * elsewhere in a name is ignored.
+ */
+const PRODUCTION_NEGATORS: ReadonlySet<string> = new Set(['non', 'not']);
+const PREPROD_QUALIFIERS: ReadonlySet<string> = new Set(['pre']);
 
 /**
  * Whether a set of detected environments confirms environment SEPARATION as the
@@ -50,6 +98,29 @@ function tokenize(value: string): string[] {
 }
 
 /**
+ * Classify a single tokenized candidate, or null. A qualified production token
+ * is resolved FIRST — "non-prod"/"not-prod" (and the joined "nonprod") →
+ * non-production, "pre-prod" → staging — so the bare production keyword below
+ * can't win it back. Otherwise tokens are matched exactly against each
+ * environment set (production first, so it wins when several tokens are present).
+ */
+function classifyTokens(tokens: string[]): string | null {
+  let prev: string | undefined;
+  for (const token of tokens) {
+    if (NON_PRODUCTION_TOKENS.has(token)) return NON_PRODUCTION_ENV;
+    if (PRODUCTION_TOKENS.has(token) && prev) {
+      if (PRODUCTION_NEGATORS.has(prev)) return NON_PRODUCTION_ENV;
+      if (PREPROD_QUALIFIERS.has(prev)) return STAGING_ENV;
+    }
+    prev = token;
+  }
+  for (const { env, tokens: keywords } of ENV_TOKEN_SETS) {
+    if (tokens.some((t) => keywords.has(t))) return env;
+  }
+  return null;
+}
+
+/**
  * Classify a list of candidate strings (e.g. an environment tag/label value,
  * then a resource name) into a canonical environment, or null if none match.
  * Candidates are tried in order, so callers should pass the most authoritative
@@ -60,10 +131,8 @@ export function classifyEnvironment(
 ): string | null {
   for (const candidate of candidates) {
     if (!candidate) continue;
-    const tokens = tokenize(candidate);
-    for (const { env, tokens: keywords } of ENV_TOKEN_SETS) {
-      if (tokens.some((t) => keywords.has(t))) return env;
-    }
+    const env = classifyTokens(tokenize(candidate));
+    if (env) return env;
   }
   return null;
 }


### PR DESCRIPTION
## Summary

Follow-up to the merged Separation of Environments work (#3182 / #3184). The `cubic-dev-ai` bot flagged **3 issues** on the review; I investigated all three — **all real** — and fixed them in this isolated PR (only the 3 check files + their tests).

| # | File | Severity | Problem |
|---|------|----------|---------|
| 1 | `environment-classification.ts` | **High** | `"non-prod"` tokenized to `["non","prod"]` and matched the bare `prod` token → classified as **production**. Caused **false FAIL** (prod + `non-prod` → production-only → "no separation") *and* **false PASS** (only non-prod envs, e.g. `non-prod-staging` + `dev` → fabricated production). Corrupts the compliance verdict. |
| 2 | `azure/.../environment-separation.ts` | Low | Tier-1 subscription `displayName` read failures were swallowed — only Tier-2 resource-group failures drove the "could not verify" vs "could not confirm" wording, so a partial read could report a confident verdict. |
| 3 | `aws/.../environment-separation.ts` | Medium | A region read failure emitted a "could not verify" **fail even when the VPCs already confirmed separation** → contradictory **pass + fail in the same run** (each becomes a separate finding via `emitOutcomes`). |

GCP already handled this correctly (checks for a confirmed pass first, only adds coverage-gap wording to the fail path) — this brings AWS/Azure to the same standard.

## Fixes

**1 — Classifier (shared by AWS/GCP/Azure).** A production token immediately preceded by `non`/`not` (or a joined `nonprod`/`notprod`/`nonproduction`/…) now classifies as **`non-production`**; `pre-prod` classifies as **`staging`** (matching the already-handled joined `preprod`). Adjacency-based, so a stray `non`/`pre` elsewhere (`prod-non-critical`) still classifies as production. The new `non-production` value only flows into display strings and the `production`-vs-non-production check — verified safe end-to-end across **both repos** (no enum/switch/Prisma column constrains env values).

**2 — Azure.** Added `anySubscriptionReadFailed`; a read failure in **either** tier now marks coverage incomplete and yields the retry-signalling "Could not verify". Pass paths are untouched (a read failure never downgrades a confirmed pass).

**3 — AWS.** Extracted a pure, unit-testable `buildEnvironmentSeparationOutcomes(vpcs, regionFailures)` (mirroring the existing `evaluateEnvironmentSeparation` pattern) that suppresses the region-failure finding once separation is confirmed. Behaviour is byte-for-byte identical to before in every branch **except** the intended fix (confirmed pass no longer paired with a fail).

## Testing

- Regression tests added for all three fixes (negated/qualified classification incl. end-to-end false-pass/false-fail guards; Azure subscription-read failure; AWS region-failure-vs-verdict matrix).
- **393/393** integration-platform tests pass; `tsc` build clean.
- Cross-checked with a 3-way adversarial review (one reviewer per fix, empirical inputs + both-repo consumer search): all three returned **correct / high confidence**, no blocker/major issues.

## Scope / isolation

No DB or API changes. Touches only the 3 env-separation check files and their test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three environment-separation correctness issues: proper negation in the classifier, accurate Azure “could not verify” coverage, and no contradictory pass+fail in AWS. Prevents false fails/passes and ensures consistent verdicts across AWS/Azure/GCP.

- **Bug Fixes**
  - Classifier: Treat `non-prod`/`not-prod`/`nonprod` as non-production, and `pre-prod` as staging. Negation is adjacency-based. Shared by AWS/Azure/GCP.
  - Azure: If any subscription name read fails, mark coverage incomplete and emit “Could not verify,” not “Could not confirm.”
  - AWS: When separation is already confirmed, suppress the region-read failure finding. If zero VPCs were read, emit only the region-failure finding. Introduces `buildEnvironmentSeparationOutcomes(...)` to handle this cleanly.
  - Added regression tests for all fixes. No DB or API changes.

<sup>Written for commit 1420c1c6362f47e8e860d2c1fad0289d0d8b7463. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

