### PR TITLE
fix(integration-platform): fail closed on capped azure env pagination

### DIFF
--- a/packages/integration-platform/src/manifests/azure/checks/__tests__/environment-separation.test.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/__tests__/environment-separation.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'bun:test';
+import type {
+  CheckContext,
+  CheckFindingResult,
+  CheckPassingResult,
+  CheckVariableValues,
+} from '../../../../types';
+import { environmentSeparationCheck } from '../environment-separation';
+
+interface CapturedResults {
+  passed: CheckPassingResult[];
+  failed: CheckFindingResult[];
+}
+
+async function runEnvironmentSeparation({
+  fetch,
+  variables = { subscription_id: 'sub-1' },
+}: {
+  fetch: (url: string) => unknown;
+  variables?: CheckVariableValues;
+}): Promise<CapturedResults> {
+  const passed: CheckPassingResult[] = [];
+  const failed: CheckFindingResult[] = [];
+  const ctx = {
+    accessToken: 'tok',
+    credentials: {},
+    variables,
+    connectionId: 'connection-id',
+    organizationId: 'organization-id',
+    metadata: {},
+    log: () => {},
+    warn: () => {},
+    error: () => {},
+    pass: (result) => passed.push(result),
+    fail: (finding) => failed.push(finding),
+    addPassingResult: () => {},
+    addFinding: () => {},
+    fetch: async (url: string) => fetch(url),
+    post: async () => ({}),
+    put: async () => ({}),
+    patch: async () => ({}),
+    delete: async () => ({}),
+    graphql: async () => ({}),
+    fetchAllPages: async () => [],
+    fetchWithCursor: async () => [],
+    fetchWithLinkHeader: async () => [],
+    getState: async () => null,
+    setState: async () => {},
+  } as CheckContext;
+
+  await environmentSeparationCheck.run(ctx);
+  return { passed, failed };
+}
+
+describe('Azure environment separation pagination coverage', () => {
+  it('does not emit a resource-group pass when ARM pagination hits the page cap', async () => {
+    const out = await runEnvironmentSeparation({
+      fetch: (url) => {
+        if (url.match(/\/subscriptions\/sub-1\?api-version/)) {
+          return { displayName: 'Company' };
+        }
+
+        if (url.includes('/resourcegroups')) {
+          const pageMatch = url.match(/[?&]page=(\d+)/);
+          const page = pageMatch ? Number(pageMatch[1]) : 0;
+          const name = page === 0 ? 'rg-prod' : 'rg-dev';
+
+          return {
+            value: [{ id: `rg-${page}`, name }],
+            nextLink: `https://management.azure.com/subscriptions/sub-1/resourcegroups?page=${
+              page + 1
+            }`,
+          };
+        }
+
+        return {};
+      },
+    });
+
+    expect(out.passed).toHaveLength(0);
+    expect(out.failed).toHaveLength(1);
+    expect(out.failed[0]!.title).toMatch(/Could not verify environment separation/);
+    expect(out.failed[0]!.evidence).toMatchObject({
+      coverageIncomplete: true,
+      resourceGroupCoverageGaps: ['page-cap'],
+      resourceGroupCoverageGapSubscriptions: ['sub-1'],
+    });
+  });
+});

--- a/packages/integration-platform/src/manifests/azure/checks/environment-separation.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/environment-separation.ts
@@ -6,7 +6,7 @@ import {
   envTagValues,
 } from '../../environment-classification';
 import { toHttpReadFailure } from '../../http-read-failure';
-import { ARM_BASE, armListAll, resolveAzureSubscriptionIds } from './shared';
+import { ARM_BASE, armListAllWithCoverage, resolveAzureSubscriptionIds } from './shared';
 
 const SUBSCRIPTION_API_VERSION = '2020-01-01';
 const RESOURCE_GROUPS_API_VERSION = '2021-04-01';
@@ -99,13 +99,21 @@ export const environmentSeparationCheck: IntegrationCheck = {
     const rgEnvSet = new Set<string>();
     const rgSamples: Array<{ name: string; environment: string }> = [];
     let anyRgReadFailed = false;
+    let resourceGroupsClassified = 0;
+    const rgCoverageGaps = new Set<string>();
+    const rgCoverageGapSubscriptions = new Set<string>();
     for (const id of subscriptionIds) {
       let resourceGroups: ResourceGroup[];
       try {
-        resourceGroups = await armListAll<ResourceGroup>(
+        const result = await armListAllWithCoverage<ResourceGroup>({
           ctx,
-          `${ARM_BASE}/subscriptions/${id}/resourcegroups?api-version=${RESOURCE_GROUPS_API_VERSION}`,
-        );
+          url: `${ARM_BASE}/subscriptions/${id}/resourcegroups?api-version=${RESOURCE_GROUPS_API_VERSION}`,
+        });
+        resourceGroups = result.items;
+        for (const gap of result.coverageGaps) {
+          rgCoverageGaps.add(gap);
+          rgCoverageGapSubscriptions.add(id);
+        }
       } catch (err) {
         anyRgReadFailed = true;
         ctx.log(
@@ -117,12 +125,15 @@ export const environmentSeparationCheck: IntegrationCheck = {
         const env = classifyResourceGroupEnv(rg);
         if (env) {
           rgEnvSet.add(env);
+          resourceGroupsClassified++;
           if (rgSamples.length < 50) rgSamples.push({ name: rg.name, environment: env });
         }
       }
     }
     const resourceGroupEnvs = [...rgEnvSet];
-    if (confirmsEnvironmentSeparation(resourceGroupEnvs)) {
+    const resourceGroupCoverageIncomplete = rgCoverageGaps.size > 0;
+    const resourceGroupSeparationDetected = confirmsEnvironmentSeparation(resourceGroupEnvs);
+    if (!resourceGroupCoverageIncomplete && resourceGroupSeparationDetected) {
       ctx.pass({
         title: 'Environments separated across resource groups',
         description: `Detected production separated from non-production across resource groups in ${subscriptionIds.length} in-scope subscription(s): ${resourceGroupEnvs.join(', ')}. Resource-group separation is logical — RGs share the subscription's access and network boundary — not full isolation.`,
@@ -138,24 +149,29 @@ export const environmentSeparationCheck: IntegrationCheck = {
       return;
     }
 
-    // Could not confirm. A read failure in EITHER tier (a subscription name we
-    // couldn't read, or resource groups we couldn't list) leaves coverage
-    // incomplete, so the verdict is "could not verify" (retry/permissions) — not
-    // the confident "could not confirm" (a complete scan that found no split).
+    // Could not confirm. A read failure or pagination gap in EITHER tier leaves
+    // coverage incomplete, so the verdict is "could not verify"
+    // (retry/permissions/scope) — not the confident "could not confirm" (a
+    // complete scan that found no split).
     const detectedAll = [...new Set([...subscriptionEnvs, ...resourceGroupEnvs])];
-    const readGaps: string[] = [];
-    if (anySubscriptionReadFailed) readGaps.push('subscriptions');
-    if (anyRgReadFailed) readGaps.push('resource groups');
-    const coverageIncomplete = readGaps.length > 0;
+    const coverageGaps: string[] = [];
+    if (anySubscriptionReadFailed) coverageGaps.push('subscriptions could not be read');
+    if (anyRgReadFailed) coverageGaps.push('resource groups could not be listed');
+    if (resourceGroupCoverageIncomplete) {
+      coverageGaps.push('resource-group pagination stopped before all groups were evaluated');
+    }
+    const coverageIncomplete = coverageGaps.length > 0;
     const base =
       detectedAll.length === 0
         ? `No in-scope Azure subscription or resource group could be classified by environment across ${subscriptionIds.length} subscription(s)`
-        : `Detected environment(s) ${detectedAll.join(', ')}, but could not confirm a production environment separated from a non-production one across ${subscriptionIds.length} in-scope subscription(s)`;
+        : resourceGroupSeparationDetected && resourceGroupCoverageIncomplete
+          ? `Detected production separated from non-production in the scanned resource groups (${resourceGroupEnvs.join(', ')}), but not all resource groups were evaluated across ${subscriptionIds.length} in-scope subscription(s)`
+          : `Detected environment(s) ${detectedAll.join(', ')}, but could not confirm a production environment separated from a non-production one across ${subscriptionIds.length} in-scope subscription(s)`;
     ctx.fail({
       title: coverageIncomplete
         ? 'Could not verify environment separation'
         : 'Could not confirm environment separation',
-      description: `${base}${coverageIncomplete ? ` (some ${readGaps.join(' and ')} could not be read)` : ''}.`,
+      description: `${base}${coverageIncomplete ? ` (${coverageGaps.join('; ')})` : ''}.`,
       resourceType: 'azure-environment-separation',
       resourceId: 'subscriptions',
       severity: 'medium',
@@ -164,8 +180,14 @@ export const environmentSeparationCheck: IntegrationCheck = {
         subscriptionEnvironments: subscriptionEnvs,
         resourceGroupEnvironments: resourceGroupEnvs,
         subscriptionsScanned: subscriptionIds.length,
-        resourceGroupsClassified: rgSamples.length,
+        resourceGroupsClassified,
         ...(coverageIncomplete ? { coverageIncomplete: true } : {}),
+        ...(resourceGroupCoverageIncomplete
+          ? {
+              resourceGroupCoverageGaps: [...rgCoverageGaps],
+              resourceGroupCoverageGapSubscriptions: [...rgCoverageGapSubscriptions],
+            }
+          : {}),
       },
     });
   },

--- a/packages/integration-platform/src/manifests/azure/checks/shared.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/shared.ts
@@ -2,6 +2,7 @@ import type { CheckContext } from '../../../types';
 import { remediationForReadFailure, toHttpReadFailure } from '../../http-read-failure';
 
 const ARM = 'https://management.azure.com';
+const ARM_PAGE_CAP = 50;
 
 /** Fan-out bound for auto-discovered subscriptions (13 checks × N subs). */
 const MAX_SUBSCRIPTIONS = 50;
@@ -112,14 +113,25 @@ export async function resolveAzureSubscriptionIds(
 }
 
 /** Paginate an Azure ARM list endpoint (`{ value: T[], nextLink? }`). */
-export async function armListAll<T>(
-  ctx: CheckContext,
-  url: string,
-): Promise<T[]> {
+export type ArmListCoverageGap = 'page-cap' | 'unexpected-next-link-host';
+
+export interface ArmListResult<T> {
+  items: T[];
+  coverageGaps: ArmListCoverageGap[];
+}
+
+export async function armListAllWithCoverage<T>({
+  ctx,
+  url,
+}: {
+  ctx: CheckContext;
+  url: string;
+}): Promise<ArmListResult<T>> {
   const out: T[] = [];
+  const coverageGaps: ArmListCoverageGap[] = [];
   let nextUrl: string | undefined = url;
   let pages = 0;
-  while (nextUrl && pages < 50) {
+  while (nextUrl && pages < ARM_PAGE_CAP) {
     const data: { value?: T[]; nextLink?: string } = await ctx.fetch(nextUrl);
     if (Array.isArray(data.value)) out.push(...data.value);
     nextUrl = data.nextLink;
@@ -129,6 +141,7 @@ export async function armListAll<T>(
       ctx.warn('Azure ARM nextLink pointed to an unexpected host; stopping pagination', {
         nextLink: nextUrl,
       });
+      coverageGaps.push('unexpected-next-link-host');
       nextUrl = undefined;
     }
     pages++;
@@ -138,8 +151,15 @@ export async function armListAll<T>(
       url,
       pages,
     });
+    coverageGaps.push('page-cap');
   }
-  return out;
+  return { items: out, coverageGaps };
+}
+
+/** Paginate an Azure ARM list endpoint (`{ value: T[], nextLink? }`). */
+export async function armListAll<T>(ctx: CheckContext, url: string): Promise<T[]> {
+  const result = await armListAllWithCoverage<T>({ ctx, url });
+  return result.items;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add coverage-aware ARM pagination helper while preserving existing armListAll callers
- treat capped or unsafe resource-group pagination as incomplete Azure environment-separation coverage
- add regression coverage for capped resource-group pagination suppressing a definitive pass

## Verification
- bun test packages/integration-platform/src/manifests/azure/checks/__tests__/environment-separation.test.ts
- bun test packages/integration-platform/src/manifests/azure/checks/__tests__/azure-checks.test.ts
- bun run --filter @trycompai/integration-platform typecheck
- git diff --check

Note: package-wide lint currently reports existing Prettier drift in 72 files, including many untouched files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail closed for Azure environment separation when ARM resource-group pagination is incomplete, preventing false-positive passes in `@trycompai/integration-platform`. Adds coverage-aware pagination and clearer evidence in failures.

- **Bug Fixes**
  - Introduced `armListAllWithCoverage` with a 50-page cap and gap detection (`'page-cap'`, `'unexpected-next-link-host'`); kept `armListAll` for existing callers.
  - Updated environment-separation check to withhold a pass if any RG pagination gap occurs, even when separation is detected; emits "Could not verify" with coverage details.
  - Added evidence fields: `coverageIncomplete`, `resourceGroupCoverageGaps`, `resourceGroupCoverageGapSubscriptions`, and accurate `resourceGroupsClassified`.
  - Improved failure descriptions to specify gaps (e.g., subscriptions not readable, RGs not listable, pagination stopped).
  - Added regression test ensuring capped RG pagination suppresses a pass.

<sup>Written for commit ee53b72495fa90cd3760bcf1690b10c9ecf1f196. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

