### PR TITLE
fix(integration-platform): make environment separation checks opt-in

### DIFF
--- a/apps/api/src/integration-platform/controllers/task-integrations.controller.ts
+++ b/apps/api/src/integration-platform/controllers/task-integrations.controller.ts
@@ -35,7 +35,8 @@ import { CredentialVaultService } from '../services/credential-vault.service';
 import { OAuthCredentialsService } from '../services/oauth-credentials.service';
 import { TaskIntegrationChecksService } from '../services/task-integration-checks.service';
 import { getStringValue } from '../utils/credential-utils';
-import { isCheckDisabledForTask } from '../utils/disabled-task-checks';
+import { isTaskCheckEnabled } from '../utils/disabled-task-checks';
+import { isTaskRunEnabledByDefault } from '../utils/task-check-defaults';
 import { getProviderSummary } from '../utils/provider-summary';
 import { getConnectionLabel } from '../utils/connection-label';
 import { loadActiveExceptionSet } from '../../cloud-security/finding-exceptions';
@@ -227,11 +228,12 @@ export class TaskIntegrationsController {
           const isDisabledForTask =
             !!taskIdForDisableState &&
             !!connection &&
-            isCheckDisabledForTask(
-              connection.metadata,
-              taskIdForDisableState,
-              check.id,
-            );
+            !isTaskCheckEnabled({
+              metadata: connection.metadata,
+              taskId: taskIdForDisableState,
+              checkId: check.id,
+              enabledByDefault: isTaskRunEnabledByDefault(check),
+            });
 
           checks.push({
             integrationId: manifest.id,
@@ -402,7 +404,14 @@ export class TaskIntegrationsController {
     // failing account still leaves the earlier accounts' results persisted.
     for (const conn of connections) {
       // Respect a check that was disconnected from this task for this account.
-      if (isCheckDisabledForTask(conn.metadata, taskId, checkId)) {
+      if (
+        !isTaskCheckEnabled({
+          metadata: conn.metadata,
+          taskId,
+          checkId,
+          enabledByDefault: isTaskRunEnabledByDefault(checkDef),
+        })
+      ) {
         continue;
       }
       const outcome = await this.runCheckForConnection({

--- a/apps/api/src/integration-platform/services/task-integration-checks.service.spec.ts
+++ b/apps/api/src/integration-platform/services/task-integration-checks.service.spec.ts
@@ -4,7 +4,10 @@ import { TaskIntegrationChecksService } from './task-integration-checks.service'
 import { ConnectionRepository } from '../repositories/connection.repository';
 import { ProviderRepository } from '../repositories/provider.repository';
 import { ConnectionService } from './connection.service';
-import { DISABLED_TASK_CHECKS_KEY } from '../utils/disabled-task-checks';
+import {
+  DISABLED_TASK_CHECKS_KEY,
+  ENABLED_TASK_CHECKS_KEY,
+} from '../utils/disabled-task-checks';
 
 jest.mock('@db', () => ({
   db: {
@@ -254,6 +257,34 @@ describe('TaskIntegrationChecksService', () => {
       const [, persistedMetadata] =
         mockConnectionService.updateConnectionMetadata.mock.calls[0];
       expect(persistedMetadata[DISABLED_TASK_CHECKS_KEY]).toEqual({});
+    });
+
+    it('records explicit opt-in when reconnecting a default-off check', async () => {
+      mockedGetManifest.mockReturnValue({
+        ...baseManifest,
+        checks: [
+          ...baseManifest.checks,
+          {
+            id: 'gcp-environment-separation',
+            name: 'Separation of environments',
+            taskRunEnabledByDefault: false,
+          },
+        ],
+      } as never);
+
+      await service.reconnectCheckToTask({
+        taskId: TASK_ID,
+        connectionId: CONNECTION_ID,
+        checkId: 'gcp-environment-separation',
+        organizationId: ORG_ID,
+      });
+
+      const [, persistedMetadata] =
+        mockConnectionService.updateConnectionMetadata.mock.calls[0];
+      expect(persistedMetadata[DISABLED_TASK_CHECKS_KEY]).toEqual({});
+      expect(persistedMetadata[ENABLED_TASK_CHECKS_KEY]).toEqual({
+        [TASK_ID]: ['gcp-environment-separation'],
+      });
     });
   });
 });

--- a/apps/api/src/integration-platform/services/task-integration-checks.service.ts
+++ b/apps/api/src/integration-platform/services/task-integration-checks.service.ts
@@ -10,9 +10,10 @@ import { ConnectionRepository } from '../repositories/connection.repository';
 import { ProviderRepository } from '../repositories/provider.repository';
 import { ConnectionService } from './connection.service';
 import {
-  withCheckDisabled,
-  withCheckEnabled,
+  withTaskCheckDisabled,
+  withTaskCheckEnabled,
 } from '../utils/disabled-task-checks';
+import { isTaskRunEnabledByDefault } from '../utils/task-check-defaults';
 
 /**
  * Handles enable/disable of a single integration check for a single task.
@@ -54,11 +55,11 @@ export class TaskIntegrationChecksService {
     await this.assertTaskInOrg(taskId, organizationId);
     await this.assertCheckExists(connection.providerId, checkId);
 
-    const nextMetadata = withCheckDisabled(
-      connection.metadata,
+    const nextMetadata = withTaskCheckDisabled({
+      metadata: connection.metadata,
       taskId,
       checkId,
-    );
+    });
     await this.connectionService.updateConnectionMetadata(
       connectionId,
       nextMetadata,
@@ -86,9 +87,14 @@ export class TaskIntegrationChecksService {
       organizationId,
     );
     await this.assertTaskInOrg(taskId, organizationId);
-    await this.assertCheckExists(connection.providerId, checkId);
+    const check = await this.assertCheckExists(connection.providerId, checkId);
 
-    const nextMetadata = withCheckEnabled(connection.metadata, taskId, checkId);
+    const nextMetadata = withTaskCheckEnabled({
+      metadata: connection.metadata,
+      taskId,
+      checkId,
+      enabledByDefault: isTaskRunEnabledByDefault(check),
+    });
     await this.connectionService.updateConnectionMetadata(
       connectionId,
       nextMetadata,
@@ -136,5 +142,6 @@ export class TaskIntegrationChecksService {
         `Check "${checkId}" is not defined for provider "${provider.slug}"`,
       );
     }
+    return check;
   }
 }

--- a/apps/api/src/integration-platform/utils/disabled-task-checks.ts
+++ b/apps/api/src/integration-platform/utils/disabled-task-checks.ts
@@ -16,25 +16,26 @@
  *
  * Storing on the connection gives us "reconnect = fresh state" for free and
  * transparently supports orgs with multiple connections per provider — each
- * connection has its own disable state.
+ * connection has its own enable/disable state. Checks that are off by default
+ * are stored under `enabledTaskChecks` only after the user reconnects them.
  */
 
 export const DISABLED_TASK_CHECKS_KEY = 'disabledTaskChecks';
+export const ENABLED_TASK_CHECKS_KEY = 'enabledTaskChecks';
 
 export type DisabledTaskChecksMap = Record<string, string[]>;
 
-/**
- * Parse the disabled task checks map from a connection's metadata JSON blob.
- * Returns an empty map if the metadata is missing, malformed, or doesn't
- * contain a `disabledTaskChecks` entry. Never throws.
- */
-export function parseDisabledTaskChecks(
-  metadata: unknown,
-): DisabledTaskChecksMap {
+function parseTaskChecksMap({
+  metadata,
+  key,
+}: {
+  metadata: unknown;
+  key: string;
+}): DisabledTaskChecksMap {
   if (!metadata || typeof metadata !== 'object') {
     return {};
   }
-  const raw = (metadata as Record<string, unknown>)[DISABLED_TASK_CHECKS_KEY];
+  const raw = (metadata as Record<string, unknown>)[key];
   if (!raw || typeof raw !== 'object') {
     return {};
   }
@@ -55,6 +56,78 @@ export function parseDisabledTaskChecks(
 }
 
 /**
+ * Parse the disabled task checks map from a connection's metadata JSON blob.
+ * Returns an empty map if the metadata is missing, malformed, or doesn't
+ * contain a `disabledTaskChecks` entry. Never throws.
+ */
+export function parseDisabledTaskChecks(
+  metadata: unknown,
+): DisabledTaskChecksMap {
+  return parseTaskChecksMap({ metadata, key: DISABLED_TASK_CHECKS_KEY });
+}
+
+export function parseEnabledTaskChecks(
+  metadata: unknown,
+): DisabledTaskChecksMap {
+  return parseTaskChecksMap({ metadata, key: ENABLED_TASK_CHECKS_KEY });
+}
+
+function removeCheckFromMap({
+  map,
+  taskId,
+  checkId,
+}: {
+  map: DisabledTaskChecksMap;
+  taskId: string;
+  checkId: string;
+}): DisabledTaskChecksMap {
+  const current = map[taskId];
+  if (!current?.includes(checkId)) return map;
+
+  const nextChecks = current.filter((id) => id !== checkId);
+  const nextMap: DisabledTaskChecksMap = { ...map };
+  if (nextChecks.length === 0) {
+    delete nextMap[taskId];
+  } else {
+    nextMap[taskId] = nextChecks;
+  }
+  return nextMap;
+}
+
+function addCheckToMap({
+  map,
+  taskId,
+  checkId,
+}: {
+  map: DisabledTaskChecksMap;
+  taskId: string;
+  checkId: string;
+}): DisabledTaskChecksMap {
+  const current = map[taskId] ?? [];
+  if (current.includes(checkId)) return map;
+  return { ...map, [taskId]: [...current, checkId] };
+}
+
+export function isTaskCheckEnabled({
+  metadata,
+  taskId,
+  checkId,
+  enabledByDefault = true,
+}: {
+  metadata: unknown;
+  taskId: string;
+  checkId: string;
+  enabledByDefault?: boolean;
+}): boolean {
+  const disabled = parseDisabledTaskChecks(metadata)[taskId] ?? [];
+  if (disabled.includes(checkId)) return false;
+  if (enabledByDefault) return true;
+
+  const enabled = parseEnabledTaskChecks(metadata)[taskId] ?? [];
+  return enabled.includes(checkId);
+}
+
+/**
  * Returns true if the given checkId is disabled for the given taskId on this
  * connection's metadata.
  */
@@ -63,9 +136,7 @@ export function isCheckDisabledForTask(
   taskId: string,
   checkId: string,
 ): boolean {
-  const map = parseDisabledTaskChecks(metadata);
-  const disabled = map[taskId];
-  return Array.isArray(disabled) && disabled.includes(checkId);
+  return !isTaskCheckEnabled({ metadata, taskId, checkId });
 }
 
 /**
@@ -78,22 +149,32 @@ export function withCheckDisabled(
   taskId: string,
   checkId: string,
 ): Record<string, unknown> {
+  return withTaskCheckDisabled({ metadata, taskId, checkId });
+}
+
+export function withTaskCheckDisabled({
+  metadata,
+  taskId,
+  checkId,
+}: {
+  metadata: unknown;
+  taskId: string;
+  checkId: string;
+}): Record<string, unknown> {
   const base: Record<string, unknown> =
     metadata && typeof metadata === 'object'
       ? { ...(metadata as Record<string, unknown>) }
       : {};
-  const map = parseDisabledTaskChecks(base);
-  const current = map[taskId] ?? [];
-  if (current.includes(checkId)) {
-    // Already disabled — return a merged copy so callers can safely write back.
-    base[DISABLED_TASK_CHECKS_KEY] = map;
-    return base;
-  }
-  const nextMap: DisabledTaskChecksMap = {
-    ...map,
-    [taskId]: [...current, checkId],
-  };
-  base[DISABLED_TASK_CHECKS_KEY] = nextMap;
+  base[DISABLED_TASK_CHECKS_KEY] = addCheckToMap({
+    map: parseDisabledTaskChecks(base),
+    taskId,
+    checkId,
+  });
+  base[ENABLED_TASK_CHECKS_KEY] = removeCheckFromMap({
+    map: parseEnabledTaskChecks(base),
+    taskId,
+    checkId,
+  });
   return base;
 }
 
@@ -107,23 +188,32 @@ export function withCheckEnabled(
   taskId: string,
   checkId: string,
 ): Record<string, unknown> {
+  return withTaskCheckEnabled({ metadata, taskId, checkId });
+}
+
+export function withTaskCheckEnabled({
+  metadata,
+  taskId,
+  checkId,
+  enabledByDefault = true,
+}: {
+  metadata: unknown;
+  taskId: string;
+  checkId: string;
+  enabledByDefault?: boolean;
+}): Record<string, unknown> {
   const base: Record<string, unknown> =
     metadata && typeof metadata === 'object'
       ? { ...(metadata as Record<string, unknown>) }
       : {};
-  const map = parseDisabledTaskChecks(base);
-  const current = map[taskId];
-  if (!current || !current.includes(checkId)) {
-    base[DISABLED_TASK_CHECKS_KEY] = map;
-    return base;
-  }
-  const nextChecks = current.filter((id) => id !== checkId);
-  const nextMap: DisabledTaskChecksMap = { ...map };
-  if (nextChecks.length === 0) {
-    delete nextMap[taskId];
-  } else {
-    nextMap[taskId] = nextChecks;
-  }
-  base[DISABLED_TASK_CHECKS_KEY] = nextMap;
+  base[DISABLED_TASK_CHECKS_KEY] = removeCheckFromMap({
+    map: parseDisabledTaskChecks(base),
+    taskId,
+    checkId,
+  });
+  const enabledMap = parseEnabledTaskChecks(base);
+  base[ENABLED_TASK_CHECKS_KEY] = enabledByDefault
+    ? removeCheckFromMap({ map: enabledMap, taskId, checkId })
+    : addCheckToMap({ map: enabledMap, taskId, checkId });
   return base;
 }

--- a/apps/api/src/integration-platform/utils/task-check-defaults.ts
+++ b/apps/api/src/integration-platform/utils/task-check-defaults.ts
@@ -1,0 +1,7 @@
+export function isTaskRunEnabledByDefault(check: unknown): boolean {
+  if (!check || typeof check !== 'object') return true;
+
+  const value = (check as { taskRunEnabledByDefault?: unknown })
+    .taskRunEnabledByDefault;
+  return typeof value === 'boolean' ? value : true;
+}

--- a/apps/api/src/integration-platform/utils/task-check-enablement.spec.ts
+++ b/apps/api/src/integration-platform/utils/task-check-enablement.spec.ts
@@ -1,0 +1,132 @@
+import {
+  DISABLED_TASK_CHECKS_KEY,
+  ENABLED_TASK_CHECKS_KEY,
+  isTaskCheckEnabled,
+  parseEnabledTaskChecks,
+  withTaskCheckDisabled,
+  withTaskCheckEnabled,
+} from './disabled-task-checks';
+
+describe('task check enablement utils', () => {
+  describe('parseEnabledTaskChecks', () => {
+    it('parses explicit opt-in checks with the same validation rules', () => {
+      const metadata = {
+        [ENABLED_TASK_CHECKS_KEY]: {
+          tsk_abc: ['gcp-environment-separation', 42, ''],
+        },
+      };
+
+      expect(parseEnabledTaskChecks(metadata)).toEqual({
+        tsk_abc: ['gcp-environment-separation'],
+      });
+    });
+  });
+
+  describe('isTaskCheckEnabled', () => {
+    it('returns true for default-on checks with no metadata', () => {
+      expect(
+        isTaskCheckEnabled({
+          metadata: null,
+          taskId: 'tsk_abc',
+          checkId: 'branch_protection',
+        }),
+      ).toBe(true);
+    });
+
+    it('returns false for default-off checks until explicitly enabled', () => {
+      expect(
+        isTaskCheckEnabled({
+          metadata: {},
+          taskId: 'tsk_abc',
+          checkId: 'gcp-environment-separation',
+          enabledByDefault: false,
+        }),
+      ).toBe(false);
+    });
+
+    it('returns true for default-off checks after explicit opt-in', () => {
+      const metadata = {
+        [ENABLED_TASK_CHECKS_KEY]: {
+          tsk_abc: ['gcp-environment-separation'],
+        },
+      };
+
+      expect(
+        isTaskCheckEnabled({
+          metadata,
+          taskId: 'tsk_abc',
+          checkId: 'gcp-environment-separation',
+          enabledByDefault: false,
+        }),
+      ).toBe(true);
+    });
+
+    it('lets explicit disconnect override explicit opt-in', () => {
+      const metadata = {
+        [DISABLED_TASK_CHECKS_KEY]: {
+          tsk_abc: ['gcp-environment-separation'],
+        },
+        [ENABLED_TASK_CHECKS_KEY]: {
+          tsk_abc: ['gcp-environment-separation'],
+        },
+      };
+
+      expect(
+        isTaskCheckEnabled({
+          metadata,
+          taskId: 'tsk_abc',
+          checkId: 'gcp-environment-separation',
+          enabledByDefault: false,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('withTaskCheckDisabled', () => {
+    it('removes explicit opt-in when disabling a default-off check', () => {
+      const metadata = {
+        [ENABLED_TASK_CHECKS_KEY]: {
+          tsk_abc: ['gcp-environment-separation'],
+        },
+      };
+
+      const result = withTaskCheckDisabled({
+        metadata,
+        taskId: 'tsk_abc',
+        checkId: 'gcp-environment-separation',
+      });
+
+      expect(result[DISABLED_TASK_CHECKS_KEY]).toEqual({
+        tsk_abc: ['gcp-environment-separation'],
+      });
+      expect(result[ENABLED_TASK_CHECKS_KEY]).toEqual({});
+    });
+  });
+
+  describe('withTaskCheckEnabled', () => {
+    it('records explicit opt-in for default-off checks', () => {
+      const result = withTaskCheckEnabled({
+        metadata: null,
+        taskId: 'tsk_abc',
+        checkId: 'gcp-environment-separation',
+        enabledByDefault: false,
+      });
+
+      expect(result[DISABLED_TASK_CHECKS_KEY]).toEqual({});
+      expect(result[ENABLED_TASK_CHECKS_KEY]).toEqual({
+        tsk_abc: ['gcp-environment-separation'],
+      });
+    });
+
+    it('does not record opt-in for default-on checks', () => {
+      const result = withTaskCheckEnabled({
+        metadata: null,
+        taskId: 'tsk_abc',
+        checkId: 'branch_protection',
+      });
+
+      expect(result[DISABLED_TASK_CHECKS_KEY]).toEqual({});
+      expect(result[ENABLED_TASK_CHECKS_KEY]).toEqual({});
+    });
+  });
+});

--- a/apps/api/src/trigger/integration-platform/run-integration-checks-schedule.spec.ts
+++ b/apps/api/src/trigger/integration-platform/run-integration-checks-schedule.spec.ts
@@ -1,8 +1,12 @@
 import { TaskFrequency } from '@trycompai/db';
 import {
   filterDueTasks,
-  resolveProviderChecks,
 } from './run-integration-checks-schedule';
+import {
+  getEnabledChecksForScheduledTask,
+  resolveProviderChecks,
+} from './scheduled-task-checks';
+import { ENABLED_TASK_CHECKS_KEY } from '../../integration-platform/utils/disabled-task-checks';
 
 // Mock @db at the module boundary so importing the orchestrator does not try
 // to connect to Postgres. We never call the scheduled `run` function itself
@@ -133,12 +137,26 @@ describe('resolveProviderChecks (static vs dynamic)', () => {
           { id: 'branch_protection', taskMapping: null },
         ],
       },
-      dynamicChecks: [{ id: 'should_not_be_used', taskMapping: 'tpl_x' }],
+      dynamicChecks: [
+        {
+          id: 'should_not_be_used',
+          taskMapping: 'tpl_x',
+          taskRunEnabledByDefault: true,
+        },
+      ],
     });
 
     expect(checks).toEqual([
-      { id: 'two_factor_auth', taskMapping: 'tpl_mfa' },
-      { id: 'branch_protection', taskMapping: null },
+      {
+        id: 'two_factor_auth',
+        taskMapping: 'tpl_mfa',
+        taskRunEnabledByDefault: true,
+      },
+      {
+        id: 'branch_protection',
+        taskMapping: null,
+        taskRunEnabledByDefault: true,
+      },
     ]);
   });
 
@@ -146,14 +164,30 @@ describe('resolveProviderChecks (static vs dynamic)', () => {
     const checks = resolveProviderChecks({
       manifest: undefined,
       dynamicChecks: [
-        { id: 'mfa_enforcement', taskMapping: 'frk_tt_mfa' },
-        { id: 'supabase_mfa', taskMapping: 'frk_tt_mfa' },
+        {
+          id: 'mfa_enforcement',
+          taskMapping: 'frk_tt_mfa',
+          taskRunEnabledByDefault: true,
+        },
+        {
+          id: 'supabase_mfa',
+          taskMapping: 'frk_tt_mfa',
+          taskRunEnabledByDefault: true,
+        },
       ],
     });
 
     expect(checks).toEqual([
-      { id: 'mfa_enforcement', taskMapping: 'frk_tt_mfa' },
-      { id: 'supabase_mfa', taskMapping: 'frk_tt_mfa' },
+      {
+        id: 'mfa_enforcement',
+        taskMapping: 'frk_tt_mfa',
+        taskRunEnabledByDefault: true,
+      },
+      {
+        id: 'supabase_mfa',
+        taskMapping: 'frk_tt_mfa',
+        taskRunEnabledByDefault: true,
+      },
     ]);
   });
 
@@ -169,6 +203,81 @@ describe('resolveProviderChecks (static vs dynamic)', () => {
       dynamicChecks: undefined,
     });
 
-    expect(checks).toEqual([{ id: 'c1', taskMapping: null }]);
+    expect(checks).toEqual([
+      { id: 'c1', taskMapping: null, taskRunEnabledByDefault: true },
+    ]);
+  });
+
+  it('preserves manifest checks that are disabled for task runs by default', () => {
+    const checks = resolveProviderChecks({
+      manifest: {
+        checks: [
+          {
+            id: 'gcp-environment-separation',
+            taskMapping: 'frk_tt_environment_separation',
+            taskRunEnabledByDefault: false,
+          },
+        ],
+      },
+      dynamicChecks: undefined,
+    });
+
+    expect(checks).toEqual([
+      {
+        id: 'gcp-environment-separation',
+        taskMapping: 'frk_tt_environment_separation',
+        taskRunEnabledByDefault: false,
+      },
+    ]);
+  });
+});
+
+describe('getEnabledChecksForScheduledTask', () => {
+  const defaultOnCheck = {
+    id: 'branch_protection',
+    taskMapping: 'tpl_code',
+    taskRunEnabledByDefault: true,
+  };
+  const optInCheck = {
+    id: 'gcp-environment-separation',
+    taskMapping: 'tpl_env',
+    taskRunEnabledByDefault: false,
+  };
+
+  it('skips opt-in checks until they are explicitly enabled for the task', () => {
+    expect(
+      getEnabledChecksForScheduledTask({
+        checks: [optInCheck],
+        taskTemplateId: 'tpl_env',
+        taskId: 'tsk_1',
+        metadata: {},
+      }),
+    ).toEqual([]);
+  });
+
+  it('includes opt-in checks after the user reconnects them for the task', () => {
+    expect(
+      getEnabledChecksForScheduledTask({
+        checks: [optInCheck],
+        taskTemplateId: 'tpl_env',
+        taskId: 'tsk_1',
+        metadata: {
+          [ENABLED_TASK_CHECKS_KEY]: {
+            tsk_1: ['gcp-environment-separation'],
+          },
+        },
+      }),
+    ).toEqual(['gcp-environment-separation']);
+  });
+
+  it('still includes normal default-on checks unless manually disabled', () => {
+    expect(
+      getEnabledChecksForScheduledTask({
+        checks: [defaultOnCheck],
+        taskTemplateId: 'tpl_code',
+        taskId: 'tsk_1',
+        metadata: {},
+      }),
+    ).toEqual(['branch_protection']);
   });
 });

--- a/apps/api/src/trigger/integration-platform/run-integration-checks-schedule.ts
+++ b/apps/api/src/trigger/integration-platform/run-integration-checks-schedule.ts
@@ -3,8 +3,12 @@ import { db, TaskFrequency } from '@db';
 import { logger, schedules } from '@trigger.dev/sdk';
 import { runTaskIntegrationChecks } from './run-task-integration-checks';
 import { runDeviceSync } from './run-device-sync';
-import { parseDisabledTaskChecks } from '../../integration-platform/utils/disabled-task-checks';
 import { isDueToday } from '../shared/is-due-today';
+import {
+  getEnabledChecksForScheduledTask,
+  resolveProviderChecks,
+  type ProviderCheck,
+} from './scheduled-task-checks';
 
 /**
  * Pure helper extracted for unit testing. Filters a list of candidate tasks
@@ -26,44 +30,6 @@ export function filterDueTasks<
       now,
     }),
   );
-}
-
-/** A provider's check reduced to what the orchestrator needs to schedule it. */
-export interface ProviderCheck {
-  id: string;
-  taskMapping: string | null;
-}
-
-/**
- * Resolve a connection's checks from EITHER the static code manifest (the 8
- * built-in integrations, present in the Trigger.dev registry) OR the dynamic
- * (DB-backed) check map for that provider slug.
- *
- * Dynamic integrations are absent from the Trigger.dev manifest registry, so
- * `getManifest` returns undefined for them here and they were silently skipped —
- * the entire reason scheduled checks never ran for them. Falling back to the DB
- * map lets the orchestrator discover their due tasks too. Static manifests win
- * when both exist (matching the registry, which never lets a dynamic manifest
- * override a code one).
- */
-export function resolveProviderChecks({
-  manifest,
-  dynamicChecks,
-}: {
-  // Loose check shape so a real `IntegrationManifest` (whose `taskMapping` is a
-  // literal-union-or-undefined) is accepted; `.map` below normalizes it.
-  manifest:
-    | { checks?: Array<{ id: string; taskMapping?: string | null }> }
-    | undefined;
-  dynamicChecks: ProviderCheck[] | undefined;
-}): ProviderCheck[] {
-  if (manifest?.checks) {
-    return manifest.checks.map((c) => ({
-      id: c.id,
-      taskMapping: c.taskMapping ?? null,
-    }));
-  }
-  return dynamicChecks ?? [];
 }
 
 /**
@@ -113,7 +79,11 @@ export const integrationChecksSchedule = schedules.task({
     const dynamicChecksBySlug = new Map<string, ProviderCheck[]>(
       dynamicIntegrations.map((d) => [
         d.slug,
-        d.checks.map((c) => ({ id: c.checkSlug, taskMapping: c.taskMapping })),
+        d.checks.map((c) => ({
+          id: c.checkSlug,
+          taskMapping: c.taskMapping,
+          taskRunEnabledByDefault: true,
+        })),
       ]),
     );
 
@@ -175,22 +145,15 @@ export const integrationChecksSchedule = schedules.task({
         );
       }
 
-      // Per-task disabled checks are stored on the connection's metadata so
-      // users can disconnect individual checks from individual tasks without
-      // tearing down the whole integration. Resolve once per connection.
-      const disabledByTask = parseDisabledTaskChecks(connection.metadata);
-
       for (const t of tasks) {
-        const disabledForThisTask = new Set(disabledByTask[t.id] ?? []);
-
-        // Find which checks apply to this task, minus any the user disabled
-        const checksForTask = checks
-          .filter(
-            (c) =>
-              c.taskMapping === t.taskTemplateId &&
-              !disabledForThisTask.has(c.id),
-          )
-          .map((c) => c.id);
+        // Find which checks apply to this task, minus checks that are either
+        // manually disabled or opt-in-only and not yet enabled for this task.
+        const checksForTask = getEnabledChecksForScheduledTask({
+          checks,
+          taskTemplateId: t.taskTemplateId,
+          taskId: t.id,
+          metadata: connection.metadata,
+        });
 
         if (checksForTask.length > 0) {
           tasksToRun.push({

--- a/apps/api/src/trigger/integration-platform/run-task-integration-checks.ts
+++ b/apps/api/src/trigger/integration-platform/run-task-integration-checks.ts
@@ -4,7 +4,8 @@ import { logger, tags, task } from '@trigger.dev/sdk';
 import { triggerEmail } from '../../email/trigger-email';
 import { TaskStatusChangedEmail } from '../../email/templates/task-status-changed';
 import { isUserUnsubscribed } from '@trycompai/email';
-import { parseDisabledTaskChecks } from '../../integration-platform/utils/disabled-task-checks';
+import { isTaskCheckEnabled } from '../../integration-platform/utils/disabled-task-checks';
+import { isTaskRunEnabledByDefault } from '../../integration-platform/utils/task-check-defaults';
 import {
   getAccessToken,
   requestValidCredentials,
@@ -342,11 +343,18 @@ export const runTaskIntegrationChecks = task({
     // metadata and skip anything that's now disabled. The rest of the flow
     // (lastSyncAt update, task status evaluation, return payload) runs as
     // before — just over the filtered list instead of the original one.
-    const disabledForThisTask = new Set(
-      parseDisabledTaskChecks(connection.metadata)[taskId] ?? [],
+    const checksById = new Map(
+      (manifest?.checks ?? []).map((check) => [check.id, check]),
     );
     const effectiveCheckIds = checkIds.filter(
-      (id) => !disabledForThisTask.has(id),
+      (id) =>
+        isTaskCheckEnabled({
+          metadata: connection.metadata,
+          taskId,
+          checkId: id,
+          enabledByDefault:
+            isTaskRunEnabledByDefault(checksById.get(id) ?? {}),
+        }),
     );
     if (effectiveCheckIds.length < checkIds.length) {
       logger.info(

--- a/apps/api/src/trigger/integration-platform/scheduled-task-checks.ts
+++ b/apps/api/src/trigger/integration-platform/scheduled-task-checks.ts
@@ -1,0 +1,62 @@
+import { isTaskCheckEnabled } from '../../integration-platform/utils/disabled-task-checks';
+
+/** A provider's check reduced to what the orchestrator needs to schedule it. */
+export interface ProviderCheck {
+  id: string;
+  taskMapping: string | null;
+  taskRunEnabledByDefault: boolean;
+}
+
+/**
+ * Resolve a connection's checks from either the static code manifest or the
+ * dynamic DB-backed check map for that provider slug.
+ */
+export function resolveProviderChecks({
+  manifest,
+  dynamicChecks,
+}: {
+  manifest:
+    | {
+        checks?: Array<{
+          id: string;
+          taskMapping?: string | null;
+          taskRunEnabledByDefault?: boolean;
+        }>;
+      }
+    | undefined;
+  dynamicChecks: ProviderCheck[] | undefined;
+}): ProviderCheck[] {
+  if (manifest?.checks) {
+    return manifest.checks.map((c) => ({
+      id: c.id,
+      taskMapping: c.taskMapping ?? null,
+      taskRunEnabledByDefault: c.taskRunEnabledByDefault ?? true,
+    }));
+  }
+  return dynamicChecks ?? [];
+}
+
+export function getEnabledChecksForScheduledTask({
+  checks,
+  taskTemplateId,
+  taskId,
+  metadata,
+}: {
+  checks: ProviderCheck[];
+  taskTemplateId: string | null;
+  taskId: string;
+  metadata: unknown;
+}): string[] {
+  return checks
+    .filter(
+      (c) =>
+        c.taskMapping === taskTemplateId &&
+        isTaskCheckEnabled({
+          metadata,
+          taskId,
+          checkId: c.id,
+          enabledByDefault: c.taskRunEnabledByDefault,
+        }),
+    )
+    .map((c) => c.id);
+}

--- a/packages/integration-platform/src/manifests/aws/checks/environment-separation.ts
+++ b/packages/integration-platform/src/manifests/aws/checks/environment-separation.ts
@@ -227,9 +227,10 @@ export const environmentSeparationCheck: IntegrationCheck = {
   id: 'aws-environment-separation',
   name: 'Separation of environments — production isolated from non-production',
   description:
-    'Verify production and non-production workloads run in distinct VPCs within the AWS account.',
+    'Optional check: confirm production and non-production separation from AWS VPC metadata when environment naming is clear.',
   service: 'ec2-vpc',
   taskMapping: TASK_TEMPLATES.separationOfEnvironments,
+  taskRunEnabledByDefault: false,
   run: async (ctx: CheckContext) => {
     const session = await resolveAwsSessionOrFail(ctx);
     if (!session) {

--- a/packages/integration-platform/src/manifests/azure/checks/environment-separation.ts
+++ b/packages/integration-platform/src/manifests/azure/checks/environment-separation.ts
@@ -70,9 +70,10 @@ export const environmentSeparationCheck: IntegrationCheck = {
   id: 'azure-environment-separation',
   name: 'Separation of environments — production isolated from non-production',
   description:
-    'Verify production and non-production are separated across Azure subscriptions or resource groups.',
+    'Optional check: confirm production and non-production separation from Azure subscription/resource-group metadata when environment naming is clear.',
   service: 'policy',
   taskMapping: TASK_TEMPLATES.separationOfEnvironments,
+  taskRunEnabledByDefault: false,
   run: async (ctx: CheckContext) => {
     const subscriptionIds = await resolveAzureSubscriptionIds(ctx);
     // resolveAzureSubscriptionIds already emitted a finding when scope is empty.

--- a/packages/integration-platform/src/manifests/gcp/checks/environment-separation.ts
+++ b/packages/integration-platform/src/manifests/gcp/checks/environment-separation.ts
@@ -126,9 +126,10 @@ export const environmentSeparationCheck: IntegrationCheck = {
   id: 'gcp-environment-separation',
   name: 'Separation of environments — production isolated from non-production',
   description:
-    'Verify production and non-production workloads are separated across distinct GCP projects.',
+    'Optional check: confirm production and non-production separation from GCP project metadata when environment naming is clear.',
   service: 'iam',
   taskMapping: TASK_TEMPLATES.separationOfEnvironments,
+  taskRunEnabledByDefault: false,
 
   run: async (ctx: CheckContext) => {
     let resolved: ResolvedProjects;

--- a/packages/integration-platform/src/task-mappings.ts
+++ b/packages/integration-platform/src/task-mappings.ts
@@ -402,7 +402,7 @@ For Merchants - https://d...`,
   },
   frk_tt_68e52a484cad0014de7a628f: {
     name: 'Separation of Environments',
-    description: `Upload proof that dev/test/staging and production are segregated, such as a cloud console screenshot or architecture diagram. Cloud metadata checks are optional when names/tags clearly identify environments.`,
+    description: `Attach proof to this task, for example in the comments, that dev/test/staging and production are segregated. Use a cloud console screenshot or architecture diagram. Cloud metadata checks are optional when names/tags clearly identify environments.`,
     department: 'it',
     frequency: 'yearly',
   },

--- a/packages/integration-platform/src/task-mappings.ts
+++ b/packages/integration-platform/src/task-mappings.ts
@@ -402,7 +402,7 @@ For Merchants - https://d...`,
   },
   frk_tt_68e52a484cad0014de7a628f: {
     name: 'Separation of Environments',
-    description: `Upload proof that dev/test/staging and production are segregated - e.g., a cloud console screenshot ...`,
+    description: `Upload proof that dev/test/staging and production are segregated, such as a cloud console screenshot or architecture diagram. Cloud metadata checks are optional when names/tags clearly identify environments.`,
     department: 'it',
     frequency: 'yearly',
   },

--- a/packages/integration-platform/src/types.ts
+++ b/packages/integration-platform/src/types.ts
@@ -676,6 +676,13 @@ export interface IntegrationCheck {
    */
   taskMapping?: TaskTemplateId;
 
+  /**
+   * Whether mapped evidence-task schedules should run this check automatically.
+   * Defaults to true. Set false for heuristic checks that should be explicit
+   * customer opt-in from the task UI.
+   */
+  taskRunEnabledByDefault?: boolean;
+
   /** Default severity for findings from this check */
   defaultSeverity?: FindingSeverity;
 


### PR DESCRIPTION
## Summary

- make AWS, GCP, and Azure separation-of-environments checks opt-in for evidence-task runs
- keep those checks visible on the task so customers can reconnect/activate them manually
- store explicit opt-ins via `enabledTaskChecks` while preserving existing `disabledTaskChecks` behavior
- update task/check copy to emphasize attaching manual screenshots or architecture diagrams to the task/comments, plus clear environment naming/tags

## Verification

- `bunx jest src/integration-platform/utils/disabled-task-checks.spec.ts src/integration-platform/utils/task-check-enablement.spec.ts src/integration-platform/services/task-integration-checks.service.spec.ts src/trigger/integration-platform/run-integration-checks-schedule.spec.ts --passWithNoTests`
- `bun test packages/integration-platform/src/manifests/gcp/checks/__tests__/gcp-checks.test.ts`
- `bun test packages/integration-platform/src/manifests/aws/checks/__tests__/aws-checks.test.ts`
- `bun test packages/integration-platform/src/manifests/azure/checks/__tests__/azure-checks.test.ts packages/integration-platform/src/manifests/azure/checks/__tests__/environment-separation.test.ts`
- `bun run --filter '@trycompai/integration-platform' typecheck`
- `bun run --filter '@trycompai/integration-platform' build`
- `git diff --check`

## Notes

- `@trycompai/api` typecheck still has unrelated repo-wide failures from existing AI SDK and generated Prisma/ISMS type mismatches. Filtering the typecheck log showed no errors from this branch's touched files.
