### PR TITLE
fix(integrations): scheduler skips MANUAL evidence tasks

### DIFF
--- a/apps/api/src/trigger/integration-platform/run-integration-checks-schedule.spec.ts
+++ b/apps/api/src/trigger/integration-platform/run-integration-checks-schedule.spec.ts
@@ -1,6 +1,9 @@
 import { TaskFrequency } from '@trycompai/db';
+import { db } from '@db';
+import { getManifest } from '@trycompai/integration-platform';
 import {
   filterDueTasks,
+  integrationChecksSchedule,
   resolveProviderChecks,
 } from './run-integration-checks-schedule';
 
@@ -13,6 +16,7 @@ jest.mock('@db', () => ({
     integrationConnection: { findMany: jest.fn() },
     task: { findMany: jest.fn(), update: jest.fn() },
     dynamicIntegration: { findMany: jest.fn() },
+    organization: { findMany: jest.fn() },
   },
   TaskFrequency: {
     daily: 'daily',
@@ -20,6 +24,10 @@ jest.mock('@db', () => ({
     monthly: 'monthly',
     quarterly: 'quarterly',
     yearly: 'yearly',
+  },
+  TaskAutomationStatus: {
+    AUTOMATED: 'AUTOMATED',
+    MANUAL: 'MANUAL',
   },
 }));
 
@@ -170,5 +178,61 @@ describe('resolveProviderChecks (static vs dynamic)', () => {
     });
 
     expect(checks).toEqual([{ id: 'c1', taskMapping: null }]);
+  });
+});
+
+describe('orchestrator excludes MANUAL tasks from scheduled runs', () => {
+  // Cast the db/getManifest mocks to their jest.Mock shape for setup.
+  const taskFindMany = (db as unknown as { task: { findMany: jest.Mock } }).task
+    .findMany;
+  const connectionFindMany = (
+    db as unknown as { integrationConnection: { findMany: jest.Mock } }
+  ).integrationConnection.findMany;
+  const dynamicFindMany = (
+    db as unknown as { dynamicIntegration: { findMany: jest.Mock } }
+  ).dynamicIntegration.findMany;
+  const orgFindMany = (
+    db as unknown as { organization: { findMany: jest.Mock } }
+  ).organization.findMany;
+  const getManifestMock = getManifest as jest.Mock;
+
+  // schedules.task is mocked to return the config, so .run is invokable here.
+  const runOrchestrator = (
+    integrationChecksSchedule as unknown as {
+      run: (p: { timestamp: Date; lastTimestamp?: Date }) => Promise<unknown>;
+    }
+  ).run;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    connectionFindMany.mockResolvedValue([
+      {
+        id: 'conn1',
+        provider: { slug: 'github' },
+        organizationId: 'org1',
+        organization: { id: 'org1', name: 'Org' },
+        metadata: null,
+      },
+    ]);
+    dynamicFindMany.mockResolvedValue([]);
+    getManifestMock.mockReturnValue({
+      checks: [{ id: 'c1', taskMapping: 'tpl_a' }],
+    });
+    taskFindMany.mockResolvedValue([]); // no due tasks → no triggers
+    orgFindMany.mockResolvedValue([]); // device-sync section is a no-op
+  });
+
+  it('queries candidate tasks with an automationStatus != MANUAL filter', async () => {
+    await runOrchestrator({ timestamp: new Date(), lastTimestamp: new Date() });
+
+    expect(taskFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          organizationId: 'org1',
+          taskTemplateId: { in: ['tpl_a'] },
+          automationStatus: { not: 'MANUAL' },
+        }),
+      }),
+    );
   });
 });

--- a/apps/api/src/trigger/integration-platform/run-integration-checks-schedule.ts
+++ b/apps/api/src/trigger/integration-platform/run-integration-checks-schedule.ts
@@ -1,5 +1,5 @@
 import { getManifest } from '@trycompai/integration-platform';
-import { db, TaskFrequency } from '@db';
+import { db, TaskAutomationStatus, TaskFrequency } from '@db';
 import { logger, schedules } from '@trigger.dev/sdk';
 import { runTaskIntegrationChecks } from './run-task-integration-checks';
 import { runDeviceSync } from './run-device-sync';
@@ -149,11 +149,15 @@ export const integrationChecksSchedule = schedules.task({
         continue;
       }
 
-      // Find tasks in this org that match these templates
+      // Find tasks in this org that match these templates. MANUAL tasks are
+      // excluded: the scheduler must not auto-run checks (or flip the status) on
+      // a task the customer manages manually — mirrors the UI, which hides the
+      // automation/checks tab when automationStatus is MANUAL.
       const candidateTasks = await db.task.findMany({
         where: {
           organizationId: connection.organizationId,
           taskTemplateId: { in: taskTemplateIds as string[] },
+          automationStatus: { not: TaskAutomationStatus.MANUAL },
         },
         select: {
           id: true,


### PR DESCRIPTION
## Problem

The daily integration-checks orchestrator (`run-integration-checks-schedule.ts`) picks candidate tasks by **org + mapped template only** — it ignores `Task.automationStatus`. So a task marked **MANUAL** could still have its mapped checks **auto-run on the schedule and its status flipped** (`done`/`failed`), overriding the customer's manual management.

This also contradicts the UI, which **already** hides the automation/checks tab when the task is manual:
```ts
// SingleTask.tsx
{task.automationStatus !== 'MANUAL' && <TabsTrigger value="automations">Automations</TabsTrigger>}
```
So today a manual task shows no checks in the UI, yet the scheduler can still run them in the background — an inconsistent, surprising state.

## Fix (small, single-source)

Add one filter to the orchestrator's candidate-task query so manual tasks are never scheduled:
```ts
where: {
  organizationId: connection.organizationId,
  taskTemplateId: { in: taskTemplateIds },
  automationStatus: { not: TaskAutomationStatus.MANUAL },   // ← added
}
```
This makes `automationStatus` authoritative for the scheduler, symmetric with the UI's `!== 'MANUAL'`. Now a task set to MANUAL is truly manual end-to-end: no checks shown, none auto-run.

## Tests

`run-integration-checks-schedule.spec.ts`: added a test that invokes the orchestrator and asserts `db.task.findMany` is called with the `automationStatus: { not: 'MANUAL' }` filter. **8/8 spec tests pass.**

## Scope / notes
- Only 2 files changed (the orchestrator + its spec). Type-safe (uses the `TaskAutomationStatus` enum, no magic string).
- Pre-existing, unrelated API typecheck errors exist in this workspace (missing `docx` dep, spec drift in `variables`/`sync-gws`/`isms` files) — **none touch this change**; my files have zero typecheck errors.
- This is the general fix discussed for making "Separation of Environments" (and any task) truly manual: set the task/template `automationStatus = MANUAL` and the scheduler will now leave it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip MANUAL tasks in the integration checks scheduler to prevent auto-running checks or flipping status on tasks managed manually. This aligns backend behavior with the UI that hides automations for manual tasks.

- **Bug Fixes**
  - Added `automationStatus: { not: 'MANUAL' }` to the `db.task.findMany` filter in the scheduler.
  - Added a spec to assert the orchestrator excludes MANUAL tasks.

<sup>Written for commit 1ee9c9f61e33f649382f93241e3d1333885bddc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

