### PR TITLE
fix(integration-platform): show setup instructions for basic/api_key integrations

### DIFF
--- a/apps/api/src/integration-platform/controllers/connections.controller.ts
+++ b/apps/api/src/integration-platform/controllers/connections.controller.ts
@@ -256,9 +256,13 @@ export class ConnectionsController {
           ? m.auth.config.credentialFields
           : m.credentialFields;
 
-      // Get setup instructions for custom auth
+      // Surface setup instructions for any credential-entry auth type (custom, api_key,
+      // basic, jwt) — not just custom. oauth2 is excluded because its setupInstructions are
+      // admin app-creation steps, not customer connect steps.
       const setupInstructions =
-        m.auth.type === 'custom' ? m.auth.config.setupInstructions : undefined;
+        m.auth.type !== 'oauth2' && 'setupInstructions' in m.auth.config
+          ? m.auth.config.setupInstructions
+          : undefined;
 
       const setupScript =
         m.auth.type === 'custom' ? m.auth.config.setupScript : undefined;
@@ -372,9 +376,12 @@ export class ConnectionsController {
         ? manifest.auth.config.credentialFields
         : manifest.credentialFields;
 
-    // Get setup instructions for custom auth
+    // Surface setup instructions for any credential-entry auth type (custom, api_key,
+    // basic, jwt) — not just custom. oauth2 is excluded because its setupInstructions are
+    // admin app-creation steps, not customer connect steps.
     const setupInstructions =
-      manifest.auth.type === 'custom'
+      manifest.auth.type !== 'oauth2' &&
+      'setupInstructions' in manifest.auth.config
         ? manifest.auth.config.setupInstructions
         : undefined;
 


### PR DESCRIPTION
## Problem

The integration connect UI shows a generic placeholder — *"You'll need your <Provider> credentials. Check your <Provider> admin console for the required values."* — for **basic** and **api_key** integrations (e.g. HiBob, Supabase), even though detailed setup instructions are authored in each provider's manifest `authConfig.config.setupInstructions`.

Customers connecting HiBob/Supabase saw the useless placeholder and didn't know they needed a HiBob **Service User ID + token** / a Supabase **Management API token** — causing repeated failed-connect support threads.

## Root cause

In `connections.controller.ts` (both the list-providers and get-provider endpoints), `setupInstructions` was only passed through when `auth.type === 'custom'`:

```ts
const setupInstructions =
  m.auth.type === 'custom' ? m.auth.config.setupInstructions : undefined;
```

So every `basic` / `api_key` / `jwt` provider returned `undefined` → the frontend's generic fallback. (The manifest loader casts `authConfig.config` straight through without Zod-stripping, so the data is present at runtime — it just wasn't being surfaced.)

## Fix

Surface `setupInstructions` for any credential-entry auth type via an `in` check, excluding `oauth2` (whose `setupInstructions` are admin app-creation steps shown in the admin UI, not customer connect steps):

```ts
const setupInstructions =
  m.auth.type !== 'oauth2' && 'setupInstructions' in m.auth.config
    ? m.auth.config.setupInstructions
    : undefined;
```

## Impact / safety

- **custom**: unchanged (still shows its instructions).
- **oauth2**: unchanged (still no customer-facing setup text).
- **basic / api_key / jwt**: now show their existing manifest instructions instead of the generic placeholder.
- Response shape unchanged (`setupInstructions: string | undefined`). Type-safe via `in`-narrowing (no casts). `@trycompai/api` typecheck clean for the changed file (remaining repo typecheck errors are pre-existing AWS-SDK/smithy + spec mocks, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show provider-specific setup instructions for basic/api_key/jwt integrations in the connect UI instead of the generic placeholder, reducing failed connects (e.g. HiBob, Supabase). Instructions are now passed through from each provider’s manifest; `oauth2` remains unchanged.

- **Bug Fixes**
  - Return `setupInstructions` when auth type is not `oauth2` and the field exists in `auth.config`.
  - Response shape unchanged (`string | undefined`); `oauth2` and `custom` behavior unaffected.

<sup>Written for commit 582a2777e5316f07f6770860b577a52ce77ee1ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

