### PR TITLE
fix(browserbase): request identity encoded api responses

### DIFF
--- a/apps/api/src/browserbase/browserbase-session.service.spec.ts
+++ b/apps/api/src/browserbase/browserbase-session.service.spec.ts
@@ -1,5 +1,11 @@
 import { ServiceUnavailableException } from '@nestjs/common';
+import Browserbase from '@browserbasehq/sdk';
 import { BrowserbaseSessionService } from './browserbase-session.service';
+
+jest.mock('@browserbasehq/sdk', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({})),
+}));
 
 type BrowserbaseClient = ReturnType<BrowserbaseSessionService['getBrowserbase']>;
 
@@ -22,7 +28,20 @@ const mockBrowserbaseClient = ({
 describe('BrowserbaseSessionService', () => {
   afterEach(() => {
     jest.useRealTimers();
+    jest.clearAllMocks();
     jest.restoreAllMocks();
+  });
+
+  it('requests identity encoded Browserbase API responses', () => {
+    const service = new BrowserbaseSessionService();
+
+    service.getBrowserbase();
+
+    expect(jest.mocked(Browserbase)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultHeaders: { 'accept-encoding': 'identity' },
+      }),
+    );
   });
 
   it('retries transient Browserbase context creation failures', async () => {

--- a/apps/api/src/browserbase/browserbase-session.service.ts
+++ b/apps/api/src/browserbase/browserbase-session.service.ts
@@ -15,6 +15,7 @@ const BROWSER_HEIGHT = 900;
 const STAGEHAND_MODEL = 'anthropic/claude-sonnet-4-6';
 const BROWSERBASE_CONTEXT_CREATE_MAX_ATTEMPTS = 3;
 const BROWSERBASE_RETRY_DELAYS_MS = [250, 750];
+const BROWSERBASE_DEFAULT_HEADERS = { 'accept-encoding': 'identity' };
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -25,6 +26,7 @@ export class BrowserbaseSessionService {
   getBrowserbase() {
     return new Browserbase({
       apiKey: process.env.BROWSERBASE_API_KEY,
+      defaultHeaders: BROWSERBASE_DEFAULT_HEADERS,
     });
   }
 


### PR DESCRIPTION
## Summary
- request identity-encoded Browserbase API responses to avoid node-fetch gunzip premature-close failures
- add coverage that the Browserbase SDK client sends the identity encoding header

## Testing
- cd apps/api && bunx jest src/browserbase --passWithNoTests
- cd apps/api && bun run typecheck (fails on existing non-Browserbase type errors)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes Browserbase context creation by retrying transient failures and returning a consistent 503 when exhausted. Forces identity-encoded API responses to prevent `node-fetch` gunzip premature-close errors.

- **Bug Fixes**
  - Retries transient context creation errors and responds with 503 Service Unavailable if all attempts fail.
  - Sets `defaultHeaders: { 'accept-encoding': 'identity' }` on the Browserbase client to avoid premature-close issues.
  - Adds Jest tests for retry behavior and `@browserbasehq/sdk` header configuration.

<sup>Written for commit c17a43ba1cf9d5a6f3bde5c978b6db642858c789. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

