### PR TITLE
fix(findings): include all enabled frameworks in overview filter dropdown

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/overview/components/FindingsTab.framework-filter.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/overview/components/FindingsTab.framework-filter.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  setMockPermissions,
+  AUDITOR_PERMISSIONS,
+  mockHasPermission,
+} from '@/test-utils/mocks/permissions';
+import type { Finding } from '@/hooks/use-findings-api';
+
+vi.mock('@/hooks/use-permissions', () => ({
+  usePermissions: () => ({ permissions: {}, hasPermission: mockHasPermission }),
+}));
+
+// Drives the framework filter options: FindingsTab fetches
+// `/v1/frameworks?includeScores=false` via useApiSWR and derives the filter
+// options from whichever frameworks the org has enabled.
+const mockUseApiSWR = vi.fn();
+vi.mock('@/hooks/use-api-swr', () => ({
+  useApiSWR: (...args: unknown[]) => mockUseApiSWR(...args),
+}));
+
+const mockUseOrganizationFindings = vi.fn();
+vi.mock('@/hooks/use-findings-api', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks/use-findings-api')>(
+    '@/hooks/use-findings-api',
+  );
+  return {
+    ...actual,
+    useOrganizationFindings: (...args: unknown[]) =>
+      mockUseOrganizationFindings(...args),
+  };
+});
+
+vi.mock('./CreateFindingSheet', () => ({
+  CreateFindingSheet: () => <div data-testid="create-sheet" />,
+}));
+
+vi.mock('./FindingDetailSheet', () => ({
+  FindingDetailSheet: () => <div data-testid="detail-sheet" />,
+}));
+
+// Render the design-system Select inline. Radix portals its content, so the
+// options are otherwise hidden until the trigger is opened; flattening them
+// keeps the dropdown options queryable.
+vi.mock('@trycompai/design-system', () => ({
+  Badge: ({ children }: any) => <span>{children}</span>,
+  Empty: ({ children }: any) => <div>{children}</div>,
+  EmptyDescription: ({ children }: any) => <p>{children}</p>,
+  EmptyHeader: ({ children }: any) => <div>{children}</div>,
+  EmptyMedia: ({ children }: any) => <div>{children}</div>,
+  EmptyTitle: ({ children }: any) => <h3>{children}</h3>,
+  InputGroup: ({ children }: any) => <div>{children}</div>,
+  InputGroupAddon: ({ children }: any) => <span>{children}</span>,
+  InputGroupInput: (props: any) => <input {...props} />,
+  Select: ({ children }: any) => <div data-testid="select">{children}</div>,
+  SelectContent: ({ children }: any) => <div>{children}</div>,
+  SelectItem: ({ children, value }: any) => (
+    <button data-value={value}>{children}</button>
+  ),
+  SelectTrigger: ({ children }: any) => <div>{children}</div>,
+  SelectValue: ({ children, placeholder }: any) => (
+    <span>{children ?? placeholder}</span>
+  ),
+  Stack: ({ children }: any) => <div>{children}</div>,
+  Table: ({ children }: any) => <table>{children}</table>,
+  TableBody: ({ children }: any) => <tbody>{children}</tbody>,
+  TableCell: ({ children }: any) => <td>{children}</td>,
+  TableHead: ({ children }: any) => <th>{children}</th>,
+  TableHeader: ({ children }: any) => <thead>{children}</thead>,
+  TableRow: ({ children, onClick }: any) => <tr onClick={onClick}>{children}</tr>,
+  Text: ({ children }: any) => <span>{children}</span>,
+}));
+
+vi.mock('@trycompai/design-system/icons', () => ({
+  Search: () => <span data-testid="search-icon" />,
+  WarningAlt: () => <span data-testid="warning-icon" />,
+}));
+
+import { FindingsTab } from './FindingsTab';
+
+function makeFinding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    id: 'fnd_1',
+    type: 'soc2',
+    status: 'open',
+    severity: 'medium',
+    content: 'Evidence missing a timestamp',
+    revisionNote: null,
+    area: null,
+    createdAt: '2026-04-01T00:00:00Z',
+    updatedAt: '2026-04-02T00:00:00Z',
+    taskId: 'tsk_1',
+    evidenceSubmissionId: null,
+    evidenceFormType: null,
+    policyId: null,
+    vendorId: null,
+    riskId: null,
+    memberId: null,
+    deviceId: null,
+    templateId: null,
+    createdById: 'mem_1',
+    organizationId: 'org_1',
+    createdBy: null,
+    createdByAdmin: null,
+    template: null,
+    task: { id: 'tsk_1', title: 'Upload MFA evidence' },
+    evidenceSubmission: null,
+    policy: null,
+    vendor: null,
+    risk: null,
+    member: null,
+    device: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Stub the `/v1/frameworks` response to mark `names` as the org's enabled
+ * frameworks. Mirrors the wrapped shape useApiSWR returns:
+ * `{ data: { data: [...], count } }`.
+ */
+function setEnabledFrameworks(names: string[]) {
+  const rows = names.map((name) => ({ framework: { name } }));
+  mockUseApiSWR.mockReturnValue({
+    data: { data: { data: rows, count: rows.length } },
+  });
+}
+
+describe('FindingsTab framework filter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setMockPermissions(AUDITOR_PERMISSIONS);
+    mockUseOrganizationFindings.mockReturnValue({
+      data: { data: [makeFinding()], status: 200 },
+      mutate: vi.fn(),
+    });
+  });
+
+  it('offers every framework the org has enabled, not a hardcoded SOC 2 / ISO 27001 pair', () => {
+    // Repro for CS-554: Aiden Risk has SOC 2 + ISO 42001 enabled (no ISO 27001).
+    setEnabledFrameworks(['SOC 2', 'ISO 42001']);
+
+    render(<FindingsTab organizationId="org_1" />);
+
+    // "All frameworks" labels both the trigger's current value and the reset
+    // option, so it renders more than once.
+    expect(screen.getAllByText('All frameworks').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('SOC 2')).toBeInTheDocument();
+    // The bug: ISO 42001 findings could not be filtered because the filter
+    // list was hardcoded to SOC 2 / ISO 27001.
+    expect(screen.getByText('ISO 42001')).toBeInTheDocument();
+    // ISO 27001 is NOT enabled for this org, so it must not be offered — the
+    // old hardcoded list wrongly included it.
+    expect(screen.queryByText('ISO 27001')).not.toBeInTheDocument();
+  });
+
+  it('offers HIPAA and GDPR when those are the enabled frameworks', () => {
+    setEnabledFrameworks(['HIPAA', 'GDPR']);
+
+    render(<FindingsTab organizationId="org_1" />);
+
+    expect(screen.getByText('HIPAA')).toBeInTheDocument();
+    expect(screen.getByText('GDPR')).toBeInTheDocument();
+    expect(screen.queryByText('SOC 2')).not.toBeInTheDocument();
+    expect(screen.queryByText('ISO 27001')).not.toBeInTheDocument();
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/overview/components/FindingsTab.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/overview/components/FindingsTab.test.tsx
@@ -12,6 +12,13 @@ vi.mock('@/hooks/use-permissions', () => ({
   usePermissions: () => ({ permissions: {}, hasPermission: mockHasPermission }),
 }));
 
+// FindingsTab fetches the org's enabled frameworks via useApiSWR to build the
+// framework filter. Stub it so these tests don't hit the real SWR hook (which
+// reaches for next/navigation's useParams).
+vi.mock('@/hooks/use-api-swr', () => ({
+  useApiSWR: () => ({ data: undefined }),
+}));
+
 const mockUseOrganizationFindings = vi.fn();
 vi.mock('@/hooks/use-findings-api', async () => {
   const actual = await vi.importActual<typeof import('@/hooks/use-findings-api')>(

--- a/apps/app/src/app/(app)/[orgId]/overview/components/FindingsTab.tsx
+++ b/apps/app/src/app/(app)/[orgId]/overview/components/FindingsTab.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { useApiSWR } from '@/hooks/use-api-swr';
 import {
+  extractOrgFrameworkTypes,
   FINDING_SEVERITY_CONFIG,
   FINDING_STATUS_CONFIG,
   FINDING_TYPE_LABELS,
@@ -54,12 +56,6 @@ const SEVERITY_OPTIONS: { value: FindingSeverity | 'all'; label: string }[] = [
   { value: FindingSeverity.high, label: 'High' },
   { value: FindingSeverity.medium, label: 'Medium' },
   { value: FindingSeverity.low, label: 'Low' },
-];
-
-const FRAMEWORK_OPTIONS: { value: FindingType | 'all'; label: string }[] = [
-  { value: 'all', label: 'All frameworks' },
-  { value: FindingType.soc2, label: FINDING_TYPE_LABELS.soc2 },
-  { value: FindingType.iso27001, label: FINDING_TYPE_LABELS.iso27001 },
 ];
 
 const capitalize = (s: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
@@ -134,6 +130,26 @@ export function FindingsTab({
   );
   const findings: Finding[] = Array.isArray(data?.data) ? data.data : [];
 
+  // Mirror the Create Finding form: the framework filter must offer every
+  // framework the org has actually enabled — not a hardcoded SOC 2 / ISO 27001
+  // pair — so findings logged against ISO 42001, HIPAA, etc. are filterable.
+  const { data: frameworksData } = useApiSWR<unknown>(
+    '/v1/frameworks?includeScores=false',
+    { refreshInterval: 0 },
+  );
+  const frameworkOptions = useMemo<
+    { value: FindingType | 'all'; label: string }[]
+  >(
+    () => [
+      { value: 'all', label: 'All frameworks' },
+      ...extractOrgFrameworkTypes(frameworksData).map((type) => ({
+        value: type,
+        label: FINDING_TYPE_LABELS[type],
+      })),
+    ],
+    [frameworksData],
+  );
+
   // Support deep links (e.g. emails + in-app notifications) that land on
   // `/overview/findings?open=<id>`. Auto-open the matching finding's sheet
   // once we've loaded the list, then strip the query param so a page
@@ -184,7 +200,7 @@ export function FindingsTab({
   const severityLabel =
     SEVERITY_OPTIONS.find((o) => o.value === severityFilter)?.label ?? 'Severity';
   const frameworkLabel =
-    FRAMEWORK_OPTIONS.find((o) => o.value === frameworkFilter)?.label ??
+    frameworkOptions.find((o) => o.value === frameworkFilter)?.label ??
     'Framework';
 
   const hasAnyFinding = findings.length > 0;
@@ -255,7 +271,7 @@ export function FindingsTab({
                   <SelectValue placeholder="Framework">{frameworkLabel}</SelectValue>
                 </SelectTrigger>
                 <SelectContent>
-                  {FRAMEWORK_OPTIONS.map((opt) => (
+                  {frameworkOptions.map((opt) => (
                     <SelectItem key={opt.value} value={opt.value}>
                       {opt.label}
                     </SelectItem>


### PR DESCRIPTION
## Problem
Users can only filter by SOC2 and ISO27001 in the Overview > Findings view, even when their org has other frameworks enabled like ISO42001 or HIPAA. This blocks them from seeing findings specific to those frameworks.

## Root cause
FindingsTab.tsx hardcodes the framework filter options to [all, soc2, iso27001] instead of deriving them from the org's actual enabled frameworks. The CreateFindingSheet on the same page does this correctly via the /v1/frameworks endpoint and extractOrgFrameworkTypes(), but the filter dropdown never got that fix.

## Fix
Apply the same pattern from CreateFindingSheet to FindingsTab: fetch enabled frameworks at component load and use those to populate the filter dropdown. The client-side filter logic and FindingType enum already support all 7 framework types, so this is just surfacing what's already wired.

## Explicitly NOT touched
Finding creation flow (already works correctly). The filter behavior when no frameworks are enabled (edge case, won't happen in practice).

## Verification
✅ org_69d943ca3fbbf2c473e97b0a now shows ISO42001 in the framework filter after enabling it
✅ findings correctly filter when selecting non-SOC2/ISO27001 frameworks
✅ hardcoded filter list replaced with dynamic org config
✅ no regression on existing SOC2/ISO27001 filtering

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Overview > Findings framework filter so it shows all frameworks enabled for the org, not just SOC 2 and ISO 27001. Users can now filter findings for ISO 42001, HIPAA, GDPR, etc. (addresses CS-554).

- **Bug Fixes**
  - Build filter options from `/v1/frameworks?includeScores=false` via `useApiSWR` and `extractOrgFrameworkTypes`; remove hardcoded list.
  - Use `FINDING_TYPE_LABELS` for labels with an "All frameworks" default.
  - Add targeted tests for mixed-framework orgs and ensure non-enabled frameworks are not shown.

<sup>Written for commit 20f4de94521b69d61a84a82e8e770e7d73972b51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

