### PR TITLE
fix(browserbase): make task auth flow primary

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/settings/browser-connection/page.tsx
+++ b/apps/app/src/app/(app)/[orgId]/settings/browser-connection/page.tsx
@@ -1,38 +1,10 @@
 import type { Metadata } from 'next';
-import { getFeatureFlags } from '@/app/posthog';
-import { requireRoutePermission } from '@/lib/permissions.server';
-import { auth } from '@/utils/auth';
-import { headers } from 'next/headers';
 import { notFound } from 'next/navigation';
-import { BrowserConnectionClient } from './components/BrowserConnectionClient';
 
 export const metadata: Metadata = {
   title: 'Browser Connection',
 };
 
-export default async function BrowserConnectionPage({
-  params,
-}: {
-  params: Promise<{ orgId: string }>;
-}) {
-  const { orgId } = await params;
-
-  await requireRoutePermission('settings/browser-connection', orgId);
-
-  const session = await auth.api.getSession({
-    headers: await headers(),
-  });
-  if (!session?.user?.id) {
-    return notFound();
-  }
-
-  const flags = await getFeatureFlags(session.user.id);
-  const isWebAutomationsEnabled =
-    flags['is-web-automations-enabled'] === true || flags['is-web-automations-enabled'] === 'true';
-
-  if (!isWebAutomationsEnabled) {
-    return notFound();
-  }
-
-  return <BrowserConnectionClient organizationId={orgId} />;
+export default function BrowserConnectionPage() {
+  return notFound();
 }

--- a/apps/app/src/app/(app)/[orgId]/settings/components/SettingsSidebar.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/settings/components/SettingsSidebar.test.tsx
@@ -24,4 +24,10 @@ describe('SettingsSidebar', () => {
 
     expect(screen.queryByRole('link', { name: 'Billing' })).not.toBeInTheDocument();
   });
+
+  it('hides Browser even when the browser tab flag is enabled', () => {
+    render(<SettingsSidebar orgId="org-1" showBillingTab={true} showBrowserTab={true} />);
+
+    expect(screen.queryByRole('link', { name: 'Browser' })).not.toBeInTheDocument();
+  });
 });

--- a/apps/app/src/app/(app)/[orgId]/settings/components/SettingsSidebar.tsx
+++ b/apps/app/src/app/(app)/[orgId]/settings/components/SettingsSidebar.tsx
@@ -17,7 +17,7 @@ type SettingsNavItem = {
   hidden?: boolean;
 };
 
-export function SettingsSidebar({ orgId, showBrowserTab, showBillingTab }: SettingsSidebarProps) {
+export function SettingsSidebar({ orgId, showBillingTab }: SettingsSidebarProps) {
   const pathname = usePathname() ?? '';
 
   const items: SettingsNavItem[] = [
@@ -38,7 +38,7 @@ export function SettingsSidebar({ orgId, showBrowserTab, showBillingTab }: Setti
       id: 'browser',
       label: 'Browser',
       path: `/${orgId}/settings/browser-connection`,
-      hidden: !showBrowserTab,
+      hidden: true,
     },
     { id: 'user', label: 'User Settings', path: `/${orgId}/settings/user` },
   ];

--- a/apps/app/src/app/(app)/[orgId]/settings/layout.tsx
+++ b/apps/app/src/app/(app)/[orgId]/settings/layout.tsx
@@ -1,4 +1,3 @@
-import { getFeatureFlags } from '@/app/posthog';
 import { requireRoutePermission } from '@/lib/permissions.server';
 import { auth } from '@/utils/auth';
 import { headers } from 'next/headers';
@@ -24,16 +23,8 @@ export default async function Layout({
     return redirect('/');
   }
 
-  let isWebAutomationsEnabled = false;
-  if (session.user?.id) {
-    const flags = await getFeatureFlags(session.user.id);
-    isWebAutomationsEnabled =
-      flags['is-web-automations-enabled'] === true ||
-      flags['is-web-automations-enabled'] === 'true';
-  }
-
   return (
-    <SettingsTabs orgId={orgId} showBrowserTab={isWebAutomationsEnabled}>
+    <SettingsTabs orgId={orgId} showBrowserTab={false}>
       {children}
     </SettingsTabs>
   );

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/BrowserAutomations.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/BrowserAutomations.tsx
@@ -26,14 +26,27 @@ export function BrowserAutomations({ taskId, isManualTask = false }: BrowserAuto
     automation?: BrowserAutomation;
   }>({ open: false, mode: 'create' });
   const [authUrl, setAuthUrl] = useState('https://github.com');
+  const authHostname = (() => {
+    try {
+      return new URL(authUrl).hostname;
+    } catch {
+      return 'this website';
+    }
+  })();
 
   // Hooks
   const context = useBrowserContext();
   const automations = useBrowserAutomations({ taskId });
 
-  const handleNeedsReauth = useCallback(() => {
-    context.startAuth(authUrl);
-  }, [context, authUrl]);
+  const handleNeedsReauth = useCallback(
+    (automationId: string) => {
+      const automation = automations.automations.find((item) => item.id === automationId);
+      const targetUrl = automation?.targetUrl ?? authUrl;
+      setAuthUrl(targetUrl);
+      context.startAuth(targetUrl);
+    },
+    [automations.automations, authUrl, context],
+  );
 
   const execution = useBrowserExecution({
     onNeedsReauth: handleNeedsReauth,
@@ -71,8 +84,8 @@ export function BrowserAutomations({ taskId, isManualTask = false }: BrowserAuto
   if (context.showAuthFlow && context.liveViewUrl) {
     return (
       <BrowserLiveView
-        title="Connect Browser"
-        subtitle="Log in to the website below to enable automations"
+        title={`Log in to ${authHostname}`}
+        subtitle="Complete login in this browser, then check and save the profile for this site."
         liveViewUrl={context.liveViewUrl}
         variant="auth"
         isChecking={context.status === 'checking'}
@@ -128,7 +141,9 @@ export function BrowserAutomations({ taskId, isManualTask = false }: BrowserAuto
         hasContext={context.status === 'has-context'}
         runningAutomationId={execution.runningAutomationId}
         onRun={execution.runAutomation}
-        onCreateClick={isManualTask ? undefined : () => setDialogState({ open: true, mode: 'create' })}
+        onCreateClick={
+          isManualTask ? undefined : () => setDialogState({ open: true, mode: 'create' })
+        }
         onEditClick={(automation) => setDialogState({ open: true, mode: 'edit', automation })}
         onDelete={automations.deleteAutomation}
         onToggleEnabled={automations.toggleAutomation}

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/browser-automations/BrowserEmptyStates.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/browser-automations/BrowserEmptyStates.tsx
@@ -32,10 +32,10 @@ export function NoContextState({ isStartingAuth, onStartAuth }: NoContextStatePr
           <div className="mx-auto w-12 h-12 rounded-full bg-muted flex items-center justify-center mb-4">
             <Screen className="h-6 w-6 text-muted-foreground" />
           </div>
-          <h4 className="text-sm font-medium mb-2">Connect your browser first</h4>
+          <h4 className="text-sm font-medium mb-2">Log in to the website first</h4>
           <p className="text-xs text-muted-foreground mb-4 max-w-sm mx-auto">
-            Browser automations require authentication. Log in to sites like GitHub, Jira, or AWS to
-            capture screenshots as evidence.
+            Enter the site you want to automate. We will save a browser profile for that hostname
+            and reuse it for future evidence runs.
           </p>
           <div className="flex flex-col gap-3 max-w-xs mx-auto">
             <div className="flex gap-2">
@@ -55,7 +55,7 @@ export function NoContextState({ isStartingAuth, onStartAuth }: NoContextStatePr
               </Button>
             </div>
             <p className="text-xs text-muted-foreground">
-              Tip: Use a dedicated service account for automations
+              Use a dedicated service account for automations when possible.
             </p>
           </div>
         </div>

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/browser-automations/BrowserLiveView.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/browser-automations/BrowserLiveView.tsx
@@ -55,7 +55,7 @@ export function BrowserLiveView({
                 loading={isChecking}
                 iconLeft={!isChecking ? <Renew size={12} /> : undefined}
               >
-                {isChecking ? 'Checking...' : 'Save & Close'}
+                {isChecking ? 'Checking...' : 'Check & Save'}
               </Button>
             )}
             <Button variant="ghost" size="sm" onClick={onCancel}>

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/hooks/types.ts
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/hooks/types.ts
@@ -37,11 +37,7 @@ export interface ContextResponse {
   isNew: boolean;
 }
 
-export type BrowserAuthProfileStatus =
-  | 'unverified'
-  | 'verified'
-  | 'needs_reauth'
-  | 'blocked';
+export type BrowserAuthProfileStatus = 'unverified' | 'verified' | 'needs_reauth' | 'blocked';
 
 export interface BrowserAuthProfile {
   id: string;
@@ -66,6 +62,11 @@ export interface ResolveAuthProfileResponse {
 export interface SessionResponse {
   sessionId: string;
   liveViewUrl: string;
+}
+
+export interface NavigateResponse {
+  success: boolean;
+  error?: string;
 }
 
 export interface AuthStatusResponse {

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/hooks/useBrowserContext.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/hooks/useBrowserContext.test.tsx
@@ -1,0 +1,134 @@
+import { apiClient } from '@/lib/api-client';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { toast } from 'sonner';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BrowserAuthProfile } from './types';
+import { useBrowserContext } from './useBrowserContext';
+
+vi.mock('@/lib/api-client', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+const unverifiedProfile = {
+  id: 'bap_1',
+  hostname: 'github.com',
+  loginIdentity: '',
+  displayName: 'github.com browser profile',
+  contextId: 'ctx_1',
+  status: 'unverified',
+} satisfies BrowserAuthProfile;
+
+describe('useBrowserContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not treat unverified profiles as connected', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({
+      data: [unverifiedProfile],
+      error: undefined,
+      status: 200,
+    });
+
+    const { result } = renderHook(() => useBrowserContext());
+
+    await act(async () => {
+      await result.current.checkContextStatus();
+    });
+
+    expect(result.current.status).toBe('no-context');
+    expect(result.current.contextId).toBeNull();
+    expect(result.current.profileId).toBeNull();
+  });
+
+  it('does not show auth Live View when target navigation fails', async () => {
+    vi.mocked(apiClient.post)
+      .mockResolvedValueOnce({
+        data: { profile: unverifiedProfile, isNew: false },
+        error: undefined,
+        status: 200,
+      })
+      .mockResolvedValueOnce({
+        data: { sessionId: 'bbs_1', liveViewUrl: 'https://live.browserbase.test/session' },
+        error: undefined,
+        status: 200,
+      })
+      .mockResolvedValueOnce({
+        data: { success: false, error: 'Navigation failed' },
+        error: undefined,
+        status: 200,
+      })
+      .mockResolvedValueOnce({ data: null, error: undefined, status: 200 });
+
+    const { result } = renderHook(() => useBrowserContext());
+
+    await act(async () => {
+      await result.current.startAuth('https://github.com');
+    });
+
+    await waitFor(() => {
+      expect(result.current.showAuthFlow).toBe(false);
+    });
+    expect(result.current.liveViewUrl).toBeNull();
+    expect(toast.error).toHaveBeenCalledWith('Navigation failed');
+    expect(apiClient.post).toHaveBeenLastCalledWith('/v1/browserbase/session/close', {
+      sessionId: 'bbs_1',
+    });
+  });
+
+  it('keeps auth Live View open when verification has not logged in yet', async () => {
+    vi.mocked(apiClient.post)
+      .mockResolvedValueOnce({
+        data: { profile: unverifiedProfile, isNew: false },
+        error: undefined,
+        status: 200,
+      })
+      .mockResolvedValueOnce({
+        data: { sessionId: 'bbs_1', liveViewUrl: 'https://live.browserbase.test/session' },
+        error: undefined,
+        status: 200,
+      })
+      .mockResolvedValueOnce({
+        data: { success: true },
+        error: undefined,
+        status: 200,
+      })
+      .mockResolvedValueOnce({
+        data: { auth: { isLoggedIn: false }, profile: unverifiedProfile },
+        error: undefined,
+        status: 200,
+      });
+
+    const { result } = renderHook(() => useBrowserContext());
+
+    await act(async () => {
+      await result.current.startAuth('https://github.com');
+    });
+
+    expect(result.current.showAuthFlow).toBe(true);
+
+    await act(async () => {
+      await result.current.checkAuth('https://github.com');
+    });
+
+    expect(result.current.showAuthFlow).toBe(true);
+    expect(result.current.liveViewUrl).toBe('https://live.browserbase.test/session');
+    expect(result.current.sessionId).toBe('bbs_1');
+    expect(apiClient.post).not.toHaveBeenCalledWith('/v1/browserbase/session/close', {
+      sessionId: 'bbs_1',
+    });
+    expect(toast.error).toHaveBeenCalledWith(
+      'Still not logged in. Finish login, then click Check & Save again.',
+    );
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/hooks/useBrowserContext.ts
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/hooks/useBrowserContext.ts
@@ -7,6 +7,7 @@ import type {
   AuthStatusResponse,
   BrowserAuthProfile,
   BrowserContextStatus,
+  NavigateResponse,
   ResolveAuthProfileResponse,
   SessionResponse,
 } from './types';
@@ -25,77 +26,81 @@ export function useBrowserContext() {
       const res = await apiClient.get<BrowserAuthProfile[]>('/v1/browserbase/profiles');
       if (res.data) {
         const verifiedProfile = res.data.find((profile) => profile.status === 'verified');
-        const firstProfile = verifiedProfile ?? res.data[0];
-        if (firstProfile) {
-          setContextId(firstProfile.contextId);
-          setProfileId(firstProfile.id);
+        if (verifiedProfile) {
+          setContextId(verifiedProfile.contextId);
+          setProfileId(verifiedProfile.id);
           setStatus('has-context');
         } else {
+          setContextId(null);
+          setProfileId(null);
           setStatus('no-context');
         }
+      } else {
+        setContextId(null);
+        setProfileId(null);
+        setStatus('no-context');
       }
     } catch {
       setStatus('no-context');
     }
   }, []);
 
-  const startAuth = useCallback(
-    async (url: string) => {
-      let startedSessionId: string | null = null;
-      try {
-        setIsStartingAuth(true);
+  const startAuth = useCallback(async (url: string) => {
+    let startedSessionId: string | null = null;
+    try {
+      setIsStartingAuth(true);
 
-        const profileRes = await apiClient.post<ResolveAuthProfileResponse>(
-          '/v1/browserbase/profiles/resolve',
-          { url },
+      const profileRes = await apiClient.post<ResolveAuthProfileResponse>(
+        '/v1/browserbase/profiles/resolve',
+        { url },
+      );
+      if (profileRes.error || !profileRes.data) {
+        throw new Error(profileRes.error || 'Failed to create auth profile');
+      }
+      setProfileId(profileRes.data.profile.id);
+
+      const sessionRes = await apiClient.post<SessionResponse>(
+        `/v1/browserbase/profiles/${profileRes.data.profile.id}/session`,
+        {},
+      );
+      if (sessionRes.error || !sessionRes.data) {
+        throw new Error(sessionRes.error || 'Failed to create session');
+      }
+      startedSessionId = sessionRes.data.sessionId;
+      setSessionId(startedSessionId);
+      setLiveViewUrl(sessionRes.data.liveViewUrl);
+
+      const navigateRes = await apiClient.post<NavigateResponse>('/v1/browserbase/navigate', {
+        sessionId: startedSessionId,
+        url,
+      });
+      if (navigateRes.error || !navigateRes.data?.success) {
+        throw new Error(
+          navigateRes.error ||
+            navigateRes.data?.error ||
+            'Failed to open the website in the browser session',
         );
-        if (profileRes.error || !profileRes.data) {
-          throw new Error(profileRes.error || 'Failed to create auth profile');
-        }
-        setContextId(profileRes.data.profile.contextId);
-        setProfileId(profileRes.data.profile.id);
+      }
 
-        const sessionRes = await apiClient.post<SessionResponse>(
-          `/v1/browserbase/profiles/${profileRes.data.profile.id}/session`,
-          {},
-        );
-        if (sessionRes.error || !sessionRes.data) {
-          throw new Error(sessionRes.error || 'Failed to create session');
-        }
-        startedSessionId = sessionRes.data.sessionId;
-        setSessionId(startedSessionId);
-        setLiveViewUrl(sessionRes.data.liveViewUrl);
+      setShowAuthFlow(true);
+      setIsStartingAuth(false);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to start authentication');
+      setShowAuthFlow(false);
+      setLiveViewUrl(null);
+      setSessionId(null);
+      setIsStartingAuth(false);
 
-        // Navigate to the URL
-        await apiClient.post(
-          '/v1/browserbase/navigate',
-          { sessionId: startedSessionId, url },
-        );
-
-        setShowAuthFlow(true);
-        setIsStartingAuth(false);
-      } catch (err) {
-        toast.error(err instanceof Error ? err.message : 'Failed to start authentication');
-        setShowAuthFlow(false);
-        setLiveViewUrl(null);
-        setSessionId(null);
-        setIsStartingAuth(false);
-
-        // If we created a session but navigation failed, close it to avoid orphaned sessions
-        if (startedSessionId) {
-          try {
-            await apiClient.post(
-              '/v1/browserbase/session/close',
-              { sessionId: startedSessionId },
-            );
-          } catch {
-            // Ignore cleanup errors (don't mask original error)
-          }
+      // If we created a session but navigation failed, close it to avoid orphaned sessions
+      if (startedSessionId) {
+        try {
+          await apiClient.post('/v1/browserbase/session/close', { sessionId: startedSessionId });
+        } catch {
+          // Ignore cleanup errors (don't mask original error)
         }
       }
-    },
-    [],
-  );
+    }
+  }, []);
 
   const checkAuth = useCallback(
     async (url: string) => {
@@ -111,26 +116,34 @@ export function useBrowserContext() {
           profile: BrowserAuthProfile;
         }>(`/v1/browserbase/profiles/${profileId}/verify`, { sessionId, url });
 
-        // Close session
-        await apiClient.post('/v1/browserbase/session/close', { sessionId });
-        setSessionId(null);
-        setLiveViewUrl(null);
-        setShowAuthFlow(false);
+        if (res.error || !res.data) {
+          throw new Error(res.error || 'Failed to check authentication');
+        }
 
-        if (res.data?.auth.isLoggedIn) {
+        if (res.data.auth.isLoggedIn) {
+          try {
+            await apiClient.post('/v1/browserbase/session/close', { sessionId });
+          } catch {
+            // Ignore cleanup errors after auth was already verified
+          }
+          setSessionId(null);
+          setLiveViewUrl(null);
+          setShowAuthFlow(false);
           toast.success(
             res.data.auth.username
               ? `Authenticated as ${res.data.auth.username}`
               : 'Authentication saved',
           );
+          setContextId(res.data.profile.contextId);
+          setProfileId(res.data.profile.id);
           setStatus('has-context');
         } else {
-          toast.error('Not logged in. Please try again.');
-          setStatus('has-context');
+          toast.error('Still not logged in. Finish login, then click Check & Save again.');
+          setStatus('no-context');
         }
       } catch (err) {
         toast.error(err instanceof Error ? err.message : 'Failed to check auth');
-        setStatus('has-context');
+        setStatus('no-context');
       }
     },
     [sessionId, profileId],

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/hooks/useBrowserExecution.ts
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/hooks/useBrowserExecution.ts
@@ -6,14 +6,11 @@ import { toast } from 'sonner';
 import type { ExecuteResponse, StartLiveResponse } from './types';
 
 interface UseBrowserExecutionOptions {
-  onNeedsReauth: () => void;
+  onNeedsReauth: (automationId: string) => void;
   onComplete: () => void;
 }
 
-export function useBrowserExecution({
-  onNeedsReauth,
-  onComplete,
-}: UseBrowserExecutionOptions) {
+export function useBrowserExecution({ onNeedsReauth, onComplete }: UseBrowserExecutionOptions) {
   const [runningAutomationId, setRunningAutomationId] = useState<string | null>(null);
   const [liveViewUrl, setLiveViewUrl] = useState<string | null>(null);
   const [sessionId, setSessionId] = useState<string | null>(null);
@@ -34,7 +31,7 @@ export function useBrowserExecution({
 
         if (startRes.data?.needsReauth) {
           toast.error('Session expired. Please re-authenticate below.');
-          onNeedsReauth();
+          onNeedsReauth(automationId);
           return;
         }
 
@@ -76,10 +73,7 @@ export function useBrowserExecution({
 
         if (startedSessionId) {
           try {
-            await apiClient.post(
-              '/v1/browserbase/session/close',
-              { sessionId: startedSessionId },
-            );
+            await apiClient.post('/v1/browserbase/session/close', { sessionId: startedSessionId });
           } catch {
             // Ignore cleanup errors (don't block UI / don't mask original error)
           }


### PR DESCRIPTION
## Summary
- hide the Settings > Browser page and sidebar entry for now
- make evidence-task browser automations treat only verified profiles as connected
- prevent blank Live View sessions by failing fast when initial navigation fails
- keep the auth Live View open when Check & Save finds the user is not logged in yet
- reauth using the automation target URL instead of the default GitHub URL

## Tests
- cd apps/app && bunx vitest run 'src/app/(app)/[orgId]/tasks/[taskId]/hooks/useBrowserContext.test.tsx' 'src/app/(app)/[orgId]/settings/components/SettingsSidebar.test.tsx' 'src/app/(app)/[orgId]/tasks/[taskId]/components/browser-automations/BrowserAutomationsList.test.tsx'
- bun run --filter '@trycompai/app' typecheck (fails on existing unrelated test/type errors in cloud-tests, documents, integrations, overview, and app/api/invitations)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make in-task authentication the primary flow for browser automations and hide the standalone Browser settings page. Improves reliability by only using verified profiles, preventing blank Live View sessions, and guiding reauth on the correct site.

- Bug Fixes
  - Hide Settings > Browser tab and page (always notFound); ignore feature flag; updated sidebar tests.
  - Treat only `verified` auth profiles as connected; `unverified` is no-context.
  - Start auth sessions by navigating to the requested URL; if navigation fails, don’t open Live View and close the session with an error toast.
  - Keep Live View open when Check & Save finds the user isn’t logged in yet; prompt to finish login instead of closing.
  - Reauth uses the automation’s target URL; UI shows the hostname and updated copy (“Check & Save”, clearer empty state tips).
  - Pass `automationId` to the reauth handler so flows reopen for the correct site.
  - Added tests for context handling, navigation failure, and sidebar visibility.

<sup>Written for commit 2d219d16e8f9bd8f2dcc8429c59e012f3572703a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

