### PR TITLE
fix(browserbase): retry session api failures

### DIFF
--- a/apps/api/src/browserbase/browserbase-session.service.spec.ts
+++ b/apps/api/src/browserbase/browserbase-session.service.spec.ts
@@ -98,6 +98,23 @@ describe('BrowserbaseSessionService', () => {
     expect(createContext).toHaveBeenCalledTimes(3);
   });
 
+  it('preserves non-retryable Browserbase failures', async () => {
+    const service = new BrowserbaseSessionService();
+    const browserbaseError = Object.assign(
+      new Error('Browserbase rejected request'),
+      { status: 400 },
+    );
+    const createContext = jest.fn().mockRejectedValue(browserbaseError);
+    jest
+      .spyOn(service, 'getBrowserbase')
+      .mockReturnValue(mockBrowserbaseClient({ createContext }));
+
+    await expect(service.createBrowserbaseContext()).rejects.toBe(
+      browserbaseError,
+    );
+    expect(createContext).toHaveBeenCalledTimes(1);
+  });
+
   it('retries transient Browserbase session retrieval failures', async () => {
     jest.useFakeTimers();
     const service = new BrowserbaseSessionService();

--- a/apps/api/src/browserbase/browserbase-session.service.spec.ts
+++ b/apps/api/src/browserbase/browserbase-session.service.spec.ts
@@ -7,21 +7,39 @@ jest.mock('@browserbasehq/sdk', () => ({
   default: jest.fn().mockImplementation(() => ({})),
 }));
 
-type BrowserbaseClient = ReturnType<BrowserbaseSessionService['getBrowserbase']>;
+type BrowserbaseClient = ReturnType<
+  BrowserbaseSessionService['getBrowserbase']
+>;
 
 const prematureCloseError = () =>
   Object.assign(new Error('Invalid response body: Premature close'), {
     code: 'ERR_STREAM_PREMATURE_CLOSE',
   });
 
+type MockBrowserbaseClientInput = {
+  createContext?: jest.Mock;
+  createSession?: jest.Mock;
+  debugSession?: jest.Mock;
+  retrieveSession?: jest.Mock;
+  updateSession?: jest.Mock;
+};
+
 const mockBrowserbaseClient = ({
-  createContext,
-}: {
-  createContext: jest.Mock;
-}): BrowserbaseClient =>
+  createContext = jest.fn(),
+  createSession = jest.fn(),
+  debugSession = jest.fn(),
+  retrieveSession = jest.fn(),
+  updateSession = jest.fn(),
+}: MockBrowserbaseClientInput): BrowserbaseClient =>
   ({
     contexts: {
       create: createContext,
+    },
+    sessions: {
+      create: createSession,
+      debug: debugSession,
+      retrieve: retrieveSession,
+      update: updateSession,
     },
   }) as unknown as BrowserbaseClient;
 
@@ -78,5 +96,52 @@ describe('BrowserbaseSessionService', () => {
 
     await expectation;
     expect(createContext).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries transient Browserbase session retrieval failures', async () => {
+    jest.useFakeTimers();
+    const service = new BrowserbaseSessionService();
+    const retrieveSession = jest
+      .fn()
+      .mockRejectedValueOnce(prematureCloseError())
+      .mockResolvedValueOnce({ contextId: 'ctx_1' });
+    jest
+      .spyOn(service, 'getBrowserbase')
+      .mockReturnValue(mockBrowserbaseClient({ retrieveSession }));
+
+    const promise = service.getSessionContextId('session_1');
+    await jest.advanceTimersByTimeAsync(250);
+
+    await expect(promise).resolves.toBe('ctx_1');
+    expect(retrieveSession).toHaveBeenCalledTimes(2);
+    expect(retrieveSession).toHaveBeenCalledWith('session_1');
+  });
+
+  it('retries transient Browserbase live view lookup failures', async () => {
+    jest.useFakeTimers();
+    const service = new BrowserbaseSessionService();
+    const createSession = jest.fn().mockResolvedValue({ id: 'session_1' });
+    const debugSession = jest
+      .fn()
+      .mockRejectedValueOnce(prematureCloseError())
+      .mockResolvedValueOnce({
+        debuggerFullscreenUrl: 'https://live.browserbase.test/session_1',
+      });
+    jest.spyOn(service, 'getBrowserbase').mockReturnValue(
+      mockBrowserbaseClient({
+        createSession,
+        debugSession,
+      }),
+    );
+
+    const promise = service.createSessionWithContext('ctx_1');
+    await jest.advanceTimersByTimeAsync(250);
+
+    await expect(promise).resolves.toEqual({
+      sessionId: 'session_1',
+      liveViewUrl: 'https://live.browserbase.test/session_1',
+    });
+    expect(createSession).toHaveBeenCalledTimes(1);
+    expect(debugSession).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/api/src/browserbase/browserbase-session.service.ts
+++ b/apps/api/src/browserbase/browserbase-session.service.ts
@@ -13,7 +13,7 @@ type Stagehand = import('@browserbasehq/stagehand').Stagehand;
 const BROWSER_WIDTH = 1440;
 const BROWSER_HEIGHT = 900;
 const STAGEHAND_MODEL = 'anthropic/claude-sonnet-4-6';
-const BROWSERBASE_CONTEXT_CREATE_MAX_ATTEMPTS = 3;
+const BROWSERBASE_API_MAX_ATTEMPTS = 3;
 const BROWSERBASE_RETRY_DELAYS_MS = [250, 750];
 const BROWSERBASE_DEFAULT_HEADERS = { 'accept-encoding': 'identity' };
 
@@ -35,27 +35,110 @@ export class BrowserbaseSessionService {
   }
 
   async createBrowserbaseContext(): Promise<string> {
-    for (
-      let attempt = 1;
-      attempt <= BROWSERBASE_CONTEXT_CREATE_MAX_ATTEMPTS;
-      attempt += 1
-    ) {
-      try {
+    return this.withBrowserbaseRetry({
+      operationName: 'context creation',
+      operation: async () => {
         const context = await this.getBrowserbase().contexts.create({
           projectId: this.getProjectId(),
         });
         return context.id;
+      },
+    });
+  }
+
+  async createSessionWithContext(
+    contextId: string,
+  ): Promise<{ sessionId: string; liveViewUrl: string }> {
+    const bb = this.getBrowserbase();
+
+    const session = await this.withBrowserbaseRetry({
+      operationName: 'session creation',
+      operation: () =>
+        bb.sessions.create({
+          projectId: this.getProjectId(),
+          browserSettings: {
+            context: {
+              id: contextId,
+              persist: true,
+            },
+            fingerprint: {
+              screen: {
+                maxHeight: BROWSER_HEIGHT,
+                maxWidth: BROWSER_WIDTH,
+                minHeight: BROWSER_HEIGHT,
+                minWidth: BROWSER_WIDTH,
+              },
+            },
+            viewport: { width: BROWSER_WIDTH, height: BROWSER_HEIGHT },
+          },
+          keepAlive: true,
+        }),
+    });
+
+    try {
+      const debug = await this.withBrowserbaseRetry({
+        operationName: 'session debug URL lookup',
+        operation: () => bb.sessions.debug(session.id),
+      });
+
+      return {
+        sessionId: session.id,
+        liveViewUrl: debug.debuggerFullscreenUrl,
+      };
+    } catch (error) {
+      try {
+        await this.closeSession(session.id);
+      } catch {
+        // Ignore best-effort cleanup errors after a failed live-view lookup.
+      }
+      throw error;
+    }
+  }
+
+  async closeSession(sessionId: string): Promise<void> {
+    await this.withBrowserbaseRetry({
+      operationName: 'session close',
+      operation: () =>
+        this.getBrowserbase().sessions.update(sessionId, {
+          projectId: this.getProjectId(),
+          status: 'REQUEST_RELEASE',
+        }),
+    });
+  }
+
+  async getSessionContextId(sessionId: string): Promise<string | undefined> {
+    const session = await this.withBrowserbaseRetry({
+      operationName: 'session retrieval',
+      operation: () => this.getBrowserbase().sessions.retrieve(sessionId),
+    });
+    return session.contextId;
+  }
+
+  private async withBrowserbaseRetry<T>({
+    operation,
+    operationName,
+  }: {
+    operation: () => Promise<T>;
+    operationName: string;
+  }): Promise<T> {
+    for (
+      let attempt = 1;
+      attempt <= BROWSERBASE_API_MAX_ATTEMPTS;
+      attempt += 1
+    ) {
+      try {
+        return await operation();
       } catch (error) {
         const retryable = isRetryableBrowserbaseUpstreamError(error);
-        if (!retryable || attempt === BROWSERBASE_CONTEXT_CREATE_MAX_ATTEMPTS) {
-          this.logger.error('Browserbase context creation failed', {
+        if (!retryable || attempt === BROWSERBASE_API_MAX_ATTEMPTS) {
+          this.logger.error(`Browserbase ${operationName} failed`, {
             attempt,
             error: getBrowserbaseErrorText(error),
           });
           throw browserbaseUnavailableException();
         }
 
-        this.logger.warn('Browserbase context creation failed; retrying', {
+        this.logger.warn(`Browserbase ${operationName} failed; retrying`, {
           attempt,
           error: getBrowserbaseErrorText(error),
         });
@@ -64,51 +147,6 @@ export class BrowserbaseSessionService {
     }
 
     throw browserbaseUnavailableException();
-  }
-
-  async createSessionWithContext(
-    contextId: string,
-  ): Promise<{ sessionId: string; liveViewUrl: string }> {
-    const bb = this.getBrowserbase();
-
-    const session = await bb.sessions.create({
-      projectId: this.getProjectId(),
-      browserSettings: {
-        context: {
-          id: contextId,
-          persist: true,
-        },
-        fingerprint: {
-          screen: {
-            maxHeight: BROWSER_HEIGHT,
-            maxWidth: BROWSER_WIDTH,
-            minHeight: BROWSER_HEIGHT,
-            minWidth: BROWSER_WIDTH,
-          },
-        },
-        viewport: { width: BROWSER_WIDTH, height: BROWSER_HEIGHT },
-      },
-      keepAlive: true,
-    });
-
-    const debug = await bb.sessions.debug(session.id);
-
-    return {
-      sessionId: session.id,
-      liveViewUrl: debug.debuggerFullscreenUrl,
-    };
-  }
-
-  async closeSession(sessionId: string): Promise<void> {
-    await this.getBrowserbase().sessions.update(sessionId, {
-      projectId: this.getProjectId(),
-      status: 'REQUEST_RELEASE',
-    });
-  }
-
-  async getSessionContextId(sessionId: string): Promise<string | undefined> {
-    const session = await this.getBrowserbase().sessions.retrieve(sessionId);
-    return session.contextId;
   }
 
   async createStagehand(sessionId: string): Promise<Stagehand> {

--- a/apps/api/src/browserbase/browserbase-session.service.ts
+++ b/apps/api/src/browserbase/browserbase-session.service.ts
@@ -130,7 +130,15 @@ export class BrowserbaseSessionService {
         return await operation();
       } catch (error) {
         const retryable = isRetryableBrowserbaseUpstreamError(error);
-        if (!retryable || attempt === BROWSERBASE_API_MAX_ATTEMPTS) {
+        if (!retryable) {
+          this.logger.error(`Browserbase ${operationName} failed`, {
+            attempt,
+            error: getBrowserbaseErrorText(error),
+          });
+          throw error;
+        }
+
+        if (attempt === BROWSERBASE_API_MAX_ATTEMPTS) {
           this.logger.error(`Browserbase ${operationName} failed`, {
             attempt,
             error: getBrowserbaseErrorText(error),


### PR DESCRIPTION
## Summary
- retry transient Browserbase SDK failures for session create/debug/retrieve/update, not only context creation
- fixes the stage error from GET /v1/sessions/:id returning ERR_STREAM_PREMATURE_CLOSE / Premature close
- keep Browserbase response headers set to identity encoding, and map exhausted retryable upstream failures to a stable 503
- best-effort close a created session if live-view URL lookup fails after retries

## Tests
- cd apps/api && bunx jest src/browserbase/browserbase-session.service.spec.ts src/browserbase/browserbase-upstream-error.spec.ts --passWithNoTests
- bunx turbo run typecheck --filter=@trycompai/api (fails on existing unrelated API type errors in assistant-chat, auth, cloud-security, integration-platform specs, and other modules)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unified retry logic for Browserbase session APIs (create, debug, retrieve, update, close) to handle transient failures. Fixes premature close errors, preserves non-retryable errors, returns 503 after max retries, and cleans up sessions if live-view lookup fails.

- **Bug Fixes**
  - Retries applied to session create/debug/retrieve/update/close and context creation (3 attempts with small backoff).
  - Non-retryable Browserbase errors (e.g., 4xx) are returned as-is.
  - Consolidated logic via a shared retry helper for consistent handling.
  - Sends identity encoding to keep responses stable.
  - Added tests for non-retryable errors, session retrieval, and live view retry behavior.

<sup>Written for commit 1683d009bc9cbc36056617c49a638cde567769dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

