### PR TITLE
feat(framework-editor): per-framework requirement sort order (FRAME-18)

### DIFF
--- a/apps/api/src/framework-editor-versions/framework-manifest-builder.spec.ts
+++ b/apps/api/src/framework-editor-versions/framework-manifest-builder.spec.ts
@@ -57,6 +57,39 @@ describe('buildManifestForFramework', () => {
     expect(manifest.tasks).toHaveLength(1);
   });
 
+  // FRAME-18: the frozen manifest must order requirements by sortOrder, then by
+  // the stable identifier key, then name. Tiebreaking by name alone would let a
+  // published manifest reorder unsorted requirements whenever a name is edited.
+  it('requests canonical requirement ordering (sortOrder → identifier → name) and preserves sortOrder', async () => {
+    (db.frameworkEditorFramework.findUnique as jest.Mock).mockResolvedValue({
+      id: 'frk_csf',
+      name: 'NIST CSF',
+      version: '2.0',
+      description: null,
+      requirements: [
+        {
+          id: 'frk_rq_gv',
+          identifier: 'GV.OC-01',
+          name: 'Organizational Context',
+          description: 'd',
+          sortOrder: 10,
+          controlTemplates: [],
+        },
+      ],
+    });
+
+    const manifest = await buildManifestForFramework('frk_csf');
+
+    const findUniqueArg = (db.frameworkEditorFramework.findUnique as jest.Mock).mock
+      .calls[0][0];
+    expect(findUniqueArg.include.requirements.orderBy).toEqual([
+      { sortOrder: { sort: 'asc', nulls: 'last' } },
+      { identifier: 'asc' },
+      { name: 'asc' },
+    ]);
+    expect(manifest.requirements[0].sortOrder).toBe(10);
+  });
+
   it('dedupes controls/policies/tasks that appear under multiple requirements', async () => {
     (db.frameworkEditorFramework.findUnique as jest.Mock).mockResolvedValue({
       id: 'frk_iso',

--- a/apps/api/src/framework-editor-versions/framework-manifest-builder.ts
+++ b/apps/api/src/framework-editor-versions/framework-manifest-builder.ts
@@ -14,7 +14,14 @@ export async function buildManifestForFramework(frameworkId: string): Promise<Fr
       requirements: {
         // FRAME-18: freeze requirements into the manifest in their configured
         // order so newly-built instances inherit the framework's sort order.
-        orderBy: [{ sortOrder: { sort: 'asc', nulls: 'last' } }, { name: 'asc' }],
+        // Secondary key is identifier (stable canonical-order key) then name —
+        // using name alone would let the frozen order shift when a descriptive
+        // name is edited.
+        orderBy: [
+          { sortOrder: { sort: 'asc', nulls: 'last' } },
+          { identifier: 'asc' },
+          { name: 'asc' },
+        ],
         include: {
           controlTemplates: {
             include: {

--- a/apps/api/src/framework-editor-versions/framework-manifest-builder.ts
+++ b/apps/api/src/framework-editor-versions/framework-manifest-builder.ts
@@ -12,6 +12,9 @@ export async function buildManifestForFramework(frameworkId: string): Promise<Fr
     where: { id: frameworkId },
     include: {
       requirements: {
+        // FRAME-18: freeze requirements into the manifest in their configured
+        // order so newly-built instances inherit the framework's sort order.
+        orderBy: [{ sortOrder: { sort: 'asc', nulls: 'last' } }, { name: 'asc' }],
         include: {
           controlTemplates: {
             include: {
@@ -108,6 +111,7 @@ export async function buildManifestForFramework(frameworkId: string): Promise<Fr
       name: r.name,
       description: r.description,
       requirementFamily: r.requirementFamily || null,
+      sortOrder: r.sortOrder ?? null,
     })),
     controls: [...controlsMap.values()],
     policies: [...policiesMap.values()],

--- a/apps/api/src/framework-editor/framework/dto/import-framework.dto.ts
+++ b/apps/api/src/framework-editor/framework/dto/import-framework.dto.ts
@@ -73,6 +73,13 @@ class ImportRequirementDto {
   @IsOptional()
   @MaxLength(255)
   requirementFamily?: string;
+
+  // FRAME-18: per-framework display order, preserved across export/import.
+  @ApiPropertyOptional({ nullable: true })
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  sortOrder?: number | null;
 }
 
 class ImportControlTemplateDto {

--- a/apps/api/src/framework-editor/framework/framework-export.service.ts
+++ b/apps/api/src/framework-editor/framework/framework-export.service.ts
@@ -64,7 +64,13 @@ export class FrameworkExportService {
 
     const requirements = await db.frameworkEditorRequirement.findMany({
       where: { frameworkId },
-      orderBy: [{ sortOrder: { sort: 'asc', nulls: 'last' } }, { name: 'asc' }],
+      // FRAME-18: export in configured order; identifier (canonical key) then
+      // name as the secondary/tertiary tiebreak, matching the manifest builder.
+      orderBy: [
+        { sortOrder: { sort: 'asc', nulls: 'last' } },
+        { identifier: 'asc' },
+        { name: 'asc' },
+      ],
     });
 
     const controlTemplates = await db.frameworkEditorControlTemplate.findMany({

--- a/apps/api/src/framework-editor/framework/framework-export.service.ts
+++ b/apps/api/src/framework-editor/framework/framework-export.service.ts
@@ -22,6 +22,7 @@ export interface ExportedFramework {
     identifier: string;
     description: string;
     requirementFamily?: string | null;
+    sortOrder?: number | null;
   }>;
   controlTemplates: Array<{
     name: string;
@@ -63,7 +64,7 @@ export class FrameworkExportService {
 
     const requirements = await db.frameworkEditorRequirement.findMany({
       where: { frameworkId },
-      orderBy: { name: 'asc' },
+      orderBy: [{ sortOrder: { sort: 'asc', nulls: 'last' } }, { name: 'asc' }],
     });
 
     const controlTemplates = await db.frameworkEditorControlTemplate.findMany({
@@ -131,6 +132,7 @@ export class FrameworkExportService {
         identifier: r.identifier,
         description: r.description,
         requirementFamily: r.requirementFamily || null,
+        sortOrder: r.sortOrder ?? null,
       })),
       controlTemplates: controlTemplates.map((ct) => ({
         name: ct.name,
@@ -194,6 +196,7 @@ export class FrameworkExportService {
               identifier: r.identifier ?? '',
               description: r.description,
               requirementFamily: r.requirementFamily || null,
+              sortOrder: r.sortOrder ?? null,
             },
           }),
         ),

--- a/apps/api/src/framework-editor/framework/framework.service.ts
+++ b/apps/api/src/framework-editor/framework/framework.service.ts
@@ -53,7 +53,9 @@ export class FrameworkEditorFrameworkService {
       where: { id },
       include: {
         requirements: {
-          orderBy: { name: 'asc' },
+          // FRAME-18: surface requirements in the framework's configured order
+          // (numbered first, unset last), so the editor grid opens pre-sorted.
+          orderBy: [{ sortOrder: { sort: 'asc', nulls: 'last' } }, { name: 'asc' }],
           include: {
             controlTemplates: { select: { id: true, name: true } },
           },

--- a/apps/api/src/framework-editor/framework/framework.service.ts
+++ b/apps/api/src/framework-editor/framework/framework.service.ts
@@ -54,8 +54,13 @@ export class FrameworkEditorFrameworkService {
       include: {
         requirements: {
           // FRAME-18: surface requirements in the framework's configured order
-          // (numbered first, unset last), so the editor grid opens pre-sorted.
-          orderBy: [{ sortOrder: { sort: 'asc', nulls: 'last' } }, { name: 'asc' }],
+          // (numbered first, unset last), tiebreaking by identifier (the
+          // canonical-order key) then name, so the editor grid opens pre-sorted.
+          orderBy: [
+            { sortOrder: { sort: 'asc', nulls: 'last' } },
+            { identifier: 'asc' },
+            { name: 'asc' },
+          ],
           include: {
             controlTemplates: { select: { id: true, name: true } },
           },

--- a/apps/api/src/framework-editor/requirement/dto/batch-update-requirements.dto.ts
+++ b/apps/api/src/framework-editor/requirement/dto/batch-update-requirements.dto.ts
@@ -2,10 +2,12 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
   IsArray,
+  IsInt,
   IsNotEmpty,
   IsString,
   IsOptional,
   MaxLength,
+  Min,
   ValidateNested,
 } from 'class-validator';
 
@@ -38,6 +40,13 @@ class BatchUpdateRequirementItem {
   @IsOptional()
   @MaxLength(255)
   requirementFamily?: string;
+
+  // Nullable so a batch update can clear an order back to "unset".
+  @ApiProperty({ required: false, nullable: true })
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  sortOrder?: number | null;
 }
 
 export class BatchUpdateRequirementsDto {

--- a/apps/api/src/framework-editor/requirement/dto/create-requirement.dto.spec.ts
+++ b/apps/api/src/framework-editor/requirement/dto/create-requirement.dto.spec.ts
@@ -47,4 +47,29 @@ describe('CreateRequirementDto', () => {
     expect(errors.length).toBeGreaterThan(0);
     expect(errors[0].property).toBe('description');
   });
+
+  // ── sortOrder (FRAME-18) ───────────────────────────────────────────
+  it('accepts a non-negative integer sortOrder', async () => {
+    const dto = toDto({ ...VALID_BASE, sortOrder: 10 });
+    const errors = await validate(dto, { whitelist: true, forbidNonWhitelisted: true });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('accepts a payload with no sortOrder', async () => {
+    const dto = toDto(VALID_BASE);
+    const errors = await validate(dto, { whitelist: true, forbidNonWhitelisted: true });
+    expect(errors.some((e) => e.property === 'sortOrder')).toBe(false);
+  });
+
+  it('rejects a negative sortOrder', async () => {
+    const dto = toDto({ ...VALID_BASE, sortOrder: -1 });
+    const errors = await validate(dto, { whitelist: true, forbidNonWhitelisted: true });
+    expect(errors.some((e) => e.property === 'sortOrder')).toBe(true);
+  });
+
+  it('rejects a non-integer sortOrder', async () => {
+    const dto = toDto({ ...VALID_BASE, sortOrder: 1.5 });
+    const errors = await validate(dto, { whitelist: true, forbidNonWhitelisted: true });
+    expect(errors.some((e) => e.property === 'sortOrder')).toBe(true);
+  });
 });

--- a/apps/api/src/framework-editor/requirement/dto/create-requirement.dto.ts
+++ b/apps/api/src/framework-editor/requirement/dto/create-requirement.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsString, IsNotEmpty, IsOptional, MaxLength } from 'class-validator';
+import { IsInt, IsNotEmpty, IsOptional, IsString, MaxLength, Min } from 'class-validator';
 
 export class CreateRequirementDto {
   @ApiProperty({ example: 'frk_abc123' })
@@ -30,4 +30,13 @@ export class CreateRequirementDto {
   @IsOptional()
   @MaxLength(255)
   requirementFamily?: string;
+
+  @ApiPropertyOptional({
+    example: 10,
+    description: 'Display order within the framework (lower sorts first).',
+  })
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  sortOrder?: number;
 }

--- a/apps/api/src/framework-editor/requirement/dto/update-requirement.dto.ts
+++ b/apps/api/src/framework-editor/requirement/dto/update-requirement.dto.ts
@@ -1,5 +1,5 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsString, IsOptional, MaxLength } from 'class-validator';
+import { IsInt, IsOptional, IsString, MaxLength, Min } from 'class-validator';
 
 export class UpdateRequirementDto {
   @ApiPropertyOptional()
@@ -25,4 +25,12 @@ export class UpdateRequirementDto {
   @IsOptional()
   @MaxLength(255)
   requirementFamily?: string;
+
+  // Nullable so the editor can clear an order back to "unset". @IsOptional()
+  // skips validation for both null and undefined, letting null pass through.
+  @ApiPropertyOptional({ nullable: true })
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  sortOrder?: number | null;
 }

--- a/apps/api/src/framework-editor/requirement/requirement.service.spec.ts
+++ b/apps/api/src/framework-editor/requirement/requirement.service.spec.ts
@@ -1,0 +1,133 @@
+jest.mock('@db', () => ({
+  db: {
+    frameworkEditorRequirement: {
+      create: jest.fn(),
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+    frameworkEditorFramework: {
+      findUnique: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  },
+}));
+
+import { db } from '@db';
+import { RequirementService } from './requirement.service';
+
+const mockDb = db as jest.Mocked<typeof db>;
+
+describe('RequirementService — sortOrder (FRAME-18)', () => {
+  let service: RequirementService;
+
+  beforeEach(() => {
+    service = new RequirementService();
+    jest.clearAllMocks();
+    (mockDb.frameworkEditorFramework.findUnique as jest.Mock).mockResolvedValue({
+      id: 'frk_1',
+    });
+    (mockDb.frameworkEditorRequirement.create as jest.Mock).mockResolvedValue({
+      id: 'frk_rq_new',
+      name: 'New',
+    });
+    (mockDb.frameworkEditorRequirement.findUnique as jest.Mock).mockResolvedValue({
+      id: 'frk_rq_1',
+    });
+    (mockDb.frameworkEditorRequirement.update as jest.Mock).mockResolvedValue({
+      id: 'frk_rq_1',
+      name: 'Updated',
+    });
+    // batchUpdate wraps the per-row update() promises in a transaction.
+    (mockDb.$transaction as jest.Mock).mockImplementation((ops: Promise<unknown>[]) =>
+      Promise.all(ops),
+    );
+  });
+
+  const createDataOf = () =>
+    (mockDb.frameworkEditorRequirement.create as jest.Mock).mock.calls[0][0].data;
+  const updateDataOf = (i = 0) =>
+    (mockDb.frameworkEditorRequirement.update as jest.Mock).mock.calls[i][0].data;
+
+  describe('create', () => {
+    it('persists a provided sortOrder', async () => {
+      await service.create({
+        frameworkId: 'frk_1',
+        name: 'R1',
+        description: 'd',
+        sortOrder: 5,
+      } as never);
+
+      expect(createDataOf().sortOrder).toBe(5);
+    });
+
+    it('defaults sortOrder to null when omitted', async () => {
+      await service.create({
+        frameworkId: 'frk_1',
+        name: 'R1',
+        description: 'd',
+      } as never);
+
+      expect(createDataOf().sortOrder).toBeNull();
+    });
+  });
+
+  describe('update', () => {
+    it('persists a provided sortOrder', async () => {
+      await service.update('frk_rq_1', { sortOrder: 7 } as never);
+      expect(updateDataOf().sortOrder).toBe(7);
+    });
+
+    it('clears sortOrder when null is sent', async () => {
+      await service.update('frk_rq_1', { sortOrder: null } as never);
+      expect(updateDataOf().sortOrder).toBeNull();
+    });
+
+    it('leaves sortOrder untouched when not provided', async () => {
+      await service.update('frk_rq_1', { name: 'Renamed' } as never);
+      expect(updateDataOf().sortOrder).toBeUndefined();
+    });
+  });
+
+  describe('batchUpdate', () => {
+    it('persists sortOrder for rows that include it (including null to clear)', async () => {
+      await service.batchUpdate([
+        { id: 'a', sortOrder: 3 },
+        { id: 'b', sortOrder: null },
+        { id: 'c', name: 'NoOrder' },
+      ]);
+
+      expect(updateDataOf(0).sortOrder).toBe(3);
+      expect(updateDataOf(1).sortOrder).toBeNull();
+      // Row without sortOrder must not include the key at all (untouched).
+      expect('sortOrder' in updateDataOf(2)).toBe(false);
+    });
+  });
+
+  describe('findAll / findAllForFramework ordering', () => {
+    beforeEach(() => {
+      (mockDb.frameworkEditorRequirement.findMany as jest.Mock).mockResolvedValue([]);
+    });
+
+    it('orders by sortOrder ascending with nulls last, then name', async () => {
+      await service.findAll();
+      const orderBy = (mockDb.frameworkEditorRequirement.findMany as jest.Mock).mock
+        .calls[0][0].orderBy;
+      expect(orderBy).toEqual([
+        { sortOrder: { sort: 'asc', nulls: 'last' } },
+        { name: 'asc' },
+      ]);
+    });
+
+    it('orders per-framework requirements the same way', async () => {
+      await service.findAllForFramework('frk_1');
+      const orderBy = (mockDb.frameworkEditorRequirement.findMany as jest.Mock).mock
+        .calls[0][0].orderBy;
+      expect(orderBy).toEqual([
+        { sortOrder: { sort: 'asc', nulls: 'last' } },
+        { name: 'asc' },
+      ]);
+    });
+  });
+});

--- a/apps/api/src/framework-editor/requirement/requirement.service.spec.ts
+++ b/apps/api/src/framework-editor/requirement/requirement.service.spec.ts
@@ -116,6 +116,7 @@ describe('RequirementService — sortOrder (FRAME-18)', () => {
         .calls[0][0].orderBy;
       expect(orderBy).toEqual([
         { sortOrder: { sort: 'asc', nulls: 'last' } },
+        { identifier: 'asc' },
         { name: 'asc' },
       ]);
     });
@@ -126,6 +127,7 @@ describe('RequirementService — sortOrder (FRAME-18)', () => {
         .calls[0][0].orderBy;
       expect(orderBy).toEqual([
         { sortOrder: { sort: 'asc', nulls: 'last' } },
+        { identifier: 'asc' },
         { name: 'asc' },
       ]);
     });

--- a/apps/api/src/framework-editor/requirement/requirement.service.ts
+++ b/apps/api/src/framework-editor/requirement/requirement.service.ts
@@ -11,7 +11,9 @@ export class RequirementService {
     return db.frameworkEditorRequirement.findMany({
       take,
       skip,
-      orderBy: { name: 'asc' },
+      // FRAME-18: numbered requirements first (ascending), unset rows last,
+      // then alphabetical by name as a stable tiebreak.
+      orderBy: [{ sortOrder: { sort: 'asc', nulls: 'last' } }, { name: 'asc' }],
       include: {
         framework: { select: { id: true, name: true } },
       },
@@ -21,7 +23,7 @@ export class RequirementService {
   async findAllForFramework(frameworkId: string) {
     return db.frameworkEditorRequirement.findMany({
       where: { frameworkId },
-      orderBy: { name: 'asc' },
+      orderBy: [{ sortOrder: { sort: 'asc', nulls: 'last' } }, { name: 'asc' }],
       include: {
         controlTemplates: { select: { id: true, name: true } },
       },
@@ -43,6 +45,7 @@ export class RequirementService {
         identifier: dto.identifier ?? '',
         description: dto.description ?? '',
         requirementFamily: dto.requirementFamily || null,
+        sortOrder: dto.sortOrder ?? null,
       },
     });
     this.logger.log(`Created requirement: ${req.name} (${req.id})`);
@@ -77,6 +80,7 @@ export class RequirementService {
       identifier?: string;
       description?: string;
       requirementFamily?: string;
+      sortOrder?: number | null;
     }>,
   ) {
     return db.$transaction(
@@ -95,6 +99,8 @@ export class RequirementService {
             ...(data.requirementFamily !== undefined && {
               requirementFamily: data.requirementFamily || null,
             }),
+            // null clears the order; undefined leaves it untouched.
+            ...(data.sortOrder !== undefined && { sortOrder: data.sortOrder }),
           },
         });
       }),

--- a/apps/api/src/framework-editor/requirement/requirement.service.ts
+++ b/apps/api/src/framework-editor/requirement/requirement.service.ts
@@ -12,8 +12,14 @@ export class RequirementService {
       take,
       skip,
       // FRAME-18: numbered requirements first (ascending), unset rows last,
-      // then alphabetical by name as a stable tiebreak.
-      orderBy: [{ sortOrder: { sort: 'asc', nulls: 'last' } }, { name: 'asc' }],
+      // then by identifier (the canonical-order key, e.g. CC6.1 / GV.OC-01),
+      // with name as a final stable tiebreak. Identifier — not name — matches
+      // the editor/app comparators and is stable when descriptive names change.
+      orderBy: [
+        { sortOrder: { sort: 'asc', nulls: 'last' } },
+        { identifier: 'asc' },
+        { name: 'asc' },
+      ],
       include: {
         framework: { select: { id: true, name: true } },
       },
@@ -23,7 +29,11 @@ export class RequirementService {
   async findAllForFramework(frameworkId: string) {
     return db.frameworkEditorRequirement.findMany({
       where: { frameworkId },
-      orderBy: [{ sortOrder: { sort: 'asc', nulls: 'last' } }, { name: 'asc' }],
+      orderBy: [
+        { sortOrder: { sort: 'asc', nulls: 'last' } },
+        { identifier: 'asc' },
+        { name: 'asc' },
+      ],
       include: {
         controlTemplates: { select: { id: true, name: true } },
       },

--- a/apps/api/src/frameworks/framework-versioning/manifest.types.ts
+++ b/apps/api/src/frameworks/framework-versioning/manifest.types.ts
@@ -21,6 +21,7 @@ export interface ManifestRequirement {
   name: string;
   description: string | null;
   requirementFamily?: string | null;
+  sortOrder?: number | null; // FRAME-18: per-framework display order
 }
 
 export interface ManifestControl {

--- a/apps/api/src/frameworks/frameworks.service.ts
+++ b/apps/api/src/frameworks/frameworks.service.ts
@@ -25,10 +25,24 @@ type RequirementDef = {
   identifier: string;
   description: string;
   requirementFamily?: string | null;
+  sortOrder?: number | null;
   frameworkId: string | null;
   customFrameworkId: string | null;
   kind: 'platform' | 'custom';
 };
+
+// FRAME-18: numbered requirements first (ascending), unset rows (incl. per-instance
+// custom requirements) last, then alphabetical by name as a stable tiebreak.
+function compareRequirementDefs(a: RequirementDef, b: RequirementDef): number {
+  const ao = a.sortOrder ?? null;
+  const bo = b.sortOrder ?? null;
+  if (ao !== bo) {
+    if (ao === null) return 1;
+    if (bo === null) return -1;
+    return ao - bo;
+  }
+  return a.name.localeCompare(b.name);
+}
 
 @Injectable()
 export class FrameworksService {
@@ -106,20 +120,19 @@ export class FrameworksService {
               identifier: r.identifier,
               description: r.description ?? '',
               requirementFamily: r.requirementFamily ?? null,
+              sortOrder: r.sortOrder ?? null,
               frameworkId: fi.frameworkId,
               customFrameworkId: null,
               kind: 'platform',
             }),
           );
-          return [...platformDefs, ...customDefs].sort((a, b) =>
-            a.name.localeCompare(b.name),
-          );
+          return [...platformDefs, ...customDefs].sort(compareRequirementDefs);
         }
       }
       // Fallback: instances with no pinned version (shouldn't happen post-backfill).
       const rows = await db.frameworkEditorRequirement.findMany({
         where: { frameworkId: fi.frameworkId },
-        orderBy: { name: 'asc' },
+        orderBy: [{ sortOrder: { sort: 'asc', nulls: 'last' } }, { name: 'asc' }],
       });
       const platformDefs: RequirementDef[] = rows.map((r) => ({
         id: r.id,
@@ -127,13 +140,12 @@ export class FrameworksService {
         identifier: r.identifier,
         description: r.description,
         requirementFamily: r.requirementFamily ?? null,
+        sortOrder: r.sortOrder ?? null,
         frameworkId: r.frameworkId,
         customFrameworkId: null,
         kind: 'platform',
       }));
-      return [...platformDefs, ...customDefs].sort((a, b) =>
-        a.name.localeCompare(b.name),
-      );
+      return [...platformDefs, ...customDefs].sort(compareRequirementDefs);
     }
     return [];
   }

--- a/apps/api/src/frameworks/frameworks.service.ts
+++ b/apps/api/src/frameworks/frameworks.service.ts
@@ -32,7 +32,9 @@ type RequirementDef = {
 };
 
 // FRAME-18: numbered requirements first (ascending), unset rows (incl. per-instance
-// custom requirements) last, then alphabetical by name as a stable tiebreak.
+// custom requirements) last, then by identifier (the canonical-order key, e.g.
+// CC6.1 / GV.OC-01) with name as a final tiebreak. Mirrors the app-side
+// `compareRequirementsByOrder` so server and client agree on the order.
 function compareRequirementDefs(a: RequirementDef, b: RequirementDef): number {
   const ao = a.sortOrder ?? null;
   const bo = b.sortOrder ?? null;
@@ -41,6 +43,10 @@ function compareRequirementDefs(a: RequirementDef, b: RequirementDef): number {
     if (bo === null) return -1;
     return ao - bo;
   }
+  const byIdentifier = (a.identifier ?? '').localeCompare(b.identifier ?? '', undefined, {
+    numeric: true,
+  });
+  if (byIdentifier !== 0) return byIdentifier;
   return a.name.localeCompare(b.name);
 }
 
@@ -132,7 +138,11 @@ export class FrameworksService {
       // Fallback: instances with no pinned version (shouldn't happen post-backfill).
       const rows = await db.frameworkEditorRequirement.findMany({
         where: { frameworkId: fi.frameworkId },
-        orderBy: [{ sortOrder: { sort: 'asc', nulls: 'last' } }, { name: 'asc' }],
+        orderBy: [
+          { sortOrder: { sort: 'asc', nulls: 'last' } },
+          { identifier: 'asc' },
+          { name: 'asc' },
+        ],
       });
       const platformDefs: RequirementDef[] = rows.map((r) => ({
         id: r.id,

--- a/apps/app/src/app/(app)/[orgId]/frameworks/[frameworkInstanceId]/components/FrameworkRequirements.tsx
+++ b/apps/app/src/app/(app)/[orgId]/frameworks/[frameworkInstanceId]/components/FrameworkRequirements.tsx
@@ -27,6 +27,7 @@ import { Search } from '@trycompai/design-system/icons';
 import { useParams, useRouter } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
 import { ExpandableDescription } from './ExpandableDescription';
+import { compareRequirementsByOrder } from './framework-controls-shared';
 import {
   REQUIREMENTS_TABLE_COLUMN_COUNT,
   REQUIREMENTS_TABLE_STYLE,
@@ -112,13 +113,9 @@ export function FrameworkRequirements({
     });
   }, [requirementDefinitions, frameworkInstanceWithControls.controls, tasks, evidenceSubmissions]);
 
-  const sortedItems = useMemo(
-    () =>
-      [...items].sort((a, b) =>
-        (a.identifier ?? '').localeCompare(b.identifier ?? '', undefined, { numeric: true }),
-      ),
-    [items],
-  );
+  // FRAME-18: order by the framework's configured sort order (numbered first,
+  // unset last), falling back to identifier for ties.
+  const sortedItems = useMemo(() => [...items].sort(compareRequirementsByOrder), [items]);
 
   const filteredItems = useMemo(() => {
     if (!searchTerm.trim()) return sortedItems;

--- a/apps/app/src/app/(app)/[orgId]/frameworks/[frameworkInstanceId]/components/framework-controls-shared.test.ts
+++ b/apps/app/src/app/(app)/[orgId]/frameworks/[frameworkInstanceId]/components/framework-controls-shared.test.ts
@@ -4,10 +4,13 @@ import type { FrameworkInstanceWithControls } from '@/lib/types/framework';
 import {
   buildControlItems,
   buildRequirementMap,
+  compareRequirementsByOrder,
   getStatusBadge,
   groupByFamily,
+  groupRequirementsByFamily,
   UNCATEGORIZED_FAMILY,
   type ControlItem,
+  type RequirementItem,
 } from './framework-controls-shared';
 
 // ---------------------------------------------------------------------------
@@ -262,5 +265,108 @@ describe('groupByFamily', () => {
     expect(groups).toHaveLength(1);
     expect(groups[0].family).toBe(UNCATEGORIZED_FAMILY);
     expect(groups[0].items).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// compareRequirementsByOrder (FRAME-18)
+// ---------------------------------------------------------------------------
+
+function reqItem(overrides: {
+  name?: string;
+  identifier?: string;
+  sortOrder?: number | null;
+  requirementFamily?: string | null;
+}): RequirementItem {
+  return makeRequirement(overrides as Partial<FrameworkEditorRequirement>) as unknown as RequirementItem;
+}
+
+describe('compareRequirementsByOrder', () => {
+  const orderOf = (sortOrders: Array<number | null>) =>
+    sortOrders
+      .map((sortOrder, i) => reqItem({ identifier: `R-${i}`, sortOrder }))
+      .sort(compareRequirementsByOrder)
+      .map((r) => r.sortOrder ?? null);
+
+  it('orders numbered requirements ascending', () => {
+    expect(orderOf([3, 1, 2])).toEqual([1, 2, 3]);
+  });
+
+  it('places unset (null) rows after numbered rows', () => {
+    expect(orderOf([null, 2, null, 1])).toEqual([1, 2, null, null]);
+  });
+
+  it('treats undefined sortOrder the same as null (sorts last)', () => {
+    const items = [
+      reqItem({ identifier: 'R-2', sortOrder: undefined }),
+      reqItem({ identifier: 'R-1', sortOrder: 5 }),
+    ];
+    expect(items.sort(compareRequirementsByOrder).map((r) => r.identifier)).toEqual([
+      'R-1',
+      'R-2',
+    ]);
+  });
+
+  it('falls back to numeric identifier order for unset rows', () => {
+    const items = [
+      reqItem({ identifier: 'R-10', sortOrder: null }),
+      reqItem({ identifier: 'R-2', sortOrder: null }),
+    ];
+    expect(items.sort(compareRequirementsByOrder).map((r) => r.identifier)).toEqual([
+      'R-2',
+      'R-10',
+    ]);
+  });
+
+  it('falls back to identifier when two rows share a sortOrder', () => {
+    const items = [
+      reqItem({ identifier: 'B', sortOrder: 1 }),
+      reqItem({ identifier: 'A', sortOrder: 1 }),
+    ];
+    expect(items.sort(compareRequirementsByOrder).map((r) => r.identifier)).toEqual(['A', 'B']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// groupRequirementsByFamily (FRAME-18)
+// ---------------------------------------------------------------------------
+
+describe('groupRequirementsByFamily', () => {
+  it('orders families by their lowest sortOrder (NIST CSF canonical order)', () => {
+    // Canonical NIST CSF order is GV → ID → PR → DE → RS → RC, which is NOT
+    // alphabetical. Numbering requirements drives the family order.
+    const items = [
+      reqItem({ identifier: 'PR.AA', sortOrder: 30, requirementFamily: 'Protect' }),
+      reqItem({ identifier: 'GV.OC', sortOrder: 10, requirementFamily: 'Govern' }),
+      reqItem({ identifier: 'ID.AM', sortOrder: 20, requirementFamily: 'Identify' }),
+      reqItem({ identifier: 'DE.CM', sortOrder: 40, requirementFamily: 'Detect' }),
+    ];
+
+    const families = groupRequirementsByFamily(items).map((g) => g.family);
+
+    expect(families).toEqual(['Govern', 'Identify', 'Protect', 'Detect']);
+  });
+
+  it('sorts requirements within a family by sortOrder', () => {
+    const items = [
+      reqItem({ identifier: 'GV.B', sortOrder: 12, requirementFamily: 'Govern' }),
+      reqItem({ identifier: 'GV.A', sortOrder: 11, requirementFamily: 'Govern' }),
+    ];
+
+    const order = groupRequirementsByFamily(items)[0].items.map((r) => r.identifier);
+
+    expect(order).toEqual(['GV.A', 'GV.B']);
+  });
+
+  it('falls back to alphabetical family order when no sortOrder is set', () => {
+    // Every existing framework today has null sortOrder — behavior is unchanged.
+    const items = [
+      reqItem({ identifier: 'Z-1', sortOrder: null, requirementFamily: 'Zoning' }),
+      reqItem({ identifier: 'A-1', sortOrder: null, requirementFamily: 'Access Control' }),
+    ];
+
+    const families = groupRequirementsByFamily(items).map((g) => g.family);
+
+    expect(families).toEqual(['Access Control', 'Zoning']);
   });
 });

--- a/apps/app/src/app/(app)/[orgId]/frameworks/[frameworkInstanceId]/components/framework-controls-shared.ts
+++ b/apps/app/src/app/(app)/[orgId]/frameworks/[frameworkInstanceId]/components/framework-controls-shared.ts
@@ -125,6 +125,27 @@ export interface RequirementFamilyGroup {
   items: RequirementItem[];
 }
 
+/**
+ * FRAME-18: order requirements by their per-framework `sortOrder` (numbered
+ * rows first, ascending), falling back to identifier (then name) for unset
+ * rows and ties. Unset (`null`/`undefined`) rows always sort last.
+ */
+export function compareRequirementsByOrder(
+  a: Pick<FrameworkEditorRequirement, 'sortOrder' | 'identifier' | 'name'>,
+  b: Pick<FrameworkEditorRequirement, 'sortOrder' | 'identifier' | 'name'>,
+): number {
+  const ao = a.sortOrder ?? null;
+  const bo = b.sortOrder ?? null;
+  if (ao !== bo) {
+    if (ao == null) return 1;
+    if (bo == null) return -1;
+    return ao - bo;
+  }
+  return (a.identifier ?? a.name).localeCompare(b.identifier ?? b.name, undefined, {
+    numeric: true,
+  });
+}
+
 export function groupRequirementsByFamily(items: RequirementItem[]): RequirementFamilyGroup[] {
   const familyMap = new Map<string, RequirementItem[]>();
   const otherItems: RequirementItem[] = [];
@@ -143,12 +164,31 @@ export function groupRequirementsByFamily(items: RequirementItem[]): Requirement
     }
   }
 
-  const sortedFamilies = Array.from(familyMap.entries()).sort(([a], [b]) =>
-    a.localeCompare(b),
-  );
+  // FRAME-18: order families by the lowest sortOrder among their requirements so
+  // a framework's configured order also drives the family order (e.g. NIST CSF
+  // Functions GV → ID → PR → DE → RS → RC). When no requirement has a sortOrder
+  // (every existing framework today), every family's min is null and this falls
+  // back to alphabetical — identical to the previous behavior.
+  const minSortOrder = (familyItems: RequirementItem[]): number | null => {
+    let min: number | null = null;
+    for (const item of familyItems) {
+      if (item.sortOrder == null) continue;
+      if (min === null || item.sortOrder < min) min = item.sortOrder;
+    }
+    return min;
+  };
+  const sortedFamilies = Array.from(familyMap.entries()).sort(([fa, ia], [fb, ib]) => {
+    const ma = minSortOrder(ia);
+    const mb = minSortOrder(ib);
+    if (ma !== mb) {
+      if (ma === null) return 1;
+      if (mb === null) return -1;
+      return ma - mb;
+    }
+    return fa.localeCompare(fb);
+  });
 
-  const sortItems = (a: RequirementItem, b: RequirementItem) =>
-    (a.identifier ?? a.name).localeCompare(b.identifier ?? b.name, undefined, { numeric: true });
+  const sortItems = compareRequirementsByOrder;
 
   const groups: RequirementFamilyGroup[] = sortedFamilies.map(([family, familyItems]) => ({
     family,

--- a/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/FrameworkRequirementsClientPage.tsx
+++ b/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/FrameworkRequirementsClientPage.tsx
@@ -37,6 +37,7 @@ interface RequirementInput {
   identifier: string;
   description: string;
   requirementFamily?: string | null;
+  sortOrder?: number | null;
   frameworkId: string;
   createdAt: string | Date;
   updatedAt: string | Date;
@@ -85,6 +86,7 @@ export function FrameworkRequirementsClientPage({
         identifier: r.identifier ?? null,
         description: r.description ?? null,
         requirementFamily: r.requirementFamily ?? null,
+        sortOrder: r.sortOrder ?? null,
         controlTemplates: r.controlTemplates ?? [],
         controlTemplatesLength: r.controlTemplates?.length ?? 0,
         createdAt: r.createdAt ? new Date(r.createdAt) : null,
@@ -117,6 +119,38 @@ export function FrameworkRequirementsClientPage({
 
   const columns = useMemo(
     () => [
+      columnHelper.accessor('sortOrder', {
+        header: 'Order',
+        size: 90,
+        // Numbered rows ascending, unset rows last, identifier as a tiebreak.
+        // (tanstack inverts this for the desc toggle.)
+        sortingFn: (a, b) => {
+          const ao = a.original.sortOrder;
+          const bo = b.original.sortOrder;
+          if (ao !== bo) {
+            if (ao == null) return 1;
+            if (bo == null) return -1;
+            return ao - bo;
+          }
+          return (a.original.identifier ?? '').localeCompare(
+            b.original.identifier ?? '',
+            undefined,
+            { numeric: true },
+          );
+        },
+        cell: ({ row, getValue }) => {
+          const value = getValue();
+          return (
+            <EditableCell
+              value={value == null ? null : String(value)}
+              rowId={row.original.id}
+              columnId="sortOrder"
+              onUpdate={updateCell}
+              placeholder="—"
+            />
+          );
+        },
+      }),
       columnHelper.accessor('requirementFamily', {
         header: 'Family',
         size: 200,
@@ -232,7 +266,9 @@ export function FrameworkRequirementsClientPage({
     [uniqueFamilies, updateCell, updateRelational, deleteRow, createdIds],
   );
 
-  const [sorting, setSorting] = useState<SortingState>([{ id: 'identifier', desc: false }]);
+  // FRAME-18: default to the framework's configured order. Numbered requirements
+  // come first; unset rows fall back to identifier order and sort last.
+  const [sorting, setSorting] = useState<SortingState>([{ id: 'sortOrder', desc: false }]);
 
   const table = useReactTable({
     data,
@@ -251,6 +287,7 @@ export function FrameworkRequirementsClientPage({
       identifier: '',
       description: '',
       requirementFamily: null,
+      sortOrder: null,
       controlTemplates: [],
       controlTemplatesLength: 0,
       createdAt: new Date(),

--- a/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/hooks/useRequirementChangeTracking.test.tsx
+++ b/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/hooks/useRequirementChangeTracking.test.tsx
@@ -28,6 +28,7 @@ function makeRow(overrides: Partial<RequirementGridRow> = {}): RequirementGridRo
     identifier: '10.3',
     description: '',
     requirementFamily: 'Access Control',
+    sortOrder: null,
     controlTemplates: [],
     controlTemplatesLength: 0,
     createdAt: new Date(),

--- a/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/hooks/useRequirementChangeTracking.ts
+++ b/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/hooks/useRequirementChangeTracking.ts
@@ -10,10 +10,21 @@ export interface RequirementGridRow {
   identifier: string | null;
   description: string | null;
   requirementFamily: string | null;
+  // FRAME-18: per-framework display order. null = unset (sorts last).
+  sortOrder: number | null;
   controlTemplates: Array<{ id: string; name: string }>;
   controlTemplatesLength: number;
   createdAt: Date | null;
   updatedAt: Date | null;
+}
+
+// Parse the free-text Order cell into a non-negative integer, or null when blank
+// / invalid. Keeps the grid's sortOrder numeric so the column sorts correctly.
+function parseSortOrder(value: string): number | null {
+  const trimmed = value.trim();
+  if (trimmed === '') return null;
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
 }
 
 export const simpleUUID = () => crypto.randomUUID();
@@ -43,6 +54,11 @@ export function useRequirementChangeTracking(
       setData((prev) =>
         prev.map((row) => {
           if (row.id !== rowId) return row;
+          // sortOrder is numeric — coerce the free-text cell to number | null
+          // so the grid sorts correctly and the API receives a valid value.
+          if (columnId === 'sortOrder') {
+            return { ...row, sortOrder: parseSortOrder(value), updatedAt: new Date() };
+          }
           return { ...row, [columnId]: value, updatedAt: new Date() };
         }),
       );
@@ -142,6 +158,7 @@ export function useRequirementChangeTracking(
             identifier: row.identifier ?? '',
             description: row.description ?? '',
             requirementFamily: row.requirementFamily ?? undefined,
+            sortOrder: row.sortOrder ?? undefined,
           }),
         });
         // Persist control links the user picked on the uncommitted row.
@@ -180,6 +197,7 @@ export function useRequirementChangeTracking(
       identifier: string;
       description: string;
       requirementFamily: string | null;
+      sortOrder: number | null;
     }> = [];
     for (const id of updatedIds) {
       if (createdIds.has(id) || deletedIds.has(id)) continue;
@@ -191,6 +209,7 @@ export function useRequirementChangeTracking(
         identifier: row.identifier ?? '',
         description: row.description ?? '',
         requirementFamily: row.requirementFamily ?? null,
+        sortOrder: row.sortOrder ?? null,
       });
     }
     if (updatesToSend.length > 0) {

--- a/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/page.tsx
+++ b/apps/framework-editor/app/(pages)/frameworks/[frameworkId]/page.tsx
@@ -14,6 +14,8 @@ interface FrameworkDetail {
     name: string;
     identifier: string;
     description: string;
+    requirementFamily: string | null;
+    sortOrder: number | null;
     frameworkId: string;
     createdAt: string;
     updatedAt: string;

--- a/packages/db/prisma/migrations/20260622000000_add_requirement_sort_order/migration.sql
+++ b/packages/db/prisma/migrations/20260622000000_add_requirement_sort_order/migration.sql
@@ -1,0 +1,3 @@
+-- FRAME-18: per-framework requirement display order.
+-- Nullable so existing requirements keep their current (identifier-based) ordering.
+ALTER TABLE "FrameworkEditorRequirement" ADD COLUMN "sortOrder" INTEGER;

--- a/packages/db/prisma/schema/framework-editor.prisma
+++ b/packages/db/prisma/schema/framework-editor.prisma
@@ -46,6 +46,10 @@ model FrameworkEditorRequirement {
   identifier        String @default("") // Unique identifier for the requirement, e.g., "cc1-1"
   description       String
   requirementFamily String?
+  // Per-framework display order (FRAME-18). Lower numbers sort first; null rows
+  // fall back to identifier ordering and sort after numbered rows. Lets frameworks
+  // like NIST CSF use their canonical order (GV → ID → PR → DE → RS → RC).
+  sortOrder         Int?
 
   controlTemplates FrameworkEditorControlTemplate[]
   requirementMaps  RequirementMap[]


### PR DESCRIPTION
## What & why

**FRAME-18** — Joe needs to control the order requirements appear in for a framework. Frameworks like **NIST CSF v2.0** use a non-alphabetical canonical order (Govern → Identify → Protect → Detect → Respond → Recover, i.e. GV → ID → PR → DE → RS → RC). The current workaround is prefixing the identifier (e.g. `001 GV.OC-01`). This adds a first-class, per-requirement **`sortOrder`** field (set it in the Framework Editor) that drives ordering everywhere requirements are displayed.

## How it works

`sortOrder` is a **nullable** int on `FrameworkEditorRequirement`. Numbered rows sort ascending first; unset (`null`) rows fall back to identifier order and sort **last**. Because every existing requirement is `null`, **behavior is unchanged for all existing frameworks** until someone sets an order.

Wired end-to-end:

- **DB** — `sortOrder Int?` + additive migration (no backfill, no reset).
- **API** — requirement create/update/batch DTOs + service persist it; requirement & framework reads `orderBy [{ sortOrder: asc, nulls: last }, { name: asc }]`; manifest builder/type freeze it into published versions; `frameworks.service` threads it into the customer-facing `requirementDefinitions`; framework export/import round-trips it.
- **Framework Editor** — new editable **"Order"** column in the requirements grid; grid default-sorts by it.
- **Customer app** — requirement views sort by `sortOrder` (flat + grouped). The grouped view also orders **families** by their lowest `sortOrder`, so the configured order drives Function order for NIST CSF — a no-op when nothing is numbered.

## Tests

- API: `requirement.service.spec.ts` (create/update/batch persist + clear; `findAll`/`findAllForFramework` ordering) and `create-requirement.dto` validation (accepts non-negative int, rejects negative / non-integer).
- App: `framework-controls-shared.test.ts` — `compareRequirementsByOrder` (ascending, nulls last, undefined-as-null, identifier tiebreak) and `groupRequirementsByFamily` (NIST canonical family order via min sortOrder; alphabetical fallback when unset).

## Verification

- `@trycompai/api` typecheck ✅ · `@trycompai/framework-editor` typecheck ✅
- `@trycompai/app` typecheck: clean for changed files (remaining errors are pre-existing & unrelated — `auth-client.ts` better-auth dual-package, an invitations route test).
- API framework-editor suite: 42 passed · requirement suite: 21 passed · app shared comparator: 26 passed · editor change-tracking: 10 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGwXoPb6qHxuHy8miVmyxT

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-requirement sort order so frameworks can control how requirements are listed (e.g., NIST CSF’s GV → ID → PR → DE → RS → RC). Existing frameworks keep their current order until a sort is set. Addresses Linear FRAME-18.

- **New Features**
  - DB: added nullable sortOrder (Int); all reads use [sortOrder asc, nulls last] → identifier → name; included in manifests and export/import.
  - API: create/update/batch accept and persist sortOrder; `frameworks.service` merges platform/custom rows and sorts using the same keys for consistency.
  - Framework Editor: new “Order” column; grid defaults to sort by order; accepts non-negative numbers and supports clearing to unset.
  - App: requirement lists sort by sortOrder (identifier tiebreak, then name); grouped view orders families by their lowest sortOrder; shared comparator added and used.
  - Tests: coverage in `@trycompai/api`, `@trycompai/framework-editor`, and `@trycompai/app`, plus a regression test asserting manifest-ordering and tiebreaks.

- **Migration**
  - Run the Prisma migration (adds the nullable column only).
  - No backfill. Null keeps today’s behavior until you set an order.
  - Meets FRAME-18 by letting editors assign positions (e.g., 001–999) per framework.

<sup>Written for commit 0af0c3d1e07686e0e0aaefeed17ab47b45f5eb5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

