### PR TITLE
fix(wizard): restore step progress indicator on return to saved profile

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/documents/isms/wizard/WizardClient.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/documents/isms/wizard/WizardClient.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { WizardProfileResponse } from './wizard-types';
+import type { PartialWizardAnswers, WizardProfileResponse } from './wizard-types';
 
 // ─── Mock the wizard hook ────────────────────────────────────
 const mockSaveAnswers = vi.fn().mockResolvedValue({ id: 'p1', answers: {}, completedAt: null });
@@ -196,6 +196,32 @@ describe('WizardClient', () => {
     expect(screen.getByText('Leadership & accountability')).toBeInTheDocument();
     // Member option from the profile is rendered in the deputy picker.
     expect(screen.getByText('Alice Owner')).toBeInTheDocument();
+  });
+
+  it('resumes on the first unsaved step after saving and returning', () => {
+    // Saved answers covering steps 1–3 (leadership, commitments, workforce &
+    // scope). Each Next / Save persists that step's full field slice, so a saved
+    // step is one whose every field is present in the stored answers.
+    const resumedAnswers: PartialWizardAnswers = {
+      deputySpo: { memberId: 'm2', toBeNamed: false },
+      internalAuditApproach: 'in_house',
+      certificationBody: 'BSI Group',
+      insurance: { has: true, insurerName: 'Acme Insure' },
+      sectorRegulators: ['FINMA'],
+      hasContractors: true,
+      capabilitiesInProduction: ['Web app'],
+      cloudScopeSplit: { customer: ['Data'], provider: ['Underlying infrastructure'] },
+    };
+    const resumedProfile: WizardProfileResponse = { ...PROFILE, answers: resumedAnswers };
+    hookState.profile = resumedProfile;
+
+    render(<WizardClient {...baseProps} fallbackData={resumedProfile} />);
+
+    // Steps 1–3 are saved → the wizard opens on step 4 (Privacy & data), not
+    // back at step 1 with the progress reset.
+    expect(screen.getByText('Step 4 of 6')).toBeInTheDocument();
+    expect(screen.getByText('Privacy & data')).toBeInTheDocument();
+    expect(screen.queryByText('Leadership & accountability')).not.toBeInTheDocument();
   });
 
   it('saves the active step partial then advances on Next', async () => {

--- a/apps/app/src/app/(app)/[orgId]/documents/isms/wizard/WizardClient.tsx
+++ b/apps/app/src/app/(app)/[orgId]/documents/isms/wizard/WizardClient.tsx
@@ -9,7 +9,7 @@ import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { useIsmsWizard } from '../hooks/useIsmsWizard';
 import { buildWizardDefaults } from './wizard-form-defaults';
-import { pickStepAnswers, WIZARD_STEPS } from './wizard-steps';
+import { pickStepAnswers, resumeStepIndex, WIZARD_STEPS } from './wizard-steps';
 import { WizardProgress } from './WizardProgress';
 import { WizardStepContent } from './WizardStepContent';
 import {
@@ -76,18 +76,23 @@ export function WizardClient({ organizationId, frameworkId, fallbackData }: Wiza
     defaultValues,
   });
 
-  const [stepIndex, setStepIndex] = useState(0);
+  // Resume on the first unsaved step so the progress rail (done / current) matches
+  // the pre-filled answers after Save progress / leaving and returning.
+  const [stepIndex, setStepIndex] = useState(() =>
+    resumeStepIndex({ answers: initialProfile?.answers ?? null }),
+  );
   const [isSaving, setIsSaving] = useState(false);
   const [isFinishing, setIsFinishing] = useState(false);
 
   // Re-seed the form if the profile arrives after mount (e.g. SSR fallback was
   // null and SWR resolved later). Only while the user hasn't edited anything, so
-  // in-progress answers are never clobbered.
+  // in-progress answers are never clobbered; also restore the resume step.
   const hasReseeded = useRef(false);
   useEffect(() => {
     if (hasReseeded.current || !profile || formState.isDirty) return;
     hasReseeded.current = true;
     reset(defaultValues);
+    setStepIndex(resumeStepIndex({ answers: profile.answers ?? null }));
   }, [profile, defaultValues, formState.isDirty, reset]);
 
   const members = Array.isArray(initialProfile?.members) ? initialProfile.members : [];

--- a/apps/app/src/app/(app)/[orgId]/documents/isms/wizard/wizard-steps.ts
+++ b/apps/app/src/app/(app)/[orgId]/documents/isms/wizard/wizard-steps.ts
@@ -5,7 +5,7 @@
  * answers for that step.
  */
 
-import type { WizardFormValues } from './wizard-types';
+import type { PartialWizardAnswers, WizardFormValues } from './wizard-types';
 
 export type WizardFieldName = keyof WizardFormValues;
 
@@ -61,4 +61,24 @@ export function pickStepAnswers({
     (slice, field) => Object.assign(slice, { [field]: values[field] }),
     {},
   );
+}
+
+/**
+ * Resolve which step to open on when the wizard is reopened. A step counts as
+ * saved once every one of its fields is present in the persisted answers — each
+ * Next / Save progress POSTs that step's full field slice, so saved steps form a
+ * prefix of the rail. Returns the first not-yet-saved step (so the progress rail
+ * and the pre-filled answers stay in sync), the last step when everything is
+ * saved, and step 0 when nothing is saved.
+ */
+export function resumeStepIndex({
+  answers,
+}: {
+  answers: PartialWizardAnswers | null;
+}): number {
+  if (!answers) return 0;
+  const firstUnsaved = WIZARD_STEPS.findIndex(
+    (step) => !step.fields.every((field) => answers[field] !== undefined),
+  );
+  return firstUnsaved === -1 ? WIZARD_STEPS.length - 1 : firstUnsaved;
 }


### PR DESCRIPTION
## Problem

When a user saves the ISMS wizard and returns to it later, all their answers are restored correctly but the progress bar shows no completed steps. Visually it looks like they're back to square one even though the data is there.

## Root cause

Step position is local React state initialized to 0 (`stepIndex = useState(0)` in WizardClient.tsx). On return, the GET /v1/isms/profile fetch restores saved answers via `buildWizardDefaults` and the re-seed effect, but `stepIndex` is never restored from that data. The progress indicator derives green checkmarks from `currentStep` comparison, so index=0 on mount paints every step as upcoming/current with no checks, creating the asymmetry where answers persist but progress looks reset.

## Fix

Derived the initial `stepIndex` from which steps already have saved answers. Since the GET endpoint already returns the profile with prior answers, we can scan which fields are populated and set `stepIndex` to at least the furthest completed step. This way when a user returns the visual progress matches the restored data.

The fix is localized to the wizard folder and frontend-only. No changes to auth, RBAC, schema, or org scoping.

## Explicitly NOT touched

All copy and feature requests from the feedback report (tooltips on sector regulators, contractor wording, cloud hosting split derivation, EU representative help text, certificate scope callouts, objective nudges, SLA defaults, pre-fill visual tags, drift-signal expectation note, step-indicator hints) are separate from this bug and left for their own PRs.

## Verification

✅ Wizard answers persist across save and return (pre-existing)
✅ Green checkmarks now visible on return if prior steps have answers
✅ Step indicator reflects how far the user got before leaving
✅ Progress bar matches restored form state on mount

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the ISMS wizard progress so returning users see completed steps as done. The wizard now resumes on the first unsaved step based on restored answers.

- **Bug Fixes**
  - Initialize `stepIndex` with `resumeStepIndex` derived from saved answers.
  - Restore `stepIndex` during re-seed when profile data loads after mount.
  - Add `resumeStepIndex` in `wizard-steps.ts` and a test that resumes to the first unsaved step.

<sup>Written for commit 94e97004b60fd84adda23391737782033580d062. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

