### PR TITLE
fix(people): allow reactivating deactivated members via update endpoint

### DIFF
--- a/apps/api/src/people/utils/member-queries.spec.ts
+++ b/apps/api/src/people/utils/member-queries.spec.ts
@@ -88,3 +88,40 @@ describe('MemberQueries.updateMember — background-check exemption fields', () 
     expect(call.data).not.toHaveProperty('backgroundCheckExemptJustification');
   });
 });
+
+describe('MemberQueries.updateMember — reactivation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (mockedDb.member.update as jest.Mock).mockResolvedValue({ id: 'mem_1' });
+  });
+
+  // Regression for "Unable to reactivate user": a member deactivated via
+  // offboarding carries deactivated:true. The status dropdown reactivates by
+  // sending { isActive: true }; without also clearing deactivated the member
+  // stays hidden from the people list, so isActive alone is not enough.
+  it('clears deactivated when reactivating via isActive: true', async () => {
+    await MemberQueries.updateMember('mem_1', 'org_1', { isActive: true });
+
+    expect(mockedDb.member.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'mem_1', organizationId: 'org_1' },
+        data: expect.objectContaining({ isActive: true, deactivated: false }),
+      }),
+    );
+  });
+
+  it('does not touch deactivated when the patch omits isActive', async () => {
+    await MemberQueries.updateMember('mem_1', 'org_1', { jobTitle: 'Engineer' });
+
+    const call = (mockedDb.member.update as jest.Mock).mock.calls[0][0];
+    expect(call.data).not.toHaveProperty('deactivated');
+  });
+
+  it('does not reactivate when deactivating via isActive: false', async () => {
+    await MemberQueries.updateMember('mem_1', 'org_1', { isActive: false });
+
+    const call = (mockedDb.member.update as jest.Mock).mock.calls[0][0];
+    expect(call.data.isActive).toBe(false);
+    expect(call.data).not.toHaveProperty('deactivated');
+  });
+});

--- a/apps/api/src/people/utils/member-queries.ts
+++ b/apps/api/src/people/utils/member-queries.ts
@@ -169,6 +169,14 @@ export class MemberQueries {
       updatePayload.backgroundCheckExemptJustification = null;
     }
 
+    // Reactivation: the status dropdown sends { isActive: true } via PATCH. A
+    // member deactivated via offboarding (or the skip-offboarding path) carries
+    // deactivated:true, which hides them from the people list. Clear it so
+    // isActive and deactivated stay in sync and the member is fully restored.
+    if (updatePayload.isActive === true) {
+      updatePayload.deactivated = false;
+    }
+
     const hasUserUpdates = name !== undefined || email !== undefined;
     const hasMemberUpdates = Object.keys(updatePayload).length > 0;
 

--- a/apps/api/src/people/utils/member-validator.spec.ts
+++ b/apps/api/src/people/utils/member-validator.spec.ts
@@ -1,0 +1,81 @@
+import { NotFoundException } from '@nestjs/common';
+import { MemberValidator } from './member-validator';
+
+jest.mock('@db', () => ({
+  db: {
+    member: {
+      findFirst: jest.fn(),
+    },
+  },
+}));
+
+import { db } from '@db';
+
+const mockedDb = db as jest.Mocked<typeof db>;
+
+describe('MemberValidator.validateMemberExists — deactivated members', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // Regression for "Unable to reactivate user": reactivation flows through the
+  // member-update path, which calls validateMemberExists first. A member
+  // deactivated via offboarding (deactivated:true) must still be found here, or
+  // the update 404s before it can clear the flag.
+  it('finds a deactivated member (does not filter deactivated:false)', async () => {
+    const deactivatedMember = {
+      id: 'mem_1',
+      userId: 'usr_1',
+      role: 'employee',
+      deactivated: true,
+      organizationId: 'org_1',
+    };
+
+    // Emulate Prisma: a query restricting deactivated:false cannot match a
+    // member whose deactivated is true.
+    (mockedDb.member.findFirst as jest.Mock).mockImplementation(
+      ({ where }: { where: Record<string, unknown> }) => {
+        if (
+          where.id !== deactivatedMember.id ||
+          where.organizationId !== deactivatedMember.organizationId
+        ) {
+          return Promise.resolve(null);
+        }
+        if (where.deactivated === false && deactivatedMember.deactivated) {
+          return Promise.resolve(null);
+        }
+        return Promise.resolve({
+          id: deactivatedMember.id,
+          userId: deactivatedMember.userId,
+          role: deactivatedMember.role,
+        });
+      },
+    );
+
+    await expect(
+      MemberValidator.validateMemberExists('mem_1', 'org_1'),
+    ).resolves.toEqual({ id: 'mem_1', userId: 'usr_1', role: 'employee' });
+  });
+
+  it('throws NotFoundException when the member is not in the organization', async () => {
+    (mockedDb.member.findFirst as jest.Mock).mockResolvedValue(null);
+
+    await expect(
+      MemberValidator.validateMemberExists('mem_x', 'org_1'),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('scopes the lookup to the organization', async () => {
+    (mockedDb.member.findFirst as jest.Mock).mockResolvedValue({
+      id: 'mem_1',
+      userId: 'usr_1',
+      role: 'employee',
+    });
+
+    await MemberValidator.validateMemberExists('mem_1', 'org_1');
+
+    const call = (mockedDb.member.findFirst as jest.Mock).mock.calls[0][0];
+    expect(call.where.id).toBe('mem_1');
+    expect(call.where.organizationId).toBe('org_1');
+  });
+});

--- a/apps/api/src/people/utils/member-validator.ts
+++ b/apps/api/src/people/utils/member-validator.ts
@@ -37,7 +37,12 @@ export class MemberValidator {
   }
 
   /**
-   * Validates that a member exists in an organization
+   * Validates that a member exists in an organization.
+   *
+   * Deactivated members are intentionally included. This check guards the
+   * member-update path, and reactivating a deactivated member (the status
+   * dropdown sends PATCH { isActive: true }) must be able to find them.
+   * Organization scoping is preserved.
    */
   static async validateMemberExists(
     memberId: string,
@@ -47,7 +52,6 @@ export class MemberValidator {
       where: {
         id: memberId,
         organizationId,
-        deactivated: false,
       },
       select: { id: true, userId: true, role: true },
     });


### PR DESCRIPTION
## Problem
Users cannot reactivate a deactivated member through the employee details form. The reactivate button fails with "Member with ID … not found in organization" even though the member exists and is visible on the page.

## Root cause
The PATCH /v1/people/:id endpoint (used by the employee details form) calls MemberValidator.validateMemberExists which filters for `deactivated:false`. When a member is deactivated this query returns null and throws the error. Meanwhile the dedicated reactivate paths (reactivateById, reactivateMember action) query without the deactivated filter and work fine. This asymmetry breaks reactivation through the standard update path.

## Fix
Removed the `deactivated:false` filter from MemberValidator.validateMemberExists so it can find both active and deactivated members. The validator's purpose is to confirm a member exists in the org, not to enforce active status. Callers that need active-only behavior can add their own checks if needed.

## Explicitly NOT touched
The dedicated reactivate endpoints which already work correctly. Update logic for other fields remains unchanged.

## Verification
✅ Deactivated member can be reactivated via employee details form
✅ Member validator finds deactivated members by id
✅ Normal update operations still work for active members

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the bug that blocked reactivating deactivated members from the employee details form. The `PATCH /v1/people/:id` path now finds deactivated members and clears `deactivated` when `isActive: true`.

- **Bug Fixes**
  - Removed the `deactivated: false` filter from `MemberValidator.validateMemberExists` so updates can find deactivated members.
  - When `isActive: true` is patched, `MemberQueries.updateMember` also sets `deactivated: false` to fully restore the member.

<sup>Written for commit e60cff098e586732913ba1032b481ff41139d1ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

