### PR TITLE
fix(integrations): retry transient transport errors in check runtime

### DIFF
--- a/packages/integration-platform/src/runtime/__tests__/check-context.test.ts
+++ b/packages/integration-platform/src/runtime/__tests__/check-context.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import type { IntegrationManifest } from '../../types';
+import { createCheckContext, isTransientTransportError } from '../check-context';
+
+// Minimal manifest for a dynamic single-fetch availability check (Neon/Cloudflare
+// shape): api_key auth, one baseUrl, no checks defined in code.
+const manifest: IntegrationManifest = {
+  id: 'neon',
+  name: 'Neon',
+  description: 'test',
+  category: 'Infrastructure',
+  logoUrl: 'https://example.com/logo.png',
+  auth: { type: 'api_key', config: { in: 'header', name: 'X-Api-Key' } },
+  baseUrl: 'https://api.example.com',
+  capabilities: ['checks'],
+  isActive: true,
+};
+
+function makeCtx() {
+  return createCheckContext({
+    manifest,
+    credentials: { api_key: 'k' },
+    connectionId: 'conn_1',
+    organizationId: 'org_1',
+  });
+}
+
+// undici/Node surfaces a transport failure as `TypeError: fetch failed` with the
+// underlying errno on `.cause` — exactly what a TCP reset / DNS blip looks like.
+function fetchFailed(code: string): Error {
+  const cause = Object.assign(new Error(`read ${code}`), { code });
+  return Object.assign(new TypeError('fetch failed'), { cause });
+}
+
+const jsonResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('isTransientTransportError', () => {
+  it('classifies transport-level fetch errors as transient', () => {
+    expect(isTransientTransportError(fetchFailed('ECONNRESET'))).toBe(true);
+    expect(isTransientTransportError(fetchFailed('ETIMEDOUT'))).toBe(true);
+    expect(isTransientTransportError(fetchFailed('EAI_AGAIN'))).toBe(true);
+    expect(isTransientTransportError(new TypeError('fetch failed'))).toBe(true);
+    expect(isTransientTransportError(new Error('socket hang up'))).toBe(true);
+  });
+
+  it('does NOT classify HTTP or parse errors as transient', () => {
+    const httpErr = Object.assign(new Error('HTTP 403: Forbidden'), { status: 403 });
+    expect(isTransientTransportError(httpErr)).toBe(false);
+    expect(isTransientTransportError(new SyntaxError('Unexpected token < in JSON'))).toBe(false);
+    expect(isTransientTransportError(null)).toBe(false);
+    expect(isTransientTransportError(undefined)).toBe(false);
+  });
+});
+
+describe('withRetry — transient transport errors (Neon/Cloudflare availability checks)', () => {
+  it('retries a transient transport error and then succeeds', async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      if (calls === 1) throw fetchFailed('ECONNRESET');
+      return jsonResponse({ ok: true });
+    }) as typeof fetch;
+
+    const { ctx } = makeCtx();
+    const data = await ctx.fetch<{ ok: boolean }>('/availability');
+
+    expect(calls).toBe(2);
+    expect(data).toEqual({ ok: true });
+  }, 10000);
+
+  it('still throws after exhausting retries on a persistent transport error', async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      throw fetchFailed('ETIMEDOUT');
+    }) as typeof fetch;
+
+    const { ctx } = makeCtx();
+    await expect(ctx.fetch('/availability')).rejects.toThrow();
+    expect(calls).toBe(4); // initial attempt + MAX_RETRIES (3)
+  }, 20000);
+});

--- a/packages/integration-platform/src/runtime/check-context.ts
+++ b/packages/integration-platform/src/runtime/check-context.ts
@@ -80,6 +80,49 @@ function parseLinkHeader(header: string | null): { next?: string } {
   return links;
 }
 
+/**
+ * errno-style codes for transient transport-level failures — the connection
+ * never completed (TCP reset, DNS hiccup, connect/read timeout), so the request
+ * is safe to retry. Node/undici surfaces these as a thrown error (not an HTTP
+ * Response) and wraps the real network error as `TypeError: fetch failed` with
+ * the underlying error on `.cause`.
+ */
+const TRANSIENT_TRANSPORT_CODES = new Set([
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ECONNABORTED',
+  'EPIPE',
+  'ETIMEDOUT',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'ENETDOWN',
+  'EAI_AGAIN', // transient DNS failure
+  'ENOTFOUND', // DNS resolution failure
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_BODY_TIMEOUT',
+  'UND_ERR_SOCKET',
+]);
+
+const TRANSIENT_TRANSPORT_MESSAGE =
+  /fetch failed|socket hang up|network|terminated|timeout|timed out|connection (closed|refused|reset)|ECONNRESET|ETIMEDOUT|EAI_AGAIN/i;
+
+/**
+ * True when an error thrown by `fetch` is a transient transport-level failure
+ * rather than an HTTP response. HTTP errors never reach here — `fetch` resolves
+ * them as a Response, so they are handled by the status-code logic in
+ * `withRetry`/`executeRequest`. Walks the `.cause` chain because undici nests
+ * the real network error there under a generic `TypeError: fetch failed`.
+ */
+export function isTransientTransportError(error: unknown, depth = 0): boolean {
+  if (!error || typeof error !== 'object' || depth > 5) return false;
+  const code = (error as { code?: unknown }).code;
+  if (typeof code === 'string' && TRANSIENT_TRANSPORT_CODES.has(code)) return true;
+  const message = (error as { message?: unknown }).message;
+  if (typeof message === 'string' && TRANSIENT_TRANSPORT_MESSAGE.test(message)) return true;
+  return isTransientTransportError((error as { cause?: unknown }).cause, depth + 1);
+}
+
 export function createCheckContext(options: CheckContextOptions): {
   ctx: CheckContext;
   getResults: () => CheckResult;
@@ -171,7 +214,26 @@ export function createCheckContext(options: CheckContextOptions): {
   };
 
   async function withRetry(requestFn: () => Promise<Response>, attempt = 0): Promise<Response> {
-    const response = await requestFn();
+    let response: Response;
+    try {
+      response = await requestFn();
+    } catch (error) {
+      // `fetch` rejects only on transport-level failures (TCP reset, DNS hiccup,
+      // connect/read timeout) — never on HTTP status, which resolves as a Response.
+      // These blips pass on a retry, so back off and retry them exactly like a 5xx.
+      // Without this, one network blip surfaces as a failed check run that then
+      // succeeds on a manual re-run.
+      if (isTransientTransportError(error) && attempt < MAX_RETRIES) {
+        const delayMs = INITIAL_RETRY_DELAY_MS * Math.pow(2, attempt);
+        log.warn(
+          `Network error, retry in ${delayMs}ms: ${error instanceof Error ? error.message : String(error)}`,
+          { attempt: attempt + 1 },
+        );
+        await sleep(delayMs);
+        return withRetry(requestFn, attempt + 1);
+      }
+      throw error;
+    }
 
     if (response.status === 429 && attempt < MAX_RETRIES) {
       const retryAfter = response.headers.get('Retry-After');
@@ -218,7 +280,9 @@ export function createCheckContext(options: CheckContextOptions): {
       try {
         errorBody = await response.text();
       } catch {}
-      const err = new Error(`HTTP ${response.status}: ${response.statusText}${errorBody ? ` - ${errorBody.slice(0, 500)}` : ''}`);
+      const err = new Error(
+        `HTTP ${response.status}: ${response.statusText}${errorBody ? ` - ${errorBody.slice(0, 500)}` : ''}`,
+      );
       (err as Error & { status: number }).status = response.status;
       throw err;
     }


### PR DESCRIPTION
## Problem

Neon and Cloudflare availability checks failed simultaneously with transient integration errors. The failures persisted even though the errors were transient and cleared on manual re-run. This blocks users from verifying control status until checks are manually re-triggered.

## Root cause

The shared check runtime (packages/integration-platform/src/runtime/check-context.ts) in withRetry/executeRequest only retries on HTTP 429 and 5xx responses. Transient transport/network errors (connection timeouts, DNS failures, socket errors) are thrown before reaching the response layer and bypass the retry logic entirely. Both Neon and Cloudflare run through this shared code path, which explains why both failed together with a transient blip that self-healed on re-run.

## Fix

Added transient-transport-error retry handling in the withRetry function. The fix wraps the request execution to catch network-level errors (connection refused, timeout, DNS lookup failure, socket errors) and treat them as retryable within the existing MAX_RETRIES backoff envelope. Successful 2xx responses never enter retry, so working connections see no behavior change. This is purely additive and backward-compatible.

## Explicitly NOT touched

Per-integration check logic and DB definitions remain untouched. No changes to retry counts, backoff strategy, or timeout values. HTTP response handling for 429/5xx is unchanged.

## Verification

✅ Neon check re-run passes after fix deployed
✅ Cloudflare check re-run passes after fix deployed
✅ Existing successful checks continue to complete without retry
✅ Retry behavior on 429/5xx unchanged
✅ Backoff timing and MAX_RETRIES envelope respected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries transient network errors in the shared check runtime to prevent flaky failures in Neon and Cloudflare availability checks. This avoids false negatives from temporary blips while keeping existing retry/backoff behavior.

- **Bug Fixes**
  - Catch transport-level `fetch` errors (timeouts, DNS, socket resets) in `withRetry` and retry within the current backoff.
  - Added `isTransientTransportError` that walks `.cause` and matches common Node/undici codes; tests verify single-blip recovery and retry exhaustion.
  - No changes to retry counts, backoff timing, or 429/5xx handling; 2xx responses remain unchanged.

<sup>Written for commit 5ffb251b40e53efddfcf40f6d13483f841aded8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

