### PR TITLE
fix(members): enable email update in employee details for admins

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/EmployeeDetails.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/EmployeeDetails.test.tsx
@@ -1,0 +1,90 @@
+import type { Member, User } from '@db';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { toast } from 'sonner';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EmployeeDetails } from './EmployeeDetails';
+
+const { mockPatch } = vi.hoisted(() => ({ mockPatch: vi.fn() }));
+
+vi.mock('@/hooks/use-api', () => ({
+  useApi: () => ({
+    organizationId: 'org_1',
+    patch: mockPatch,
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  }),
+}));
+
+// DepartmentSelect pulls the runtime `Departments` enum from @db; its behaviour
+// is irrelevant to email editing.
+vi.mock('@/components/DepartmentSelect', () => ({
+  DepartmentSelect: () => null,
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+const employee = {
+  id: 'mem_1',
+  userId: 'usr_1',
+  organizationId: 'org_1',
+  role: 'employee',
+  createdAt: new Date(),
+  department: 'engineering',
+  jobTitle: 'Engineer',
+  isActive: true,
+  onboardDate: null,
+  offboardDate: null,
+  user: {
+    id: 'usr_1',
+    name: 'Manoj Madhavan',
+    email: 'manoj.madhavan@plurilock.com',
+  },
+} as unknown as Member & { user: User };
+
+describe('EmployeeDetails email editing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPatch.mockResolvedValue({ data: {}, status: 200 });
+  });
+
+  it('lets an admin change the login email and PATCHes it to the people endpoint', async () => {
+    const user = userEvent.setup();
+    render(<EmployeeDetails employee={employee} canEdit />);
+
+    const emailInput = screen.getByLabelText('Email');
+    // Regression: the field used to be hardcoded disabled+readOnly.
+    expect(emailInput).not.toBeDisabled();
+
+    await user.clear(emailInput);
+    await user.type(emailInput, 'mmadhavan@aurorait.com');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(mockPatch).toHaveBeenCalledWith('/v1/people/mem_1', {
+        email: 'mmadhavan@aurorait.com',
+      });
+    });
+  });
+
+  it('disables the email field for read-only users', () => {
+    render(<EmployeeDetails employee={employee} canEdit={false} />);
+    expect(screen.getByLabelText('Email')).toBeDisabled();
+  });
+
+  it('blocks save and does not PATCH when the email is cleared', async () => {
+    const user = userEvent.setup();
+    render(<EmployeeDetails employee={employee} canEdit />);
+
+    const emailInput = screen.getByLabelText('Email');
+    await user.clear(emailInput);
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(toast.error).toHaveBeenCalledWith('Email is required');
+    expect(mockPatch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/EmployeeDetails.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/EmployeeDetails.tsx
@@ -29,6 +29,11 @@ const STATUS_OPTIONS = [
   { value: 'inactive', label: 'Inactive' },
 ];
 
+// Mirrors the backend's @IsEmail() on UpdatePeopleDto.email so the form rejects
+// values the PATCH /v1/people/:id endpoint would reject anyway.
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const isValidEmail = (value: string) => EMAIL_REGEX.test(value);
+
 export const EmployeeDetails = ({
   employee,
   canEdit,
@@ -39,6 +44,7 @@ export const EmployeeDetails = ({
   canEdit: boolean;
 }) => {
   const [name, setName] = useState(employee.user.name ?? '');
+  const [email, setEmail] = useState(employee.user.email ?? '');
   const [jobTitle, setJobTitle] = useState(employee.jobTitle ?? '');
   const [department, setDepartment] = useState<string>(employee.department ?? 'none');
   const [status, setStatus] = useState<string>(employee.isActive ? 'active' : 'inactive');
@@ -55,6 +61,7 @@ export const EmployeeDetails = ({
 
   const hasChanges = useMemo(() => {
     const nameChanged = name !== (employee.user.name ?? '');
+    const emailChanged = email !== (employee.user.email ?? '');
     const jobTitleChanged = jobTitle !== (employee.jobTitle ?? '');
     const departmentChanged = department !== (employee.department ?? 'none');
     const statusChanged = status !== (employee.isActive ? 'active' : 'inactive');
@@ -65,8 +72,8 @@ export const EmployeeDetails = ({
       (offboardDate?.toISOString() ?? null) !==
       (employee.offboardDate ? new Date(employee.offboardDate).toISOString() : null);
 
-    return nameChanged || jobTitleChanged || departmentChanged || statusChanged || onboardDateChanged || offboardDateChanged;
-  }, [name, jobTitle, department, status, onboardDate, offboardDate, employee]);
+    return nameChanged || emailChanged || jobTitleChanged || departmentChanged || statusChanged || onboardDateChanged || offboardDateChanged;
+  }, [name, email, jobTitle, department, status, onboardDate, offboardDate, employee]);
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -76,8 +83,19 @@ export const EmployeeDetails = ({
       return;
     }
 
+    const trimmedEmail = email.trim();
+    if (!trimmedEmail) {
+      toast.error('Email is required');
+      return;
+    }
+    if (!isValidEmail(trimmedEmail)) {
+      toast.error('Enter a valid email address');
+      return;
+    }
+
     const updateData: {
       name?: string;
+      email?: string;
       department?: string;
       isActive?: boolean;
       jobTitle?: string;
@@ -87,6 +105,9 @@ export const EmployeeDetails = ({
 
     if (name !== (employee.user.name ?? '')) {
       updateData.name = name;
+    }
+    if (trimmedEmail !== (employee.user.email ?? '')) {
+      updateData.email = trimmedEmail;
     }
     if (jobTitle !== (employee.jobTitle ?? '')) {
       updateData.jobTitle = jobTitle;
@@ -151,15 +172,16 @@ export const EmployeeDetails = ({
               />
             </Stack>
 
-            {/* Email Field (read-only) */}
+            {/* Email Field (login email) */}
             <Stack gap="sm">
               <Label htmlFor="email">Email</Label>
               <Input
                 id="email"
                 type="email"
-                value={employee.user.email ?? ''}
-                disabled
-                readOnly
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="employee@example.com"
+                disabled={!canEdit}
               />
             </Stack>
 


### PR DESCRIPTION
## Problem
Org admins cannot change a member's login email address via the UI, forcing them to request support. Customers report "no self-serve way" to update email addresses.

## Root cause
EmployeeDetails.tsx hard-codes the email input field as `disabled readOnly` even though the PATCH /v1/people/:id endpoint fully supports email updates (UpdatePeopleDto.email, MemberQueries.updateMember write User.email correctly). Frontend blocks a working backend feature.

## Fix
Remove the `disabled readOnly` attributes from the email input in EmployeeDetails.tsx and include email in the updateData payload when changed. The permission check (canEdit, owner/admin-gated) already exists at page level, so no additional auth is needed. This mirrors how other editable fields work in the component.

## Explicitly NOT touched
Do not enable self-serve email changes for non-admin users. Do not add email verification flows or modify better-auth session config. Keep the permission boundary at org admin + owner only.

## Verification
✅ Email field renders enabled for org admins/owners
✅ Email value includes in update payload and sends to PATCH /v1/people/:id
✅ Email updates persist in database
✅ Non-admin users still see email as read-only
✅ Other employee fields (name, role, etc) continue working as before

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let org admins and owners update a member’s login email in Employee Details. Validates the email and only sends it to PATCH /v1/people/:id when changed; non-admins stay read-only.

- **Bug Fixes**
  - Made the Email field editable when `canEdit` is true; disabled otherwise.
  - Trimmed and validated email (regex); toasts on empty or invalid values.
  - Included `email` in PATCH payload only when changed.
  - Added tests for admin edit flow, read-only users, and empty-email blocking.

<sup>Written for commit 54720b02ae39dd9c43307a826689ec4ca637b6ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

