### PR TITLE
fix(evidence): display user email fallback when name is empty

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/tasks/components/ModernTaskListItem.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/components/ModernTaskListItem.tsx
@@ -124,7 +124,9 @@ export function ModernTaskListItem({
                 />
               ) : (
                 <span className="text-muted-foreground text-xs font-medium">
-                  {member.user?.name?.charAt(0) ?? '?'}
+                  {member.user?.name?.charAt(0) ||
+                    member.user?.email?.charAt(0).toUpperCase() ||
+                    '?'}
                 </span>
               )}
             </div>

--- a/apps/app/src/app/(app)/[orgId]/tasks/components/TaskAssigneeDisplay.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/components/TaskAssigneeDisplay.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ModernTaskListItem } from './ModernTaskListItem';
+import { TaskList } from './TaskList';
+import { TasksByCategory } from './TasksByCategory';
+
+// next/navigation is mocked locally (not via the global setup) so we can add
+// useParams (needed by TaskList) and vary the search params per test.
+const nav = vi.hoisted(() => ({ search: new URLSearchParams() }));
+const nuqs = vi.hoisted(() => ({ assignee: null as string | null }));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn(), back: vi.fn() }),
+  usePathname: () => '/org_1/tasks',
+  useSearchParams: () => nav.search,
+  useParams: () => ({ orgId: 'org_1' }),
+  redirect: vi.fn(),
+}));
+
+vi.mock('nuqs', () => ({
+  useQueryState: (key: string) => [key === 'assignee' ? nuqs.assignee : null, vi.fn()],
+}));
+
+type TasksByCategoryProps = Parameters<typeof TasksByCategory>[0];
+type CategoryTask = TasksByCategoryProps['tasks'][number];
+type MemberWithUser = TasksByCategoryProps['members'][number];
+
+function makeTask(overrides: Partial<CategoryTask> = {}): CategoryTask {
+  return {
+    id: 'tsk_1',
+    title: 'Evidence item',
+    description: null,
+    status: 'todo',
+    assigneeId: 'mem_1',
+    controls: [{ id: 'ctl_1', name: 'Access Control' }],
+    evidenceAutomations: [],
+    ...overrides,
+  } as unknown as CategoryTask;
+}
+
+function makeMember({
+  name,
+  email,
+  role = 'employee',
+}: {
+  name: string;
+  email: string;
+  role?: string;
+}): MemberWithUser {
+  return {
+    id: 'mem_1',
+    role,
+    user: { id: 'usr_1', name, email, image: null },
+  } as unknown as MemberWithUser;
+}
+
+afterEach(() => {
+  nav.search = new URLSearchParams();
+  nuqs.assignee = null;
+});
+
+// An employee whose User.name is empty (e.g. "Akmal") must still be identified
+// by email instead of rendering blank in the evidence list.
+const AKMAL_EMAIL = 'akmal@example.com';
+
+describe('TasksByCategory assignee cell', () => {
+  it('falls back to the email when the assignee has no name', () => {
+    nav.search = new URLSearchParams('category=ctl_1');
+
+    render(
+      <TasksByCategory
+        tasks={[makeTask()]}
+        members={[makeMember({ name: '', email: AKMAL_EMAIL })]}
+      />,
+    );
+
+    expect(screen.getByText(AKMAL_EMAIL)).toBeInTheDocument();
+  });
+});
+
+describe('ModernTaskListItem assignee avatar', () => {
+  it('shows the email initial when the assignee has no name', () => {
+    render(
+      <ModernTaskListItem
+        task={makeTask()}
+        members={[makeMember({ name: '', email: AKMAL_EMAIL })]}
+        onClick={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('A')).toBeInTheDocument();
+  });
+});
+
+describe('TaskList "Everyone" assignee filter', () => {
+  it('falls back to the email when the selected assignee has no name', () => {
+    nuqs.assignee = 'mem_1';
+
+    render(
+      <TaskList
+        tasks={[]}
+        members={[makeMember({ name: '', email: AKMAL_EMAIL, role: 'owner' })]}
+        frameworkInstances={[]}
+        activeTab="categories"
+      />,
+    );
+
+    expect(screen.getByText(AKMAL_EMAIL)).toBeInTheDocument();
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/tasks/components/TaskList.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/components/TaskList.tsx
@@ -709,7 +709,9 @@ export function TaskList({
                               </AvatarFallback>
                             </Avatar>
                             <span className="truncate">
-                              {selectedMember.user.name ?? 'Unknown member'}
+                              {selectedMember.user.name ||
+                                selectedMember.user.email ||
+                                'Unknown member'}
                             </span>
                           </div>
                         );
@@ -732,7 +734,7 @@ export function TaskList({
                               {member.user.name?.charAt(0)?.toUpperCase() ?? '?'}
                             </AvatarFallback>
                           </Avatar>
-                          <span>{member.user.name ?? 'Unknown member'}</span>
+                          <span>{member.user.name || member.user.email || 'Unknown member'}</span>
                         </div>
                       </SelectItem>
                     ))}

--- a/apps/app/src/app/(app)/[orgId]/tasks/components/TasksByCategory.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/components/TasksByCategory.tsx
@@ -353,7 +353,9 @@ export function TasksByCategory({ tasks, members, statusFilter }: TasksByCategor
                                 </span>
                               )}
                             </div>
-                            <span className="truncate">{member.user?.name ?? 'Unassigned'}</span>
+                            <span className="truncate">
+                              {member.user?.name || member.user?.email || 'Unassigned'}
+                            </span>
                           </div>
                         ) : (
                           <span className="text-xs text-muted-foreground">Unassigned</span>


### PR DESCRIPTION
## Problem
Employee name not displaying in the evidence list view (Everyone > Evidence) even though the person can be assigned and sorted by. The name field appears blank for Akmal and potentially other users.

## Root cause
Asymmetric fallback logic across components rendering the same user data. SelectAssignee.tsx correctly uses `user.name || user.email || 'Unknown User'` (line 98, 139), but TasksByCategory.tsx (line 356) and TaskList.tsx (line 712/735) use `user.name ?? 'Unassigned'` and `user.name ?? 'Unknown member'` respectively. The nullish coalescing operator `??` does not catch empty strings, so a falsy but defined name renders blank instead of falling back to email like the assign picker does. This creates the exact scenario described: assignable and sortable but visually blank.

## Fix
Aligned fallback logic across all three components to mirror SelectAssignee's pattern: `name || email || fallback`. Updated TasksByCategory.tsx and TaskList.tsx to check name truthiness and fall back to email before using a generic placeholder.

## Explicitly NOT touched
- User schema or auth layer
- RBAC or permissions
- Billing or org scoping
- Backend data or API contracts
- Any sorting or assignment logic

## Verification
✅ Evidence list now displays user email when name is empty or falsy
✅ Assign picker behavior unchanged
✅ Filter display consistent with list rendering
✅ Backward compatible, no data migrations needed
✅ Tested with empty name, null name, and valid name cases

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blank assignee names in Evidence by falling back to the user’s email when the name is empty. Unifies display logic across the task list, category view, and avatar initials.

- **Bug Fixes**
  - Use `name || email || placeholder` in `TasksByCategory.tsx` and `TaskList.tsx`.
  - Avatar fallback shows the email initial in `ModernTaskListItem.tsx`.
  - Added `TaskAssigneeDisplay.test.tsx` to cover empty-name cases across views.

<sup>Written for commit ed1dee6cc5c089dd1ed090d3966df2c8ed265180. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

