### PR TITLE
fix(trust-portal): review access button links to correct page

### DIFF
--- a/apps/api/src/trust-portal/trust-access.service.spec.ts
+++ b/apps/api/src/trust-portal/trust-access.service.spec.ts
@@ -1,6 +1,7 @@
 import { GetObjectCommand } from '@aws-sdk/client-s3';
 import { db } from '@db';
 import { getSignedUrl } from '../app/s3';
+import { CreateAccessRequestDto } from './dto/trust-access.dto';
 import { TrustAccessService } from './trust-access.service';
 
 jest.mock('@db', () => ({
@@ -442,6 +443,54 @@ describe('TrustAccessService signNda NDA copy', () => {
     expect(emailService.sendAccessGrantedEmail).toHaveBeenCalledTimes(1);
     expect(emailService.sendAccessGrantedEmail).toHaveBeenCalledWith(
       expect.objectContaining({ ndaBypassed: false }),
+    );
+  });
+});
+
+describe('TrustAccessService access request notification', () => {
+  const emailService = {
+    sendAccessRequestNotification: jest.fn(),
+  };
+  const service = new TrustAccessService(
+    ...([{}, emailService, {}, {}, {}] as unknown as ConstructorParameters<
+      typeof TrustAccessService
+    >),
+  );
+
+  const ORIGINAL_BETTER_AUTH_URL = process.env.BETTER_AUTH_URL;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.BETTER_AUTH_URL = 'https://app.trycomp.ai';
+  });
+
+  afterAll(() => {
+    process.env.BETTER_AUTH_URL = ORIGINAL_BETTER_AUTH_URL;
+  });
+
+  it('points the review button at the access requests page, not the trust overview', async () => {
+    // contactEmail present -> single recipient, no member fallback lookup.
+    mockDb.trust.findUnique.mockResolvedValue({ contactEmail: 'owner@acme.com' });
+
+    const dto: CreateAccessRequestDto = {
+      name: 'Jane Doe',
+      email: 'jane@example.com',
+    };
+
+    await service['sendAccessRequestNotificationToOrg'](
+      'org_123',
+      'tar_456',
+      'Acme Inc',
+      dto,
+    );
+
+    expect(emailService.sendAccessRequestNotification).toHaveBeenCalledTimes(1);
+    // Must deep-link to the pending requests list, NOT /org_123/trust (the
+    // trust portal settings/overview page).
+    expect(emailService.sendAccessRequestNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reviewUrl: 'https://app.trycomp.ai/org_123/trust/access-requests',
+      }),
     );
   });
 });

--- a/apps/api/src/trust-portal/trust-access.service.ts
+++ b/apps/api/src/trust-portal/trust-access.service.ts
@@ -430,8 +430,9 @@ export class TrustAccessService {
       return;
     }
 
-    // Construct review URL
-    const reviewUrl = `${process.env.BETTER_AUTH_URL}/${organizationId}/trust`;
+    // Construct review URL pointing at the pending access requests list, not
+    // the trust portal settings/overview page.
+    const reviewUrl = `${process.env.BETTER_AUTH_URL}/${organizationId}/trust/access-requests`;
 
     // Send notification to all recipients
     const emailPromises = notificationEmails.map((email) =>


### PR DESCRIPTION
## Problem

When users receive a Trust Center access request email, the "Review Access" button links to the main Trust settings page instead of the specific access request that needs review. This forces users to navigate manually to find the request.

## Root cause

In trust-access.service.ts line 434, the reviewUrl is hardcoded to point to `${BETTER_AUTH_URL}/${organizationId}/trust`, which renders the general Trust Portal settings page. The function receives requestId but never uses it to construct the correct URL. The actual access requests review page exists at `/{orgId}/trust/access-requests` but the email link bypasses it entirely.

## Fix

Append `/access-requests` to the reviewUrl construction so the link points directly to the access requests page where users can immediately see and review the pending request.

## Explicitly NOT touched

No changes to email template logic, request creation flow, or permission checks. This is purely a URL routing fix in the service layer.

## Verification

✅ Access request email generates with correct review link
✅ Link navigates to access-requests page not settings page
✅ Existing tests pass with updated URL

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Trust Center email “Review Access” button to deep-link to the access requests page instead of the Trust settings, so approvers land directly on pending requests.

- **Bug Fixes**
  - Build `reviewUrl` as `${BETTER_AUTH_URL}/${organizationId}/trust/access-requests` in `trust-access.service.ts`.
  - Added a unit test to verify the email includes the deep link.

<sup>Written for commit 3021cbfb3764ecd76fff31473aae161b037bfc60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

