### PR TITLE
fix(gcp-scc): allow exceptions on public bucket findings by using fallback resource identity

### DIFF
--- a/apps/api/src/cloud-security/providers/gcp-security.service.spec.ts
+++ b/apps/api/src/cloud-security/providers/gcp-security.service.spec.ts
@@ -822,4 +822,45 @@ describe('GCPSecurityService.scanSecurityFindings — all-scopes-failed guard', 
 
     expect(findings).toEqual([]);
   });
+
+  // Regression: SCC public-bucket findings (PUBLIC_BUCKET_ACL) sometimes come
+  // back with an empty `finding.resourceName` while the resource identity lives
+  // on `result.resource.name`. Storing resourceId: "" made "Mark as exception"
+  // throw 'This finding cannot be marked as an exception — it lacks a stable
+  // check/resource identity'. The mapping must fall back to result.resource.name
+  // so the finding keeps a stable, non-empty resourceId.
+  it('falls back to result.resource.name for resourceId when finding.resourceName is empty (public bucket)', async () => {
+    fetchMock.mockResolvedValue(
+      sccPage([
+        {
+          finding: {
+            name: 'organizations/1/sources/-/findings/pub-bucket-1',
+            category: 'PUBLIC_BUCKET_ACL',
+            description: 'Bucket is public',
+            severity: 'HIGH',
+            state: 'ACTIVE',
+            resourceName: '', // SCC omitted the per-finding resource name
+            eventTime: '2026-01-01T00:00:00Z',
+            createTime: '2026-01-01T00:00:00Z',
+          },
+          resource: {
+            name: '//storage.googleapis.com/projects/acme/buckets/public-bucket',
+            type: 'storage.googleapis.com/Bucket',
+            projectDisplayName: 'acme',
+          },
+        },
+      ]),
+    );
+
+    const findings = await service.scanSecurityFindings(
+      { access_token: 'tok' },
+      { project_ids: ['acme'] },
+    );
+
+    expect(findings).toHaveLength(1);
+    // Pre-fix this was '' → resolveFindingForException rejected the finding.
+    expect(findings[0].resourceId).toBe(
+      '//storage.googleapis.com/projects/acme/buckets/public-bucket',
+    );
+  });
 });

--- a/apps/api/src/cloud-security/providers/gcp-security.service.spec.ts
+++ b/apps/api/src/cloud-security/providers/gcp-security.service.spec.ts
@@ -863,4 +863,40 @@ describe('GCPSecurityService.scanSecurityFindings — all-scopes-failed guard', 
       '//storage.googleapis.com/projects/acme/buckets/public-bucket',
     );
   });
+
+  // Regression: when SCC omits BOTH `finding.resourceName` AND
+  // `result.resource.name`, the old `|| ''` tail left resourceId empty — the
+  // exact state the exception resolver rejects. The chain must bottom out at
+  // `finding.name` (the finding's canonical id), which SCC always populates,
+  // so resourceId is guaranteed non-empty.
+  it('falls back to finding.name and never leaves resourceId empty when both resourceName and resource.name are absent', async () => {
+    fetchMock.mockResolvedValue(
+      sccPage([
+        {
+          finding: {
+            name: 'organizations/1/sources/-/findings/no-resource-1',
+            category: 'PUBLIC_BUCKET_ACL',
+            description: 'Bucket is public',
+            severity: 'HIGH',
+            state: 'ACTIVE',
+            resourceName: '', // SCC omitted the per-finding resource name
+            eventTime: '2026-01-01T00:00:00Z',
+            createTime: '2026-01-01T00:00:00Z',
+          },
+          // No `resource` block at all → result.resource?.name is undefined.
+        },
+      ]),
+    );
+
+    const findings = await service.scanSecurityFindings(
+      { access_token: 'tok' },
+      { project_ids: ['acme'] },
+    );
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].resourceId).not.toBe('');
+    expect(findings[0].resourceId).toBe(
+      'organizations/1/sources/-/findings/no-resource-1',
+    );
+  });
 });

--- a/apps/api/src/cloud-security/providers/gcp-security.service.ts
+++ b/apps/api/src/cloud-security/providers/gcp-security.service.ts
@@ -1415,7 +1415,12 @@ export class GCPSecurityService {
                 f.description || `Security finding: ${f.category}`,
               severity: this.mapSeverity(f.severity),
               resourceType: result.resource?.type ?? 'gcp-resource',
-              resourceId: f.resourceName,
+              // SCC sometimes omits the per-finding `resourceName` (notably
+              // PUBLIC_BUCKET_ACL findings) while the stable identity still
+              // lives on `result.resource.name`. Falling back keeps a
+              // non-empty resourceId so the finding can be marked as an
+              // exception (an empty resourceId is rejected by the resolver).
+              resourceId: f.resourceName || result.resource?.name || '',
               remediation,
               evidence: {
                 findingKey,

--- a/apps/api/src/cloud-security/providers/gcp-security.service.ts
+++ b/apps/api/src/cloud-security/providers/gcp-security.service.ts
@@ -1417,10 +1417,13 @@ export class GCPSecurityService {
               resourceType: result.resource?.type ?? 'gcp-resource',
               // SCC sometimes omits the per-finding `resourceName` (notably
               // PUBLIC_BUCKET_ACL findings) while the stable identity still
-              // lives on `result.resource.name`. Falling back keeps a
-              // non-empty resourceId so the finding can be marked as an
-              // exception (an empty resourceId is rejected by the resolver).
-              resourceId: f.resourceName || result.resource?.name || '',
+              // lives on `result.resource.name`. If both are absent, fall back
+              // to `f.name` — the finding's own canonical id (also used for
+              // dedup above and as `id`), which SCC always populates. Ending
+              // the chain there keeps resourceId guaranteed non-empty so the
+              // finding can be marked as an exception (an empty resourceId is
+              // rejected by the resolver).
+              resourceId: f.resourceName || result.resource?.name || f.name,
               remediation,
               evidence: {
                 findingKey,


### PR DESCRIPTION
## Problem

Customers cannot mark GCP public bucket findings as exceptions in Comp AI. The system rejects the action with "This finding cannot be marked as an exception it lacks a stable check/resource identity". This blocks workflow for accepting reviewed and acknowledged risks on SCC findings.

## Root cause

The SCC emitter in gcp-security.service.ts only anchors resourceId to the finding's resourceName field. For GCP public bucket findings from SCC, this field is often empty or missing. The code never falls back to the result.resource.name that SCC provides, leaving us with an empty resourceId string. The exception guard at exception.service.ts:223 then rejects any attempt to create an exception for findings with blank resourceId.

## Fix

Updated the resourceId assignment to use a cascade fallback: prefer resourceName, then fall back to result.resource.name, then f.name as a final anchor. This ensures every finding gets a stable non-empty identity without changing the behavior of findings that already have a proper resourceName. The change is one line and completely backward compatible.

## Explicitly NOT touched

- Authentication or authorization logic
- Database schema or migrations
- Billing or metering
- Secret handling
- Any other SCC emitter logic

## Verification

✅ Findings with existing resourceName continue to use it unchanged
✅ GCP public bucket findings now populate resourceId from result.resource.name
✅ Exception creation succeeds for previously-blocked findings
✅ No schema or auth layer modifications needed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the inability to mark GCP SCC public bucket findings as exceptions by falling back to `result.resource.name`, and then `finding.name`, when `finding.resourceName` is missing. Restores “Mark as exception” without changing behavior for findings that already include `resourceName`.

- **Bug Fixes**
  - Set `resourceId` to `f.resourceName || result.resource?.name || f.name` to guarantee a stable, non-empty ID.
  - Added regression tests for `PUBLIC_BUCKET_ACL` and for missing `resource` to ensure exception creation succeeds.

<sup>Written for commit fe7f906be14a1004de7b05010341caed252a8f02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

