### PR TITLE
fix(browserbase): retry stagehand init to survive premature close

### DIFF
--- a/apps/api/src/browserbase/browserbase-session.service.spec.ts
+++ b/apps/api/src/browserbase/browserbase-session.service.spec.ts
@@ -1,11 +1,27 @@
 import { ServiceUnavailableException } from '@nestjs/common';
 import Browserbase from '@browserbasehq/sdk';
 import { BrowserbaseSessionService } from './browserbase-session.service';
+import { browserbaseUnavailableException } from './browserbase-upstream-error';
 
 jest.mock('@browserbasehq/sdk', () => ({
   __esModule: true,
   default: jest.fn().mockImplementation(() => ({})),
 }));
+
+// Stagehand is loaded via a dynamic ESM import that jest cannot intercept, so
+// tests spy on the loadStagehand() seam and supply a fake constructor instead.
+type StagehandClass = Awaited<
+  ReturnType<BrowserbaseSessionService['loadStagehand']>
+>;
+
+const mockStagehandClass = ({
+  init,
+  close,
+}: {
+  init: jest.Mock;
+  close: jest.Mock;
+}): StagehandClass =>
+  jest.fn().mockImplementation(() => ({ init, close })) as unknown as StagehandClass;
 
 type BrowserbaseClient = ReturnType<
   BrowserbaseSessionService['getBrowserbase']
@@ -160,5 +176,79 @@ describe('BrowserbaseSessionService', () => {
     });
     expect(createSession).toHaveBeenCalledTimes(1);
     expect(debugSession).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries transient Stagehand init failures', async () => {
+    jest.useFakeTimers();
+    const service = new BrowserbaseSessionService();
+    const init = jest
+      .fn()
+      .mockRejectedValueOnce(prematureCloseError())
+      .mockResolvedValueOnce(undefined);
+    const close = jest.fn().mockResolvedValue(undefined);
+    const StagehandCtor = mockStagehandClass({ init, close });
+    jest.spyOn(service, 'loadStagehand').mockResolvedValue(StagehandCtor);
+
+    const promise = service.createStagehand('session_1');
+    await jest.advanceTimersByTimeAsync(250);
+
+    await expect(promise).resolves.toEqual({ init, close });
+    expect(StagehandCtor).toHaveBeenCalledTimes(2);
+    expect(init).toHaveBeenCalledTimes(2);
+    // The partially-initialized instance is closed before retrying.
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws a service unavailable exception after Stagehand init retry exhaustion', async () => {
+    jest.useFakeTimers();
+    const service = new BrowserbaseSessionService();
+    const init = jest.fn().mockRejectedValue(prematureCloseError());
+    const close = jest.fn().mockResolvedValue(undefined);
+    jest
+      .spyOn(service, 'loadStagehand')
+      .mockResolvedValue(mockStagehandClass({ init, close }));
+
+    const promise = service.createStagehand('session_1');
+    const expectation = expect(promise).rejects.toBeInstanceOf(
+      ServiceUnavailableException,
+    );
+    await jest.advanceTimersByTimeAsync(1_000);
+
+    await expectation;
+    expect(init).toHaveBeenCalledTimes(3);
+    expect(close).toHaveBeenCalledTimes(3);
+  });
+
+  it('preserves non-retryable Stagehand init failures', async () => {
+    const service = new BrowserbaseSessionService();
+    const sessionNotFound = Object.assign(new Error('Session not found'), {
+      status: 404,
+    });
+    const init = jest.fn().mockRejectedValue(sessionNotFound);
+    const close = jest.fn().mockResolvedValue(undefined);
+    jest
+      .spyOn(service, 'loadStagehand')
+      .mockResolvedValue(mockStagehandClass({ init, close }));
+
+    await expect(service.createStagehand('session_1')).rejects.toBe(
+      sessionNotFound,
+    );
+    expect(init).toHaveBeenCalledTimes(1);
+    // Even a non-retryable failure closes the partial instance.
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('navigateToUrl returns the friendly unavailable message when init keeps failing', async () => {
+    const service = new BrowserbaseSessionService();
+    jest
+      .spyOn(service, 'createStagehand')
+      .mockRejectedValue(browserbaseUnavailableException());
+
+    await expect(
+      service.navigateToUrl('session_1', 'https://github.com'),
+    ).resolves.toEqual({
+      success: false,
+      error: 'Browserbase is temporarily unavailable. Please retry in a moment.',
+    });
   });
 });

--- a/apps/api/src/browserbase/browserbase-session.service.ts
+++ b/apps/api/src/browserbase/browserbase-session.service.ts
@@ -157,22 +157,47 @@ export class BrowserbaseSessionService {
     throw browserbaseUnavailableException();
   }
 
-  async createStagehand(sessionId: string): Promise<Stagehand> {
+  async loadStagehand(): Promise<
+    typeof import('@browserbasehq/stagehand').Stagehand
+  > {
     const { Stagehand } = await import('@browserbasehq/stagehand');
-    const stagehand = new Stagehand({
-      env: 'BROWSERBASE',
-      apiKey: process.env.BROWSERBASE_API_KEY,
-      projectId: this.getProjectId(),
-      browserbaseSessionID: sessionId,
-      model: {
-        modelName: STAGEHAND_MODEL,
-        apiKey: process.env.ANTHROPIC_API_KEY,
-      },
-      verbose: 1,
-    });
+    return Stagehand;
+  }
 
-    await stagehand.init();
-    return stagehand;
+  async createStagehand(sessionId: string): Promise<Stagehand> {
+    const Stagehand = await this.loadStagehand();
+
+    // Stagehand.init() resumes the session by calling the Browserbase API on
+    // its own internal SDK client (outside getBrowserbase()), so transient
+    // upstream failures there — e.g. "Premature close" — bypass the per-call
+    // retry that wraps our direct SDK calls. Retry init the same way, closing
+    // any half-initialized instance between attempts so we don't leak it.
+    return this.withBrowserbaseRetry({
+      operationName: 'stagehand initialization',
+      operation: async () => {
+        const stagehand = new Stagehand({
+          env: 'BROWSERBASE',
+          apiKey: process.env.BROWSERBASE_API_KEY,
+          projectId: this.getProjectId(),
+          browserbaseSessionID: sessionId,
+          model: {
+            modelName: STAGEHAND_MODEL,
+            apiKey: process.env.ANTHROPIC_API_KEY,
+          },
+          verbose: 1,
+        });
+
+        try {
+          await stagehand.init();
+          return stagehand;
+        } catch (error) {
+          // keepAlive:true means close() will not end the Browserbase session,
+          // so the next attempt can resume the same sessionId.
+          await this.safeCloseStagehand(stagehand);
+          throw error;
+        }
+      },
+    });
   }
 
   async safeCloseStagehand(stagehand: Stagehand): Promise<void> {


### PR DESCRIPTION
## Problem

Connecting a **Browser Automation** profile (enter a site → **Connect**) intermittently failed with:

```
Invalid response body while trying to fetch https://api.browserbase.com/v1/sessions/<id>: Premature close
```

## Root cause

The failing `GET /v1/sessions/<id>` runs **inside `stagehand.init()`**, not in our own code.

The Connect flow is `resolve → session → navigate`. The `navigate` step calls `createStagehand(sessionId)` → `stagehand.init()`. Because we pass an existing `browserbaseSessionID`, Stagehand v3 takes its **resume path** and calls `bb.sessions.retrieve(id)` on **its own internal `new Browserbase({ apiKey })` client** (`@browserbasehq/stagehand/.../launch/browserbase.js`). That client is:

- **outside** `getBrowserbase()`, so it isn't covered by our `withBrowserbaseRetry` wrapper, **and**
- **without** the `accept-encoding: identity` mitigation we added in `c8ed2e910`.

`Premature close` is an undici body-stream error thrown during JSON parsing **after** a `200` response, so the Browserbase SDK's own `maxRetries` (which only retries on fetch-reject or non-ok status, before the body is read) does not cover it either.

The tell: the user saw the **raw** SDK message, not our wrapper's `"Browserbase is temporarily unavailable…"`. Since `isRetryableBrowserbaseUpstreamError` already matches `"premature close"`, the only way the raw message surfaces is that the failing call bypassed the wrapper — i.e. it's Stagehand-internal.

> Note: the earlier retry work (PR #3211) wraps only our **direct** SDK calls, so it does **not** cover this `init()` path. This PR is the required follow-up.

## Fix

Wrap `stagehand.init()` inside `createStagehand` with the existing `withBrowserbaseRetry`. The operation closure closes any half-initialized instance before re-throwing — `keepAlive: true` means `close()` does **not** end the Browserbase session, so the retry resumes the same `sessionId`.

This covers **all three** `createStagehand` call sites — `navigateToUrl` (Connect), `checkLoginStatus` (Check & Save), and `executeBrowserEvidence` (scheduled/manual evidence runs) — and converts the raw error into a clean `503` once retries are exhausted. Verified that `classifyBrowserAutomationError` maps the new `ServiceUnavailableException` to the same `unknown/session` bucket as the old raw error, so there's no regression on evidence runs.

The dynamic Stagehand import is extracted into a `loadStagehand()` seam so the retry can be unit-tested (jest can't intercept a native dynamic `import()` under `module: nodenext`).

## Testing

- 4 new unit tests (transient-retry, exhaustion → 503, non-retryable passthrough, friendly message reaches the user).
- All **77** browserbase tests pass; typecheck clean for the changed files.
- Not exercised against a live Browserbase premature-close (hard to reproduce on demand) — verified via unit tests + code trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013zSwXMqVNvWLJBZEot9x12

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries `stagehand.init()` when resuming Browserbase sessions to survive transient "Premature close" errors. This stabilizes Connect, login checks, and evidence runs, and returns a clean 503 if retries are exhausted.

- **Bug Fixes**
  - Wraps `@browserbasehq/stagehand` init in `withBrowserbaseRetry`; closes partial instances between attempts while keeping the session alive.
  - Applies to all `createStagehand` call sites: `navigateToUrl`, `checkLoginStatus`, `executeBrowserEvidence`.
  - Converts exhausted retries into a friendly 503 and user-facing message.
  - Adds unit tests for retry behavior, exhaustion, and non-retryable errors.

- **Refactors**
  - Extracts dynamic import to `loadStagehand()` to enable mocking in tests of `@browserbasehq/stagehand` and the internal `@browserbasehq/sdk` call path.

<sup>Written for commit 78030f63b4006bfa9e1dc77f7d93c3b7d86c5930. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

