### PR TITLE
fix(api): unblock API build — add familyId to update-policy frameworks schema

### DIFF
--- a/apps/api/src/trigger/policies/update-policy.ts
+++ b/apps/api/src/trigger/policies/update-policy.ts
@@ -26,6 +26,9 @@ export const updatePolicy = schemaTask({
         description: z.string(),
         visible: z.boolean(),
         organizationId: z.string().nullable().default(null),
+        // FRAME-20: frameworks now carry a family pointer; keep this payload
+        // schema in step with the FrameworkEditorFramework shape it's typed as.
+        familyId: z.string().nullable().default(null),
         createdAt: z.date(),
         updatedAt: z.date(),
       }),


### PR DESCRIPTION
## Hotfix — main is currently un-deployable

FRAME-20 (#3222, merged) added a non-null `familyId` to `FrameworkEditorFramework`. The API's `update-policy` trigger task (`apps/api/src/trigger/policies/update-policy.ts`) hand-writes a `frameworks` zod schema that's consumed as `UpdatePolicyParams.frameworks: FrameworkEditorFramework[]`. The new required field made that payload type non-assignable, so **`nest build` fails** in the Docker/ECS API image:

```
src/trigger/policies/update-policy.ts:45 - error TS2345
  Property 'familyId' is missing ... but required in ... FrameworkEditorFramework[]
```

This is a **second copy** of the same task — FRAME-20 already fixed `apps/app`'s copy (`tasks/onboarding/update-policy.ts`) but this API copy was missed, and the API build isn't exercised by the same CI path, so it only surfaced on the post-merge image build.

## Fix
Add `familyId: z.string().nullable().default(null)` to the task's `frameworks` schema — identical to the fix already in the app copy. One-line, additive, no behavior change (callers that don't send it default to null).

## Verification
- `bunx nest build` (the exact failing Docker step) no longer reports the familyId error.
- Grep confirms **no** `familyId`-missing errors remain anywhere in the API.
- The only other local error (`auth.server.ts`) is a worktree-only duplicate-`better-auth` resolution quirk — it does **not** occur in the clean Docker build (the original failure log got past `auth.server.ts` and failed only at `update-policy.ts`), and `nest build` reported exactly 1 error (this familyId one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGwXoPb6qHxuHy8miVmyxT

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `familyId` to the API’s update-policy `frameworks` schema to match the `FrameworkEditorFramework` shape from FRAME-20, fixing the type mismatch and unblocking the API build. The field is `z.string().nullable().default(null)` to preserve current behavior.

<sup>Written for commit f7fcc0c72fe1019134bf28140625ceeecd3172b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

