### PR TITLE
fix(integrations): persist Zoho multi-DC api_domain so OAuth tokens hit the right region

### DIFF
--- a/apps/api/src/integration-platform/controllers/oauth.controller.ts
+++ b/apps/api/src/integration-platform/controllers/oauth.controller.ts
@@ -517,6 +517,9 @@ export class OAuthController {
     token_type?: string;
     expires_in?: number;
     scope?: string;
+    // Multi-DC providers (e.g. Zoho) return the data-center-specific API host
+    // here; it is persisted so the check runtime targets the correct region.
+    api_domain?: string;
   }> {
     const callbackUrl = `${process.env.BASE_URL || 'http://localhost:3333'}/v1/integrations/oauth/callback`;
 

--- a/apps/api/src/integration-platform/services/credential-vault.api-domain.spec.ts
+++ b/apps/api/src/integration-platform/services/credential-vault.api-domain.spec.ts
@@ -1,0 +1,157 @@
+jest.mock('@db', () => ({
+  db: {},
+}));
+
+import { CredentialVaultService } from './credential-vault.service';
+import { CredentialRepository } from '../repositories/credential.repository';
+import { ConnectionRepository } from '../repositories/connection.repository';
+import type { IntegrationConnection, IntegrationCredentialVersion } from '@db';
+
+const encrypted = (value: string) => ({
+  encrypted: value,
+  iv: 'iv',
+  tag: 'tag',
+  salt: 'salt',
+});
+
+const makeConnection = (): IntegrationConnection => ({
+  id: 'conn_1',
+  providerId: 'prv_1',
+  organizationId: 'org_1',
+  status: 'active',
+  authStrategy: 'oauth2',
+  activeCredentialVersionId: 'cred_1',
+  lastSyncAt: null,
+  nextSyncAt: null,
+  syncCadence: null,
+  metadata: {},
+  variables: {},
+  errorMessage: null,
+  refreshLeaseUntil: null,
+  refreshLeaseToken: null,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+});
+
+const makeCredentialVersion = (): IntegrationCredentialVersion => ({
+  id: 'cred_1',
+  connectionId: 'conn_1',
+  encryptedPayload: {},
+  version: 1,
+  expiresAt: null,
+  rotatedAt: null,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+});
+
+const buildService = () => {
+  const credentialRepository = new CredentialRepository();
+  const connectionRepository = new ConnectionRepository();
+  const createSpy = jest
+    .spyOn(credentialRepository, 'create')
+    .mockResolvedValue(makeCredentialVersion());
+  jest.spyOn(credentialRepository, 'deleteOldVersions').mockResolvedValue(0);
+  jest.spyOn(connectionRepository, 'update').mockResolvedValue(makeConnection());
+  const service = new CredentialVaultService(
+    credentialRepository,
+    connectionRepository,
+  );
+  jest
+    .spyOn(service, 'encrypt')
+    .mockImplementation(async (value) => encrypted(value));
+  return { service, createSpy };
+};
+
+describe('CredentialVaultService multi-DC api_domain handling', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('captures api_domain from a token response and stores it in plaintext', async () => {
+    const { service, createSpy } = buildService();
+    // When the response carries api_domain we must not need the stored value.
+    const getCredsSpy = jest.spyOn(service, 'getDecryptedCredentials');
+
+    await service.storeOAuthTokens('conn_1', {
+      access_token: 'zoho-access',
+      refresh_token: 'zoho-refresh',
+      expires_in: 3600,
+      token_type: 'Bearer',
+      api_domain: 'https://www.zohoapis.eu',
+    });
+
+    const createInput = createSpy.mock.calls[0]?.[0];
+    if (!createInput) throw new Error('Expected credential version to be created');
+
+    // Stored as a plaintext string (not encrypted) so the check runtime can
+    // read it as ctx.credentials.api_domain and route to the right region.
+    expect(createInput.encryptedPayload.api_domain).toBe(
+      'https://www.zohoapis.eu',
+    );
+    // Secrets are still encrypted.
+    expect(createInput.encryptedPayload.access_token).toEqual(
+      encrypted('zoho-access'),
+    );
+    // No need to read the prior credential when the response already has it.
+    expect(getCredsSpy).not.toHaveBeenCalled();
+  });
+
+  it('preserves an existing api_domain when a refresh response omits it', async () => {
+    const { service, createSpy } = buildService();
+    jest
+      .spyOn(service, 'getDecryptedCredentials')
+      .mockResolvedValue({ api_domain: 'https://www.zohoapis.in' });
+
+    // A refresh response that does not echo api_domain.
+    await service.storeOAuthTokens('conn_1', {
+      access_token: 'refreshed-access',
+      refresh_token: 'zoho-refresh',
+      expires_in: 3600,
+      token_type: 'Bearer',
+    });
+
+    const createInput = createSpy.mock.calls[0]?.[0];
+    if (!createInput) throw new Error('Expected credential version to be created');
+
+    expect(createInput.encryptedPayload.api_domain).toBe(
+      'https://www.zohoapis.in',
+    );
+  });
+
+  it('stores no api_domain for providers that never send one (backward compatible)', async () => {
+    const { service, createSpy } = buildService();
+    // Typical single-DC provider: nothing in the response, nothing stored.
+    jest.spyOn(service, 'getDecryptedCredentials').mockResolvedValue({});
+
+    await service.storeOAuthTokens('conn_1', {
+      access_token: 'github-access',
+      refresh_token: 'github-refresh',
+      expires_in: 3600,
+      token_type: 'Bearer',
+    });
+
+    const createInput = createSpy.mock.calls[0]?.[0];
+    if (!createInput) throw new Error('Expected credential version to be created');
+
+    expect(createInput.encryptedPayload).not.toHaveProperty('api_domain');
+  });
+
+  it('does not fail token storage if the prior api_domain cannot be read', async () => {
+    const { service, createSpy } = buildService();
+    jest
+      .spyOn(service, 'getDecryptedCredentials')
+      .mockRejectedValue(new Error('decrypt failed'));
+
+    await expect(
+      service.storeOAuthTokens('conn_1', {
+        access_token: 'access',
+        refresh_token: 'refresh',
+        expires_in: 3600,
+        token_type: 'Bearer',
+      }),
+    ).resolves.toBeUndefined();
+
+    const createInput = createSpy.mock.calls[0]?.[0];
+    if (!createInput) throw new Error('Expected credential version to be created');
+    expect(createInput.encryptedPayload).not.toHaveProperty('api_domain');
+  });
+});

--- a/apps/api/src/integration-platform/services/credential-vault.service.ts
+++ b/apps/api/src/integration-platform/services/credential-vault.service.ts
@@ -55,6 +55,14 @@ export interface OAuthTokens {
   token_type?: string;
   expires_in?: number;
   scope?: string;
+  /**
+   * Data-center-specific API host returned by multi-DC OAuth providers. Zoho,
+   * for example, returns `api_domain: "https://www.zohoapis.eu"` and the access
+   * token is only valid against that host. When present it is persisted so the
+   * check runtime targets the correct regional host. Single-DC providers never
+   * send this field and are unaffected.
+   */
+  api_domain?: string;
 }
 
 export interface TokenRefreshConfig {
@@ -177,6 +185,32 @@ export class CredentialVaultService {
     }
     if (tokens.scope) {
       encryptedPayload.scope = tokens.scope;
+    }
+
+    // Multi-data-center OAuth providers (e.g. Zoho) return a data-center-
+    // specific API host as `api_domain` in their token/refresh responses, and
+    // the access token only works against that host — calling a hardcoded
+    // default host makes the provider reject the token (Zoho responds
+    // INVALID_TOKEN). Persist it so the check runtime can route requests to the
+    // correct region. Providers that don't send `api_domain` (the vast
+    // majority) store nothing here and behave exactly as before.
+    let apiDomain =
+      typeof tokens.api_domain === 'string' ? tokens.api_domain : undefined;
+    if (!apiDomain) {
+      // A later refresh response may omit api_domain even when the original
+      // grant included it; preserve the previously captured value instead of
+      // dropping back to the runtime's default host.
+      try {
+        const existing = await this.getDecryptedCredentials(connectionId);
+        if (typeof existing?.api_domain === 'string') {
+          apiDomain = existing.api_domain;
+        }
+      } catch {
+        // Best-effort preservation; if the prior value can't be read, skip it.
+      }
+    }
+    if (apiDomain) {
+      encryptedPayload.api_domain = apiDomain;
     }
 
     // Calculate expiration
@@ -446,6 +480,10 @@ export class CredentialVaultService {
       token_type: tokens.token_type,
       expires_in: tokens.expires_in,
       scope: tokens.scope,
+      // Carry through the data-center host on refresh. storeOAuthTokens
+      // preserves the previously captured value when a refresh response omits
+      // it, so a working api_domain is never downgraded.
+      api_domain: tokens.api_domain,
     };
 
     await this.storeOAuthTokens(connectionId, tokensToStore);


### PR DESCRIPTION
## Problem

A customer's Zoho CRM checks fail with **`INVALID_TOKEN` / "Token expired"** even though the connection is authorized and the OAuth token refreshes successfully.

Root cause: **Zoho is a multi-data-center provider** (US/EU/IN/AU/JP/CN). Each account's access token is only valid against that account's regional API host, which Zoho returns as **`api_domain`** in its token *and* refresh responses (e.g. `https://www.zohoapis.eu`). Our OAuth engine captured `access_token` / `refresh_token` / `scope` / `expires_in` but **dropped `api_domain`**. So the Zoho check fell back to the default US host (`www.zohoapis.com`), and Zoho rejected a non-US token with `INVALID_TOKEN`. The token was fine — we were just calling the wrong region.

## Fix

Capture and persist `api_domain` at the two points where Zoho returns it:

- **Token exchange** (`oauth.controller.ts` → `exchangeCodeForTokens`): added `api_domain` to the return type so it flows into `storeOAuthTokens` (the controller already passes the raw token object through unmodified).
- **Token storage** (`credential-vault.service.ts` → `storeOAuthTokens`): store `api_domain` in plaintext alongside `scope`/`token_type`/`expires_at`. If a later refresh response omits it, **preserve** the previously captured value (mirrors the existing refresh-token preservation) so a working host is never downgraded back to the default.
- **Token refresh** (`attemptTokenRefresh`): carry `api_domain` through into the stored token set.

The dynamic-check runtime already exposes the full decrypted credential record as `ctx.credentials`, and the Zoho check already reads `ctx.credentials.api_domain` with a `www.zohoapis.com` fallback — so **no check change is needed**.

## Why this is safe for every other integration

`api_domain` is a **Zoho-only field**. Verified end-to-end:

- `getDecryptedCredentials` returns *all* payload fields (no whitelist), and the runner passes that whole record into `runAllChecks` as `credentials` — so a stored `api_domain` reaches `ctx.credentials` for Zoho, and is simply absent for everyone else.
- For any provider that doesn't send `api_domain` (GitHub, Google, Slack, …): nothing is captured, nothing is stored, behavior is **byte-for-byte unchanged**.
- For a US Zoho account: `api_domain` = `https://www.zohoapis.com`, identical to today's default — no behavior change.
- For a non-US Zoho account: now correct instead of broken.
- The exchange and refresh **URLs are untouched** (`accounts.zoho.com`); this PR only persists the host the provider tells us to use for API calls. The evidence (this customer connected successfully and the engine refreshes their token at `accounts.zoho.com`) shows that path already works cross-DC for them — the only gap was the discarded `api_domain`.

## Tests

`credential-vault.api-domain.spec.ts` (4 new tests):
- captures `api_domain` from a token response and stores it in **plaintext** (so the runtime can read it);
- **preserves** an existing `api_domain` when a refresh response omits it;
- stores **nothing** for providers that never send one (backward compatible);
- never fails token storage if the prior value can't be read (best-effort).

All 16 credential-vault specs pass (incl. existing Google refresh/storage regression). The two touched files typecheck clean (remaining repo typecheck errors are pre-existing AI-SDK `LanguageModelV3`/`EmbeddingModelV3` mismatches in unrelated modules).

## ⚠️ Validation status — read before merge

- **Regression risk: none** — verified by code + tests (additive, Zoho-only field, other providers unchanged).
- **Customer fix: high confidence but not yet live-validated against a real non-US Zoho account** from this environment (I can't complete a browser OAuth flow here). After deploy, the customer's `api_domain` is repopulated on their **next token refresh** (already happening per their logs) or on **reconnect** — either path resolves the `INVALID_TOKEN`. Recommend a quick confirm against the customer's connection after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AU5798EG3PQdRuYSPJgXmy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist Zoho’s multi-DC `api_domain` during OAuth so API calls hit the correct regional host, fixing INVALID_TOKEN errors for non-US accounts. Captures `api_domain` on token exchange and refresh, stores it in plaintext, and preserves it when omitted.

- **Bug Fixes**
  - Capture `api_domain` in the token exchange result and pass it to storage.
  - Store `api_domain` alongside other fields and preserve the previous value if a refresh omits it.
  - Carry `api_domain` through refresh so the runtime routes requests to the right region; no check changes needed.
  - Non-Zoho providers are unaffected; added tests to cover capture, preservation, and backward compatibility.

<sup>Written for commit 923128658d02057ae9a8eeeaefaf52890f464203. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

