### PR TITLE
fix(browserbase): disable Stagehand hosted API to unblock connect

### DIFF
--- a/apps/api/src/browserbase/browserbase-session.service.spec.ts
+++ b/apps/api/src/browserbase/browserbase-session.service.spec.ts
@@ -238,6 +238,26 @@ describe('BrowserbaseSessionService', () => {
     expect(close).toHaveBeenCalledTimes(1);
   });
 
+  it('runs Stagehand with the hosted API disabled', async () => {
+    const service = new BrowserbaseSessionService();
+    const init = jest.fn().mockResolvedValue(undefined);
+    const close = jest.fn().mockResolvedValue(undefined);
+    const StagehandCtor = mockStagehandClass({ init, close });
+    jest.spyOn(service, 'loadStagehand').mockResolvedValue(StagehandCtor);
+
+    await service.createStagehand('session_1');
+
+    // disableAPI:true skips Stagehand's hosted POST /sessions/start (the source
+    // of "Unknown error: 400"); the session still resumes over CDP.
+    expect(StagehandCtor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: 'BROWSERBASE',
+        browserbaseSessionID: 'session_1',
+        disableAPI: true,
+      }),
+    );
+  });
+
   it('navigateToUrl returns the friendly unavailable message when init keeps failing', async () => {
     const service = new BrowserbaseSessionService();
     jest

--- a/apps/api/src/browserbase/browserbase-session.service.ts
+++ b/apps/api/src/browserbase/browserbase-session.service.ts
@@ -167,11 +167,18 @@ export class BrowserbaseSessionService {
   async createStagehand(sessionId: string): Promise<Stagehand> {
     const Stagehand = await this.loadStagehand();
 
-    // Stagehand.init() resumes the session by calling the Browserbase API on
-    // its own internal SDK client (outside getBrowserbase()), so transient
-    // upstream failures there — e.g. "Premature close" — bypass the per-call
-    // retry that wraps our direct SDK calls. Retry init the same way, closing
-    // any half-initialized instance between attempts so we don't leak it.
+    // We create and own the Browserbase session ourselves, and this feature only
+    // needs CDP navigation plus local inference. Stagehand's default hosted-API
+    // mode adds a POST /sessions/start round-trip that is unnecessary here and is
+    // the source of opaque "Unknown error: <status>" failures. disableAPI:true
+    // skips it: the session still resumes over CDP and extract/act/agent run
+    // locally against ANTHROPIC_API_KEY.
+    //
+    // init() still performs a Browserbase API round-trip to resume the session,
+    // whose transient failures — e.g. "Premature close" — bypass the retry that
+    // wraps our direct SDK calls, so retry init too, closing any half-initialized
+    // instance between attempts to avoid leaking it. Stagehand strips upstream
+    // error bodies from its throws, so forward its error logs into our logger.
     return this.withBrowserbaseRetry({
       operationName: 'stagehand initialization',
       operation: async () => {
@@ -180,11 +187,19 @@ export class BrowserbaseSessionService {
           apiKey: process.env.BROWSERBASE_API_KEY,
           projectId: this.getProjectId(),
           browserbaseSessionID: sessionId,
+          disableAPI: true,
           model: {
             modelName: STAGEHAND_MODEL,
             apiKey: process.env.ANTHROPIC_API_KEY,
           },
           verbose: 1,
+          logger: (line) => {
+            if ((line.level ?? 1) === 0) {
+              this.logger.error(
+                `Stagehand[${line.category ?? 'log'}]: ${line.message}`,
+              );
+            }
+          },
         });
 
         try {

--- a/apps/api/src/trigger/browser-automation/run-browser-automation.ts
+++ b/apps/api/src/trigger/browser-automation/run-browser-automation.ts
@@ -188,7 +188,7 @@ async function sendTaskStatusChangeEmails(params: {
  */
 export const runBrowserAutomation = task({
   id: 'run-browser-automation',
-  maxDuration: 1000 * 60 * 10, // 10 minutes per automation
+  maxDuration: 60 * 10, // 10 minutes per automation — Trigger.dev maxDuration is in SECONDS
   queue: {
     concurrencyLimit: browserAutomationConcurrencyLimit(),
   },

--- a/apps/api/src/trigger/browser-automation/run-browser-automations-schedule.ts
+++ b/apps/api/src/trigger/browser-automation/run-browser-automations-schedule.ts
@@ -93,7 +93,7 @@ export function limitAutomationBatch<
 export const browserAutomationsSchedule = schedules.task({
   id: 'browser-automations-schedule',
   cron: '0 5 * * *', // Daily at 5:00 AM UTC
-  maxDuration: 1000 * 60 * 30, // 30 minutes
+  maxDuration: 60 * 30, // 30 minutes — Trigger.dev maxDuration is in SECONDS
   run: async (payload) => {
     logger.info('Starting daily browser automations orchestrator', {
       scheduledAt: payload.timestamp,


### PR DESCRIPTION
## Problem

Browser Automations **won't connect** — clicking **Connect** fails with **"Unknown error: 400"**. This is a *different* failure from the premature-close one fixed in #3225.

## Root cause (verified)

`/navigate` → `createStagehand()` → `stagehand.init()`. With `disableAPI` left at its default (`false`), Stagehand first calls its **hosted managed API** (`POST https://api.stagehand.browserbase.com/v1/sessions/start`) *before* connecting via CDP. That hosted call returns a `400`, and Stagehand throws `"Unknown error: 400"` after **stripping the real reason** out of the error (`@browserbasehq/stagehand/.../v3/api.js:85-92`).

The key insight from a full audit of the feature: **this feature needs nothing from the hosted API.**
- `navigateToUrl` only does `page.goto()` + `sendCDP()` — pure CDP, no LLM.
- `checkLoginStatus` (verify) and evidence runs use `extract` / `agent({cua})`, which run against **local** handlers + our `ANTHROPIC_API_KEY`.

All three paths route through `createStagehand`, so the hosted-API round-trip is the single point of failure for connect, login-verify, **and** scheduled evidence runs.

## Fix

Set **`disableAPI: true`** in the Stagehand constructor. Verified against Stagehand v3.3.0 internals:
- `apiClient` is built **only** inside the `if (!disableAPI && !experimental)` block (`v3.js:826/827`), so `disableAPI:true` → `apiClient` stays null → no `/sessions/start` call → the 400 cannot occur.
- The Browserbase session still resumes over CDP (`createBrowserbaseSession` runs unconditionally at `v3.js:865`).
- `extract` (`v3.js:1110` else-branch) and the CUA `agent` (`v3.js:1594` else-branch) fall back to **local** handlers when `apiClient` is null; `anthropic/claude-sonnet-4-6` is in `AVAILABLE_CUA_MODELS` and resolves via `@ai-sdk/anthropic` (dep present).

Also in this PR:
- **Forward Stagehand's own error logs into the NestJS logger** (`logger` constructor hook). Stagehand strips upstream error bodies from its throws, so without this we're blind — this is why "Unknown error: 400" was opaque. Now the real reason lands in our logs.
- **Fix Trigger.dev `maxDuration` units** for the scheduled runner + orchestrator: they were `1000*60*N` (≈166h / 500h), so the intended 10-/30-minute safety abort never tripped. `maxDuration` is in **seconds** (matches the convention in `run-device-sync.ts` and its spec).

The `init()` retry from #3225 is kept — it still protects the CDP session-resume round-trip (a different upstream than the hosted API).

## Testing

- New test asserts `createStagehand` constructs Stagehand with `disableAPI: true`.
- All **86** browserbase + trigger/browser-automation tests pass; typecheck clean for changed files.

## Honest caveat

I verified in code that `extract`/CUA fall back to local handlers, but I could not exercise a live Browserbase run. **Connect/navigate is no-LLM and fully unblocked**; please confirm one **verify** ("Check & Save") and one **evidence run** so we validate local-inference parity. If anything still fails, the new logger forwarding will now surface the real reason in the API logs instead of "Unknown error: 400".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013zSwXMqVNvWLJBZEot9x12

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable Stagehand’s hosted API to stop “Unknown error: 400” on Connect and run automations via CDP + local inference. Also fix task timeouts and forward Stagehand logs for clearer errors.

- **Bug Fixes**
  - Pass `disableAPI: true` to Stagehand so it skips `POST /sessions/start`; CDP resume still works and `extract`/CUA run locally with `ANTHROPIC_API_KEY`.
  - Forward Stagehand error logs to the NestJS logger via the `logger` hook to surface real upstream reasons.
  - Keep `init()` retry for CDP session resume.
  - Set `maxDuration` in seconds in `run-browser-automation` (10m) and `browser-automations-schedule` (30m).

<sup>Written for commit d74c644b6f47f5c5c419e0e9c25ebe4f3396fcdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

