### PR TITLE
fix(background-checks): drop HEIC/HEIF from manual upload accept list

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/BackgroundCheckAttachForm.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/BackgroundCheckAttachForm.test.tsx
@@ -41,7 +41,10 @@ describe('BackgroundCheckAttachForm', () => {
     expect(accept).toContain('application/pdf');
     expect(accept).toMatch(/image\/png/);
     expect(accept).toMatch(/image\/jpeg/);
-    expect(accept).toMatch(/image\/heic/);
+    expect(accept).toMatch(/image\/webp/);
+    // HEIC/HEIF intentionally excluded — the API can't validate/store them and
+    // most browsers can't display them; offering them would fail server-side.
+    expect(accept).not.toMatch(/image\/heic/);
   });
 
   it('still accepts a PDF report', () => {

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/BackgroundCheckAttachForm.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/BackgroundCheckAttachForm.tsx
@@ -44,19 +44,21 @@ interface AttachFormProps {
 const MAX_FILE_BYTES = 25 * 1024 * 1024;
 
 // Reports are usually PDFs, but the manual identity fallback is a passport
-// photo (JPEG/PNG/HEIC). The API accepts these same types — see
-// validateFileContent in apps/api/src/utils/file-type-validation.ts.
+// photo (JPEG/PNG/WEBP). Keep this in lock-step with what the API actually
+// accepts — validateFileContent in apps/api/src/utils/file-type-validation.ts.
+// HEIC/HEIF are intentionally excluded: the API can't validate/store them and
+// most browsers can't display them, so they'd fail server-side or store
+// unviewable evidence. (Candidates' own uploads convert HEIC->JPEG in the
+// browser via apps/web normalizeIdImage; this admin attach form does not.)
 const ACCEPTED_MIME_TYPES = [
   'application/pdf',
   'image/png',
   'image/jpeg',
   'image/webp',
-  'image/heic',
-  'image/heif',
 ];
 
 const FILE_ACCEPT_ATTR =
-  'application/pdf,image/png,image/jpeg,image/webp,image/heic,image/heif,.pdf,.png,.jpg,.jpeg,.webp,.heic,.heif';
+  'application/pdf,image/png,image/jpeg,image/webp,.pdf,.png,.jpg,.jpeg,.webp';
 
 export function BackgroundCheckAttachForm({
   values,
@@ -81,7 +83,7 @@ export function BackgroundCheckAttachForm({
       return;
     }
     if (file.type && !ACCEPTED_MIME_TYPES.includes(file.type)) {
-      setFileError('Upload a PDF or image file (PDF, PNG, JPG, HEIC).');
+      setFileError('Upload a PDF or image file (PDF, PNG, JPG, WEBP).');
       return;
     }
     setFileError(null);
@@ -178,7 +180,7 @@ export function BackgroundCheckAttachForm({
           )}
         </Text>
         <Text size="xs" variant="muted">
-          PDF or image (PNG, JPG, HEIC) · up to 25 MB · stored encrypted in your evidence vault
+          PDF or image (PNG, JPG, WEBP) · up to 25 MB · stored encrypted in your evidence vault
         </Text>
         {fileError && (
           <p className="mt-2 text-xs text-destructive">{fileError}</p>


### PR DESCRIPTION
## Why

Follow-up to #3233. That PR correctly widened the background-check attach form to accept images (it previously rejected images the API already accepted), but it also added **`image/heic` + `image/heif`** — which the API doesn't take.

`validateFileContent` (apps/api/src/utils/file-type-validation.ts) validates by magic bytes and only accepts **PNG / JPEG / WEBP / PDF**. So a HEIC/HEIF upload via this form would be **rejected server-side**, and even if stored, most browsers (Chrome/Firefox) can't display HEIC — i.e. unviewable evidence. So the form was offering a format that can't actually work here.

## Change

Align the form's accepted types + helper/error copy with what the API actually accepts: **PDF, PNG, JPEG, WEBP**. PDF and the other image formats are unaffected.

## Note on HEIC

Candidates' own ID uploads already support HEIC by converting it to JPEG in the browser (`apps/web` `normalizeIdImage.ts`) before anything reaches AWS. This admin attach form does **no** such conversion, so listing HEIC here was misleading. If HEIC support is wanted on this form later, the correct fix is **client-side conversion** (mirror the candidate flow), not accepting raw HEIC at the API.

## Tests

`BackgroundCheckAttachForm.test.tsx` updated — the accept-attribute test now asserts WEBP is offered and HEIC is **not**. 4/4 pass.

Related: CS-570, #3233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `image/heic` and `image/heif` from the background-check attach form to match API validation and avoid uploads that fail or can’t be viewed. Aligns accepted types, helper/error copy, and tests to support only PDF, PNG, JPEG, and WEBP, satisfying CS-570 and correcting the follow-up from #3233.

<sup>Written for commit 6cbd40f7ea61a5ab74039799e93b5d673bcc0256. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

