### PR TITLE
fix(browserbase): surface the underlying cause on exhausted retries

### DIFF
--- a/apps/api/src/browserbase/browserbase-session.service.spec.ts
+++ b/apps/api/src/browserbase/browserbase-session.service.spec.ts
@@ -114,6 +114,22 @@ describe('BrowserbaseSessionService', () => {
     expect(createContext).toHaveBeenCalledTimes(3);
   });
 
+  it('includes the underlying cause in the exhausted-retry message', async () => {
+    jest.useFakeTimers();
+    const service = new BrowserbaseSessionService();
+    const createContext = jest.fn().mockRejectedValue(prematureCloseError());
+    jest
+      .spyOn(service, 'getBrowserbase')
+      .mockReturnValue(mockBrowserbaseClient({ createContext }));
+
+    const promise = service.createBrowserbaseContext().catch((error) => error);
+    await jest.advanceTimersByTimeAsync(1_000);
+    const error = await promise;
+
+    expect(error).toBeInstanceOf(ServiceUnavailableException);
+    expect(error.message).toContain('Premature close');
+  });
+
   it('preserves non-retryable Browserbase failures', async () => {
     const service = new BrowserbaseSessionService();
     const browserbaseError = Object.assign(

--- a/apps/api/src/browserbase/browserbase-session.service.ts
+++ b/apps/api/src/browserbase/browserbase-session.service.ts
@@ -143,7 +143,9 @@ export class BrowserbaseSessionService {
             attempt,
             error: getBrowserbaseErrorText(error),
           });
-          throw browserbaseUnavailableException();
+          // Surface the underlying cause in the message so an exhausted retry
+          // is diagnosable from the UI/response, not just the server logs.
+          throw browserbaseUnavailableException(getBrowserbaseErrorText(error));
         }
 
         this.logger.warn(`Browserbase ${operationName} failed; retrying`, {

--- a/apps/api/src/browserbase/browserbase-upstream-error.spec.ts
+++ b/apps/api/src/browserbase/browserbase-upstream-error.spec.ts
@@ -26,4 +26,12 @@ describe('browserbase upstream errors', () => {
       'Browserbase is temporarily unavailable. Please retry in a moment.',
     );
   });
+
+  it('appends the underlying cause when provided', () => {
+    const error = browserbaseUnavailableException('Premature close');
+
+    expect(error.message).toBe(
+      'Browserbase is temporarily unavailable. Please retry in a moment. (Premature close)',
+    );
+  });
 });

--- a/apps/api/src/browserbase/browserbase-upstream-error.ts
+++ b/apps/api/src/browserbase/browserbase-upstream-error.ts
@@ -65,7 +65,9 @@ export const isRetryableBrowserbaseUpstreamError = (
   return RETRYABLE_MESSAGE_PARTS.some((part) => message.includes(part));
 };
 
-export const browserbaseUnavailableException = () =>
+export const browserbaseUnavailableException = (detail?: string) =>
   new ServiceUnavailableException(
-    'Browserbase is temporarily unavailable. Please retry in a moment.',
+    detail
+      ? `Browserbase is temporarily unavailable. Please retry in a moment. (${detail})`
+      : 'Browserbase is temporarily unavailable. Please retry in a moment.',
   );


### PR DESCRIPTION
## Why

When a Browserbase/Stagehand call fails all 3 retries, `withBrowserbaseRetry` threw a generic **"Browserbase is temporarily unavailable. Please retry in a moment."** — which **hides the real upstream error**. We hit this repeatedly while debugging the connect flow: the message tells the user (and us) nothing about *what* actually failed, forcing a server-log hunt every time.

## Change

`browserbaseUnavailableException(detail?)` now appends the underlying error text when provided, and the retry-exhaustion path passes it through:

```
Browserbase is temporarily unavailable. Please retry in a moment. (<real cause>)
```

So an exhausted retry is diagnosable straight from the UI/response — e.g. `(... : Premature close)` or `(Stagehand connect timeout ...)` — instead of being opaque. Non-retryable errors are unchanged (they already surface their own message). The no-detail call site keeps the original message.

Follow-up to #3225 (init retry) and #3230 (disableAPI). Builds on both.

## Tests
- `browserbaseUnavailableException('Premature close')` includes the detail.
- Exhausted-retry path includes the underlying cause in the thrown message.
- All 16 browserbase session/upstream tests pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013zSwXMqVNvWLJBZEot9x12

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces the underlying upstream error when Browserbase retries are exhausted by appending the cause to the "temporarily unavailable" message. This makes failures diagnosable from the UI/response without digging through server logs.

- **Bug Fixes**
  - `browserbaseUnavailableException(detail?)` now appends the provided cause; behavior unchanged when no detail is passed.
  - Exhausted-retry path in `BrowserbaseSessionService` passes `getBrowserbaseErrorText(error)` to the exception; tests added to cover both paths.

<sup>Written for commit acdfd1ea2bb3032cdc3929e739cf7a6f61583176. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

