### PR TITLE
fix(browserbase): attach Stagehand over CDP to avoid premature-close on session resume

### DIFF
--- a/apps/api/src/browserbase/browserbase-session.service.spec.ts
+++ b/apps/api/src/browserbase/browserbase-session.service.spec.ts
@@ -178,6 +178,25 @@ describe('BrowserbaseSessionService', () => {
     expect(debugSession).toHaveBeenCalledTimes(2);
   });
 
+  it('resolves the session connect URL via the identity-encoded client', async () => {
+    jest.useFakeTimers();
+    const service = new BrowserbaseSessionService();
+    const retrieveSession = jest
+      .fn()
+      .mockRejectedValueOnce(prematureCloseError())
+      .mockResolvedValueOnce({ connectUrl: 'wss://connect.browserbase.test/s1' });
+    jest
+      .spyOn(service, 'getBrowserbase')
+      .mockReturnValue(mockBrowserbaseClient({ retrieveSession }));
+
+    const promise = service.getSessionConnectUrl('session_1');
+    await jest.advanceTimersByTimeAsync(250);
+
+    await expect(promise).resolves.toBe('wss://connect.browserbase.test/s1');
+    expect(retrieveSession).toHaveBeenCalledTimes(2);
+    expect(retrieveSession).toHaveBeenCalledWith('session_1');
+  });
+
   it('retries transient Stagehand init failures', async () => {
     jest.useFakeTimers();
     const service = new BrowserbaseSessionService();
@@ -188,6 +207,9 @@ describe('BrowserbaseSessionService', () => {
     const close = jest.fn().mockResolvedValue(undefined);
     const StagehandCtor = mockStagehandClass({ init, close });
     jest.spyOn(service, 'loadStagehand').mockResolvedValue(StagehandCtor);
+    jest
+      .spyOn(service, 'getSessionConnectUrl')
+      .mockResolvedValue('wss://connect.browserbase.test/s1');
 
     const promise = service.createStagehand('session_1');
     await jest.advanceTimersByTimeAsync(250);
@@ -207,6 +229,9 @@ describe('BrowserbaseSessionService', () => {
     jest
       .spyOn(service, 'loadStagehand')
       .mockResolvedValue(mockStagehandClass({ init, close }));
+    jest
+      .spyOn(service, 'getSessionConnectUrl')
+      .mockResolvedValue('wss://connect.browserbase.test/s1');
 
     const promise = service.createStagehand('session_1');
     const expectation = expect(promise).rejects.toBeInstanceOf(
@@ -229,6 +254,9 @@ describe('BrowserbaseSessionService', () => {
     jest
       .spyOn(service, 'loadStagehand')
       .mockResolvedValue(mockStagehandClass({ init, close }));
+    jest
+      .spyOn(service, 'getSessionConnectUrl')
+      .mockResolvedValue('wss://connect.browserbase.test/s1');
 
     await expect(service.createStagehand('session_1')).rejects.toBe(
       sessionNotFound,
@@ -238,22 +266,24 @@ describe('BrowserbaseSessionService', () => {
     expect(close).toHaveBeenCalledTimes(1);
   });
 
-  it('runs Stagehand with the hosted API disabled', async () => {
+  it('attaches Stagehand to the resolved CDP URL instead of resuming via Browserbase', async () => {
     const service = new BrowserbaseSessionService();
     const init = jest.fn().mockResolvedValue(undefined);
     const close = jest.fn().mockResolvedValue(undefined);
     const StagehandCtor = mockStagehandClass({ init, close });
     jest.spyOn(service, 'loadStagehand').mockResolvedValue(StagehandCtor);
+    jest
+      .spyOn(service, 'getSessionConnectUrl')
+      .mockResolvedValue('wss://connect.browserbase.test/s1');
 
     await service.createStagehand('session_1');
 
-    // disableAPI:true skips Stagehand's hosted POST /sessions/start (the source
-    // of "Unknown error: 400"); the session still resumes over CDP.
+    // env:'LOCAL' + cdpUrl attaches over CDP and avoids Stagehand's own
+    // bb.sessions.retrieve (the "Premature close" source).
     expect(StagehandCtor).toHaveBeenCalledWith(
       expect.objectContaining({
-        env: 'BROWSERBASE',
-        browserbaseSessionID: 'session_1',
-        disableAPI: true,
+        env: 'LOCAL',
+        localBrowserLaunchOptions: { cdpUrl: 'wss://connect.browserbase.test/s1' },
       }),
     );
   });

--- a/apps/api/src/browserbase/browserbase-session.service.ts
+++ b/apps/api/src/browserbase/browserbase-session.service.ts
@@ -114,6 +114,17 @@ export class BrowserbaseSessionService {
     return session.contextId;
   }
 
+  async getSessionConnectUrl(sessionId: string): Promise<string> {
+    const session = await this.withBrowserbaseRetry({
+      operationName: 'session connect URL lookup',
+      operation: () => this.getBrowserbase().sessions.retrieve(sessionId),
+    });
+    if (!session.connectUrl) {
+      throw new Error('Browserbase session is missing a connect URL.');
+    }
+    return session.connectUrl;
+  }
+
   private async withBrowserbaseRetry<T>({
     operation,
     operationName,
@@ -167,27 +178,25 @@ export class BrowserbaseSessionService {
   async createStagehand(sessionId: string): Promise<Stagehand> {
     const Stagehand = await this.loadStagehand();
 
-    // We create and own the Browserbase session ourselves, and this feature only
-    // needs CDP navigation plus local inference. Stagehand's default hosted-API
-    // mode adds a POST /sessions/start round-trip that is unnecessary here and is
-    // the source of opaque "Unknown error: <status>" failures. disableAPI:true
-    // skips it: the session still resumes over CDP and extract/act/agent run
-    // locally against ANTHROPIC_API_KEY.
-    //
-    // init() still performs a Browserbase API round-trip to resume the session,
-    // whose transient failures — e.g. "Premature close" — bypass the retry that
-    // wraps our direct SDK calls, so retry init too, closing any half-initialized
-    // instance between attempts to avoid leaking it. Stagehand strips upstream
-    // error bodies from its throws, so forward its error logs into our logger.
+    // Resolve the CDP connect URL ourselves with our identity-encoded client.
+    // Stagehand's BROWSERBASE mode would instead call bb.sessions.retrieve on its
+    // OWN Browserbase client, which lacks our accept-encoding:identity header and
+    // so fails deterministically with "Premature close" (response decompression
+    // mishandling) in our runtime — the same failure the identity header already
+    // fixes for our own calls. Attaching via env:'LOCAL' + cdpUrl makes Stagehand
+    // connect straight to the session over CDP without that call; extract/act/
+    // agent then run locally against ANTHROPIC_API_KEY.
+    const cdpUrl = await this.getSessionConnectUrl(sessionId);
+
+    // A transient CDP attach can still fail; retry init, closing any
+    // half-initialized instance between attempts to avoid leaking it. Stagehand
+    // strips upstream error bodies from its throws, so forward its error logs.
     return this.withBrowserbaseRetry({
       operationName: 'stagehand initialization',
       operation: async () => {
         const stagehand = new Stagehand({
-          env: 'BROWSERBASE',
-          apiKey: process.env.BROWSERBASE_API_KEY,
-          projectId: this.getProjectId(),
-          browserbaseSessionID: sessionId,
-          disableAPI: true,
+          env: 'LOCAL',
+          localBrowserLaunchOptions: { cdpUrl },
           model: {
             modelName: STAGEHAND_MODEL,
             apiKey: process.env.ANTHROPIC_API_KEY,
@@ -206,8 +215,6 @@ export class BrowserbaseSessionService {
           await stagehand.init();
           return stagehand;
         } catch (error) {
-          // keepAlive:true means close() will not end the Browserbase session,
-          // so the next attempt can resume the same sessionId.
           await this.safeCloseStagehand(stagehand);
           throw error;
         }


### PR DESCRIPTION
## Proven by staging logs

After #3230 (`disableAPI`) shipped, the hosted-API `400` is **gone**. Connect now fails one step later — at the **Browserbase session resume**:

```
WARN  Browserbase stagehand initialization failed; retrying  { attempt: 1, error: 'Invalid response body while trying to fetch https://api.browserbase.com/v1/sessions/<id>: Premature close' }
... attempt: 2 ... attempt: 3
ERROR Browserbase stagehand initialization failed
ERROR ServiceUnavailableException: Browserbase is temporarily unavailable. Please retry in a moment. (Invalid response body ... : Premature close)
```

All 3 attempts fail identically within ~1.2s — it's **deterministic**, so the retry can't help.

## Root cause

`stagehand.init()` (BROWSERBASE mode) resumes the session by calling `bb.sessions.retrieve(<id>)` on **Stagehand's own internal Browserbase client**. That client lacks the `accept-encoding: identity` header we added to *our* client in `c8ed2e910` specifically to stop this compression-induced "Premature close." In the same connect flow, our identity-encoded calls (`contexts.create`, `sessions.create`, `sessions.debug`) all succeed — only Stagehand's gzip `retrieve` fails. Same endpoint, same network; the header is the only difference. Stagehand hardcodes `new Browserbase({ apiKey })`, so we can't inject the header into it.

## Fix

Resolve the session's `connectUrl` **ourselves** via our identity-encoded client (`getSessionConnectUrl`, retry-wrapped), then attach Stagehand with `env: 'LOCAL'` + `localBrowserLaunchOptions.cdpUrl`. Stagehand then connects straight to the live session over CDP (`connectOverCDP`, verified at `v3.js:678-701`) and **never makes its own `bb.sessions.*` call** — the premature-close source is removed.

- `extract` / `act` / `agent({cua})` run locally against `ANTHROPIC_API_KEY` (LOCAL mode uses no hosted API — same as the `disableAPI` path).
- We keep owning the session lifecycle (`keepAlive` on create, `closeSession` on cleanup); LOCAL mode won't touch it.
- WebAuthn `sendCDP`, `page.goto`, `page.screenshot` are all CDP — unaffected by the env switch.

## Testing
- New test: `getSessionConnectUrl` resolves `connectUrl` via the identity-encoded client and retries a premature-close.
- New test: `createStagehand` attaches with `env: 'LOCAL'` + the resolved `cdpUrl` (no BROWSERBASE resume).
- Retry/exhaustion/non-retryable init tests updated. All 79 browserbase tests pass; typecheck clean.

## Honest note
This directly removes the exact call that's failing in the staging logs, and the `connectUrl` lookup uses the identity-encoded client that already works in this same flow — so confidence is high. I still can't run a live Browserbase session from here, so please retest **Connect → Check & Save → one evidence run** on staging once deployed. If anything fails, the forwarded Stagehand logs + the enriched 503 message (#3238) will show the real cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013zSwXMqVNvWLJBZEot9x12

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attach Stagehand to Browserbase over CDP using the resolved `connectUrl` to eliminate deterministic “Premature close” failures during session resume. This bypasses Stagehand’s internal Browserbase client and keeps our identity-encoded client in control.

- **Bug Fixes**
  - Added `getSessionConnectUrl()` to fetch the session’s `connectUrl` via our Browserbase client with retry and `accept-encoding: identity`.
  - Initialize Stagehand with `env: 'LOCAL'` and `localBrowserLaunchOptions.cdpUrl` to connect over CDP (no `bb.sessions.retrieve` or hosted API); tests added for connect URL lookup and LOCAL CDP attach.

<sup>Written for commit b7a8e7ef4d13f9dd69f1a19394e88b20e9c7f2e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

