### PR TITLE
feat(integration-platform): capture + surface OAuth connect failures

### DIFF
--- a/apps/api/src/integration-platform/controllers/internal-integration-debug.controller.ts
+++ b/apps/api/src/integration-platform/controllers/internal-integration-debug.controller.ts
@@ -125,4 +125,22 @@ export class InternalIntegrationDebugController {
       checkId: body.checkId,
     });
   }
+
+  /**
+   * Read recently captured OAuth callback errors (recorded by the frontend on a
+   * failed connect). Use this to diagnose "the integration won't connect" for
+   * any org/provider — the exact provider error is here instead of lost.
+   */
+  @Get('oauth-errors')
+  async listOAuthErrors(
+    @Query('organizationId') organizationId?: string,
+    @Query('providerSlug') providerSlug?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.debugService.listOAuthErrors({
+      organizationId,
+      providerSlug,
+      limit: parseOptionalInt(limit),
+    });
+  }
 }

--- a/apps/api/src/integration-platform/controllers/oauth-errors.controller.spec.ts
+++ b/apps/api/src/integration-platform/controllers/oauth-errors.controller.spec.ts
@@ -1,0 +1,65 @@
+jest.mock('@db', () => ({
+  db: { integrationOAuthError: { create: jest.fn() } },
+}));
+// The real auth guards import better-auth, which fails to load under jest's ESM
+// shim. Mock them so the controller module can be imported; they're not under
+// test here (we test the record() handler logic).
+jest.mock('../../auth/hybrid-auth.guard', () => ({ HybridAuthGuard: class {} }));
+jest.mock('../../auth/permission.guard', () => ({ PermissionGuard: class {} }));
+jest.mock('../../auth/require-permission.decorator', () => ({
+  RequirePermission: () => () => undefined,
+}));
+jest.mock('../../auth/auth-context.decorator', () => ({
+  OrganizationId: () => () => undefined,
+  UserId: () => () => undefined,
+}));
+
+import { db } from '@db';
+import { OAuthErrorsController } from './oauth-errors.controller';
+
+const mockedDb = db as unknown as {
+  integrationOAuthError: { create: jest.Mock };
+};
+
+describe('OAuthErrorsController', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('records an OAuth error scoped to the org + user', async () => {
+    mockedDb.integrationOAuthError.create.mockResolvedValue({});
+    const controller = new OAuthErrorsController();
+
+    const res = await controller.record('org_1', 'user_1', {
+      providerSlug: 'quickbooks-online',
+      error: 'token_exchange_failed',
+      errorDescription: 'Sandbox app not allowed',
+    });
+
+    expect(res).toEqual({ recorded: true });
+    expect(mockedDb.integrationOAuthError.create).toHaveBeenCalledWith({
+      data: {
+        organizationId: 'org_1',
+        userId: 'user_1',
+        providerSlug: 'quickbooks-online',
+        errorCode: 'token_exchange_failed',
+        errorDescription: 'Sandbox app not allowed',
+      },
+    });
+  });
+
+  it('handles a missing user and missing optional fields (nulls, no secrets)', async () => {
+    mockedDb.integrationOAuthError.create.mockResolvedValue({});
+    const controller = new OAuthErrorsController();
+
+    await controller.record('org_2', undefined, { providerSlug: 'zoho-crm' });
+
+    expect(mockedDb.integrationOAuthError.create).toHaveBeenCalledWith({
+      data: {
+        organizationId: 'org_2',
+        userId: null,
+        providerSlug: 'zoho-crm',
+        errorCode: null,
+        errorDescription: null,
+      },
+    });
+  });
+});

--- a/apps/api/src/integration-platform/controllers/oauth-errors.controller.ts
+++ b/apps/api/src/integration-platform/controllers/oauth-errors.controller.ts
@@ -1,0 +1,60 @@
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { ApiExcludeController } from '@nestjs/swagger';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+import { db } from '@db';
+import { HybridAuthGuard } from '../../auth/hybrid-auth.guard';
+import { PermissionGuard } from '../../auth/permission.guard';
+import { RequirePermission } from '../../auth/require-permission.decorator';
+import { OrganizationId, UserId } from '../../auth/auth-context.decorator';
+
+class RecordOAuthErrorDto {
+  @IsString()
+  @MaxLength(100)
+  providerSlug!: string;
+
+  /** OAuth error code from the provider redirect (e.g. "access_denied"). */
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  error?: string;
+
+  /** Human-readable error description from the provider redirect. */
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  errorDescription?: string;
+}
+
+/**
+ * Records an OAuth callback error that the frontend captured from the redirect
+ * URL (`?error=...&error_description=...`). This is the *capture* side of OAuth
+ * error visibility — it does NOT touch the shared OAuth callback flow. The
+ * stored rows are read back via the internal debug API
+ * (`GET /internal/integration-debug/oauth-errors`).
+ *
+ * Never receives or stores secrets: the frontend only forwards the error code +
+ * description, never the auth `code` or any token.
+ */
+@ApiExcludeController()
+@Controller({ path: 'integrations/oauth-errors', version: '1' })
+@UseGuards(HybridAuthGuard, PermissionGuard)
+export class OAuthErrorsController {
+  @Post()
+  @RequirePermission('integration', 'create')
+  async record(
+    @OrganizationId() organizationId: string,
+    @UserId() userId: string | undefined,
+    @Body() body: RecordOAuthErrorDto,
+  ): Promise<{ recorded: true }> {
+    await db.integrationOAuthError.create({
+      data: {
+        organizationId,
+        userId: userId ?? null,
+        providerSlug: body.providerSlug,
+        errorCode: body.error ?? null,
+        errorDescription: body.errorDescription ?? null,
+      },
+    });
+    return { recorded: true };
+  }
+}

--- a/apps/api/src/integration-platform/integration-platform.module.ts
+++ b/apps/api/src/integration-platform/integration-platform.module.ts
@@ -3,6 +3,7 @@ import { AuthModule } from '../auth/auth.module';
 import { CloudSecurityModule } from '../cloud-security/cloud-security.module';
 import { OAuthController } from './controllers/oauth.controller';
 import { OAuthAppsController } from './controllers/oauth-apps.controller';
+import { OAuthErrorsController } from './controllers/oauth-errors.controller';
 import { ConnectionsController } from './controllers/connections.controller';
 import { AdminIntegrationsController } from './controllers/admin-integrations.controller';
 import { DynamicIntegrationsController } from './controllers/dynamic-integrations.controller';
@@ -42,6 +43,7 @@ import { GenericDeviceSyncService } from './services/generic-device-sync.service
   controllers: [
     OAuthController,
     OAuthAppsController,
+    OAuthErrorsController,
     ConnectionsController,
     AdminIntegrationsController,
     DynamicIntegrationsController,

--- a/apps/api/src/integration-platform/services/internal-integration-debug.service.spec.ts
+++ b/apps/api/src/integration-platform/services/internal-integration-debug.service.spec.ts
@@ -3,6 +3,7 @@ jest.mock('@db', () => ({
     integrationConnection: { findMany: jest.fn(), findUnique: jest.fn() },
     integrationCredentialVersion: { findUnique: jest.fn(), findMany: jest.fn() },
     integrationCheckRun: { findFirst: jest.fn(), findMany: jest.fn() },
+    integrationOAuthError: { findMany: jest.fn() },
   },
 }));
 
@@ -22,6 +23,7 @@ const mockedDb = db as unknown as {
   integrationConnection: { findMany: jest.Mock; findUnique: jest.Mock };
   integrationCredentialVersion: { findUnique: jest.Mock; findMany: jest.Mock };
   integrationCheckRun: { findFirst: jest.Mock; findMany: jest.Mock };
+  integrationOAuthError: { findMany: jest.Mock };
 };
 
 const makeService = (runner: Partial<ConnectionCheckRunnerService> = {}) =>
@@ -265,6 +267,37 @@ describe('InternalIntegrationDebugService', () => {
         service.testCandidateCode({ connectionId: 'missing', code: 'x' }),
       ).rejects.toBeInstanceOf(NotFoundException);
       expect(runCandidateCheck).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('listOAuthErrors', () => {
+    it('filters by org + provider and clamps a non-numeric limit', async () => {
+      mockedDb.integrationOAuthError.findMany.mockResolvedValue([
+        {
+          id: 'ioe_1',
+          organizationId: 'org_1',
+          providerSlug: 'quickbooks-online',
+          errorCode: 'token_exchange_failed',
+          errorDescription: 'sandbox',
+          createdAt: new Date(),
+        },
+      ]);
+      const service = makeService();
+
+      const { errors, total } = await service.listOAuthErrors({
+        organizationId: 'org_1',
+        providerSlug: 'quickbooks-online',
+        limit: Number('nope'),
+      });
+
+      expect(total).toBe(1);
+      expect(errors[0].errorCode).toBe('token_exchange_failed');
+      const args = mockedDb.integrationOAuthError.findMany.mock.calls[0][0];
+      expect(args.where).toEqual({
+        organizationId: 'org_1',
+        providerSlug: 'quickbooks-online',
+      });
+      expect(Number.isFinite(args.take)).toBe(true);
     });
   });
 });

--- a/apps/api/src/integration-platform/services/internal-integration-debug.service.ts
+++ b/apps/api/src/integration-platform/services/internal-integration-debug.service.ts
@@ -313,4 +313,30 @@ export class InternalIntegrationDebugService {
       checkId,
     });
   }
+
+  /**
+   * Read recently captured OAuth callback errors (recorded by the frontend when
+   * a connect redirects back with an error). Makes a failed connect diagnosable
+   * after the fact instead of being invisible.
+   */
+  async listOAuthErrors(params: {
+    organizationId?: string;
+    providerSlug?: string;
+    limit?: number;
+  }) {
+    const { organizationId, providerSlug } = params;
+    const rawLimit = params.limit ?? NaN;
+    const limit = Number.isFinite(rawLimit)
+      ? Math.min(Math.max(rawLimit, 1), 200)
+      : 50;
+    const errors = await db.integrationOAuthError.findMany({
+      where: {
+        ...(organizationId ? { organizationId } : {}),
+        ...(providerSlug ? { providerSlug } : {}),
+      },
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+    });
+    return { errors, total: errors.length };
+  }
 }

--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/ProviderDetailView.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/ProviderDetailView.tsx
@@ -112,6 +112,7 @@ export function ProviderDetailView({
   const [gcpSelectedProjectIds, setGcpSelectedProjectIds] = useState<string[]>([]);
   const oauthBootstrapHandledRef = useRef(false);
   const settingsQueryHandledRef = useRef(false);
+  const oauthErrorHandledRef = useRef(false);
 
   // OAuth return (?success=true): strip query, detect org/projects (NOT services yet — user must select projects first)
   useEffect(() => {
@@ -225,6 +226,33 @@ export function ProviderDetailView({
     setSettingsOpen(true);
     router.replace(`/${orgId}/integrations/${provider.id}`, { scroll: false });
   }, [orgId, provider.id, router, searchParams, selectedConnection?.id]);
+
+  // Surface + record an OAuth failure that lands on the provider page. The
+  // backend redirects with `?error=...&error_description=...`; show the user the
+  // real reason and record it (best-effort) so failed connects are diagnosable.
+  useEffect(() => {
+    if (oauthErrorHandledRef.current) return;
+    const error = searchParams.get('error');
+    if (!error) return;
+
+    oauthErrorHandledRef.current = true;
+    const errorDescription = searchParams.get('error_description');
+    toast.error(`Connection failed: ${errorDescription || error}`);
+
+    void api
+      .post(
+        '/v1/integrations/oauth-errors',
+        {
+          providerSlug: provider.id,
+          error,
+          errorDescription: errorDescription ?? undefined,
+        },
+        orgId,
+      )
+      .catch(() => {});
+
+    router.replace(`/${orgId}/integrations/${provider.id}`, { scroll: false });
+  }, [orgId, provider.id, router, searchParams]);
 
   return (
     <>

--- a/apps/app/src/app/(app)/[orgId]/integrations/components/PlatformIntegrations.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/components/PlatformIntegrations.tsx
@@ -7,6 +7,7 @@ import {
   useIntegrationMutations,
   useIntegrationProviders,
 } from '@/hooks/use-integration-platform';
+import { api } from '@/lib/api-client';
 import { usePermissions } from '@/hooks/use-permissions';
 import { useVendors } from '@/hooks/use-vendors';
 import { Badge } from '@trycompai/ui/badge';
@@ -129,6 +130,7 @@ export function PlatformIntegrations({ className, taskTemplates }: PlatformInteg
   const [selectedCategory, setSelectedCategory] = useState<IntegrationCategory | 'All'>('All');
   const [connectingProvider, setConnectingProvider] = useState<string | null>(null);
   const hasHandledOAuthRef = useRef(false);
+  const hasHandledOAuthErrorRef = useRef(false);
 
   // Custom integration dialog state
   const [selectedCustomIntegration, setSelectedCustomIntegration] = useState<Integration | null>(
@@ -328,6 +330,38 @@ export function PlatformIntegrations({ className, taskTemplates }: PlatformInteg
     url.searchParams.delete('provider');
     window.history.replaceState({}, '', url.toString());
   }, [searchParams, providers, loadingProviders, router, orgId]);
+
+  // Surface + record OAuth failures that land back here. The backend redirects
+  // with `?error=...&error_description=...`; previously that was shown to no one
+  // and stored nowhere. Now we tell the user the real reason and record it so a
+  // failed connect is diagnosable later (read via the internal debug API).
+  useEffect(() => {
+    if (hasHandledOAuthErrorRef.current) return;
+
+    const error = searchParams.get('error');
+    if (!error) return;
+
+    hasHandledOAuthErrorRef.current = true;
+    const errorDescription = searchParams.get('error_description');
+    const providerSlug = searchParams.get('provider') || 'unknown';
+
+    toast.error(`Connection failed: ${errorDescription || error}`);
+
+    // Best-effort — never let recording (or its failure) affect the UI.
+    void api
+      .post(
+        '/v1/integrations/oauth-errors',
+        { providerSlug, error, errorDescription: errorDescription ?? undefined },
+        orgId,
+      )
+      .catch(() => {});
+
+    const url = new URL(window.location.href);
+    url.searchParams.delete('error');
+    url.searchParams.delete('error_description');
+    url.searchParams.delete('provider');
+    window.history.replaceState({}, '', url.toString());
+  }, [searchParams, orgId]);
 
   // Create a map from templateId to taskId for quick lookup
   const templateToTaskMap = useMemo(

--- a/packages/db/prisma/migrations/20260623120000_add_integration_oauth_error/migration.sql
+++ b/packages/db/prisma/migrations/20260623120000_add_integration_oauth_error/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "IntegrationOAuthError" (
+    "id" TEXT NOT NULL DEFAULT generate_prefixed_cuid('ioe'::text),
+    "organizationId" TEXT NOT NULL,
+    "userId" TEXT,
+    "providerSlug" TEXT NOT NULL,
+    "errorCode" TEXT,
+    "errorDescription" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "IntegrationOAuthError_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "IntegrationOAuthError_organizationId_providerSlug_idx" ON "IntegrationOAuthError"("organizationId", "providerSlug");
+
+-- CreateIndex
+CREATE INDEX "IntegrationOAuthError_createdAt_idx" ON "IntegrationOAuthError"("createdAt");

--- a/packages/db/prisma/schema/integration-oauth-error.prisma
+++ b/packages/db/prisma/schema/integration-oauth-error.prisma
@@ -1,0 +1,24 @@
+// ===== Integration OAuth error capture =====
+// Append-only diagnostic log of OAuth callback errors, recorded by the frontend
+// when an OAuth connect redirects back with `?error=...&error_description=...`.
+// This makes failed connects diagnosable after the fact (the redirect error was
+// previously shown to no one and stored nowhere). No FK relations — it must be
+// writable even when no IntegrationConnection exists yet (connect failed before
+// one was created). Never stores secrets (no auth `code`, no tokens).
+model IntegrationOAuthError {
+  id               String   @id @default(dbgenerated("generate_prefixed_cuid('ioe'::text)"))
+  /// Organization that initiated the OAuth flow.
+  organizationId   String
+  /// User that initiated it (from the session), if available.
+  userId           String?
+  /// Provider slug (e.g. "quickbooks-online", "zoho-crm").
+  providerSlug     String
+  /// OAuth error code from the provider redirect (e.g. "access_denied", "token_exchange_failed").
+  errorCode        String?
+  /// Human-readable error description from the provider redirect.
+  errorDescription String?
+  createdAt        DateTime @default(now())
+
+  @@index([organizationId, providerSlug])
+  @@index([createdAt])
+}


### PR DESCRIPTION
## Problem
When an OAuth connect fails, the failure is **invisible after the moment it happens**. The shared callback logs the error to ephemeral server logs and redirects the user back with `?error=…&error_description=…`, but:
- the **frontend only handled `?success=`** and silently ignored the error, and
- **nothing was persisted.**

So when a customer says "the integration won't connect" (the QuickBooks / CalendarBridge case), there's no error to look up — you'd have to dig through server logs by timestamp, or ask the customer to copy the URL.

## What this does (without touching the shared OAuth callback)
The error already arrives at our frontend in the redirect URL — we just throw it away. This captures it there:

- **Frontend** (`PlatformIntegrations.tsx` grid + `ProviderDetailView.tsx`): the redirect handlers now also read `?error=`/`?error_description=`, **show the user the real reason** (toast), record it best-effort, and clean the URL. It's an additive `error` branch next to the existing `success` branch — the success path is unchanged.
- **New table `IntegrationOAuthError`**: `CREATE TABLE` only (no `ALTER`, no impact on existing data). No FK relations, because a connect failure has **no `IntegrationConnection` yet**. **Never stores the auth `code` or tokens** — only provider, error code, description, org/user, timestamp.
- **New write endpoint** `POST /v1/integrations/oauth-errors` (session-authed, brand-new controller) that the frontend posts to.
- **New internal read endpoint** `GET /v1/internal/integration-debug/oauth-errors?organizationId=&providerSlug=` so a failed connect is diagnosable by org/provider via the internal debug API.

**The shared `oauthCallback` is not modified** — that was the explicit "don't risk the whole flow" constraint. All changes are additive.

## Result
Next time a connect fails:
- the **user sees the real error** instead of silence, and
- we can look it up: `GET /v1/internal/integration-debug/oauth-errors?organizationId=…&providerSlug=…`.

## Security
- No secrets stored: the frontend forwards only the error code + description (never the one-time auth `code` or any token); the write endpoint persists exactly those fields.
- Write endpoint is session-authed + org-scoped (`@OrganizationId`); read endpoint is internal-token gated like the rest of the debug API.

## Tests
- `oauth-errors.controller.spec.ts` (2): records with org/user; handles missing user + optional fields (nulls, no secrets).
- `internal-integration-debug.service.spec.ts` (+1): `listOAuthErrors` filters by org/provider and clamps a non-numeric limit.
- 11/11 integration-platform debug/oauth tests pass; touched API + frontend files typecheck clean (remaining `@trycompai/app` typecheck errors are pre-existing on `main`).

## Migration
One new table (`20260623120000_add_integration_oauth_error`). Safe `CREATE TABLE` + two indexes; no existing tables touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AU5798EG3PQdRuYSPJgXmy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Capture and surface OAuth connect failures so users see the real error and we can diagnose failures later, without changing the shared OAuth callback. Success flow is unchanged.

- **New Features**
  - Frontend: handle `?error`/`?error_description` in `PlatformIntegrations` and `ProviderDetailView`; show a toast, POST a record, then clean the URL.
  - API: `POST /v1/integrations/oauth-errors` (session + permission authed) to store provider slug, error code, description, org, and user; no auth codes or tokens.
  - Debug: `GET /v1/internal/integration-debug/oauth-errors?organizationId=&providerSlug=&limit=` to fetch recent failures for an org/provider.
  - DB: new append-only `IntegrationOAuthError` with indexes on `(organizationId, providerSlug)` and `createdAt`.

- **Migration**
  - Create table `IntegrationOAuthError` via `20260623120000_add_integration_oauth_error`; no existing tables altered.

<sup>Written for commit 7d7792d29bc481fa790708e3ccfe69a245f16f49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

