### PR TITLE
fix(cloud-security): combine GCP direct-API checks with SCC, skip SCC when unavailable

### DIFF
--- a/apps/api/src/cloud-security/cloud-security.service.scan-gcp.spec.ts
+++ b/apps/api/src/cloud-security/cloud-security.service.scan-gcp.spec.ts
@@ -19,6 +19,7 @@ interface ScanGcpParams {
   credentials: Record<string, unknown>;
   variables: Record<string, unknown>;
   enabledServices: string[] | undefined;
+  disabledServices: ReadonlySet<string>;
   connectionId: string;
   organizationId: string;
   providerSlug: string;
@@ -42,6 +43,7 @@ const PARAMS: ScanGcpParams = {
   credentials: { access_token: 'tok' },
   variables: { project_ids: ['p1', 'p2'] },
   enabledServices: undefined,
+  disabledServices: new Set<string>(),
   connectionId: 'icn_1',
   organizationId: 'org_1',
   providerSlug: 'gcp',
@@ -208,5 +210,49 @@ describe('CloudSecurityService.scanGcp', () => {
       passed: true,
       severity: 'info',
     });
+  });
+
+  it('excludes checks for a disabled service from the direct-API run', async () => {
+    mockGetManifest.mockReturnValue({
+      checks: [
+        { id: 'gcp-storage-no-public-access' }, // → cloud-storage
+        { id: 'gcp-iam-no-primitive-roles' }, // → iam
+      ],
+    });
+    mockRunAllChecks.mockResolvedValue(directCheckResult('failed'));
+    gcpService.scanSecurityFindings.mockRejectedValue(
+      new Error('Security Command Center Legacy has been disabled by Google.'),
+    );
+
+    await callScanGcp(service, {
+      ...PARAMS,
+      disabledServices: new Set(['cloud-storage']),
+    });
+
+    // Only the iam check is handed to the runner — the disabled storage check is dropped.
+    const firstCallArg = mockRunAllChecks.mock.calls[0][0] as {
+      manifest: { checks: Array<{ id: string }> };
+    };
+    expect(firstCallArg.manifest.checks.map((c) => c.id)).toEqual([
+      'gcp-iam-no-primitive-roles',
+    ]);
+  });
+
+  it('runs no direct checks (returns []) when every covered service is disabled', async () => {
+    mockGetManifest.mockReturnValue({
+      checks: [{ id: 'gcp-storage-no-public-access' }], // only cloud-storage
+    });
+    gcpService.scanSecurityFindings.mockRejectedValue(
+      new Error('Security Command Center Legacy has been disabled by Google.'),
+    );
+
+    const result = await callScanGcp(service, {
+      ...PARAMS,
+      disabledServices: new Set(['cloud-storage']),
+    });
+
+    expect(result.findings).toEqual([]);
+    expect(result.scanMode).toBe(GCP_SCAN_MODE_DIRECT);
+    expect(mockRunAllChecks).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/cloud-security/cloud-security.service.scan-gcp.spec.ts
+++ b/apps/api/src/cloud-security/cloud-security.service.scan-gcp.spec.ts
@@ -1,0 +1,212 @@
+jest.mock('@db', () => ({ db: {}, Prisma: {} }));
+
+const mockGetManifest = jest.fn();
+const mockRunAllChecks = jest.fn();
+jest.mock('@trycompai/integration-platform', () => ({
+  getManifest: (...args: unknown[]) => mockGetManifest(...args),
+  runAllChecks: (...args: unknown[]) => mockRunAllChecks(...args),
+}));
+
+import {
+  CloudSecurityService,
+  type SecurityFinding,
+} from './cloud-security.service';
+import { GCP_SCAN_MODE_DIRECT, GCP_SCAN_MODE_SCC } from './gcp-scan-fallback';
+
+type Ctor = ConstructorParameters<typeof CloudSecurityService>;
+
+interface ScanGcpParams {
+  credentials: Record<string, unknown>;
+  variables: Record<string, unknown>;
+  enabledServices: string[] | undefined;
+  connectionId: string;
+  organizationId: string;
+  providerSlug: string;
+}
+
+function callScanGcp(
+  service: CloudSecurityService,
+  params: ScanGcpParams,
+): Promise<{ findings: SecurityFinding[]; scanMode: string }> {
+  return (
+    service as unknown as {
+      scanGcp: (p: ScanGcpParams) => Promise<{
+        findings: SecurityFinding[];
+        scanMode: string;
+      }>;
+    }
+  ).scanGcp(params);
+}
+
+const PARAMS: ScanGcpParams = {
+  credentials: { access_token: 'tok' },
+  variables: { project_ids: ['p1', 'p2'] },
+  enabledServices: undefined,
+  connectionId: 'icn_1',
+  organizationId: 'org_1',
+  providerSlug: 'gcp',
+};
+
+const directCheckResult = (
+  status: 'success' | 'failed' | 'error',
+  error?: string,
+) => ({
+  durationMs: 1,
+  totalFindings: status === 'failed' ? 1 : 0,
+  totalPassing: status === 'success' ? 1 : 0,
+  results: [
+    {
+      checkId: 'storage-public-access',
+      checkName: 'Storage public access',
+      status,
+      error,
+      durationMs: 1,
+      result: {
+        logs: [],
+        summary: {
+          totalChecked: 1,
+          passed: status === 'success' ? 1 : 0,
+          failed: status === 'failed' ? 1 : 0,
+        },
+        findings:
+          status === 'failed'
+            ? [
+                {
+                  status: 'open' as const,
+                  title: 'Bucket publicly accessible: b1',
+                  description: 'public',
+                  resourceType: 'gcp-storage-bucket',
+                  resourceId: 'p1/b1',
+                  severity: 'high' as const,
+                  remediation: 'fix it',
+                  evidence: { bucket: 'b1' },
+                },
+              ]
+            : [],
+        passingResults:
+          status === 'success'
+            ? [
+                {
+                  collectedAt: new Date(),
+                  title: 'Bucket private: b2',
+                  description: 'ok',
+                  resourceType: 'gcp-storage-bucket',
+                  resourceId: 'p1/b2',
+                  evidence: { bucket: 'b2' },
+                },
+              ]
+            : [],
+      },
+    },
+  ],
+});
+
+describe('CloudSecurityService.scanGcp', () => {
+  let gcpService: { scanSecurityFindings: jest.Mock };
+  let service: CloudSecurityService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    gcpService = { scanSecurityFindings: jest.fn() };
+    mockGetManifest.mockReturnValue({
+      checks: [{ id: 'storage-public-access' }],
+    });
+    service = new CloudSecurityService(
+      {} as unknown as Ctor[0],
+      {} as unknown as Ctor[1],
+      gcpService as unknown as Ctor[2],
+      {} as unknown as Ctor[3],
+      {} as unknown as Ctor[4],
+      {} as unknown as Ctor[5],
+    );
+  });
+
+  const sccFinding: SecurityFinding = {
+    id: 'scc-1',
+    title: 'Public Bucket Acl',
+    description: 'x',
+    severity: 'high',
+    resourceType: 'gcp-resource',
+    resourceId: 'r1',
+    evidence: { findingKey: 'gcp-cloud-storage-public-bucket-acl' },
+    createdAt: new Date().toISOString(),
+  };
+
+  it('combines our direct findings with SCC into one list, tagged gcp_scc, when SCC works', async () => {
+    mockRunAllChecks.mockResolvedValue(directCheckResult('failed'));
+    gcpService.scanSecurityFindings.mockResolvedValue([sccFinding]);
+
+    const result = await callScanGcp(service, PARAMS);
+
+    expect(result.scanMode).toBe(GCP_SCAN_MODE_SCC);
+    // One combined list: 1 direct finding + 1 SCC finding (no source split).
+    expect(result.findings).toHaveLength(2);
+    expect(result.findings.map((f) => f.title)).toEqual(
+      expect.arrayContaining([
+        'Bucket publicly accessible: b1',
+        'Public Bucket Acl',
+      ]),
+    );
+    expect(mockRunAllChecks).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    'Security Command Center Legacy has been disabled by Google. Please activate the Standard or Premium tier.',
+    'SCC_NOT_ACTIVATED: Security Command Center is not activated for project p1.',
+    'Permission denied. Grant "Security Center Findings Viewer" role at the organization level.',
+  ])(
+    'shows direct-API checks only (tagged gcp_direct) when SCC is structurally unavailable: %s',
+    async (message) => {
+      mockRunAllChecks.mockResolvedValue(directCheckResult('failed'));
+      gcpService.scanSecurityFindings.mockRejectedValue(new Error(message));
+
+      const result = await callScanGcp(service, PARAMS);
+
+      expect(result.scanMode).toBe(GCP_SCAN_MODE_DIRECT);
+      expect(result.findings).toHaveLength(1);
+      expect(result.findings[0]).toMatchObject({
+        title: 'Bucket publicly accessible: b1',
+        passed: false,
+      });
+    },
+  );
+
+  it('shows direct-API checks only when SCC errors transiently (does not abort)', async () => {
+    mockRunAllChecks.mockResolvedValue(directCheckResult('failed'));
+    gcpService.scanSecurityFindings.mockRejectedValue(
+      new Error('GCP API error (500): internal error'),
+    );
+
+    const result = await callScanGcp(service, PARAMS);
+
+    expect(result.scanMode).toBe(GCP_SCAN_MODE_DIRECT);
+    expect(result.findings).toHaveLength(1);
+  });
+
+  it('throws (preserves prior run) when our OWN checks all error, even if SCC works', async () => {
+    mockRunAllChecks.mockResolvedValue(
+      directCheckResult('error', 'invalid_grant: token expired'),
+    );
+    gcpService.scanSecurityFindings.mockResolvedValue([sccFinding]);
+
+    await expect(callScanGcp(service, PARAMS)).rejects.toThrow(
+      /GCP direct-API checks all failed/,
+    );
+  });
+
+  it('returns direct passing findings (clean account) when SCC is unavailable', async () => {
+    mockRunAllChecks.mockResolvedValue(directCheckResult('success'));
+    gcpService.scanSecurityFindings.mockRejectedValue(
+      new Error('Security Command Center Legacy has been disabled by Google.'),
+    );
+
+    const result = await callScanGcp(service, PARAMS);
+
+    expect(result.scanMode).toBe(GCP_SCAN_MODE_DIRECT);
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0]).toMatchObject({
+      passed: true,
+      severity: 'info',
+    });
+  });
+});

--- a/apps/api/src/cloud-security/cloud-security.service.ts
+++ b/apps/api/src/cloud-security/cloud-security.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { db, Prisma } from '@db';
-import { getManifest } from '@trycompai/integration-platform';
+import { getManifest, runAllChecks } from '@trycompai/integration-platform';
 import { runs, tasks } from '@trigger.dev/sdk';
 import { CredentialVaultService } from '../integration-platform/services/credential-vault.service';
 import { OAuthCredentialsService } from '../integration-platform/services/oauth-credentials.service';
@@ -9,7 +9,16 @@ import { AWSSecurityService } from './providers/aws-security.service';
 import { AzureSecurityService } from './providers/azure-security.service';
 import { AWS_SERVICE_TASK_MAPPINGS } from './aws-task-mappings';
 import { CloudReconciliationService } from './reconciliation.service';
-import { type AwsScanMode, resolveAwsScanMode } from './aws-scan-mode';
+import { resolveAwsScanMode } from './aws-scan-mode';
+import {
+  GCP_SCAN_MODE_DIRECT,
+  GCP_SCAN_MODE_SCC,
+  formatCheckLog,
+  gcpCheckResultsToFindings,
+  isSccStructurallyUnavailable,
+  toCheckCredentials,
+  toCheckVariables,
+} from './gcp-scan-fallback';
 
 export interface SecurityFinding {
   id: string;
@@ -273,26 +282,36 @@ export class CloudSecurityService {
         }
       }
 
-      // AWS-only — which engine produced this scan. Persisted on the run
-      // so reconciliation only diffs like-for-like (cross-mode findingKeys
-      // live in different namespaces). Null for GCP / Azure runs.
-      let awsScanMode: AwsScanMode | null = null;
+      // Which detection engine produced this scan. Persisted on the run so
+      // reconciliation only diffs like-for-like — different engines emit
+      // findingKeys in different namespaces, so a cross-engine diff would mark
+      // every prior finding falsely "resolved". Null for Azure.
+      //   - AWS: 'comp_scanners' | 'security_hub'
+      //   - GCP: 'gcp_scc' (Security Command Center) | 'gcp_direct' (API checks)
+      let runScanMode: string | null = null;
 
       switch (providerSlug) {
-        case 'gcp':
-          findings = await this.gcpService.scanSecurityFindings(
+        case 'gcp': {
+          const gcp = await this.scanGcp({
             credentials,
             variables,
             enabledServices,
-          );
+            connectionId,
+            organizationId,
+            providerSlug,
+          });
+          findings = gcp.findings;
+          runScanMode = gcp.scanMode;
           break;
+        }
         case 'aws': {
           // AWS scan-mode lives on connection.metadata (non-secret, frontend-
           // readable); credentials are encrypted blobs intended for the AWS
           // SDK. Read from metadata so a single source of truth.
           const metadata =
             (connection.metadata as Record<string, unknown> | null) ?? {};
-          awsScanMode = resolveAwsScanMode(metadata.awsScanMode);
+          const awsScanMode = resolveAwsScanMode(metadata.awsScanMode);
+          runScanMode = awsScanMode;
           findings = await this.awsService.scanSecurityFindings(
             credentials,
             variables,
@@ -323,7 +342,7 @@ export class CloudSecurityService {
         connectionId,
         providerSlug,
         findings,
-        awsScanMode,
+        runScanMode,
       );
 
       // Reconcile against the prior scan to record resolutions and regressions.
@@ -414,6 +433,152 @@ export class CloudSecurityService {
         error: errorMessage,
       };
     }
+  }
+
+  /**
+   * GCP Cloud Tests scan = our direct-API checks (always) + Security Command
+   * Center (when available), combined into one finding list.
+   *
+   * Our direct-API manifest checks (storage / IAM / firewall / Cloud SQL / …)
+   * read the GCP APIs directly with the OAuth token, so they always work and
+   * are the baseline. SCC is a supplement that adds its own findings (60+
+   * detector categories) on top.
+   *
+   * Google retired the free "Legacy" SCC tier, so orgs that haven't activated
+   * SCC Standard/Premium error on every SCC query. That must NOT fail the scan
+   * — it previously aborted everything and froze the dashboard (CS issue,
+   * bevri.ai 2026-06). So an SCC error just drops the SCC layer for that run;
+   * the customer still gets the direct-API checks.
+   *
+   * Both sources run in parallel. The only hard failure is when our OWN checks
+   * can't run at all (e.g. a dead token) — `scanGcpDirectChecks` throws then so
+   * the outer catch preserves the prior good run rather than storing nothing.
+   *
+   * The returned scanMode tags the run by whether SCC contributed, so
+   * reconciliation never diffs an SCC-bearing run (findings carry findingKeys)
+   * against a direct-only run (no findingKeys) — a cross-source diff would mark
+   * every prior finding falsely "resolved".
+   */
+  private async scanGcp(params: {
+    credentials: Record<string, unknown>;
+    variables: Record<string, unknown>;
+    enabledServices: string[] | undefined;
+    connectionId: string;
+    organizationId: string;
+    providerSlug: string;
+  }): Promise<{ findings: SecurityFinding[]; scanMode: string }> {
+    const {
+      credentials,
+      variables,
+      enabledServices,
+      connectionId,
+      organizationId,
+      providerSlug,
+    } = params;
+
+    const [directResult, sccResult] = await Promise.allSettled([
+      this.scanGcpDirectChecks({
+        credentials,
+        variables,
+        connectionId,
+        organizationId,
+        providerSlug,
+      }),
+      this.gcpService.scanSecurityFindings(
+        credentials,
+        variables,
+        enabledServices,
+      ),
+    ]);
+
+    // Our checks are the baseline. If they couldn't run at all, fail the scan so
+    // the prior good run is preserved (don't overwrite it with a thin result).
+    if (directResult.status === 'rejected') {
+      throw directResult.reason;
+    }
+    const directFindings = directResult.value;
+
+    // SCC is best-effort. When it works, append its findings (one combined
+    // list); when it doesn't, log why and show the direct-API checks only.
+    if (sccResult.status === 'fulfilled') {
+      return {
+        findings: [...directFindings, ...sccResult.value],
+        scanMode: GCP_SCAN_MODE_SCC,
+      };
+    }
+
+    const err = sccResult.reason;
+    const message = err instanceof Error ? err.message : String(err);
+    this.logger.warn(
+      isSccStructurallyUnavailable(err)
+        ? `GCP SCC not available for connection ${connectionId} (${message}); showing direct-API checks only`
+        : `GCP SCC scan errored for connection ${connectionId} (${message}); showing direct-API checks only this run`,
+    );
+    return { findings: directFindings, scanMode: GCP_SCAN_MODE_DIRECT };
+  }
+
+  /**
+   * Run the GCP integration-platform manifest checks (direct GCP API reads)
+   * in-process and convert their results to SecurityFindings. This is the same
+   * check set the `run-connection-checks` task runs; we run it here so the
+   * manual "Scan" button refreshes findings even when SCC is dead.
+   *
+   * Guardrail: if EVERY check errored (e.g. an invalid token or missing read
+   * access), throw instead of returning [] — an empty result would store a
+   * fresh "success" run with zero findings, hiding the prior good run and
+   * false-resolving every finding. Throwing lets the outer catch preserve the
+   * prior run.
+   */
+  private async scanGcpDirectChecks(params: {
+    credentials: Record<string, unknown>;
+    variables: Record<string, unknown>;
+    connectionId: string;
+    organizationId: string;
+    providerSlug: string;
+  }): Promise<SecurityFinding[]> {
+    const {
+      credentials,
+      variables,
+      connectionId,
+      organizationId,
+      providerSlug,
+    } = params;
+
+    const manifest = getManifest(providerSlug);
+    if (!manifest?.checks || manifest.checks.length === 0) {
+      throw new Error(
+        `GCP direct-API checks unavailable: no manifest checks for ${providerSlug}`,
+      );
+    }
+
+    const accessToken =
+      typeof credentials.access_token === 'string'
+        ? credentials.access_token
+        : undefined;
+
+    const result = await runAllChecks({
+      manifest,
+      accessToken,
+      credentials: toCheckCredentials(credentials),
+      variables: toCheckVariables(variables),
+      connectionId,
+      organizationId,
+      logger: {
+        info: (msg, data) => this.logger.log(formatCheckLog(msg, data)),
+        warn: (msg, data) => this.logger.warn(formatCheckLog(msg, data)),
+        error: (msg, data) => this.logger.error(formatCheckLog(msg, data)),
+      },
+    });
+
+    const anyCheckSucceeded = result.results.some((r) => r.status !== 'error');
+    if (!anyCheckSucceeded) {
+      const firstError = result.results.find((r) => r.error)?.error;
+      throw new Error(
+        `GCP direct-API checks all failed${firstError ? `: ${firstError}` : ''}`,
+      );
+    }
+
+    return gcpCheckResultsToFindings(result);
   }
 
   /**
@@ -668,9 +833,11 @@ export class CloudSecurityService {
     connectionId: string,
     provider: string,
     findings: SecurityFinding[],
-    // AWS only — which engine produced these findings. Stored on the run so
-    // reconciliation can avoid cross-mode diffs. Null for GCP / Azure runs.
-    awsScanMode: AwsScanMode | null,
+    // Detection engine that produced these findings — AWS scan mode
+    // ('comp_scanners'/'security_hub') or GCP source ('gcp_scc'/'gcp_direct').
+    // Stored on the run so reconciliation only diffs same-engine runs. Null for
+    // Azure / untagged runs.
+    scanMode: string | null,
   ): Promise<string> {
     const passedCount = findings.filter((f) => f.passed).length;
     const failedCount = findings.filter((f) => !f.passed).length;
@@ -705,7 +872,7 @@ export class CloudSecurityService {
           passedCount,
           failedCount,
           scannedServices,
-          scanMode: awsScanMode,
+          scanMode,
         },
       });
 

--- a/apps/api/src/cloud-security/cloud-security.service.ts
+++ b/apps/api/src/cloud-security/cloud-security.service.ts
@@ -15,6 +15,7 @@ import {
   GCP_SCAN_MODE_SCC,
   formatCheckLog,
   gcpCheckResultsToFindings,
+  isGcpCheckServiceDisabled,
   isSccStructurallyUnavailable,
   toCheckCredentials,
   toCheckVariables,
@@ -296,6 +297,7 @@ export class CloudSecurityService {
             credentials,
             variables,
             enabledServices,
+            disabledServices,
             connectionId,
             organizationId,
             providerSlug,
@@ -463,6 +465,7 @@ export class CloudSecurityService {
     credentials: Record<string, unknown>;
     variables: Record<string, unknown>;
     enabledServices: string[] | undefined;
+    disabledServices: ReadonlySet<string>;
     connectionId: string;
     organizationId: string;
     providerSlug: string;
@@ -471,6 +474,7 @@ export class CloudSecurityService {
       credentials,
       variables,
       enabledServices,
+      disabledServices,
       connectionId,
       organizationId,
       providerSlug,
@@ -480,6 +484,7 @@ export class CloudSecurityService {
       this.scanGcpDirectChecks({
         credentials,
         variables,
+        disabledServices,
         connectionId,
         organizationId,
         providerSlug,
@@ -523,15 +528,21 @@ export class CloudSecurityService {
    * check set the `run-connection-checks` task runs; we run it here so the
    * manual "Scan" button refreshes findings even when SCC is dead.
    *
-   * Guardrail: if EVERY check errored (e.g. an invalid token or missing read
-   * access), throw instead of returning [] — an empty result would store a
+   * Honors the per-service disable toggle: checks mapped to a service the user
+   * disabled are skipped (matching how the SCC path drops disabled services), so
+   * a combined run never shows findings for a service the customer turned off.
+   *
+   * Guardrail: if EVERY check that ran errored (e.g. an invalid token or missing
+   * read access), throw instead of returning [] — an empty result would store a
    * fresh "success" run with zero findings, hiding the prior good run and
    * false-resolving every finding. Throwing lets the outer catch preserve the
-   * prior run.
+   * prior run. (Zero checks because the user disabled everything is NOT a
+   * failure — that returns [] legitimately.)
    */
   private async scanGcpDirectChecks(params: {
     credentials: Record<string, unknown>;
     variables: Record<string, unknown>;
+    disabledServices: ReadonlySet<string>;
     connectionId: string;
     organizationId: string;
     providerSlug: string;
@@ -539,6 +550,7 @@ export class CloudSecurityService {
     const {
       credentials,
       variables,
+      disabledServices,
       connectionId,
       organizationId,
       providerSlug,
@@ -551,13 +563,22 @@ export class CloudSecurityService {
       );
     }
 
+    const enabledChecks = manifest.checks.filter(
+      (check) => !isGcpCheckServiceDisabled(check.id, disabledServices),
+    );
+    if (enabledChecks.length === 0) {
+      // The user disabled every service these checks cover — scan nothing here
+      // (intentional empty, not a failure). SCC may still contribute findings.
+      return [];
+    }
+
     const accessToken =
       typeof credentials.access_token === 'string'
         ? credentials.access_token
         : undefined;
 
     const result = await runAllChecks({
-      manifest,
+      manifest: { ...manifest, checks: enabledChecks },
       accessToken,
       credentials: toCheckCredentials(credentials),
       variables: toCheckVariables(variables),

--- a/apps/api/src/cloud-security/gcp-ai-remediation.prompt.ts
+++ b/apps/api/src/cloud-security/gcp-ai-remediation.prompt.ts
@@ -70,7 +70,7 @@ export type GcpFixPlan = z.infer<typeof gcpFixPlanSchema>;
 
 // ─── System Prompt ──────────────────────────────────────────────────────────
 
-export const GCP_SYSTEM_PROMPT = `You are a GCP security remediation expert. You analyze Security Command Center findings and produce structured fix plans using GCP REST API calls.
+export const GCP_SYSTEM_PROMPT = `You are a GCP security remediation expert. You analyze GCP security findings — from Security Command Center (SCC) OR from Comp AI's direct GCP API checks — and produce structured fix plans using GCP REST API calls. The two sources describe the same kinds of issues; treat them identically.
 
 A human will ALWAYS review your plan before execution. Be precise and correct.
 
@@ -187,15 +187,17 @@ For each step, provide:
 ### Pub/Sub
 - PUBSUB_CMEK_DISABLED: canAutoFix=false — CMEK cannot be added to existing topics, requires recreation
 
-## PARSING SCC FINDING EVIDENCE
+## PARSING FINDING EVIDENCE
 
-The finding evidence contains rich data from Security Command Center:
+SCC findings carry rich structured evidence:
 - resourceName: Full GCP resource path (e.g., "//storage.googleapis.com/buckets/my-bucket")
 - category: SCC finding category (e.g., "PUBLIC_BUCKET_ACL", "OPEN_FIREWALL")
 - projectDisplayName: GCP project name
 - severity: CRITICAL, HIGH, MEDIUM, LOW
 - externalUri: Link to the resource in GCP Console
 - compliances: Compliance mappings (CIS, PCI-DSS, etc.)
+
+Comp AI direct-check findings have NO SCC \`category\`/\`resourceName\`/\`externalUri\`. For those, infer the fix from the Title, Description, Existing Remediation Guidance, Resource Type, Resource ID, and whatever keys the evidence DOES carry (e.g. projectId, bucket, role, members). The Resource ID is your concrete target — e.g. resourceType "gcp-storage-bucket" with resourceId "my-proj/my-bucket" → bucket "my-bucket" in project "my-proj". Match the issue semantically to the same fix you would apply for the equivalent SCC category (e.g. a "Bucket publicly accessible" finding == PUBLIC_BUCKET_ACL; "Primitive role in use" == PRIMITIVE_ROLES_USED; "open firewall" == OPEN_FIREWALL) and apply the same canAutoFix rules.
 
 To convert resourceName to API URL:
 - "//storage.googleapis.com/buckets/my-bucket" → https://storage.googleapis.com/storage/v1/b/my-bucket
@@ -264,7 +266,7 @@ When you set canAutoFix=false, you MUST provide clear guidedSteps:
 3. For PATCH requests, ALWAYS specify updateMask in queryParams
 4. URLs must start with https:// and contain googleapis.com
 5. currentState and proposedState must use the SAME keys for comparison
-6. The fix must address the EXACT issue the SCC finding reports
+6. The fix must address the EXACT issue the finding reports (SCC or direct check)
 7. For getIamPolicy: ALWAYS include body { "options": { "requestedPolicyVersion": 3 } } — without this, auditConfigs and conditions are NOT returned
 8. For setIamPolicy: body MUST be { "policy": <FULL policy from getIamPolicy with modifications merged> }. Include etag, version, ALL bindings, and auditConfigs. A partial policy DELETES everything not included`;
 
@@ -280,9 +282,9 @@ export function buildGcpFixPlanPrompt(finding: {
   findingKey: string;
   evidence: Record<string, unknown>;
 }): string {
-  return `Analyze this GCP Security Command Center finding and generate a fix plan using GCP REST API calls.
+  return `Analyze this GCP security finding and generate a fix plan using GCP REST API calls.
 
-IMPORTANT: Your fix must change the EXACT GCP resource/setting that caused this finding. The SCC will re-check the same thing.
+IMPORTANT: Your fix must change the EXACT GCP resource/setting that caused this finding. The next scan will re-check the same thing.
 
 FINDING:
 - Title: ${finding.title}

--- a/apps/api/src/cloud-security/gcp-scan-fallback.spec.ts
+++ b/apps/api/src/cloud-security/gcp-scan-fallback.spec.ts
@@ -1,0 +1,150 @@
+import type { RunAllChecksResult } from '@trycompai/integration-platform';
+import {
+  GCP_SCAN_MODE_DIRECT,
+  GCP_SCAN_MODE_SCC,
+  gcpCheckResultsToFindings,
+  isSccStructurallyUnavailable,
+  toCheckCredentials,
+  toCheckVariables,
+} from './gcp-scan-fallback';
+
+describe('isSccStructurallyUnavailable', () => {
+  it.each([
+    'SCC_NOT_ACTIVATED: Security Command Center is not activated for project x.',
+    'Security Command Center Legacy has been disabled by Google. Please activate the Standard or Premium tier.',
+    'Permission denied. Grant "Security Center Findings Viewer" role at the organization level.',
+  ])('treats structural SCC errors as unavailable: %s', (message) => {
+    expect(isSccStructurallyUnavailable(new Error(message))).toBe(true);
+  });
+
+  it.each([
+    'OAuth scopes insufficient. Reconnect the GCP integration.',
+    'GCP API error (500): internal error',
+    'GCP API error (429): rate limited',
+    'some unexpected network blip',
+  ])('treats transient/unknown errors as NOT structural: %s', (message) => {
+    expect(isSccStructurallyUnavailable(new Error(message))).toBe(false);
+  });
+
+  it('handles non-Error throwables', () => {
+    expect(isSccStructurallyUnavailable('SCC_NOT_ACTIVATED: nope')).toBe(true);
+    expect(isSccStructurallyUnavailable(undefined)).toBe(false);
+  });
+
+  it('exposes distinct run-source tags', () => {
+    expect(GCP_SCAN_MODE_SCC).not.toBe(GCP_SCAN_MODE_DIRECT);
+  });
+});
+
+describe('toCheckCredentials', () => {
+  it('keeps strings and all-string arrays, drops everything else', () => {
+    expect(
+      toCheckCredentials({
+        access_token: 'tok',
+        regions: ['us', 'eu'],
+        count: 3,
+        nested: { a: 1 },
+        mixed: ['ok', 2],
+      }),
+    ).toEqual({ access_token: 'tok', regions: ['us', 'eu'] });
+  });
+});
+
+describe('toCheckVariables', () => {
+  it('keeps primitives + string[] + undefined, drops mixed arrays and objects', () => {
+    expect(
+      toCheckVariables({
+        project_ids: ['a', 'b'],
+        name: 'x',
+        max: 10,
+        enabled: true,
+        optional: undefined,
+        mixed: ['a', 1],
+        obj: { k: 'v' },
+      }),
+    ).toEqual({
+      project_ids: ['a', 'b'],
+      name: 'x',
+      max: 10,
+      enabled: true,
+      optional: undefined,
+    });
+  });
+});
+
+describe('gcpCheckResultsToFindings', () => {
+  const result: RunAllChecksResult = {
+    durationMs: 1,
+    totalFindings: 1,
+    totalPassing: 1,
+    results: [
+      {
+        checkId: 'storage-public-access',
+        checkName: 'Storage public access',
+        status: 'failed',
+        durationMs: 1,
+        result: {
+          logs: [],
+          summary: { totalChecked: 2, passed: 1, failed: 1 },
+          findings: [
+            {
+              status: 'open',
+              title: 'Bucket publicly accessible: b1',
+              description: 'public',
+              resourceType: 'gcp-storage-bucket',
+              resourceId: 'proj/b1',
+              severity: 'high',
+              remediation: 'remove allUsers',
+              evidence: { bucket: 'b1', findingKey: 'k1' },
+            },
+          ],
+          passingResults: [
+            {
+              collectedAt: new Date(),
+              title: 'Bucket private: b2',
+              description: 'ok',
+              resourceType: 'gcp-storage-bucket',
+              resourceId: 'proj/b2',
+              evidence: { bucket: 'b2' },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  it('maps failures to passed:false and passing to passed:true info findings', () => {
+    const findings = gcpCheckResultsToFindings(result);
+    expect(findings).toHaveLength(2);
+
+    const failure = findings.find((f) => !f.passed);
+    expect(failure).toMatchObject({
+      title: 'Bucket publicly accessible: b1',
+      severity: 'high',
+      resourceType: 'gcp-storage-bucket',
+      resourceId: 'proj/b1',
+      remediation: 'remove allUsers',
+      passed: false,
+    });
+    // Evidence preserved verbatim (findingKey carries through for reconciliation)
+    expect(failure?.evidence).toEqual({ bucket: 'b1', findingKey: 'k1' });
+
+    const passing = findings.find((f) => f.passed);
+    expect(passing).toMatchObject({
+      title: 'Bucket private: b2',
+      severity: 'info',
+      passed: true,
+    });
+  });
+
+  it('returns [] for an empty result set', () => {
+    expect(
+      gcpCheckResultsToFindings({
+        durationMs: 0,
+        totalFindings: 0,
+        totalPassing: 0,
+        results: [],
+      }),
+    ).toEqual([]);
+  });
+});

--- a/apps/api/src/cloud-security/gcp-scan-fallback.ts
+++ b/apps/api/src/cloud-security/gcp-scan-fallback.ts
@@ -11,6 +11,39 @@ export const GCP_SCAN_MODE_SCC = 'gcp_scc';
 export const GCP_SCAN_MODE_DIRECT = 'gcp_direct';
 
 /**
+ * Cloud Tests serviceId each GCP manifest check belongs to, so the direct-API
+ * checks honor the user's per-service disable toggle the same way the SCC path
+ * does. A check with NO entry here is never gated (always runs) — a missing
+ * mapping must never silently hide findings.
+ *
+ * We gate on `disabledServices` (the explicit user opt-out) rather than the
+ * full `enabledServices` set: `enabledServices` also requires a service to have
+ * been auto-detected, but the direct checks are the always-on baseline (the
+ * manual Scan button doesn't run detection first), so gating on detection could
+ * hide real findings for a service the user never disabled.
+ */
+const GCP_CHECK_SERVICE: Record<string, string> = {
+  'gcp-storage-no-public-access': 'cloud-storage',
+  'gcp-storage-encryption': 'cloud-storage',
+  'gcp-iam-no-primitive-roles': 'iam',
+  'gcp-vpc-no-open-firewalls': 'vpc-network',
+  'gcp-cloud-sql-ssl-enforced': 'cloud-sql',
+  'gcp-cloud-sql-backups-enabled': 'cloud-sql',
+  'gcp-cloud-sql-encryption': 'cloud-sql',
+  'gcp-cloud-monitoring-alerting': 'cloud-monitoring',
+  // gcp-environment-separation spans multiple services → intentionally ungated.
+};
+
+/** True when a check maps to a service the user explicitly disabled. */
+export function isGcpCheckServiceDisabled(
+  checkId: string,
+  disabledServices: ReadonlySet<string>,
+): boolean {
+  const service = GCP_CHECK_SERVICE[checkId];
+  return service !== undefined && disabledServices.has(service);
+}
+
+/**
  * True when an SCC error means SCC is structurally unavailable for the whole
  * connection (so the direct-API fallback is the right move), as opposed to a
  * transient/unknown error (where we'd rather preserve the prior run and let the

--- a/apps/api/src/cloud-security/gcp-scan-fallback.ts
+++ b/apps/api/src/cloud-security/gcp-scan-fallback.ts
@@ -1,0 +1,132 @@
+import type { RunAllChecksResult } from '@trycompai/integration-platform';
+import type { SecurityFinding } from './cloud-security.service';
+
+/**
+ * GCP run-source tags persisted on IntegrationCheckRun.scanMode so
+ * reconciliation only diffs same-source runs. Security Command Center findings
+ * carry findingKeys; direct-API findings do not — cross-diffing the two would
+ * mark every prior finding falsely "resolved".
+ */
+export const GCP_SCAN_MODE_SCC = 'gcp_scc';
+export const GCP_SCAN_MODE_DIRECT = 'gcp_direct';
+
+/**
+ * True when an SCC error means SCC is structurally unavailable for the whole
+ * connection (so the direct-API fallback is the right move), as opposed to a
+ * transient/unknown error (where we'd rather preserve the prior run and let the
+ * customer retry). Matches the structured errors thrown by
+ * GCPSecurityService.fetchFindings:
+ *   - 'SCC_NOT_ACTIVATED: …'  (SERVICE_DISABLED / not-used / 404 not-found)
+ *   - '…Security Command Center Legacy has been disabled…'
+ *   - 'Permission denied. Grant "Security Center Findings Viewer" …'
+ *
+ * Deliberately NOT matched (re-thrown so the prior run is preserved):
+ *   - 'OAuth scopes insufficient…' — the same token drives the direct checks,
+ *     so falling back would just fail again.
+ *   - 'GCP API error (5xx): …'    — likely transient; retry beats degrading.
+ */
+export function isSccStructurallyUnavailable(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.startsWith('SCC_NOT_ACTIVATED:') ||
+    message.includes('Security Command Center Legacy') ||
+    message.includes('Security Center Findings Viewer')
+  );
+}
+
+/**
+ * Convert decrypted credentials to the `string | string[]` shape the
+ * integration-platform check runner expects. Drops values that are neither a
+ * string nor an all-string array (e.g. nested objects) rather than coercing.
+ */
+export function toCheckCredentials(
+  credentials: Record<string, unknown>,
+): Record<string, string | string[]> {
+  const out: Record<string, string | string[]> = {};
+  for (const [key, value] of Object.entries(credentials)) {
+    if (typeof value === 'string') {
+      out[key] = value;
+    } else if (Array.isArray(value)) {
+      const strings = value.filter((v): v is string => typeof v === 'string');
+      if (strings.length === value.length) out[key] = strings;
+    }
+  }
+  return out;
+}
+
+/**
+ * Narrow connection.variables to the value types the check runner accepts
+ * (string | number | boolean | string[] | undefined). Mixed-type arrays and
+ * objects are dropped rather than coerced.
+ */
+export function toCheckVariables(
+  variables: Record<string, unknown>,
+): Record<string, string | number | boolean | string[] | undefined> {
+  const out: Record<string, string | number | boolean | string[] | undefined> =
+    {};
+  for (const [key, value] of Object.entries(variables)) {
+    if (
+      value === undefined ||
+      typeof value === 'string' ||
+      typeof value === 'number' ||
+      typeof value === 'boolean'
+    ) {
+      out[key] = value;
+    } else if (Array.isArray(value)) {
+      const strings = value.filter((v): v is string => typeof v === 'string');
+      if (strings.length === value.length) out[key] = strings;
+    }
+  }
+  return out;
+}
+
+/** Compact a check-runner log line + structured data into one string. */
+export function formatCheckLog(
+  message: string,
+  data?: Record<string, unknown>,
+): string {
+  return data ? `${message} ${JSON.stringify(data)}` : message;
+}
+
+/**
+ * Flatten runAllChecks output into SecurityFindings. Failures become
+ * passed:false findings; passingResults become passed:true 'info' findings.
+ * Evidence is preserved verbatim so any serviceId/findingKey carries through to
+ * grouping and reconciliation.
+ */
+export function gcpCheckResultsToFindings(
+  result: RunAllChecksResult,
+): SecurityFinding[] {
+  const now = new Date().toISOString();
+  const findings: SecurityFinding[] = [];
+  for (const checkResult of result.results) {
+    for (const finding of checkResult.result.findings) {
+      findings.push({
+        id: `${checkResult.checkId}:${finding.resourceId}`,
+        title: finding.title,
+        description: finding.description,
+        severity: finding.severity,
+        resourceType: finding.resourceType,
+        resourceId: finding.resourceId,
+        remediation: finding.remediation,
+        evidence: finding.evidence ?? {},
+        createdAt: now,
+        passed: false,
+      });
+    }
+    for (const passing of checkResult.result.passingResults) {
+      findings.push({
+        id: `${checkResult.checkId}:${passing.resourceId}`,
+        title: passing.title,
+        description: passing.description,
+        severity: 'info',
+        resourceType: passing.resourceType,
+        resourceId: passing.resourceId,
+        evidence: passing.evidence ?? {},
+        createdAt: now,
+        passed: true,
+      });
+    }
+  }
+  return findings;
+}


### PR DESCRIPTION
## Problem

Customer (Harsha, org `bevri.ai`, 2 GCP projects) reported every GCP **Scan** dies on the Security Command Center error — `"Security Command Center Legacy has been disabled by Google…"` — returns `success:false`, saves nothing, and the dashboard freezes on the last run (38 passed / 11 failed / 49 total). His fixes (removed open firewall, uniform bucket access, env labels) can never be reflected.

He correctly argued SCC isn't actually required: the 49 results were collected with SCC already disabled and carry resource-level detail that comes from reading the GCP APIs directly.

## Root cause

For GCP, the "Scan" button's path ran **only** Security Command Center:

`CloudTestsSection.handleRunScan` → `POST /v1/cloud-security/scan/:id` → `CloudSecurityService.scan()` → `switch case 'gcp'` → `gcpService.scanSecurityFindings()` (SCC REST API).

Google retired the free **"Legacy" SCC tier**, so for any org that hasn't activated SCC Standard/Premium every SCC query now errors. With both project scopes failing, the all-scopes-failed guard (PR #3108) re-throws, `scan()` returns `success:false`, and `storeFindings` is skipped — nothing is persisted, so the dashboard stays on the prior run.

The 49 findings Harsha sees come from the integration-platform direct-API checks (`runAllChecks`, the same checks `run-connection-checks` runs) — which the Scan button never invoked.

## Fix

GCP scans now run **our direct-API checks (always) + Security Command Center (when available), combined into one finding list**:

- Our direct-API manifest checks (storage / IAM / firewall / Cloud SQL / …) read the GCP APIs directly with the OAuth token, so they always work — the always-on baseline.
- SCC runs **in parallel** as a best-effort supplement: its findings are appended when it works, and it's **silently skipped** (direct-only) when it errors — Legacy disabled / not activated / permission / transient.
- **One combined list**, grouped by service. No "our checks vs SCC" split in the UI.

### Guards (so this doesn't reintroduce older bugs)

- **Preserve the prior run on catastrophic failure.** The only hard failure is when our *own* checks can't run at all (e.g. a dead token) — `scanGcpDirectChecks` throws then, so the outer catch keeps the prior good run instead of overwriting it with nothing. Keeps PR #3108's protection intact.
- **Reconciliation isolation.** SCC findings carry `findingKey`s; direct findings don't, and reconciliation picks the prior run without filtering by `checkId`. Runs are tagged `scanMode` `gcp_scc` (SCC contributed) / `gcp_direct` (direct only) — the same nullable column AWS uses for its engine discriminator — so the two never cross-diff, which would otherwise mark every prior finding falsely "resolved".

## Blast radius (verified)

- **Evidence-task automation untouched** — `runTaskIntegrationChecks` (daily schedule), `run-connection-checks`, and `autoSatisfyTasks` (AWS-only) are not modified.
- **Check engine untouched** — `runAllChecks` is *called* (read-only GETs to Google) but not modified, nor are the checks/manifest.
- **AWS/Azure scans behavior-preserving** — only an `awsScanMode` → `runScanMode` local rename.
- `scanMode` (the run column) is read **only** by `reconciliation.service.ts` — no frontend/query/history consumer — so the GCP tags affect only reconciliation's prior-run scoping (a no-op for code-based findings, which lack findingKeys).
- No frontend change needed: `handleRunScan` already refetches on success.

## Tests

- `gcp-scan-fallback.spec.ts` + `cloud-security.service.scan-gcp.spec.ts` — 20 cases (combine direct + SCC → `gcp_scc`; SCC structurally unavailable → direct-only `gcp_direct`; transient SCC error → direct-only, no abort; our own checks all-error → throw/preserve prior; clean-account passing path; helper unit tests).
- Full `cloud-security` suite green (369 passing; the 1 unrelated failing suite is a pre-existing DB/TLS env error in `remediation.controller.spec.ts`).
- Typecheck clean for changed files (remaining API errors are pre-existing AI-SDK `V3↔V2` mismatches in unrelated files).

## Notes / known follow-ups (not in this PR)

- **Overlap:** for customers with SCC active, SCC and our checks can occasionally flag the same issue (e.g. a public bucket), so it may appear twice. This is rare in practice (SCC Standard returns few findings; dead-SCC customers see none). If it ever gets noisy we can suppress SCC categories our direct checks already cover.
- The scan runs synchronously behind the ALB (300s). Fine for typical orgs; very large GCP estates may eventually want the async `run-connection-checks` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015b1aNsKBRSNPFB6dL6mxqi
