### PR TITLE
refactor(organization): typed update payload + verified-account provisioning

### DIFF
--- a/apps/api/src/auth/auth.server.ts
+++ b/apps/api/src/auth/auth.server.ts
@@ -293,6 +293,20 @@ export const auth = betterAuth({
   trustedOrigins: getTrustedOrigins(),
   emailAndPassword: {
     enabled: true,
+    requireEmailVerification: true,
+  },
+  emailVerification: {
+    sendOnSignUp: true,
+    sendVerificationEmail: async ({ user, url }) => {
+      if (process.env.NODE_ENV === 'development') {
+        console.log('[Auth] Sending verification email to:', user.email);
+      }
+      await triggerEmail({
+        to: user.email,
+        subject: 'Verify your email for Comp AI',
+        react: MagicLinkEmail({ email: user.email, url }),
+      });
+    },
   },
   advanced: {
     database: {

--- a/apps/api/src/organization-access/organization-access.service.spec.ts
+++ b/apps/api/src/organization-access/organization-access.service.spec.ts
@@ -8,6 +8,9 @@ jest.mock('@db', () => ({
       findUnique: jest.fn(),
       update: jest.fn(),
     },
+    user: {
+      findFirst: jest.fn(),
+    },
   },
 }));
 
@@ -15,6 +18,9 @@ const mockedDb = db as unknown as {
   organization: {
     findUnique: jest.Mock;
     update: jest.Mock;
+  };
+  user: {
+    findFirst: jest.Mock;
   };
 };
 
@@ -39,6 +45,7 @@ describe('OrganizationAccessService', () => {
     delete process.env.SELF_HOSTED;
     delete process.env.NEXT_PUBLIC_SELF_HOSTED;
     mockedDb.organization.update.mockResolvedValue({});
+    mockedDb.user.findFirst.mockResolvedValue({ emailVerified: true });
   });
 
   afterAll(() => {
@@ -133,6 +140,29 @@ describe('OrganizationAccessService', () => {
     });
     expect(isDomainActiveCustomer).not.toHaveBeenCalled();
     expect(mockedDb.organization.update).toHaveBeenCalled();
+  });
+
+  it('does not grant on @trycomp.ai email when the account email is unverified', async () => {
+    mockedDb.organization.findUnique.mockResolvedValue({
+      id: 'org_1',
+      hasAccess: false,
+      website: 'acme.com',
+    });
+    mockedDb.user.findFirst.mockResolvedValue({ emailVerified: false });
+    const { service, isDomainActiveCustomer } = buildService();
+
+    const result = await service.autoApproveAccess({
+      organizationId: 'org_1',
+      userEmail: 'tofik@trycomp.ai',
+    });
+
+    expect(result).toEqual({
+      hasAccess: false,
+      autoApproved: false,
+      reason: 'not-eligible',
+    });
+    expect(isDomainActiveCustomer).not.toHaveBeenCalled();
+    expect(mockedDb.organization.update).not.toHaveBeenCalled();
   });
 
   it('grants when user email domain matches org website AND is an active Stripe customer', async () => {

--- a/apps/api/src/organization-access/organization-access.service.ts
+++ b/apps/api/src/organization-access/organization-access.service.ts
@@ -80,10 +80,16 @@ export class OrganizationAccessService {
       return { hasAccess: false, autoApproved: false, reason: 'not-eligible' };
     }
 
-    const isTrycompEmail = userEmailDomain === 'trycomp.ai';
+    const isTrycompEmailDomain = userEmailDomain === 'trycomp.ai';
+
+    // Only treat an @trycomp.ai address as an internal team member once the
+    // account's email has actually been verified. The domain on its own proves
+    // nothing about who controls the mailbox.
+    const isVerifiedTrycompEmail =
+      isTrycompEmailDomain && (await this.isEmailVerified(userEmail));
 
     const canAutoApproveViaDomain =
-      !isTrycompEmail &&
+      !isTrycompEmailDomain &&
       Boolean(orgWebsiteDomain) &&
       userEmailDomain === orgWebsiteDomain &&
       !isPublicEmailDomain(userEmailDomain);
@@ -92,9 +98,9 @@ export class OrganizationAccessService {
       ? await this.stripeService.isDomainActiveCustomer(userEmailDomain)
       : false;
 
-    if (isTrycompEmail || isStripeCustomer) {
+    if (isVerifiedTrycompEmail || isStripeCustomer) {
       await this.grantAccess(organizationId);
-      const reason: AutoApproveReason = isTrycompEmail
+      const reason: AutoApproveReason = isVerifiedTrycompEmail
         ? 'trycomp-email'
         : 'stripe-customer';
       this.logger.log(
@@ -104,6 +110,17 @@ export class OrganizationAccessService {
     }
 
     return { hasAccess: false, autoApproved: false, reason: 'not-eligible' };
+  }
+
+  private async isEmailVerified(email: string | undefined): Promise<boolean> {
+    if (!email) {
+      return false;
+    }
+    const user = await db.user.findFirst({
+      where: { email },
+      select: { emailVerified: true },
+    });
+    return user?.emailVerified === true;
   }
 
   private async grantAccess(organizationId: string): Promise<void> {

--- a/apps/api/src/organization/dto/update-organization.dto.ts
+++ b/apps/api/src/organization/dto/update-organization.dto.ts
@@ -53,4 +53,24 @@ export class UpdateOrganizationDto {
   @IsOptional()
   @IsBoolean()
   backgroundCheckStepEnabled?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  evidenceApprovalEnabled?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  deviceAgentStepEnabled?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  securityTrainingStepEnabled?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  whistleblowerReportEnabled?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  accessRequestFormEnabled?: boolean;
 }

--- a/apps/api/src/organization/dto/update-organization.dto.ts
+++ b/apps/api/src/organization/dto/update-organization.dto.ts
@@ -1,14 +1,56 @@
-export interface UpdateOrganizationDto {
+import { IsBoolean, IsInt, IsOptional, IsString } from 'class-validator';
+
+/**
+ * Fields an organization member may update on their own organization.
+ *
+ * Note: this is a class (not an interface) on purpose — the global
+ * ValidationPipe runs with `whitelist` + `forbidNonWhitelisted`, which only
+ * enforce the contract when class-validator metadata survives to runtime.
+ * Properties that are not represented here are rejected by the pipe. The
+ * request/response documentation lives in `organization-api-bodies.ts`.
+ */
+export class UpdateOrganizationDto {
+  @IsOptional()
+  @IsString()
   name?: string;
+
+  @IsOptional()
+  @IsString()
   slug?: string;
+
+  @IsOptional()
+  @IsString()
   logo?: string;
+
+  @IsOptional()
+  @IsString()
   metadata?: string;
+
+  @IsOptional()
+  @IsString()
   website?: string;
+
+  @IsOptional()
+  @IsBoolean()
   onboardingCompleted?: boolean;
-  hasAccess?: boolean;
+
+  @IsOptional()
+  @IsInt()
   fleetDmLabelId?: number;
+
+  @IsOptional()
+  @IsBoolean()
   isFleetSetupCompleted?: boolean;
+
+  @IsOptional()
+  @IsString()
   primaryColor?: string;
+
+  @IsOptional()
+  @IsBoolean()
   advancedModeEnabled?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
   backgroundCheckStepEnabled?: boolean;
 }

--- a/apps/api/src/organization/organization.controller.ts
+++ b/apps/api/src/organization/organization.controller.ts
@@ -24,7 +24,7 @@ import { PermissionGuard } from '../auth/permission.guard';
 import { RequirePermission } from '../auth/require-permission.decorator';
 import { ApiKeyService } from '../auth/api-key.service';
 import type { AuthContext as AuthContextType } from '../auth/types';
-import type { UpdateOrganizationDto } from './dto/update-organization.dto';
+import { UpdateOrganizationDto } from './dto/update-organization.dto';
 import type { TransferOwnershipDto } from './dto/transfer-ownership.dto';
 import { OrganizationService } from './organization.service';
 import { GET_ORGANIZATION_RESPONSES } from './schemas/get-organization.responses';

--- a/apps/api/src/organization/organization.service.spec.ts
+++ b/apps/api/src/organization/organization.service.spec.ts
@@ -64,6 +64,23 @@ describe('OrganizationService.updateById', () => {
     expect(arg.data.website).toBe('https://acme.com');
   });
 
+  it('persists the org-owned onboarding and portal toggles', async () => {
+    await service.updateById('org_1', {
+      evidenceApprovalEnabled: true,
+      deviceAgentStepEnabled: false,
+      securityTrainingStepEnabled: false,
+      whistleblowerReportEnabled: false,
+      accessRequestFormEnabled: true,
+    });
+
+    const arg = mockedDb.organization.update.mock.calls[0][0];
+    expect(arg.data.evidenceApprovalEnabled).toBe(true);
+    expect(arg.data.deviceAgentStepEnabled).toBe(false);
+    expect(arg.data.securityTrainingStepEnabled).toBe(false);
+    expect(arg.data.whistleblowerReportEnabled).toBe(false);
+    expect(arg.data.accessRequestFormEnabled).toBe(true);
+  });
+
   it('never persists hasAccess supplied through the update payload', async () => {
     const payload = {
       name: 'New Name',

--- a/apps/api/src/organization/organization.service.spec.ts
+++ b/apps/api/src/organization/organization.service.spec.ts
@@ -1,0 +1,78 @@
+jest.mock('@db', () => ({
+  db: {
+    organization: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+  Role: {},
+}));
+
+jest.mock('../app/s3', () => ({
+  s3Client: {},
+  getSignedUrl: jest.fn(),
+  PutObjectCommand: jest.fn(),
+  GetObjectCommand: jest.fn(),
+  APP_AWS_ORG_ASSETS_BUCKET: 'bucket',
+}));
+
+jest.mock('@trycompai/auth', () => ({
+  allRoles: {},
+}));
+
+import { db } from '@db';
+import { OrganizationService } from './organization.service';
+import type { UpdateOrganizationDto } from './dto/update-organization.dto';
+
+const mockedDb = db as unknown as {
+  organization: { findUnique: jest.Mock; update: jest.Mock };
+};
+
+describe('OrganizationService.updateById', () => {
+  const service = new OrganizationService();
+  const existing = {
+    id: 'org_1',
+    name: 'Acme',
+    slug: 'acme',
+    logo: null,
+    metadata: null,
+    website: null,
+    onboardingCompleted: false,
+    hasAccess: false,
+    fleetDmLabelId: null,
+    isFleetSetupCompleted: false,
+    primaryColor: null,
+    advancedModeEnabled: false,
+    createdAt: new Date(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedDb.organization.findUnique.mockResolvedValue(existing);
+    mockedDb.organization.update.mockResolvedValue(existing);
+  });
+
+  it('persists the profile fields that were provided', async () => {
+    await service.updateById('org_1', {
+      name: 'New Name',
+      website: 'https://acme.com',
+    });
+
+    const arg = mockedDb.organization.update.mock.calls[0][0];
+    expect(arg.where).toEqual({ id: 'org_1' });
+    expect(arg.data.name).toBe('New Name');
+    expect(arg.data.website).toBe('https://acme.com');
+  });
+
+  it('never persists hasAccess supplied through the update payload', async () => {
+    const payload = {
+      name: 'New Name',
+      hasAccess: true,
+    } as unknown as UpdateOrganizationDto;
+
+    await service.updateById('org_1', payload);
+
+    const arg = mockedDb.organization.update.mock.calls[0][0];
+    expect(arg.data).not.toHaveProperty('hasAccess');
+  });
+});

--- a/apps/api/src/organization/organization.service.ts
+++ b/apps/api/src/organization/organization.service.ts
@@ -101,6 +101,11 @@ export class OrganizationService {
         primaryColor: updateData.primaryColor,
         advancedModeEnabled: updateData.advancedModeEnabled,
         backgroundCheckStepEnabled: updateData.backgroundCheckStepEnabled,
+        evidenceApprovalEnabled: updateData.evidenceApprovalEnabled,
+        deviceAgentStepEnabled: updateData.deviceAgentStepEnabled,
+        securityTrainingStepEnabled: updateData.securityTrainingStepEnabled,
+        whistleblowerReportEnabled: updateData.whistleblowerReportEnabled,
+        accessRequestFormEnabled: updateData.accessRequestFormEnabled,
       };
 
       const updatedOrganization = await db.organization.update({

--- a/apps/api/src/organization/organization.service.ts
+++ b/apps/api/src/organization/organization.service.ts
@@ -87,10 +87,25 @@ export class OrganizationService {
         throw new NotFoundException(`Organization with ID ${id} not found`);
       }
 
-      // Update the organization with only provided fields
+      // Persist only the profile fields an organization owner may change.
+      // Platform- and billing-managed flags are set through their own flows.
+      const data = {
+        name: updateData.name,
+        slug: updateData.slug,
+        logo: updateData.logo,
+        metadata: updateData.metadata,
+        website: updateData.website,
+        onboardingCompleted: updateData.onboardingCompleted,
+        fleetDmLabelId: updateData.fleetDmLabelId,
+        isFleetSetupCompleted: updateData.isFleetSetupCompleted,
+        primaryColor: updateData.primaryColor,
+        advancedModeEnabled: updateData.advancedModeEnabled,
+        backgroundCheckStepEnabled: updateData.backgroundCheckStepEnabled,
+      };
+
       const updatedOrganization = await db.organization.update({
         where: { id },
-        data: updateData,
+        data,
         select: {
           id: true,
           name: true,

--- a/apps/api/src/organization/schemas/organization-api-bodies.ts
+++ b/apps/api/src/organization/schemas/organization-api-bodies.ts
@@ -35,11 +35,6 @@ export const UPDATE_ORGANIZATION_BODY: ApiBodyOptions = {
         description: 'Whether onboarding is completed',
         example: true,
       },
-      hasAccess: {
-        type: 'boolean',
-        description: 'Whether organization has access to the platform',
-        example: true,
-      },
       fleetDmLabelId: {
         type: 'integer',
         description: 'FleetDM label ID for device management',

--- a/apps/api/src/organization/schemas/organization-api-bodies.ts
+++ b/apps/api/src/organization/schemas/organization-api-bodies.ts
@@ -61,6 +61,31 @@ export const UPDATE_ORGANIZATION_BODY: ApiBodyOptions = {
           'Whether the background-check step is required during member onboarding. Set to false to turn off the "Require background checks" setting; true to require it.',
         example: true,
       },
+      evidenceApprovalEnabled: {
+        type: 'boolean',
+        description: 'Whether evidence requires approval before it is accepted.',
+        example: false,
+      },
+      deviceAgentStepEnabled: {
+        type: 'boolean',
+        description: 'Whether the device-agent step is enabled during member onboarding.',
+        example: true,
+      },
+      securityTrainingStepEnabled: {
+        type: 'boolean',
+        description: 'Whether the security-training step is enabled during member onboarding.',
+        example: true,
+      },
+      whistleblowerReportEnabled: {
+        type: 'boolean',
+        description: 'Whether the whistleblower reporting feature is enabled.',
+        example: true,
+      },
+      accessRequestFormEnabled: {
+        type: 'boolean',
+        description: 'Whether the trust-portal access request form is enabled.',
+        example: true,
+      },
     },
     additionalProperties: false,
   },

--- a/apps/app/src/app/(app)/setup/actions/create-organization-minimal.ts
+++ b/apps/app/src/app/(app)/setup/actions/create-organization-minimal.ts
@@ -42,9 +42,11 @@ export const createOrganizationMinimal = authActionClientWithoutOrg
         };
       }
 
-      // Check if user email domain is trycomp.ai
+      // Internal team accounts (verified @trycomp.ai) have access provisioned up front.
       const userEmail = session.user.email;
-      const isTryCompEmail = userEmail?.endsWith('@trycomp.ai') ?? false;
+      const isVerifiedTryCompEmail =
+        (userEmail?.endsWith('@trycomp.ai') ?? false) &&
+        session.user.emailVerified === true;
 
       // Check if self-hosted
       const isSelfHosted = env.NEXT_PUBLIC_SELF_HOSTED === 'true';
@@ -129,9 +131,9 @@ export const createOrganizationMinimal = authActionClientWithoutOrg
           name: parsedInput.organizationName,
           website: parsedInput.website,
           onboardingCompleted: false, // Explicitly set to false
-          // Auto-enable for trycomp.ai emails, local development, or self-hosted instances
+          // Auto-enable for verified internal accounts, local development, or self-hosted instances
           ...((process.env.NEXT_PUBLIC_APP_ENV !== 'production' ||
-            isTryCompEmail ||
+            isVerifiedTryCompEmail ||
             isSelfHosted) && {
             hasAccess: true,
           }),

--- a/apps/app/src/app/(app)/setup/actions/create-organization.ts
+++ b/apps/app/src/app/(app)/setup/actions/create-organization.ts
@@ -35,9 +35,11 @@ export const createOrganization = authActionClientWithoutOrg
         };
       }
 
-      // Check if user email domain is trycomp.ai
+      // Internal team accounts (verified @trycomp.ai) have access provisioned up front.
       const userEmail = session.user.email;
-      const isTryCompEmail = userEmail?.endsWith('@trycomp.ai') ?? false;
+      const isVerifiedTryCompEmail =
+        (userEmail?.endsWith('@trycomp.ai') ?? false) &&
+        session.user.emailVerified === true;
 
       // Create a new organization directly in the database
       const randomSuffix = Math.floor(100000 + Math.random() * 900000).toString();
@@ -53,8 +55,9 @@ export const createOrganization = authActionClientWithoutOrg
         data: {
           name: parsedInput.organizationName,
           website: parsedInput.website,
-          // Auto-enable for trycomp.ai emails or local development
-          ...((process.env.NEXT_PUBLIC_APP_ENV !== 'production' || isTryCompEmail) && {
+          // Auto-enable for verified internal accounts or local development
+          ...((process.env.NEXT_PUBLIC_APP_ENV !== 'production' ||
+            isVerifiedTryCompEmail) && {
             hasAccess: true,
           }),
           members: {


### PR DESCRIPTION
## Summary

Routine hardening and cleanup across organization update and account provisioning:

- **Typed update payload** — `UpdateOrganizationDto` is now a class (was an interface), so the global `ValidationPipe` (`whitelist` + `forbidNonWhitelisted`) actually enforces the request contract at runtime. `updateById` now persists an explicit set of profile fields rather than spreading the raw request body.
- **Email verification** — credential sign-in now requires a verified email (`requireEmailVerification`, plus a verification email on sign-up).
- **Verified-account provisioning** — internal account auto-provisioning is gated on a verified email, in the auto-approve service and in both organization-creation flows.

## Test plan

- [x] `cd apps/api && npx jest src/organization src/organization-access` — 23 passing (incl. new `updateById` unit tests)
- [x] Typecheck clean for changed files
- [ ] Smoke-test sign-up / sign-in email verification in staging
- [ ] `packages/docs/openapi.json` regenerates on next API dev boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthened org update validation, kept UI toggles allowed, and gated internal access on verified emails. Credential sign-in now requires email verification to secure org provisioning.

- **Refactors**
  - Validated the update payload with a typed `UpdateOrganizationDto`; kept onboarding/portal toggles in the allowlist and OpenAPI, and `updateById` now persists only allowed fields with tests.
  - Removed `hasAccess` from the update payload/OpenAPI.

- **New Features**
  - Require email verification for email/password sign-in and send a verification email on sign-up.
  - Auto-provision internal access only for verified `@trycomp.ai` emails in org-access and both organization creation flows.

<sup>Written for commit ff069c1771a0205e7b79fc8b7901242ee697e38a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

