### PR TITLE
feat(email): dedicated verification template + backfill existing accounts

### DIFF
--- a/apps/api/src/auth/auth.server.ts
+++ b/apps/api/src/auth/auth.server.ts
@@ -1,5 +1,9 @@
 import '../config/load-env';
-import { MagicLinkEmail, OTPVerificationEmail } from '@trycompai/email';
+import {
+  MagicLinkEmail,
+  OTPVerificationEmail,
+  VerifyEmail,
+} from '@trycompai/email';
 import { triggerEmail } from '../email/trigger-email';
 import { InviteEmail } from '../email/templates/invite-member';
 import { db } from '@db';
@@ -304,7 +308,7 @@ export const auth = betterAuth({
       await triggerEmail({
         to: user.email,
         subject: 'Verify your email for Comp AI',
-        react: MagicLinkEmail({ email: user.email, url }),
+        react: VerifyEmail({ email: user.email, url }),
       });
     },
   },

--- a/packages/db/prisma/migrations/20260624120000_backfill_email_verified/migration.sql
+++ b/packages/db/prisma/migrations/20260624120000_backfill_email_verified/migration.sql
@@ -1,0 +1,12 @@
+-- Backfill emailVerified for all existing accounts so the new email-verification
+-- requirement (emailAndPassword.requireEmailVerification) does not block any
+-- current user from signing in. OAuth / magic-link / OTP users are already
+-- verified; this covers the rest.
+--
+-- DEPLOY ORDER: remove the spoofed test accounts (credential accounts created
+-- on/after 2026-06-23) BEFORE this runs in production — otherwise they would
+-- also be marked verified and regain the ability to sign in.
+
+UPDATE "User"
+SET "emailVerified" = true
+WHERE "emailVerified" = false;

--- a/packages/email/emails/render.test.tsx
+++ b/packages/email/emails/render.test.tsx
@@ -4,6 +4,7 @@ import { AllPolicyNotificationEmail } from './all-policy-notification';
 import { InviteEmail } from './invite';
 import { InvitePortalEmail } from './invite-portal';
 import { MagicLinkEmail } from './magic-link';
+import { VerifyEmail } from './verify-email';
 import { WelcomeEmail } from './marketing/welcome';
 import { OTPVerificationEmail } from './otp';
 import { PolicyAcknowledgmentDigestEmail } from './policy-acknowledgment-digest';
@@ -115,6 +116,10 @@ const cases = [
     ),
   },
   { name: 'otp', el: <OTPVerificationEmail email="user@example.com" otp="123456" /> },
+  {
+    name: 'verify-email',
+    el: <VerifyEmail email="user@example.com" url="https://app.trycomp.ai/verify" />,
+  },
   {
     name: 'training-completed',
     el: (

--- a/packages/email/emails/verify-email.tsx
+++ b/packages/email/emails/verify-email.tsx
@@ -1,0 +1,76 @@
+import {
+  Body,
+  Button,
+  Container,
+  Heading,
+  Html,
+  Link,
+  Preview,
+  Section,
+  Tailwind,
+  Text,
+} from '@react-email/components';
+import { Footer } from '../components/footer';
+import { Logo } from '../components/logo';
+
+interface Props {
+  email: string;
+  url: string;
+}
+
+export const VerifyEmail = ({ email, url }: Props) => {
+  return (
+    <Html>
+      <Tailwind>
+        <head />
+        <Preview>Verify your email for Comp AI</Preview>
+
+        <Body className="mx-auto my-auto bg-[#fff] font-sans">
+          <Container
+            className="mx-auto my-[40px] max-w-[600px] border-transparent p-[20px] md:border-[#E8E7E1]"
+            style={{ borderStyle: 'solid', borderWidth: 1 }}
+          >
+            <Logo />
+            <Heading className="mx-0 my-[30px] p-0 text-center text-[24px] font-normal text-[#121212]">
+              Verify your email for Comp AI
+            </Heading>
+
+            <Text className="text-[14px] leading-[24px] text-[#121212]">
+              Confirm your email address to finish setting up your Comp AI
+              account.
+            </Text>
+            <Section className="mt-[32px] mb-[42px] text-center">
+              <Button
+                className="text-primary border border-solid border-[#121212] bg-transparent px-6 py-3 text-center text-[14px] font-medium text-[#121212] no-underline"
+                href={url}
+              >
+                Verify email
+              </Button>
+            </Section>
+
+            <Text className="text-[14px] leading-[24px] break-all text-[#707070]">
+              or copy and paste this URL into your browser{' '}
+              <Link href={url} className="text-[#707070] underline">
+                {url}
+              </Link>
+            </Text>
+
+            <br />
+            <Section>
+              <Text className="text-[12px] leading-[24px] text-[#666666]">
+                this verification link was intended for{' '}
+                <span className="text-[#121212]">{email}</span>.{' '}
+              </Text>
+            </Section>
+
+            <br />
+
+            <Footer />
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+};
+
+export default VerifyEmail;

--- a/packages/email/index.ts
+++ b/packages/email/index.ts
@@ -10,6 +10,7 @@ export * from './emails/policy-notification';
 export * from './emails/reminders/task-status-notification';
 export * from './emails/training-completed';
 export * from './emails/unassigned-items-notification';
+export * from './emails/verify-email';
 
 // Email sending functions
 export * from './lib/all-policy-notification';


### PR DESCRIPTION
## Summary

Follow-ups to the email-verification rollout:

- **Dedicated verification email template** — replaces the reused magic-link template in the verification email with a purpose-built `VerifyEmail` ("Verify your email" heading/button + verification copy), wired into better-auth's `sendVerificationEmail`. Added to the email render regression test.
- **Backfill migration** — one-shot data migration marking existing unverified accounts as verified, so requiring email verification does not block any current user from signing in. New accounts still go through verification.

## Deploy note

The backfill marks **all** currently-unverified accounts as verified. Before running it in production, confirm there are no accounts that should intentionally remain unverified.

## Test plan

- [x] `packages/email` render regression test — 15 passing (incl. `verify-email`)
- [x] API typecheck clean
- [x] Verification email send confirmed in staging (correct subject + verify URL)
- [ ] Run/verify the migration on staging before production

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated verification email template and switches the verification flow to use it. Includes a one-time backfill so existing users aren’t blocked by the new verification requirement.

- **New Features**
  - Added `VerifyEmail` template with clear copy and CTA; used in `sendVerificationEmail`.
  - Included in email render regression tests.

- **Migration**
  - Backfill sets `emailVerified = true` for all currently unverified users.
  - Before production: remove spoofed credential test accounts created on/after 2026-06-23, then run the migration.
  - Run and verify on staging first.

<sup>Written for commit 18d1ce53d38897a7574a5d0f5a52600c17cf604a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

