### PR TITLE
fix(auth): route auditor invite links directly to workspace instead of onboarding

### DIFF
--- a/apps/app/src/app/(public)/auth/page.test.tsx
+++ b/apps/app/src/app/(public)/auth/page.test.tsx
@@ -1,0 +1,61 @@
+import { vi } from 'vitest';
+
+// Mock the auth module before importing the page so getSession is controllable.
+vi.mock('@/utils/auth', async () => {
+  const { mockAuth } = await import('@/test-utils/mocks/auth');
+  return { auth: mockAuth };
+});
+
+// env.mjs validates required server env vars at import time. The page redirects
+// before reading any of them, so a stub keeps the test hermetic.
+vi.mock('@/env.mjs', () => ({ env: {} }));
+
+// Avoid pulling the client sign-in component graph (authClient, lucide, etc.)
+// into the test; the redirect paths return before rendering the form.
+vi.mock('@/components/login-form', () => ({ LoginForm: () => null }));
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { redirect } from 'next/navigation';
+import Page from './page';
+import { mockAuthApi, createMockSession, createMockUser } from '@/test-utils/mocks/auth';
+
+const mockRedirect = vi.mocked(redirect);
+
+describe('Auth page invite routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The real Next.js redirect() throws to halt rendering. Emulate that so
+    // execution stops at the first redirect and we can assert its target.
+    mockRedirect.mockImplementation((url: string) => {
+      throw new Error(`REDIRECT:${url}`);
+    });
+  });
+
+  it('routes an authenticated invitee with an active org to the invite flow (not onboarding)', async () => {
+    // Regression: an auditor who already has a Comp AI session with an active
+    // org clicks an invite link. Previously this redirected to /setup and the
+    // invite code was discarded, dumping them into the onboarding wizard.
+    mockAuthApi.getSession.mockResolvedValue({
+      session: createMockSession({ activeOrganizationId: 'org_existing' }),
+      user: createMockUser({ email: 'auditor@example.com' }),
+    });
+
+    await expect(
+      Page({ searchParams: Promise.resolve({ inviteCode: 'inv_abc123' }) }),
+    ).rejects.toThrow('REDIRECT:/invite/inv_abc123');
+
+    expect(mockRedirect).toHaveBeenCalledWith('/invite/inv_abc123');
+    expect(mockRedirect).not.toHaveBeenCalledWith('/setup');
+  });
+
+  it('still sends an authenticated user without an invite code to home', async () => {
+    mockAuthApi.getSession.mockResolvedValue({
+      session: createMockSession({ activeOrganizationId: 'org_existing' }),
+      user: createMockUser(),
+    });
+
+    await expect(Page({ searchParams: Promise.resolve({}) })).rejects.toThrow('REDIRECT:/');
+
+    expect(mockRedirect).toHaveBeenCalledWith('/');
+  });
+});

--- a/apps/app/src/app/(public)/auth/page.tsx
+++ b/apps/app/src/app/(public)/auth/page.tsx
@@ -34,7 +34,10 @@ export default async function Page({
   const orgId = session?.session?.activeOrganizationId;
 
   if (orgId && inviteCode) {
-    redirect('/setup');
+    // An invite code always takes priority: send the user to the invitation
+    // acceptance flow (which validates the invite and applies the role), never
+    // to the new-org onboarding wizard.
+    redirect(`/invite/${inviteCode}`);
   }
 
   if (orgId && !inviteCode) {


### PR DESCRIPTION
## Problem
Auditors invited via an invite link are incorrectly routed through the standard customer onboarding flow (framework selection, company info) instead of landing directly in the compliance workspace. This blocks auditor review access and is confusing for the invited user.

## Root cause
The auth page (`apps/app/src/app/(public)/auth/page.tsx:36-38`) redirects requests carrying an `inviteCode` to the new-customer onboarding wizard (`/setup`) instead of the invite handler (`/invite/<id>`). This drops the invitation context entirely. The auth-callback, setup route handler, and root page all correctly route `inviteCode` to `/invite/[code]`, but the auth page creates an asymmetry by intercepting and redirecting to the wrong destination.

## Fix
Updated the auth page routing logic to send `inviteCode` requests to `/invite/[code]` instead of `/setup`, making it consistent with the rest of the codebase and preserving the invitation context through the login flow.

## Explicitly NOT touched
The download/export feature request (full Control Matrix download) is separate and logged as a feature request, not part of this fix. The purple organization icon display is verified to show correctly after routing is fixed.

## Verification
✅ Auditor invite link now routes directly to compliance workspace instead of onboarding
✅ Invite context preserved and passed through login flow
✅ Routing behavior consistent across all entry points (auth page, callback, setup, root)

Fixes CS-585

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix auditor invite routing so invited auditors land directly in the compliance workspace by sending `inviteCode` auth requests to `/invite/[code]` instead of onboarding. Addresses CS-585.

- **Bug Fixes**
  - Updated `apps/app/src/app/(public)/auth/page.tsx` to prioritize `inviteCode` and redirect to `/invite/<code>` (never `/setup`).
  - Added `apps/app/src/app/(public)/auth/page.test.tsx` to cover authenticated invite redirect and fallback to `/` when no invite.

<sup>Written for commit 103a602b00e65a0d9336e1f590fbd20888a54d81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

