### PR TITLE
fix(rbac): add secrets permission to custom role editor ui

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/settings/roles/components/PermissionMatrix.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/settings/roles/components/PermissionMatrix.test.tsx
@@ -258,6 +258,37 @@ describe('PermissionMatrix', () => {
       expect(RESOURCES.find((r) => r.key === 'pentest')).toBeDefined();
     });
   });
+
+  // CS-591: the role editor exposed no toggle for the `secret` resource, so
+  // admins could not grant secrets access to custom roles. Users were told to
+  // use "Integrations write", which only grants `integration:*` — the Secrets
+  // page then 403s on GET /v1/secrets (RequirePermission('secret','read')) and
+  // renders empty. The matrix must surface a dedicated Secrets toggle.
+  describe('Secrets management (CS-591)', () => {
+    it('includes secret resource in RESOURCES list', () => {
+      expect(RESOURCES.find((r) => r.key === 'secret')).toBeDefined();
+    });
+
+    it('renders a Secrets row in the matrix', () => {
+      const mockOnChange = vi.fn();
+      render(<PermissionMatrix value={{}} onChange={mockOnChange} />);
+
+      expect(screen.getByText('Secrets')).toBeInTheDocument();
+    });
+
+    it('maps Write to full secret CRUD including read (unblocks the Secrets page)', () => {
+      // accessLevelToPermissions is exactly what handleAccessChange calls when
+      // an admin picks "Write"; it must include 'read' so the assigned user
+      // passes RequirePermission('secret','read') on GET /v1/secrets.
+      expect(accessLevelToPermissions('secret', 'edit')).toEqual([
+        'create', 'read', 'update', 'delete',
+      ]);
+    });
+
+    it('maps Read (view) to secret:read', () => {
+      expect(accessLevelToPermissions('secret', 'view')).toEqual(['read']);
+    });
+  });
 });
 
 describe('Utility Functions', () => {

--- a/apps/app/src/app/(app)/[orgId]/settings/roles/components/PermissionMatrix.tsx
+++ b/apps/app/src/app/(app)/[orgId]/settings/roles/components/PermissionMatrix.tsx
@@ -34,6 +34,7 @@ const RESOURCE_LABELS: Record<string, { label: string; description: string }> = 
   questionnaire: { label: 'Questionnaires', description: 'Manage security questionnaires' },
   integration: { label: 'Integrations', description: 'Manage third-party integrations' },
   apiKey: { label: 'API Keys', description: 'Manage API keys for programmatic access' },
+  secret: { label: 'Secrets', description: 'Manage secrets and encrypted credentials for automations' },
   trust: { label: 'Trust Center', description: 'Manage trust portal settings and access requests' },
   pentest: { label: 'Penetration Tests', description: 'Manage penetration testing activities' },
 };
@@ -45,7 +46,7 @@ const RESOURCE_SECTIONS: Array<{ label: string; keys: string[] }> = [
     keys: [
       'organization', 'member', 'control', 'evidence', 'policy', 'risk',
       'vendor', 'task', 'framework', 'audit', 'finding', 'questionnaire',
-      'integration', 'apiKey', 'trust',
+      'integration', 'apiKey', 'secret', 'trust',
     ],
   },
   {


### PR DESCRIPTION
## Problem

Users with custom roles that include Integrations write access cannot view or manage secrets. The Secrets page renders empty and there is no visible permission in the custom roles UI to grant secrets management access.

## Root cause

The custom role editor (PermissionMatrix.tsx) hardcodes a list of resource labels and sections but omits the 'secret' resource entirely. The permission system on the backend already defines and enforces secret: [redacted] through the full stack (permissions.ts, secrets.controller.ts, route definitions), but the frontend editor never renders a toggle for it. When custom roles are submitted, the derived permissions list only includes resources that appear in the hardcoded RESOURCE_LABELS, so secret: [redacted] is never grantable explaining both the empty Secrets page and the missing permission gap.

## Fix

Add 'secret' to the RESOURCE_LABELS and RESOURCE_SECTIONS in PermissionMatrix.tsx. This is a purely frontend additive change. The API already validates submitted role permissions against the full statement schema which includes secret, so no backend changes are required.

## Explicitly NOT touched

- Permissions engine or validation logic
- Backend role submission or RBAC enforcement
- Secrets controller or route definitions
- Other resource permissions or sections

## Verification

✅ Custom role editor now renders a toggle for secrets permission
✅ Assigning secret: [redacted] to a custom role allows users to view and manage secrets
✅ Role submission validates correctly with secret permission included
✅ Existing admin and other role permissions remain unchanged

Fixes CS-591

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Secrets permission to the custom role editor so admins can grant secrets access. Fixes CS-591 by restoring the Secrets page for users with custom roles.

- **Bug Fixes**
  - Added `secret` to `RESOURCE_LABELS` and `RESOURCE_SECTIONS` in `PermissionMatrix.tsx` to render a “Secrets” row.
  - Mapped Read to `secret:read` and Write to CRUD (`create`, `read`, `update`, `delete`); added tests to cover both.
  - Frontend-only change; backend already supports `secret:*`. Assign the new permission to affected roles to unblock the Secrets page.

<sup>Written for commit 5f43411d8cee1928c355d72c3b6dfe920f081652. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

