### PR TITLE
feat(integration-platform): dynamic-integration self-heal layer

### DIFF
--- a/apps/api/src/integration-platform/controllers/dynamic-integrations.controller.ts
+++ b/apps/api/src/integration-platform/controllers/dynamic-integrations.controller.ts
@@ -363,7 +363,27 @@ export class DynamicIntegrationsController {
       throw new HttpException('Check not found', HttpStatus.NOT_FOUND);
     }
 
-    await this.dynamicCheckRepo.update(checkId, body);
+    // `source`/`note` are versioning metadata, not check columns — pull them out
+    // so they're never forwarded to the check update.
+    const { source, note, ...updateData } = body;
+
+    // Snapshot the current (pre-change) logic so this edit can be rolled back.
+    // Best-effort: a versioning failure must NEVER block the actual update.
+    try {
+      await this.dynamicCheckRepo.recordVersion({
+        checkId,
+        definition: check.definition as Prisma.InputJsonValue,
+        variables: check.variables as Prisma.InputJsonValue,
+        source: typeof source === 'string' ? source : 'api',
+        note: typeof note === 'string' ? note : undefined,
+      });
+    } catch (err) {
+      this.logger.error(
+        `Failed to record version for check ${checkId} (update proceeding): ${err}`,
+      );
+    }
+
+    await this.dynamicCheckRepo.update(checkId, updateData);
     await this.loaderService.invalidateCache();
 
     return { success: true };
@@ -386,6 +406,70 @@ export class DynamicIntegrationsController {
     await this.loaderService.invalidateCache();
 
     return { success: true };
+  }
+
+  /**
+   * List a check's edit history (newest first). Includes the snapshotted
+   * definition/variables so a caller can preview or diff a prior version.
+   */
+  @Get(':id/checks/:checkId/versions')
+  async listCheckVersions(
+    @Param('id') id: string,
+    @Param('checkId') checkId: string,
+  ) {
+    const check = await this.dynamicCheckRepo.findById(checkId);
+    if (!check || check.integrationId !== id) {
+      throw new HttpException('Check not found', HttpStatus.NOT_FOUND);
+    }
+
+    const versions = await this.dynamicCheckRepo.listVersions(checkId);
+    return { versions };
+  }
+
+  /**
+   * Roll a check back to a previous version. Snapshots the current logic first
+   * (so the rollback is itself reversible), then restores the chosen version's
+   * definition + variables onto the live check.
+   */
+  @Post(':id/checks/:checkId/restore/:versionId')
+  async restoreCheckVersion(
+    @Param('id') id: string,
+    @Param('checkId') checkId: string,
+    @Param('versionId') versionId: string,
+  ) {
+    const check = await this.dynamicCheckRepo.findById(checkId);
+    if (!check || check.integrationId !== id) {
+      throw new HttpException('Check not found', HttpStatus.NOT_FOUND);
+    }
+
+    const version = await this.dynamicCheckRepo.findVersionById(versionId);
+    if (!version || version.checkId !== checkId) {
+      throw new HttpException('Version not found', HttpStatus.NOT_FOUND);
+    }
+
+    // Snapshot the current state first so a restore can itself be undone.
+    // Best-effort: never block the restore on a versioning failure.
+    try {
+      await this.dynamicCheckRepo.recordVersion({
+        checkId,
+        definition: check.definition as Prisma.InputJsonValue,
+        variables: check.variables as Prisma.InputJsonValue,
+        source: 'restore',
+        note: `Restored to version ${versionId}`,
+      });
+    } catch (err) {
+      this.logger.error(
+        `Failed to snapshot before restore for check ${checkId} (restore proceeding): ${err}`,
+      );
+    }
+
+    await this.dynamicCheckRepo.update(checkId, {
+      definition: version.definition as Prisma.InputJsonValue,
+      variables: version.variables as Prisma.InputJsonValue,
+    });
+    await this.loaderService.invalidateCache();
+
+    return { success: true, restoredFrom: versionId };
   }
 
   // ==================== Activation ====================

--- a/apps/api/src/integration-platform/controllers/dynamic-integrations.versioning.spec.ts
+++ b/apps/api/src/integration-platform/controllers/dynamic-integrations.versioning.spec.ts
@@ -1,0 +1,164 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpException } from '@nestjs/common';
+import { DynamicIntegrationsController } from './dynamic-integrations.controller';
+import { InternalTokenGuard } from '../../auth/internal-token.guard';
+import { DynamicIntegrationRepository } from '../repositories/dynamic-integration.repository';
+import { DynamicCheckRepository } from '../repositories/dynamic-check.repository';
+import { ProviderRepository } from '../repositories/provider.repository';
+import { CheckRunRepository } from '../repositories/check-run.repository';
+import { DynamicManifestLoaderService } from '../services/dynamic-manifest-loader.service';
+
+jest.mock('@db', () => ({ db: {} }));
+jest.mock('@trycompai/integration-platform', () => ({
+  validateIntegrationDefinition: jest.fn(),
+  SyncDefinitionSchema: { parse: jest.fn() },
+}));
+
+describe('DynamicIntegrationsController — check versioning', () => {
+  let controller: DynamicIntegrationsController;
+
+  const INTEGRATION_ID = 'din_abc';
+  const CHECK_ID = 'dck_abc';
+
+  const oldCheck = {
+    id: CHECK_ID,
+    integrationId: INTEGRATION_ID,
+    definition: { steps: [{ type: 'code', code: 'OLD' }] },
+    variables: [{ key: 'region' }],
+  };
+
+  const dynamicCheckRepo = {
+    findById: jest.fn(),
+    update: jest.fn(),
+    recordVersion: jest.fn(),
+    listVersions: jest.fn(),
+    findVersionById: jest.fn(),
+  };
+  const loaderService = { invalidateCache: jest.fn() };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    dynamicCheckRepo.findById.mockResolvedValue(oldCheck);
+    dynamicCheckRepo.update.mockResolvedValue(oldCheck);
+    dynamicCheckRepo.recordVersion.mockResolvedValue({ id: 'dckv_1' });
+    loaderService.invalidateCache.mockResolvedValue(undefined);
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DynamicIntegrationsController],
+      providers: [
+        { provide: DynamicIntegrationRepository, useValue: {} },
+        { provide: DynamicCheckRepository, useValue: dynamicCheckRepo },
+        { provide: ProviderRepository, useValue: {} },
+        { provide: CheckRunRepository, useValue: {} },
+        { provide: DynamicManifestLoaderService, useValue: loaderService },
+      ],
+    })
+      .overrideGuard(InternalTokenGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get(DynamicIntegrationsController);
+  });
+
+  describe('updateCheck', () => {
+    it('snapshots the OLD logic before applying the update', async () => {
+      await controller.updateCheck(INTEGRATION_ID, CHECK_ID, {
+        definition: { steps: [{ type: 'code', code: 'NEW' }] },
+        source: 'agent',
+        note: 'fix project-scoped keys',
+      });
+
+      // version captured the pre-change definition/variables
+      expect(dynamicCheckRepo.recordVersion).toHaveBeenCalledWith({
+        checkId: CHECK_ID,
+        definition: oldCheck.definition,
+        variables: oldCheck.variables,
+        source: 'agent',
+        note: 'fix project-scoped keys',
+      });
+      // version recorded BEFORE the update
+      const verOrder =
+        dynamicCheckRepo.recordVersion.mock.invocationCallOrder[0];
+      const updOrder = dynamicCheckRepo.update.mock.invocationCallOrder[0];
+      expect(verOrder).toBeLessThan(updOrder);
+    });
+
+    it('strips source/note from the data forwarded to the check update', async () => {
+      await controller.updateCheck(INTEGRATION_ID, CHECK_ID, {
+        definition: { steps: [] },
+        source: 'agent',
+        note: 'x',
+      });
+      expect(dynamicCheckRepo.update).toHaveBeenCalledWith(CHECK_ID, {
+        definition: { steps: [] },
+      });
+    });
+
+    it('still applies the update if versioning fails (best-effort)', async () => {
+      dynamicCheckRepo.recordVersion.mockRejectedValueOnce(new Error('boom'));
+      const res = await controller.updateCheck(INTEGRATION_ID, CHECK_ID, {
+        definition: { steps: [] },
+      });
+      expect(res).toEqual({ success: true });
+      expect(dynamicCheckRepo.update).toHaveBeenCalled();
+    });
+
+    it('404s when the check does not belong to the integration', async () => {
+      dynamicCheckRepo.findById.mockResolvedValueOnce({
+        ...oldCheck,
+        integrationId: 'din_other',
+      });
+      await expect(
+        controller.updateCheck(INTEGRATION_ID, CHECK_ID, {}),
+      ).rejects.toBeInstanceOf(HttpException);
+      expect(dynamicCheckRepo.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('restoreCheckVersion', () => {
+    const version = {
+      id: 'dckv_1',
+      checkId: CHECK_ID,
+      definition: { steps: [{ type: 'code', code: 'RESTORED' }] },
+      variables: [],
+    };
+
+    it('snapshots current state, then restores the version logic', async () => {
+      dynamicCheckRepo.findVersionById.mockResolvedValue(version);
+
+      const res = await controller.restoreCheckVersion(
+        INTEGRATION_ID,
+        CHECK_ID,
+        'dckv_1',
+      );
+
+      expect(dynamicCheckRepo.recordVersion).toHaveBeenCalledWith(
+        expect.objectContaining({ checkId: CHECK_ID, source: 'restore' }),
+      );
+      expect(dynamicCheckRepo.update).toHaveBeenCalledWith(CHECK_ID, {
+        definition: version.definition,
+        variables: version.variables,
+      });
+      expect(res).toEqual({ success: true, restoredFrom: 'dckv_1' });
+    });
+
+    it('404s when the version belongs to a different check', async () => {
+      dynamicCheckRepo.findVersionById.mockResolvedValue({
+        ...version,
+        checkId: 'dck_other',
+      });
+      await expect(
+        controller.restoreCheckVersion(INTEGRATION_ID, CHECK_ID, 'dckv_1'),
+      ).rejects.toBeInstanceOf(HttpException);
+      expect(dynamicCheckRepo.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('listCheckVersions', () => {
+    it('returns the version history for the check', async () => {
+      dynamicCheckRepo.listVersions.mockResolvedValue([{ id: 'dckv_1' }]);
+      const res = await controller.listCheckVersions(INTEGRATION_ID, CHECK_ID);
+      expect(res).toEqual({ versions: [{ id: 'dckv_1' }] });
+    });
+  });
+});

--- a/apps/api/src/integration-platform/controllers/internal-integration-debug.controller.ts
+++ b/apps/api/src/integration-platform/controllers/internal-integration-debug.controller.ts
@@ -143,4 +143,22 @@ export class InternalIntegrationDebugController {
       limit: parseOptionalInt(limit),
     });
   }
+
+  /**
+   * The self-heal agent's work queue: check runs HELD as inconclusive (our-side /
+   * transient failures, never shown to the customer as red). The agent polls
+   * this, then diagnoses + fixes each. Filter by provider / org.
+   */
+  @Get('inconclusive-runs')
+  async listInconclusiveRuns(
+    @Query('providerSlug') providerSlug?: string,
+    @Query('organizationId') organizationId?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.debugService.listInconclusiveRuns({
+      providerSlug,
+      organizationId,
+      limit: parseOptionalInt(limit),
+    });
+  }
 }

--- a/apps/api/src/integration-platform/controllers/internal-integration-debug.controller.ts
+++ b/apps/api/src/integration-platform/controllers/internal-integration-debug.controller.ts
@@ -37,6 +37,18 @@ class TestCandidateBody {
   checkId?: string;
 }
 
+class RerunCheckBody {
+  /** The check to re-run and persist. */
+  @IsString()
+  @IsNotEmpty()
+  checkId!: string;
+
+  /** The task this run belongs to (so task-scoped history stays correct). */
+  @IsOptional()
+  @IsString()
+  taskId?: string;
+}
+
 /**
  * Internal-token-gated diagnostic toolkit for dynamic integrations. Lets an
  * operator/agent do the full debug loop over HTTP — inspect any connection,
@@ -123,6 +135,25 @@ export class InternalIntegrationDebugController {
       connectionId,
       code: body.code,
       checkId: body.checkId,
+    });
+  }
+
+  /**
+   * Re-run a single check for one connection AND PERSIST a fresh run. Called by
+   * the self-heal agent right after it applies a fix, for every connection that
+   * was held — a now-fixed check produces a fresh 'success' the customer sees,
+   * while one still failing our-side is re-held as 'inconclusive'. Unlike /run +
+   * /test (verification-only), this writes a real IntegrationCheckRun.
+   */
+  @Post('connections/:connectionId/rerun')
+  async rerunConnectionCheck(
+    @Param('connectionId') connectionId: string,
+    @Body() body: RerunCheckBody,
+  ) {
+    return this.debugService.rerunAndPersistCheck({
+      connectionId,
+      checkId: body.checkId,
+      taskId: body.taskId,
     });
   }
 

--- a/apps/api/src/integration-platform/controllers/task-integrations.controller.spec.ts
+++ b/apps/api/src/integration-platform/controllers/task-integrations.controller.spec.ts
@@ -402,6 +402,74 @@ describe('TaskIntegrationsController', () => {
       );
     });
 
+    it('does NOT mark a dynamic task done when a finding is held, even with passes', async () => {
+      mockProviderRepository.findById.mockResolvedValue({
+        id: 'prov_neon',
+        slug: 'neon',
+      });
+      mockDynamicIntegrationFindFirst.mockResolvedValue({ id: 'din_neon' });
+      mockConnectionRepository.findById.mockResolvedValue({
+        id: 'conn_1',
+        organizationId: 'org_1',
+        providerId: 'prov_neon',
+        status: 'active',
+      });
+      mockConnectionRepository.findActiveByProviderAndOrg.mockResolvedValue([
+        {
+          id: 'conn_1',
+          organizationId: 'org_1',
+          providerId: 'prov_neon',
+          metadata: {},
+          variables: {},
+        },
+      ]);
+      // One passing result + one our-side (404) held finding.
+      mockedRunAllChecks.mockResolvedValue({
+        results: [
+          {
+            checkId: 'aws-s3-encryption',
+            checkName: 'X',
+            status: 'failed',
+            durationMs: 10,
+            error: undefined,
+            result: {
+              findings: [
+                {
+                  resourceType: 'platform',
+                  resourceId: 'neon',
+                  title: 'unhealthy',
+                  description: '404',
+                  severity: 'high',
+                  remediation: 'x',
+                  evidence: { error: 'http_404' },
+                },
+              ],
+              passingResults: [
+                {
+                  resourceType: 't',
+                  resourceId: 'ok1',
+                  title: 'ok',
+                  description: 'ok',
+                },
+              ],
+              summary: { totalChecked: 2 },
+              logs: [],
+            },
+          },
+        ],
+      });
+
+      const result = await controller.runCheckForTask('task_1', 'org_1', {
+        connectionId: 'conn_1',
+        checkId: 'aws-s3-encryption',
+      });
+
+      // A held check is unresolved → the task must NOT go done (which would hide
+      // it behind the passing result); it stays indeterminate until the fix lands.
+      expect(result.taskStatus).toBeNull();
+      expect(mockTaskUpdate).not.toHaveBeenCalled();
+    });
+
     it('still fails the task for a dynamic integration on a REAL finding', async () => {
       // Same dynamic provider, but a genuine compliance finding (no error signal).
       mockProviderRepository.findById.mockResolvedValue({

--- a/apps/api/src/integration-platform/controllers/task-integrations.controller.spec.ts
+++ b/apps/api/src/integration-platform/controllers/task-integrations.controller.spec.ts
@@ -394,11 +394,12 @@ describe('TaskIntegrationsController', () => {
       // Held → indeterminate: task is neither failed nor flipped to done.
       expect(result.taskStatus).toBeNull();
       expect(mockTaskUpdate).not.toHaveBeenCalled();
-      // The run ROW is held as 'inconclusive' (not 'failed') so the customer
-      // never sees it in the task UI and the self-heal agent picks it up.
+      // The run ROW is held as 'inconclusive' (not 'failed') with failedCount 0
+      // (held findings are not confirmed failures) so no consumer can read it as
+      // a failure; the self-heal agent still picks it up via the stored results.
       expect(mockCheckRunRepository.complete).toHaveBeenCalledWith(
         'icr_x',
-        expect.objectContaining({ status: 'inconclusive' }),
+        expect.objectContaining({ status: 'inconclusive', failedCount: 0 }),
       );
     });
 

--- a/apps/api/src/integration-platform/controllers/task-integrations.controller.spec.ts
+++ b/apps/api/src/integration-platform/controllers/task-integrations.controller.spec.ts
@@ -394,6 +394,12 @@ describe('TaskIntegrationsController', () => {
       // Held → indeterminate: task is neither failed nor flipped to done.
       expect(result.taskStatus).toBeNull();
       expect(mockTaskUpdate).not.toHaveBeenCalled();
+      // The run ROW is held as 'inconclusive' (not 'failed') so the customer
+      // never sees it in the task UI and the self-heal agent picks it up.
+      expect(mockCheckRunRepository.complete).toHaveBeenCalledWith(
+        'icr_x',
+        expect.objectContaining({ status: 'inconclusive' }),
+      );
     });
 
     it('still fails the task for a dynamic integration on a REAL finding', async () => {
@@ -426,6 +432,12 @@ describe('TaskIntegrationsController', () => {
       });
 
       expect(result.taskStatus).toBe('failed');
+      // A genuine compliance finding is a REAL failure — the run row stays
+      // 'failed' (visible to the customer), never held.
+      expect(mockCheckRunRepository.complete).toHaveBeenCalledWith(
+        'icr_x',
+        expect.objectContaining({ status: 'failed' }),
+      );
     });
 
     it('does NOT fail the task when the only finding is excepted (goes done)', async () => {

--- a/apps/api/src/integration-platform/controllers/task-integrations.controller.spec.ts
+++ b/apps/api/src/integration-platform/controllers/task-integrations.controller.spec.ts
@@ -22,6 +22,10 @@ jest.mock('@db', () => ({
   db: {
     task: { findUnique: jest.fn(), update: jest.fn() },
     findingException: { findMany: jest.fn() },
+    // Self-heal hold gates on whether the provider is a dynamic integration.
+    // Default (undefined → not dynamic) keeps these static-manifest tests on
+    // their existing path.
+    dynamicIntegration: { findFirst: jest.fn() },
   },
 }));
 
@@ -46,6 +50,9 @@ const mockTaskUpdate = mockedTask.update;
 const mockFindingExceptionFindMany = (
   db as unknown as { findingException: { findMany: jest.Mock } }
 ).findingException.findMany;
+const mockDynamicIntegrationFindFirst = (
+  db as unknown as { dynamicIntegration: { findFirst: jest.Mock } }
+).dynamicIntegration.findFirst;
 
 const MANIFEST = {
   id: 'aws',
@@ -107,6 +114,41 @@ function failingResult() {
               description: 'x',
               severity: 'high',
               remediation: 'fix',
+            },
+          ],
+          passingResults: [],
+          summary: { totalChecked: 1 },
+          logs: [],
+        },
+      },
+    ],
+  };
+}
+
+// A check that "failed" for an OUR-SIDE reason (the finding's evidence carries an
+// http_404), as the self-heal layer should hold rather than show.
+function ourSideFailingResult() {
+  return {
+    results: [
+      {
+        checkId: 'aws-s3-encryption',
+        checkName: 'S3 — default encryption enabled',
+        status: 'failed',
+        durationMs: 10,
+        error: undefined,
+        result: {
+          findings: [
+            {
+              resourceType: 'platform',
+              resourceId: 'neon',
+              title: 'endpoint unhealthy',
+              description: '/projects returned HTTP 404',
+              severity: 'high',
+              remediation: 'x',
+              evidence: {
+                error: 'http_404',
+                message: '/projects returned HTTP 404',
+              },
             },
           ],
           passingResults: [],
@@ -317,6 +359,73 @@ describe('TaskIntegrationsController', () => {
           data: expect.objectContaining({ status: 'failed' }),
         }),
       );
+    });
+
+    it('HOLDS an our-side failure for a dynamic integration (task NOT failed)', async () => {
+      // Provider is a dynamic integration → the hold applies.
+      mockProviderRepository.findById.mockResolvedValue({
+        id: 'prov_neon',
+        slug: 'neon',
+      });
+      mockDynamicIntegrationFindFirst.mockResolvedValue({ id: 'din_neon' });
+      mockConnectionRepository.findById.mockResolvedValue({
+        id: 'conn_1',
+        organizationId: 'org_1',
+        providerId: 'prov_neon',
+        status: 'active',
+      });
+      mockConnectionRepository.findActiveByProviderAndOrg.mockResolvedValue([
+        {
+          id: 'conn_1',
+          organizationId: 'org_1',
+          providerId: 'prov_neon',
+          metadata: {},
+          variables: {},
+        },
+      ]);
+      // The only finding failed for an our-side reason (404).
+      mockedRunAllChecks.mockResolvedValue(ourSideFailingResult());
+
+      const result = await controller.runCheckForTask('task_1', 'org_1', {
+        connectionId: 'conn_1',
+        checkId: 'aws-s3-encryption',
+      });
+
+      // Held → indeterminate: task is neither failed nor flipped to done.
+      expect(result.taskStatus).toBeNull();
+      expect(mockTaskUpdate).not.toHaveBeenCalled();
+    });
+
+    it('still fails the task for a dynamic integration on a REAL finding', async () => {
+      // Same dynamic provider, but a genuine compliance finding (no error signal).
+      mockProviderRepository.findById.mockResolvedValue({
+        id: 'prov_neon',
+        slug: 'neon',
+      });
+      mockDynamicIntegrationFindFirst.mockResolvedValue({ id: 'din_neon' });
+      mockConnectionRepository.findById.mockResolvedValue({
+        id: 'conn_1',
+        organizationId: 'org_1',
+        providerId: 'prov_neon',
+        status: 'active',
+      });
+      mockConnectionRepository.findActiveByProviderAndOrg.mockResolvedValue([
+        {
+          id: 'conn_1',
+          organizationId: 'org_1',
+          providerId: 'prov_neon',
+          metadata: {},
+          variables: {},
+        },
+      ]);
+      mockedRunAllChecks.mockResolvedValue(failingResult());
+
+      const result = await controller.runCheckForTask('task_1', 'org_1', {
+        connectionId: 'conn_1',
+        checkId: 'aws-s3-encryption',
+      });
+
+      expect(result.taskStatus).toBe('failed');
     });
 
     it('does NOT fail the task when the only finding is excepted (goes done)', async () => {

--- a/apps/api/src/integration-platform/controllers/task-integrations.controller.ts
+++ b/apps/api/src/integration-platform/controllers/task-integrations.controller.ts
@@ -42,6 +42,7 @@ import { loadActiveExceptionSet } from '../../cloud-security/finding-exceptions'
 import {
   countEffectiveFailures,
   decideTaskStatus,
+  decideRunStatus,
   splitFailuresByDisposition,
   failureSignalsFromEvidence,
   type ClassifiableFailure,
@@ -676,23 +677,14 @@ export class TaskIntegrationsController {
         ...failureSignalsFromEvidence(f.evidence, checkResult.status),
       }));
 
-      // Per-account run status. For DYNAMIC integrations, a run that failed only
-      // for our-side/transient reasons is recorded as 'inconclusive' (the
-      // self-heal queue) instead of 'failed' — so the customer never sees it and
-      // the agent fixes it. Identical rule to the scheduled path; static
-      // integrations keep the success/failed mapping.
-      let runStatus: 'success' | 'failed' | 'inconclusive' =
-        checkResult.status === 'error' ? 'failed' : checkResult.status;
-      if (isDynamic) {
-        if (checkResult.status === 'error') {
-          runStatus = 'inconclusive';
-        } else if (
-          failures.length > 0 &&
-          splitFailuresByDisposition(failures).effective.length === 0
-        ) {
-          runStatus = 'inconclusive';
-        }
-      }
+      // Per-account run status (shared rule): a dynamic run that failed only for
+      // our-side/transient reasons is held as 'inconclusive' (customer never sees
+      // it; the agent fixes it). Static integrations keep success/failed.
+      const runStatus = decideRunStatus({
+        resultStatus: checkResult.status,
+        failures,
+        isDynamic,
+      });
 
       await this.checkRunRepository.complete(checkRun.id, {
         status: runStatus,

--- a/apps/api/src/integration-platform/controllers/task-integrations.controller.ts
+++ b/apps/api/src/integration-platform/controllers/task-integrations.controller.ts
@@ -695,7 +695,11 @@ export class TaskIntegrationsController {
           checkResult.result.passingResults.length +
             checkResult.result.findings.length,
         passedCount: checkResult.result.passingResults.length,
-        failedCount: checkResult.result.findings.length,
+        // A held (inconclusive) run has no CONFIRMED failures — its findings are
+        // our-side/transient, not real fails — so failedCount is 0. The raw
+        // findings still persist as results for the agent to diagnose.
+        failedCount:
+          runStatus === 'inconclusive' ? 0 : checkResult.result.findings.length,
         errorMessage: checkResult.error,
         logs: JSON.parse(
           JSON.stringify(checkResult.result.logs),

--- a/apps/api/src/integration-platform/controllers/task-integrations.controller.ts
+++ b/apps/api/src/integration-platform/controllers/task-integrations.controller.ts
@@ -394,6 +394,15 @@ export class TaskIntegrationsController {
     const connections =
       activeConnections.length > 0 ? activeConnections : [referencedConnection];
 
+    // Determined once: a dynamic integration holds our-side/transient failures
+    // as 'inconclusive' — both on each per-account run row (so the customer never
+    // sees it and the self-heal agent picks it up) AND excluded from task status
+    // below. Mirrors the scheduled path.
+    const isDynamic = !!(await db.dynamicIntegration.findFirst({
+      where: { slug: provider.slug, isActive: true },
+      select: { id: true },
+    }));
+
     let totalFindings = 0;
     let totalPassing = 0;
     let accountsRun = 0;
@@ -416,6 +425,7 @@ export class TaskIntegrationsController {
         checkDef,
         taskId,
         organizationId,
+        isDynamic,
       });
       accountsRun += 1;
       totalFindings += outcome.findings;
@@ -442,10 +452,6 @@ export class TaskIntegrationsController {
     // (same rule as the scheduled path): they must not fail the task. Static/AWS
     // behavior is unchanged. Safe degradation: a finding with no readable error
     // signal classifies as a real failure, exactly as today.
-    const isDynamic = !!(await db.dynamicIntegration.findFirst({
-      where: { slug: provider.slug, isActive: true },
-      select: { id: true },
-    }));
     const statusFailures = isDynamic
       ? splitFailuresByDisposition(failingFindings).effective
       : failingFindings;
@@ -455,7 +461,10 @@ export class TaskIntegrationsController {
         `Held ${heldCount} our-side/transient finding(s) as inconclusive for task ${taskId} (manual run; not shown as failed)`,
       );
     }
-    const effectiveFailures = countEffectiveFailures(statusFailures, exceptions);
+    const effectiveFailures = countEffectiveFailures(
+      statusFailures,
+      exceptions,
+    );
     // Held findings are indeterminate — exclude them from the finding count so an
     // all-held run doesn't flip the task to "done" either.
     const newStatus = decideTaskStatus(
@@ -521,8 +530,16 @@ export class TaskIntegrationsController {
     checkDef: IntegrationCheckDef;
     taskId: string;
     organizationId: string;
+    isDynamic: boolean;
   }): Promise<ConnectionCheckOutcome> {
-    const { connection, manifest, checkDef, taskId, organizationId } = params;
+    const {
+      connection,
+      manifest,
+      checkDef,
+      taskId,
+      organizationId,
+      isDynamic,
+    } = params;
     const connectionId = connection.id;
 
     // Create the run up front so even an account that fails credential
@@ -648,8 +665,37 @@ export class TaskIntegrationsController {
         await this.checkRunRepository.addResults(resultsToStore);
       }
 
+      // Classifiable failures for this account — built once, used for both the
+      // held-run decision below and the returned outcome (the caller aggregates
+      // them for task status).
+      const failures = checkResult.result.findings.map((f) => ({
+        connectionId,
+        checkId: checkDef.id,
+        resourceId: f.resourceId,
+        // Redacted error signals for self-heal classification (dynamic only).
+        ...failureSignalsFromEvidence(f.evidence, checkResult.status),
+      }));
+
+      // Per-account run status. For DYNAMIC integrations, a run that failed only
+      // for our-side/transient reasons is recorded as 'inconclusive' (the
+      // self-heal queue) instead of 'failed' — so the customer never sees it and
+      // the agent fixes it. Identical rule to the scheduled path; static
+      // integrations keep the success/failed mapping.
+      let runStatus: 'success' | 'failed' | 'inconclusive' =
+        checkResult.status === 'error' ? 'failed' : checkResult.status;
+      if (isDynamic) {
+        if (checkResult.status === 'error') {
+          runStatus = 'inconclusive';
+        } else if (
+          failures.length > 0 &&
+          splitFailuresByDisposition(failures).effective.length === 0
+        ) {
+          runStatus = 'inconclusive';
+        }
+      }
+
       await this.checkRunRepository.complete(checkRun.id, {
-        status: checkResult.status === 'error' ? 'failed' : checkResult.status,
+        status: runStatus,
         durationMs: checkResult.durationMs,
         totalChecked:
           checkResult.result.summary?.totalChecked ||
@@ -664,7 +710,7 @@ export class TaskIntegrationsController {
       });
 
       this.logger.log(
-        `Check ${checkDef.id} for task ${taskId} (connection ${connectionId}): ${checkResult.status} - ${checkResult.result.findings.length} findings, ${checkResult.result.passingResults.length} passing`,
+        `Check ${checkDef.id} for task ${taskId} (connection ${connectionId}): ${runStatus} - ${checkResult.result.findings.length} findings, ${checkResult.result.passingResults.length} passing`,
       );
 
       return {
@@ -673,13 +719,7 @@ export class TaskIntegrationsController {
         status: checkResult.status,
         findings: checkResult.result.findings.length,
         passing: checkResult.result.passingResults.length,
-        failures: checkResult.result.findings.map((f) => ({
-          connectionId,
-          checkId: checkDef.id,
-          resourceId: f.resourceId,
-          // Redacted error signals for self-heal classification (dynamic only).
-          ...failureSignalsFromEvidence(f.evidence, checkResult.status),
-        })),
+        failures,
       };
     } catch (error) {
       await this.checkRunRepository.complete(checkRun.id, {

--- a/apps/api/src/integration-platform/controllers/task-integrations.controller.ts
+++ b/apps/api/src/integration-platform/controllers/task-integrations.controller.ts
@@ -42,6 +42,9 @@ import { loadActiveExceptionSet } from '../../cloud-security/finding-exceptions'
 import {
   countEffectiveFailures,
   decideTaskStatus,
+  splitFailuresByDisposition,
+  failureSignalsFromEvidence,
+  type ClassifiableFailure,
 } from '../utils/task-check-evaluation';
 import {
   capEvidence,
@@ -62,8 +65,9 @@ interface ConnectionCheckOutcome {
   status: 'success' | 'failed' | 'error';
   findings: number;
   passing: number;
-  /** resourceIds of this account's failing findings, for exception filtering. */
-  failingResourceIds: string[];
+  /** This account's failing findings (+ redacted error signals) for exception
+   *  filtering and self-heal classification. */
+  failures: ClassifiableFailure[];
 }
 
 interface TaskIntegrationCheck {
@@ -397,11 +401,7 @@ export class TaskIntegrationsController {
     let lastCheckRunId: string | undefined;
     // Failing findings across all accounts (keyed like an exception) so task
     // status can exclude explicitly-excepted ones below.
-    const failingFindings: Array<{
-      connectionId: string;
-      checkId: string;
-      resourceId: string;
-    }> = [];
+    const failingFindings: ClassifiableFailure[] = [];
 
     // Sequential so each per-account run commits as it completes — a slow or
     // failing account still leaves the earlier accounts' results persisted.
@@ -421,9 +421,7 @@ export class TaskIntegrationsController {
       totalFindings += outcome.findings;
       totalPassing += outcome.passing;
       if (outcome.status === 'error') hasExecutionError = true;
-      for (const resourceId of outcome.failingResourceIds) {
-        failingFindings.push({ connectionId: conn.id, checkId, resourceId });
-      }
+      failingFindings.push(...outcome.failures);
       lastCheckRunId = outcome.checkRunId;
     }
 
@@ -440,14 +438,30 @@ export class TaskIntegrationsController {
     // rule, via the shared helpers). Any real (non-excepted) finding → failed;
     // else any passing result → done; else leave unchanged.
     const exceptions = await loadActiveExceptionSet(organizationId);
-    const effectiveFailures = countEffectiveFailures(
-      failingFindings,
-      exceptions,
-    );
+    // For DYNAMIC integrations, hold our-side/transient failures as inconclusive
+    // (same rule as the scheduled path): they must not fail the task. Static/AWS
+    // behavior is unchanged. Safe degradation: a finding with no readable error
+    // signal classifies as a real failure, exactly as today.
+    const isDynamic = !!(await db.dynamicIntegration.findFirst({
+      where: { slug: provider.slug, isActive: true },
+      select: { id: true },
+    }));
+    const statusFailures = isDynamic
+      ? splitFailuresByDisposition(failingFindings).effective
+      : failingFindings;
+    const heldCount = failingFindings.length - statusFailures.length;
+    if (heldCount > 0) {
+      this.logger.log(
+        `Held ${heldCount} our-side/transient finding(s) as inconclusive for task ${taskId} (manual run; not shown as failed)`,
+      );
+    }
+    const effectiveFailures = countEffectiveFailures(statusFailures, exceptions);
+    // Held findings are indeterminate — exclude them from the finding count so an
+    // all-held run doesn't flip the task to "done" either.
     const newStatus = decideTaskStatus(
       effectiveFailures,
       totalPassing,
-      totalFindings,
+      totalFindings - heldCount,
     );
 
     if (newStatus) {
@@ -603,7 +617,7 @@ export class TaskIntegrationsController {
           status: 'error',
           findings: 0,
           passing: 0,
-          failingResourceIds: [],
+          failures: [],
         };
       }
 
@@ -659,9 +673,13 @@ export class TaskIntegrationsController {
         status: checkResult.status,
         findings: checkResult.result.findings.length,
         passing: checkResult.result.passingResults.length,
-        failingResourceIds: checkResult.result.findings.map(
-          (f) => f.resourceId,
-        ),
+        failures: checkResult.result.findings.map((f) => ({
+          connectionId,
+          checkId: checkDef.id,
+          resourceId: f.resourceId,
+          // Redacted error signals for self-heal classification (dynamic only).
+          ...failureSignalsFromEvidence(f.evidence, checkResult.status),
+        })),
       };
     } catch (error) {
       await this.checkRunRepository.complete(checkRun.id, {
@@ -683,7 +701,7 @@ export class TaskIntegrationsController {
         status: 'error',
         findings: 0,
         passing: 0,
-        failingResourceIds: [],
+        failures: [],
       };
     }
   }

--- a/apps/api/src/integration-platform/controllers/task-integrations.controller.ts
+++ b/apps/api/src/integration-platform/controllers/task-integrations.controller.ts
@@ -472,6 +472,7 @@ export class TaskIntegrationsController {
       effectiveFailures,
       totalPassing,
       totalFindings - heldCount,
+      heldCount,
     );
 
     if (newStatus) {

--- a/apps/api/src/integration-platform/repositories/check-run.repository.spec.ts
+++ b/apps/api/src/integration-platform/repositories/check-run.repository.spec.ts
@@ -143,7 +143,7 @@ describe('CheckRunRepository.findLatestPerConnectionAndCheckByTask', () => {
     expect(result.filter((r) => r.id === 'rA')).toHaveLength(1);
   });
 
-  it('excludes disconnected connections in both queries', async () => {
+  it('excludes disconnected connections and held (inconclusive) runs in both queries', async () => {
     mockGroupBy.mockResolvedValue([
       {
         connectionId: 'A',
@@ -165,6 +165,13 @@ describe('CheckRunRepository.findLatestPerConnectionAndCheckByTask', () => {
       expect(call[0].where.connection).toEqual({
         status: { not: 'disconnected' },
       });
+      // Held runs are never surfaced to the customer.
+      expect(call[0].where.status).toEqual({ not: 'inconclusive' });
+    }
+    // groupBy must exclude held runs too, so a check with ONLY held runs yields
+    // no group → that account shows "not run yet", never a red.
+    for (const call of mockGroupBy.mock.calls) {
+      expect(call[0].where.status).toEqual({ not: 'inconclusive' });
     }
   });
 

--- a/apps/api/src/integration-platform/repositories/check-run.repository.ts
+++ b/apps/api/src/integration-platform/repositories/check-run.repository.ts
@@ -209,6 +209,13 @@ export class CheckRunRepository {
     const where = {
       taskId,
       connection: { status: { not: 'disconnected' } },
+      // Held (our-side/transient) runs are stored as `inconclusive` so the
+      // self-heal agent can fix them under the hood, but the customer must NEVER
+      // see them. Excluding them here means the task UI shows each account's
+      // latest REAL (non-held) run — or nothing if a check has only ever been
+      // held ("not run yet") — never a red caused by our own bug. Once the
+      // agent's fix lands, the next real run surfaces here normally.
+      status: { not: 'inconclusive' },
     } satisfies Prisma.IntegrationCheckRunWhereInput;
 
     // Every (connection, check) group that has runs for this task, with its

--- a/apps/api/src/integration-platform/repositories/check-run.repository.ts
+++ b/apps/api/src/integration-platform/repositories/check-run.repository.ts
@@ -27,7 +27,9 @@ export interface CreateCheckRunDto {
 }
 
 export interface CompleteCheckRunDto {
-  status: 'success' | 'failed';
+  // 'inconclusive' = held our-side/transient failure (dynamic self-heal queue);
+  // hidden from the customer and picked up by the agent. See run paths.
+  status: 'success' | 'failed' | 'inconclusive';
   durationMs: number;
   totalChecked: number;
   passedCount: number;

--- a/apps/api/src/integration-platform/repositories/dynamic-check.repository.ts
+++ b/apps/api/src/integration-platform/repositories/dynamic-check.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { db } from '@db';
-import type { DynamicCheck, Prisma } from '@db';
+import type { DynamicCheck, DynamicCheckVersion, Prisma } from '@db';
 
 @Injectable()
 export class DynamicCheckRepository {
@@ -55,6 +55,43 @@ export class DynamicCheckRepository {
 
   async delete(id: string): Promise<void> {
     await db.dynamicCheck.delete({ where: { id } });
+  }
+
+  // ==================== Version history (rollback + audit) ====================
+
+  /**
+   * Record an immutable snapshot of a check's logic. Call this with the check's
+   * CURRENT (pre-change) definition + variables BEFORE applying an edit, so the
+   * snapshot is a rollback point. Never store secrets in `note`.
+   */
+  async recordVersion(data: {
+    checkId: string;
+    definition: Prisma.InputJsonValue;
+    variables: Prisma.InputJsonValue;
+    source?: string;
+    note?: string;
+  }): Promise<DynamicCheckVersion> {
+    return db.dynamicCheckVersion.create({
+      data: {
+        checkId: data.checkId,
+        definition: data.definition,
+        variables: data.variables,
+        source: data.source ?? 'api',
+        note: data.note,
+      },
+    });
+  }
+
+  /** List a check's version history, newest first. */
+  async listVersions(checkId: string): Promise<DynamicCheckVersion[]> {
+    return db.dynamicCheckVersion.findMany({
+      where: { checkId },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async findVersionById(id: string): Promise<DynamicCheckVersion | null> {
+    return db.dynamicCheckVersion.findUnique({ where: { id } });
   }
 
   async deleteAllForIntegration(integrationId: string): Promise<void> {

--- a/apps/api/src/integration-platform/services/check-failure-classifier.spec.ts
+++ b/apps/api/src/integration-platform/services/check-failure-classifier.spec.ts
@@ -1,0 +1,80 @@
+import { classifyCheckFailure } from './check-failure-classifier';
+
+describe('classifyCheckFailure', () => {
+  it('treats a runtime exception as our-side', () => {
+    const r = classifyCheckFailure({ threw: true, errorText: 'x is not a function' });
+    expect(r.class).toBe('our_side');
+    expect(r.customerActionable).toBe(false);
+  });
+
+  it('treats a failure with no execution signal as a real compliance finding', () => {
+    const r = classifyCheckFailure({});
+    expect(r.class).toBe('compliance');
+  });
+
+  it.each([500, 502, 503, 408, 429])('treats HTTP %i as transient', (status) => {
+    expect(classifyCheckFailure({ httpStatus: status }).class).toBe('transient');
+  });
+
+  it.each([
+    'request timed out',
+    'fetch failed',
+    'ECONNRESET',
+    'service unavailable',
+  ])('treats network text "%s" as transient', (errorText) => {
+    expect(classifyCheckFailure({ errorText }).class).toBe('transient');
+  });
+
+  it.each([401, 403])('treats HTTP %i as customer-side + actionable', (status) => {
+    const r = classifyCheckFailure({ httpStatus: status });
+    expect(r.class).toBe('customer_side');
+    expect(r.customerActionable).toBe(true);
+  });
+
+  it.each([
+    'Invalid API key',
+    'token has expired',
+    'your key was revoked',
+    'organization is not entitled for api access',
+    'please upgrade your plan',
+  ])('treats creds/plan text "%s" as customer-side', (errorText) => {
+    expect(classifyCheckFailure({ errorText }).class).toBe('customer_side');
+  });
+
+  it.each([
+    'not allowed to perform actions outside the project this key is scoped to',
+    'org_id is required',
+    'not allowed for organization API keys',
+    'this endpoint is deprecated',
+    'res.text is not a function',
+  ])('treats our-bug text "%s" as our-side', (errorText) => {
+    expect(classifyCheckFailure({ errorText }).class).toBe('our_side');
+  });
+
+  it.each([404, 400, 405, 422])('treats HTTP %i as our-side', (status) => {
+    expect(classifyCheckFailure({ httpStatus: status }).class).toBe('our_side');
+  });
+
+  it('never blames the customer for an ambiguous execution failure (defaults our-side)', () => {
+    const r = classifyCheckFailure({ errorText: 'something weird happened' });
+    expect(r.class).toBe('our_side');
+    expect(r.customerActionable).toBe(false);
+  });
+
+  it('treats a customer-looking error as our-side when the whole fleet is failing', () => {
+    const r = classifyCheckFailure({
+      httpStatus: 403,
+      fleet: { passing: 0, failing: 5 },
+    });
+    expect(r.class).toBe('our_side');
+  });
+
+  it('keeps a 401 as customer-side when other connections are passing', () => {
+    const r = classifyCheckFailure({
+      httpStatus: 401,
+      fleet: { passing: 9, failing: 1 },
+    });
+    expect(r.class).toBe('customer_side');
+    expect(r.customerActionable).toBe(true);
+  });
+});

--- a/apps/api/src/integration-platform/services/check-failure-classifier.ts
+++ b/apps/api/src/integration-platform/services/check-failure-classifier.ts
@@ -1,0 +1,138 @@
+/**
+ * Classifies WHY a dynamic-integration check failed, so the self-heal layer can
+ * decide what the customer sees:
+ *
+ *   - 'compliance'    → the check evaluated fine and returned a real finding
+ *                        (customer is genuinely non-compliant). SHOW as a fail.
+ *   - 'transient'     → timeout / 5xx / rate-limit. RETRY, show nothing.
+ *   - 'customer_side' → their credentials / plan / config. Show "action needed".
+ *   - 'our_side'      → our bug / a vendor change we don't handle yet. HIDE the
+ *                        red, hand to the agent / open a ticket.
+ *
+ * Guiding rule (the product guarantee): NEVER blame the customer without positive
+ * proof. Any ambiguous EXECUTION failure defaults to 'our_side', and a customer-
+ * looking error that is actually failing fleet-wide is treated as 'our_side'.
+ *
+ * Pure function — no I/O, no secrets. `errorText` MUST be pre-redacted by the caller.
+ */
+
+export type FailureClass =
+  | 'compliance'
+  | 'transient'
+  | 'customer_side'
+  | 'our_side';
+
+export interface ClassifyInput {
+  /** HTTP status the failure carried, if any (e.g. 401, 404, 503). */
+  httpStatus?: number | null;
+  /** Error message / response-body snippet. MUST already be redacted of secrets. */
+  errorText?: string | null;
+  /** True if the runtime itself threw (a code error), not a vendor response. */
+  threw?: boolean;
+  /**
+   * Optional fleet signal for the SAME check across the provider's other active
+   * connections. Used only to avoid blaming a single customer for a fleet-wide
+   * (i.e. our-side) breakage.
+   */
+  fleet?: { passing: number; failing: number } | null;
+}
+
+export interface ClassifyResult {
+  class: FailureClass;
+  reason: string;
+  /** True only for a confirmed customer_side result (safe to ask them to act). */
+  customerActionable: boolean;
+}
+
+const TRANSIENT_RE =
+  /(timeout|timed out|etimedout|econnreset|econnrefused|socket hang up|network error|fetch failed|eai_again|temporarily unavailable|service unavailable|try again)/i;
+
+const CUSTOMER_RE =
+  /(invalid api key|invalid token|invalid credentials|unauthorized|authentication failed|access denied|token (has )?expired|expired token|revoked|not entitled|api access is not|no access to the api|upgrade your plan|plan does ?n.?t include|plan does not include|insufficient (permission|scope|privileges))/i;
+
+const OUR_SIDE_RE =
+  /(scoped to|org_id is required|not allowed for organization|deprecated|no longer supported|is not a function|cannot read propert|undefined is not|unexpected (token|response|status|end of)|method not allowed|missing_header|malformed)/i;
+
+function make(
+  cls: FailureClass,
+  reason: string,
+  customerActionable = false,
+): ClassifyResult {
+  return { class: cls, reason, customerActionable };
+}
+
+export function classifyCheckFailure(input: ClassifyInput): ClassifyResult {
+  const status = input.httpStatus ?? null;
+  const text = input.errorText ?? '';
+  const fleet = input.fleet ?? null;
+  // "Failing for many, passing for none" = almost certainly our bug, not one
+  // customer's problem.
+  const fleetWide = !!fleet && fleet.failing >= 2 && fleet.passing === 0;
+
+  // 1. A runtime exception in our own code is unambiguously our-side.
+  if (input.threw) {
+    return make('our_side', 'Runtime error while executing the check.');
+  }
+
+  const hasHttpError = status != null && status >= 400;
+  const hasErrorText = text.trim().length > 0;
+
+  // 2. No execution-failure signal at all → the check evaluated and returned a
+  //    genuine finding. Show it (this is the product working correctly).
+  if (!hasHttpError && !hasErrorText) {
+    return make('compliance', 'Check evaluated and returned a finding.');
+  }
+
+  // 3. Transient — retry, show nothing.
+  if (
+    status === 408 ||
+    status === 425 ||
+    status === 429 ||
+    (status != null && status >= 500) ||
+    TRANSIENT_RE.test(text)
+  ) {
+    return make('transient', 'Transient network/availability error.');
+  }
+
+  // 4. Customer-side — requires a positive signal (hard 401/403 or an explicit
+  //    creds/plan message). Even then, if the whole fleet is failing it is ours.
+  const customerSignal = status === 401 || status === 403 || CUSTOMER_RE.test(text);
+  if (customerSignal) {
+    if (fleetWide) {
+      return make(
+        'our_side',
+        'Auth/plan-looking error, but the check is failing fleet-wide → treat as our-side.',
+      );
+    }
+    return make(
+      'customer_side',
+      'Authentication/authorization/plan issue specific to this connection.',
+      true,
+    );
+  }
+
+  // 5. Known our-side shapes: 4xx on endpoints we should handle, deprecated
+  //    endpoints, unhandled response shapes, etc.
+  if (
+    status === 404 ||
+    status === 400 ||
+    status === 405 ||
+    status === 422 ||
+    OUR_SIDE_RE.test(text)
+  ) {
+    return make(
+      'our_side',
+      'Endpoint/response our check does not handle (our bug or a vendor change).',
+    );
+  }
+
+  // 6. Fleet tiebreaker + conservative default: never blame the customer without
+  //    proof — any remaining ambiguous execution failure is treated as our-side.
+  if (fleetWide) {
+    return make('our_side', 'Ambiguous error failing fleet-wide → our-side.');
+  }
+  return make(
+    'our_side',
+    'Ambiguous execution failure → defaulting to our-side (never blame the customer without proof).',
+  );
+}

--- a/apps/api/src/integration-platform/services/internal-integration-debug.service.spec.ts
+++ b/apps/api/src/integration-platform/services/internal-integration-debug.service.spec.ts
@@ -1,8 +1,15 @@
 jest.mock('@db', () => ({
   db: {
     integrationConnection: { findMany: jest.fn(), findUnique: jest.fn() },
-    integrationCredentialVersion: { findUnique: jest.fn(), findMany: jest.fn() },
-    integrationCheckRun: { findFirst: jest.fn(), findMany: jest.fn() },
+    integrationCredentialVersion: {
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+    },
+    integrationCheckRun: {
+      findFirst: jest.fn(),
+      findMany: jest.fn(),
+      groupBy: jest.fn(),
+    },
     integrationOAuthError: { findMany: jest.fn() },
   },
 }));
@@ -22,14 +29,16 @@ const encryptedBlob = {
 const mockedDb = db as unknown as {
   integrationConnection: { findMany: jest.Mock; findUnique: jest.Mock };
   integrationCredentialVersion: { findUnique: jest.Mock; findMany: jest.Mock };
-  integrationCheckRun: { findFirst: jest.Mock; findMany: jest.Mock };
+  integrationCheckRun: {
+    findFirst: jest.Mock;
+    findMany: jest.Mock;
+    groupBy: jest.Mock;
+  };
   integrationOAuthError: { findMany: jest.Mock };
 };
 
 const makeService = (runner: Partial<ConnectionCheckRunnerService> = {}) =>
-  new InternalIntegrationDebugService(
-    runner as ConnectionCheckRunnerService,
-  );
+  new InternalIntegrationDebugService(runner as ConnectionCheckRunnerService);
 
 describe('InternalIntegrationDebugService', () => {
   afterEach(() => jest.clearAllMocks());
@@ -87,8 +96,14 @@ describe('InternalIntegrationDebugService', () => {
         present: true,
         value: 'https://www.zohoapis.eu',
       });
-      expect(fields.scope).toEqual({ present: true, value: 'ZohoCRM.users.READ' });
-      expect(fields.region).toEqual({ present: true, value: 'us2.ninjarmm.com' });
+      expect(fields.scope).toEqual({
+        present: true,
+        value: 'ZohoCRM.users.READ',
+      });
+      expect(fields.region).toEqual({
+        present: true,
+        value: 'us2.ninjarmm.com',
+      });
 
       // Absolutely no plaintext secret value anywhere in the response.
       expect(JSON.stringify(connections)).not.toContain('should-be-masked');
@@ -236,7 +251,16 @@ describe('InternalIntegrationDebugService', () => {
         organizationId: 'org_42',
       });
       const runCandidateCheck = jest.fn().mockResolvedValue({
-        results: [{ checkId: 'candidate', result: { findings: [], passingResults: [{ title: 'ok' }], logs: [] } }],
+        results: [
+          {
+            checkId: 'candidate',
+            result: {
+              findings: [],
+              passingResults: [{ title: 'ok' }],
+              logs: [],
+            },
+          },
+        ],
         totalFindings: 0,
         totalPassing: 1,
         durationMs: 7,
@@ -303,13 +327,14 @@ describe('InternalIntegrationDebugService', () => {
 
   describe('listInconclusiveRuns (self-heal work queue)', () => {
     it('queries only inconclusive runs, filtered by provider, newest first', async () => {
+      const completedAt = new Date();
       mockedDb.integrationCheckRun.findMany.mockResolvedValue([
         {
           id: 'icr_1',
           checkId: 'neon_app_availability',
           checkName: 'App Availability',
           status: 'inconclusive',
-          completedAt: new Date(),
+          completedAt,
           connection: {
             id: 'icn_1',
             organizationId: 'org_1',
@@ -326,6 +351,14 @@ describe('InternalIntegrationDebugService', () => {
           ],
         },
       ]);
+      // Latest run for this (conn, check) IS the inconclusive one → kept.
+      mockedDb.integrationCheckRun.groupBy.mockResolvedValue([
+        {
+          connectionId: 'icn_1',
+          checkId: 'neon_app_availability',
+          _max: { completedAt },
+        },
+      ]);
 
       const service = makeService();
       const { runs, total } = await service.listInconclusiveRuns({
@@ -340,6 +373,54 @@ describe('InternalIntegrationDebugService', () => {
       expect(args.where.connection.provider).toEqual({ slug: 'neon' });
       expect(args.orderBy).toEqual({ completedAt: 'desc' });
       expect(args.take).toBe(10);
+    });
+
+    it('drops a stale inconclusive run when a newer run superseded it', async () => {
+      const stale = new Date('2026-06-01T00:00:00Z');
+      const newer = new Date('2026-06-02T00:00:00Z');
+      mockedDb.integrationCheckRun.findMany.mockResolvedValue([
+        {
+          id: 'icr_old',
+          checkId: 'neon_app_availability',
+          checkName: 'App Availability',
+          status: 'inconclusive',
+          completedAt: stale,
+          connection: {
+            id: 'icn_1',
+            organizationId: 'org_1',
+            provider: { slug: 'neon', name: 'Neon' },
+          },
+          results: [],
+        },
+      ]);
+      // A newer run (e.g. a success after we fixed it) exists for the same pair.
+      mockedDb.integrationCheckRun.groupBy.mockResolvedValue([
+        {
+          connectionId: 'icn_1',
+          checkId: 'neon_app_availability',
+          _max: { completedAt: newer },
+        },
+      ]);
+
+      const service = makeService();
+      const { runs, total } = await service.listInconclusiveRuns({
+        providerSlug: 'neon',
+        limit: 10,
+      });
+
+      expect(total).toBe(0);
+      expect(runs).toHaveLength(0);
+    });
+
+    it('returns empty without a groupBy query when nothing is held', async () => {
+      mockedDb.integrationCheckRun.findMany.mockResolvedValue([]);
+
+      const service = makeService();
+      const { runs, total } = await service.listInconclusiveRuns({ limit: 10 });
+
+      expect(total).toBe(0);
+      expect(runs).toHaveLength(0);
+      expect(mockedDb.integrationCheckRun.groupBy).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/integration-platform/services/internal-integration-debug.service.spec.ts
+++ b/apps/api/src/integration-platform/services/internal-integration-debug.service.spec.ts
@@ -300,4 +300,46 @@ describe('InternalIntegrationDebugService', () => {
       expect(Number.isFinite(args.take)).toBe(true);
     });
   });
+
+  describe('listInconclusiveRuns (self-heal work queue)', () => {
+    it('queries only inconclusive runs, filtered by provider, newest first', async () => {
+      mockedDb.integrationCheckRun.findMany.mockResolvedValue([
+        {
+          id: 'icr_1',
+          checkId: 'neon_app_availability',
+          checkName: 'App Availability',
+          status: 'inconclusive',
+          completedAt: new Date(),
+          connection: {
+            id: 'icn_1',
+            organizationId: 'org_1',
+            provider: { slug: 'neon', name: 'Neon' },
+          },
+          results: [
+            {
+              resourceId: 'neon',
+              resourceType: 'platform',
+              title: 'x',
+              description: 'y',
+              evidence: { error: 'http_404' },
+            },
+          ],
+        },
+      ]);
+
+      const service = makeService();
+      const { runs, total } = await service.listInconclusiveRuns({
+        providerSlug: 'neon',
+        limit: 10,
+      });
+
+      expect(total).toBe(1);
+      expect(runs[0].status).toBe('inconclusive');
+      const args = mockedDb.integrationCheckRun.findMany.mock.calls[0][0];
+      expect(args.where.status).toBe('inconclusive');
+      expect(args.where.connection.provider).toEqual({ slug: 'neon' });
+      expect(args.orderBy).toEqual({ completedAt: 'desc' });
+      expect(args.take).toBe(10);
+    });
+  });
 });

--- a/apps/api/src/integration-platform/services/internal-integration-debug.service.spec.ts
+++ b/apps/api/src/integration-platform/services/internal-integration-debug.service.spec.ts
@@ -11,6 +11,7 @@ jest.mock('@db', () => ({
       groupBy: jest.fn(),
     },
     integrationOAuthError: { findMany: jest.fn() },
+    dynamicIntegration: { findFirst: jest.fn() },
   },
 }));
 
@@ -18,6 +19,7 @@ import { NotFoundException } from '@nestjs/common';
 import { db } from '@db';
 import { InternalIntegrationDebugService } from './internal-integration-debug.service';
 import type { ConnectionCheckRunnerService } from './connection-check-runner.service';
+import type { CheckRunRepository } from '../repositories/check-run.repository';
 
 const encryptedBlob = {
   encrypted: 'Y2lwaGVydGV4dA==',
@@ -35,10 +37,17 @@ const mockedDb = db as unknown as {
     groupBy: jest.Mock;
   };
   integrationOAuthError: { findMany: jest.Mock };
+  dynamicIntegration: { findFirst: jest.Mock };
 };
 
-const makeService = (runner: Partial<ConnectionCheckRunnerService> = {}) =>
-  new InternalIntegrationDebugService(runner as ConnectionCheckRunnerService);
+const makeService = (
+  runner: Partial<ConnectionCheckRunnerService> = {},
+  checkRunRepo: Partial<CheckRunRepository> = {},
+) =>
+  new InternalIntegrationDebugService(
+    runner as ConnectionCheckRunnerService,
+    checkRunRepo as CheckRunRepository,
+  );
 
 describe('InternalIntegrationDebugService', () => {
   afterEach(() => jest.clearAllMocks());
@@ -421,6 +430,102 @@ describe('InternalIntegrationDebugService', () => {
       expect(total).toBe(0);
       expect(runs).toHaveLength(0);
       expect(mockedDb.integrationCheckRun.groupBy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('rerunAndPersistCheck (self-heal re-run + persist)', () => {
+    const runResult = (status: string, findings: unknown[] = []) => ({
+      results: [
+        {
+          checkId: 'neon_x',
+          checkName: 'Neon X',
+          status,
+          durationMs: 5,
+          error: undefined,
+          result: {
+            findings,
+            passingResults:
+              status === 'success'
+                ? [
+                    {
+                      resourceType: 't',
+                      resourceId: 'r',
+                      title: 'ok',
+                      description: 'ok',
+                    },
+                  ]
+                : [],
+            summary: { totalChecked: 1 },
+            logs: [],
+          },
+        },
+      ],
+    });
+
+    const makeRepo = () => ({
+      create: jest.fn().mockResolvedValue({ id: 'icr_new' }),
+      addResults: jest.fn().mockResolvedValue({}),
+      complete: jest.fn().mockResolvedValue({}),
+    });
+
+    it('persists a fresh SUCCESS run when the fixed check now passes', async () => {
+      mockedDb.integrationConnection.findUnique.mockResolvedValue({
+        organizationId: 'org_1',
+        provider: { slug: 'neon' },
+      });
+      mockedDb.dynamicIntegration.findFirst.mockResolvedValue({
+        id: 'din_neon',
+      });
+      const runChecks = jest.fn().mockResolvedValue(runResult('success'));
+      const repo = makeRepo();
+
+      const service = makeService({ runChecks }, repo);
+      const out = await service.rerunAndPersistCheck({
+        connectionId: 'icn_1',
+        checkId: 'neon_x',
+        taskId: 'task_1',
+      });
+
+      expect(out.status).toBe('success');
+      expect(repo.complete).toHaveBeenCalledWith(
+        'icr_new',
+        expect.objectContaining({ status: 'success' }),
+      );
+    });
+
+    it('re-holds as INCONCLUSIVE when the check still fails our-side (404)', async () => {
+      mockedDb.integrationConnection.findUnique.mockResolvedValue({
+        organizationId: 'org_1',
+        provider: { slug: 'neon' },
+      });
+      mockedDb.dynamicIntegration.findFirst.mockResolvedValue({
+        id: 'din_neon',
+      });
+      const runChecks = jest.fn().mockResolvedValue(
+        runResult('failed', [
+          {
+            resourceType: 'platform',
+            resourceId: 'neon',
+            title: 'unhealthy',
+            description: '404',
+            evidence: { error: 'http_404' },
+          },
+        ]),
+      );
+      const repo = makeRepo();
+
+      const service = makeService({ runChecks }, repo);
+      const out = await service.rerunAndPersistCheck({
+        connectionId: 'icn_1',
+        checkId: 'neon_x',
+        taskId: 'task_1',
+      });
+
+      expect(out.status).toBe('inconclusive');
+      expect(repo.complete).toHaveBeenCalledWith(
+        'icr_new',
+        expect.objectContaining({ status: 'inconclusive' }),
+      );
     });
   });
 });

--- a/apps/api/src/integration-platform/services/internal-integration-debug.service.spec.ts
+++ b/apps/api/src/integration-platform/services/internal-integration-debug.service.spec.ts
@@ -382,6 +382,9 @@ describe('InternalIntegrationDebugService', () => {
       expect(args.where.connection.provider).toEqual({ slug: 'neon' });
       expect(args.orderBy).toEqual({ completedAt: 'desc' });
       expect(args.take).toBe(10);
+      // Nested failing results are BOUNDED so a check with thousands of findings
+      // can't dump an unbounded payload to the agent poller.
+      expect(args.select.results.take).toBe(20);
     });
 
     it('drops a stale inconclusive run when a newer run superseded it', async () => {

--- a/apps/api/src/integration-platform/services/internal-integration-debug.service.spec.ts
+++ b/apps/api/src/integration-platform/services/internal-integration-debug.service.spec.ts
@@ -524,7 +524,7 @@ describe('InternalIntegrationDebugService', () => {
       expect(out.status).toBe('inconclusive');
       expect(repo.complete).toHaveBeenCalledWith(
         'icr_new',
-        expect.objectContaining({ status: 'inconclusive' }),
+        expect.objectContaining({ status: 'inconclusive', failedCount: 0 }),
       );
     });
   });

--- a/apps/api/src/integration-platform/services/internal-integration-debug.service.ts
+++ b/apps/api/src/integration-platform/services/internal-integration-debug.service.ts
@@ -540,7 +540,10 @@ export class InternalIntegrationDebugService {
         checkResult.result.passingResults.length +
           checkResult.result.findings.length,
       passedCount: checkResult.result.passingResults.length,
-      failedCount: checkResult.result.findings.length,
+      // Held (inconclusive) runs have no CONFIRMED failures — findings persist as
+      // results for the agent, but the run shows 0 failures.
+      failedCount:
+        status === 'inconclusive' ? 0 : checkResult.result.findings.length,
       errorMessage: checkResult.error,
       logs: JSON.parse(
         JSON.stringify(checkResult.result.logs),

--- a/apps/api/src/integration-platform/services/internal-integration-debug.service.ts
+++ b/apps/api/src/integration-platform/services/internal-integration-debug.service.ts
@@ -43,12 +43,14 @@ export class InternalIntegrationDebugService {
    * Build a non-sensitive view of a credential payload. Never decrypts; never
    * returns a secret value.
    */
-  private buildCredentialMetadata(version: {
-    version: number;
-    createdAt: Date;
-    expiresAt: Date | null;
-    encryptedPayload: unknown;
-  } | null) {
+  private buildCredentialMetadata(
+    version: {
+      version: number;
+      createdAt: Date;
+      expiresAt: Date | null;
+      encryptedPayload: unknown;
+    } | null,
+  ) {
     if (!version) return null;
     const payload =
       version.encryptedPayload && typeof version.encryptedPayload === 'object'
@@ -77,7 +79,9 @@ export class InternalIntegrationDebugService {
       version: version.version,
       createdAt: version.createdAt,
       expiresAt: version.expiresAt,
-      expired: version.expiresAt ? version.expiresAt.getTime() < Date.now() : false,
+      expired: version.expiresAt
+        ? version.expiresAt.getTime() < Date.now()
+        : false,
       fields,
     };
   }
@@ -357,7 +361,7 @@ export class InternalIntegrationDebugService {
     const limit = Number.isFinite(rawLimit)
       ? Math.min(Math.max(rawLimit, 1), 200)
       : 50;
-    const runs = await db.integrationCheckRun.findMany({
+    const candidates = await db.integrationCheckRun.findMany({
       where: {
         status: 'inconclusive',
         connection: {
@@ -391,6 +395,41 @@ export class InternalIntegrationDebugService {
           },
         },
       },
+    });
+    if (candidates.length === 0) return { runs: [], total: 0 };
+
+    // Runs are append-only and a held `inconclusive` status is never cleared, so
+    // once a check recovers (or we fix it) a newer run exists and the old
+    // inconclusive row becomes stale. Surface a check only if its LATEST run is
+    // still inconclusive — otherwise the agent would re-attempt already-healthy
+    // checks on every poll. (The agent also re-verifies live as a backstop.)
+    const pairs = new Map<string, { connectionId: string; checkId: string }>();
+    for (const run of candidates) {
+      const key = `${run.connection.id} ${run.checkId}`;
+      if (!pairs.has(key)) {
+        pairs.set(key, {
+          connectionId: run.connection.id,
+          checkId: run.checkId,
+        });
+      }
+    }
+    const latestPerPair = await db.integrationCheckRun.groupBy({
+      by: ['connectionId', 'checkId'],
+      where: { OR: Array.from(pairs.values()) },
+      _max: { completedAt: true },
+    });
+    const latestByPair = new Map(
+      latestPerPair.map((g) => [
+        `${g.connectionId} ${g.checkId}`,
+        g._max.completedAt?.getTime() ?? 0,
+      ]),
+    );
+    const runs = candidates.filter((run) => {
+      const latest =
+        latestByPair.get(`${run.connection.id} ${run.checkId}`) ?? 0;
+      // Keep only if this inconclusive run is the latest for its (conn, check) —
+      // i.e. no newer run (of any status) has superseded it.
+      return (run.completedAt?.getTime() ?? 0) >= latest;
     });
     return { runs, total: runs.length };
   }

--- a/apps/api/src/integration-platform/services/internal-integration-debug.service.ts
+++ b/apps/api/src/integration-platform/services/internal-integration-debug.service.ts
@@ -397,6 +397,11 @@ export class InternalIntegrationDebugService {
         },
         results: {
           where: { passed: false },
+          // Bound the nested failing results: a check can produce thousands of
+          // findings (each with evidence). The agent only needs a sample to
+          // diagnose (it reads the first few), so cap the payload per run.
+          take: 20,
+          orderBy: { collectedAt: 'asc' },
           select: {
             resourceId: true,
             resourceType: true,

--- a/apps/api/src/integration-platform/services/internal-integration-debug.service.ts
+++ b/apps/api/src/integration-platform/services/internal-integration-debug.service.ts
@@ -1,9 +1,15 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { db } from '@db';
+import type { Prisma } from '@db';
 import {
   ConnectionCheckRunnerService,
   type RunAllChecksResult,
 } from './connection-check-runner.service';
+import { CheckRunRepository } from '../repositories/check-run.repository';
+import {
+  decideRunStatus,
+  failureSignalsFromEvidence,
+} from '../utils/task-check-evaluation';
 
 /**
  * Read-only/diagnostic toolkit for dynamic integrations, used by internal
@@ -26,7 +32,10 @@ export class InternalIntegrationDebugService {
   private static readonly SECRET_KEY_RE =
     /(secret|password|passwd|pwd|private|access[_-]?token|refresh[_-]?token|client[_-]?secret|api[_-]?key|apikey|bearer|signing)/i;
 
-  constructor(private readonly runner: ConnectionCheckRunnerService) {}
+  constructor(
+    private readonly runner: ConnectionCheckRunnerService,
+    private readonly checkRunRepository: CheckRunRepository,
+  ) {}
 
   private isEncryptedData(value: unknown): boolean {
     return (
@@ -377,6 +386,8 @@ export class InternalIntegrationDebugService {
         checkName: true,
         status: true,
         completedAt: true,
+        // taskId so the agent can re-run + persist for the right task after a fix.
+        taskId: true,
         connection: {
           select: {
             id: true,
@@ -432,5 +443,113 @@ export class InternalIntegrationDebugService {
       return (run.completedAt?.getTime() ?? 0) >= latest;
     });
     return { runs, total: runs.length };
+  }
+
+  /**
+   * Re-run ONE check for ONE connection AND PERSIST a fresh run. Used by the
+   * self-heal agent right after it applies a fix: re-running every affected
+   * customer's connection means a now-fixed check produces a fresh 'success'
+   * (the customer sees green without doing anything), while one still failing
+   * for an our-side reason is re-held as 'inconclusive' (still hidden). Unlike
+   * /run + /test (verification-only, never persist) this writes a real run via
+   * the same create -> addResults -> complete path the run paths use, so the run
+   * status is decided by the SAME shared rule (held vs shown).
+   */
+  async rerunAndPersistCheck(params: {
+    connectionId: string;
+    checkId: string;
+    taskId?: string | null;
+  }): Promise<{ status: 'success' | 'failed' | 'inconclusive' }> {
+    const { connectionId, checkId, taskId } = params;
+    const connection = await db.integrationConnection.findUnique({
+      where: { id: connectionId },
+      select: { organizationId: true, provider: { select: { slug: true } } },
+    });
+    if (!connection) {
+      throw new NotFoundException(`Connection ${connectionId} not found`);
+    }
+
+    // Execute on the real runtime in-process (runChecks never persists).
+    const result = await this.runner.runChecks({
+      connectionId,
+      organizationId: connection.organizationId,
+      checkId,
+    });
+    const checkResult = result.results[0];
+    if (!checkResult) {
+      throw new NotFoundException(
+        `Check ${checkId} produced no result for connection ${connectionId}`,
+      );
+    }
+
+    const isDynamic = !!(await db.dynamicIntegration.findFirst({
+      where: { slug: connection.provider?.slug ?? '', isActive: true },
+      select: { id: true },
+    }));
+
+    const failures = checkResult.result.findings.map((f) => ({
+      connectionId,
+      checkId,
+      resourceId: f.resourceId,
+      ...failureSignalsFromEvidence(f.evidence, checkResult.status),
+    }));
+    const status = decideRunStatus({
+      resultStatus: checkResult.status,
+      failures,
+      isDynamic,
+    });
+
+    const checkRun = await this.checkRunRepository.create({
+      connectionId,
+      taskId: taskId ?? undefined,
+      checkId,
+      checkName: checkResult.checkName,
+    });
+    const resultsToStore = [
+      ...checkResult.result.passingResults.map((r) => ({
+        checkRunId: checkRun.id,
+        passed: true,
+        resourceType: r.resourceType,
+        resourceId: r.resourceId,
+        title: r.title,
+        description: r.description,
+        evidence: r.evidence
+          ? (JSON.parse(JSON.stringify(r.evidence)) as Prisma.InputJsonValue)
+          : undefined,
+      })),
+      ...checkResult.result.findings.map((f) => ({
+        checkRunId: checkRun.id,
+        passed: false,
+        resourceType: f.resourceType,
+        resourceId: f.resourceId,
+        title: f.title,
+        description: f.description,
+        severity: f.severity,
+        remediation: f.remediation,
+        evidence: f.evidence as Prisma.InputJsonValue,
+      })),
+    ];
+    if (resultsToStore.length > 0) {
+      await this.checkRunRepository.addResults(resultsToStore);
+    }
+    await this.checkRunRepository.complete(checkRun.id, {
+      status,
+      durationMs: checkResult.durationMs,
+      totalChecked:
+        checkResult.result.summary?.totalChecked ??
+        checkResult.result.passingResults.length +
+          checkResult.result.findings.length,
+      passedCount: checkResult.result.passingResults.length,
+      failedCount: checkResult.result.findings.length,
+      errorMessage: checkResult.error,
+      logs: JSON.parse(
+        JSON.stringify(checkResult.result.logs),
+      ) as Prisma.InputJsonValue,
+    });
+
+    this.logger.log(
+      `Self-heal re-run: connection ${connectionId}, check ${checkId} -> ${status}`,
+    );
+    return { status };
   }
 }

--- a/apps/api/src/integration-platform/services/internal-integration-debug.service.ts
+++ b/apps/api/src/integration-platform/services/internal-integration-debug.service.ts
@@ -339,4 +339,59 @@ export class InternalIntegrationDebugService {
     });
     return { errors, total: errors.length };
   }
+
+  /**
+   * The self-heal agent's work queue: check runs HELD as inconclusive (an
+   * our-side / transient failure the customer never saw as a red "failed"). The
+   * agent polls this, then diagnoses + fixes each via run/test/PATCH. Newest
+   * first. Failing results (with evidence) are included so the agent can classify
+   * without an extra round-trip.
+   */
+  async listInconclusiveRuns(params: {
+    providerSlug?: string;
+    organizationId?: string;
+    limit?: number;
+  }) {
+    const { providerSlug, organizationId } = params;
+    const rawLimit = params.limit ?? NaN;
+    const limit = Number.isFinite(rawLimit)
+      ? Math.min(Math.max(rawLimit, 1), 200)
+      : 50;
+    const runs = await db.integrationCheckRun.findMany({
+      where: {
+        status: 'inconclusive',
+        connection: {
+          ...(organizationId ? { organizationId } : {}),
+          ...(providerSlug ? { provider: { slug: providerSlug } } : {}),
+        },
+      },
+      orderBy: { completedAt: 'desc' },
+      take: limit,
+      select: {
+        id: true,
+        checkId: true,
+        checkName: true,
+        status: true,
+        completedAt: true,
+        connection: {
+          select: {
+            id: true,
+            organizationId: true,
+            provider: { select: { slug: true, name: true } },
+          },
+        },
+        results: {
+          where: { passed: false },
+          select: {
+            resourceId: true,
+            resourceType: true,
+            title: true,
+            description: true,
+            evidence: true,
+          },
+        },
+      },
+    });
+    return { runs, total: runs.length };
+  }
 }

--- a/apps/api/src/integration-platform/utils/redact-secrets.spec.ts
+++ b/apps/api/src/integration-platform/utils/redact-secrets.spec.ts
@@ -1,0 +1,49 @@
+import { redactSecrets } from './redact-secrets';
+
+describe('redactSecrets', () => {
+  it('redacts bearer tokens', () => {
+    const out = redactSecrets('failed with Authorization: Bearer abc123SECRETtoken9999');
+    expect(out).not.toContain('abc123SECRETtoken9999');
+    expect(out).toContain('[redacted]');
+  });
+
+  it('redacts key=value secrets', () => {
+    const out = redactSecrets('api_key=sk-livesomethingverysecret123456');
+    expect(out).not.toContain('sk-livesomethingverysecret123456');
+  });
+
+  it('redacts common provider key prefixes', () => {
+    expect(redactSecrets('used lin_api_B0KvAzszsMGg8Xyw')).not.toContain('B0KvAzsz');
+    expect(redactSecrets('token ghp_abcdef 1234567890')).not.toContain('ghp_abcdef');
+  });
+
+  it('redacts JWTs', () => {
+    const jwt = 'eyJhbGciOi.eyJzdWIiOiIxMjM0.SflKxwRJSMeKKF2QT4';
+    expect(redactSecrets(`token ${jwt}`)).not.toContain('SflKxwRJSMeKKF2QT4');
+  });
+
+  it('redacts emails (PII)', () => {
+    expect(redactSecrets('user jake@humanlayerlab.com failed')).not.toContain(
+      'jake@humanlayerlab.com',
+    );
+  });
+
+  it('redacts long opaque tokens', () => {
+    expect(
+      redactSecrets('subject was AKIAIOSFODNN7EXAMPLEKEY1234567890abc'),
+    ).not.toContain('AKIAIOSFODNN7EXAMPLEKEY1234567890abc');
+  });
+
+  it('keeps classification-relevant words intact', () => {
+    const out = redactSecrets(
+      'not allowed to perform actions outside the project this key is scoped to',
+    );
+    expect(out).toContain('scoped to');
+  });
+
+  it('handles null/empty safely', () => {
+    expect(redactSecrets(null)).toBe('');
+    expect(redactSecrets(undefined)).toBe('');
+    expect(redactSecrets('')).toBe('');
+  });
+});

--- a/apps/api/src/integration-platform/utils/redact-secrets.spec.ts
+++ b/apps/api/src/integration-platform/utils/redact-secrets.spec.ts
@@ -2,7 +2,9 @@ import { redactSecrets } from './redact-secrets';
 
 describe('redactSecrets', () => {
   it('redacts bearer tokens', () => {
-    const out = redactSecrets('failed with Authorization: Bearer abc123SECRETtoken9999');
+    const out = redactSecrets(
+      'failed with Authorization: Bearer abc123SECRETtoken9999',
+    );
     expect(out).not.toContain('abc123SECRETtoken9999');
     expect(out).toContain('[redacted]');
   });
@@ -12,9 +14,23 @@ describe('redactSecrets', () => {
     expect(out).not.toContain('sk-livesomethingverysecret123456');
   });
 
+  it('redacts quoted JSON keys/values + short secrets (not only long tokens)', () => {
+    const out = redactSecrets(
+      '{"api_key": "short1", "client_secret":"xyz789"}',
+    );
+    expect(out).not.toContain('short1');
+    expect(out).not.toContain('xyz789');
+    expect(redactSecrets('password=hunter2')).not.toContain('hunter2');
+    expect(redactSecrets('"pwd":"p1"')).not.toContain('p1');
+  });
+
   it('redacts common provider key prefixes', () => {
-    expect(redactSecrets('used lin_api_B0KvAzszsMGg8Xyw')).not.toContain('B0KvAzsz');
-    expect(redactSecrets('token ghp_abcdef 1234567890')).not.toContain('ghp_abcdef');
+    expect(redactSecrets('used lin_api_B0KvAzszsMGg8Xyw')).not.toContain(
+      'B0KvAzsz',
+    );
+    expect(redactSecrets('token ghp_abcdef 1234567890')).not.toContain(
+      'ghp_abcdef',
+    );
   });
 
   it('redacts JWTs', () => {

--- a/apps/api/src/integration-platform/utils/redact-secrets.spec.ts
+++ b/apps/api/src/integration-platform/utils/redact-secrets.spec.ts
@@ -22,6 +22,12 @@ describe('redactSecrets', () => {
     expect(out).not.toContain('xyz789');
     expect(redactSecrets('password=hunter2')).not.toContain('hunter2');
     expect(redactSecrets('"pwd":"p1"')).not.toContain('p1');
+    // A quoted value with SPACES must be fully redacted (not just first token).
+    const spaced = redactSecrets(
+      '{"password": "correct horse battery staple"}',
+    );
+    expect(spaced).not.toContain('horse');
+    expect(spaced).not.toContain('staple');
   });
 
   it('redacts common provider key prefixes', () => {

--- a/apps/api/src/integration-platform/utils/redact-secrets.ts
+++ b/apps/api/src/integration-platform/utils/redact-secrets.ts
@@ -1,0 +1,33 @@
+/**
+ * Best-effort scrubbing of secrets/PII from free text BEFORE it is used for
+ * failure classification, logged, or stored (e.g. in a check's error evidence or
+ * a Linear ticket). The self-heal layer must never leak credentials.
+ *
+ * Conservative by design: over-redacting error text is harmless (the classifier
+ * keys off words like "scoped to" / status codes, not token values), whereas
+ * under-redacting could leak a secret. Returns a string safe to persist/show.
+ */
+
+const PATTERNS: Array<[RegExp, string]> = [
+  // Authorization headers / bearer + basic tokens
+  [/\b(bearer|basic)\s+[A-Za-z0-9._\-+/=]+/gi, '$1 [redacted]'],
+  [/\b(authorization|x-api-key|api[_-]?key|token|secret|password|passwd|pwd)\b(\s*[:=]\s*)("?)[^\s"',}]+\3/gi, '$1$2[redacted]'],
+  // Common provider key prefixes (sk-, lin_api_, ghp_, xoxb-, AKIA…, etc.)
+  [/\b(sk|pk|rk)-[A-Za-z0-9]{6,}/g, '[redacted]'],
+  [/\b(lin_api_|ghp_|gho_|ghs_|github_pat_|xox[baprs]-|glpat-|AKIA|ASIA)[A-Za-z0-9_\-]{6,}/g, '[redacted]'],
+  // JWTs (three base64url segments)
+  [/\beyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+/g, '[redacted]'],
+  // Email addresses (PII)
+  [/\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b/g, '[redacted-email]'],
+  // Long opaque tokens (>=24 chars of token-ish characters)
+  [/\b[A-Za-z0-9_\-]{24,}\b/g, '[redacted]'],
+];
+
+export function redactSecrets(input: string | null | undefined): string {
+  if (!input) return '';
+  let out = String(input);
+  for (const [re, repl] of PATTERNS) {
+    out = out.replace(re, repl);
+  }
+  return out;
+}

--- a/apps/api/src/integration-platform/utils/redact-secrets.ts
+++ b/apps/api/src/integration-platform/utils/redact-secrets.ts
@@ -11,10 +11,12 @@
 const PATTERNS: Array<[RegExp, string]> = [
   // Authorization headers / bearer + basic tokens
   [/\b(bearer|basic)\s+[A-Za-z0-9._+/=-]+/gi, '$1 [redacted]'],
-  // Sensitive key/value pairs in any shape — incl. quoted JSON keys/values
-  // (`"client_secret": "x"`, `{"pwd":"x"}`) which the first-token form missed.
+  // Sensitive key/value pairs in any shape — incl. quoted JSON keys/values with
+  // SPACES (`"client_secret": "a b c"`, `{"pwd":"x"}`). The value matches a full
+  // double/single-quoted string or an unquoted token, so a spaced secret can't
+  // leak its tail (the first-token form did). Keeps the key name for context.
   [
-    /(["']?\b(?:authorization|x-api-key|api[_-]?key|client[_-]?secret|access[_-]?token|refresh[_-]?token|password|passwd|pwd|secret|token)\b["']?\s*[:=]\s*)(["']?)[^\s"',}]+\2/gi,
+    /(["']?\b(?:authorization|x-api-key|api[_-]?key|client[_-]?secret|access[_-]?token|refresh[_-]?token|password|passwd|pwd|secret|token)\b["']?\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s"',}]+)/gi,
     '$1[redacted]',
   ],
   // Common provider key prefixes (sk-, lin_api_, ghp_, xoxb-, AKIA…, etc.)

--- a/apps/api/src/integration-platform/utils/redact-secrets.ts
+++ b/apps/api/src/integration-platform/utils/redact-secrets.ts
@@ -10,17 +10,25 @@
 
 const PATTERNS: Array<[RegExp, string]> = [
   // Authorization headers / bearer + basic tokens
-  [/\b(bearer|basic)\s+[A-Za-z0-9._\-+/=]+/gi, '$1 [redacted]'],
-  [/\b(authorization|x-api-key|api[_-]?key|token|secret|password|passwd|pwd)\b(\s*[:=]\s*)("?)[^\s"',}]+\3/gi, '$1$2[redacted]'],
+  [/\b(bearer|basic)\s+[A-Za-z0-9._+/=-]+/gi, '$1 [redacted]'],
+  // Sensitive key/value pairs in any shape — incl. quoted JSON keys/values
+  // (`"client_secret": "x"`, `{"pwd":"x"}`) which the first-token form missed.
+  [
+    /(["']?\b(?:authorization|x-api-key|api[_-]?key|client[_-]?secret|access[_-]?token|refresh[_-]?token|password|passwd|pwd|secret|token)\b["']?\s*[:=]\s*)(["']?)[^\s"',}]+\2/gi,
+    '$1[redacted]',
+  ],
   // Common provider key prefixes (sk-, lin_api_, ghp_, xoxb-, AKIA…, etc.)
   [/\b(sk|pk|rk)-[A-Za-z0-9]{6,}/g, '[redacted]'],
-  [/\b(lin_api_|ghp_|gho_|ghs_|github_pat_|xox[baprs]-|glpat-|AKIA|ASIA)[A-Za-z0-9_\-]{6,}/g, '[redacted]'],
+  [
+    /\b(lin_api_|ghp_|gho_|ghs_|github_pat_|xox[baprs]-|glpat-|AKIA|ASIA)[A-Za-z0-9_-]{6,}/g,
+    '[redacted]',
+  ],
   // JWTs (three base64url segments)
-  [/\beyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+/g, '[redacted]'],
+  [/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g, '[redacted]'],
   // Email addresses (PII)
-  [/\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b/g, '[redacted-email]'],
+  [/\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g, '[redacted-email]'],
   // Long opaque tokens (>=24 chars of token-ish characters)
-  [/\b[A-Za-z0-9_\-]{24,}\b/g, '[redacted]'],
+  [/\b[A-Za-z0-9_-]{24,}\b/g, '[redacted]'],
 ];
 
 export function redactSecrets(input: string | null | undefined): string {

--- a/apps/api/src/integration-platform/utils/task-check-evaluation.runstatus.spec.ts
+++ b/apps/api/src/integration-platform/utils/task-check-evaluation.runstatus.spec.ts
@@ -1,0 +1,105 @@
+import {
+  decideRunStatus,
+  type ClassifiableFailure,
+} from './task-check-evaluation';
+
+const fail = (
+  over: Partial<ClassifiableFailure> = {},
+): ClassifiableFailure => ({
+  connectionId: 'c',
+  checkId: 'k',
+  resourceId: 'r',
+  ...over,
+});
+
+describe('decideRunStatus', () => {
+  // Static / AWS / GCP / Azure — isDynamic=false → NEVER held; identical to the
+  // historical mapping (error → failed, else raw status).
+  describe('non-dynamic (never held)', () => {
+    it('success → success', () => {
+      expect(
+        decideRunStatus({
+          resultStatus: 'success',
+          failures: [],
+          isDynamic: false,
+        }),
+      ).toBe('success');
+    });
+    it('failed (even an our-side-looking 404) → failed', () => {
+      expect(
+        decideRunStatus({
+          resultStatus: 'failed',
+          failures: [fail({ httpStatus: 404 })],
+          isDynamic: false,
+        }),
+      ).toBe('failed');
+    });
+    it('execution error → failed', () => {
+      expect(
+        decideRunStatus({
+          resultStatus: 'error',
+          failures: [fail({ threw: true })],
+          isDynamic: false,
+        }),
+      ).toBe('failed');
+    });
+  });
+
+  // Dynamic — our-side/transient held as inconclusive; real failures shown.
+  describe('dynamic', () => {
+    it('success → success', () => {
+      expect(
+        decideRunStatus({
+          resultStatus: 'success',
+          failures: [],
+          isDynamic: true,
+        }),
+      ).toBe('success');
+    });
+    it('execution error → inconclusive (held)', () => {
+      expect(
+        decideRunStatus({
+          resultStatus: 'error',
+          failures: [],
+          isDynamic: true,
+        }),
+      ).toBe('inconclusive');
+    });
+    it('all failures our-side (404) → inconclusive (held)', () => {
+      expect(
+        decideRunStatus({
+          resultStatus: 'failed',
+          failures: [fail({ httpStatus: 404 })],
+          isDynamic: true,
+        }),
+      ).toBe('inconclusive');
+    });
+    it('genuine compliance finding (no error signal) → failed (shown)', () => {
+      expect(
+        decideRunStatus({
+          resultStatus: 'failed',
+          failures: [fail()],
+          isDynamic: true,
+        }),
+      ).toBe('failed');
+    });
+    it('customer-side (401) → failed (shown — action needed)', () => {
+      expect(
+        decideRunStatus({
+          resultStatus: 'failed',
+          failures: [fail({ httpStatus: 401 })],
+          isDynamic: true,
+        }),
+      ).toBe('failed');
+    });
+    it('mixed held + real → failed (any effective failure surfaces)', () => {
+      expect(
+        decideRunStatus({
+          resultStatus: 'failed',
+          failures: [fail({ httpStatus: 404 }), fail({ resourceId: 'r2' })],
+          isDynamic: true,
+        }),
+      ).toBe('failed');
+    });
+  });
+});

--- a/apps/api/src/integration-platform/utils/task-check-evaluation.signals.spec.ts
+++ b/apps/api/src/integration-platform/utils/task-check-evaluation.signals.spec.ts
@@ -54,6 +54,10 @@ describe('failureSignalsFromEvidence', () => {
     expect(
       failureSignalsFromEvidence({ status: 'weird' }).httpStatus,
     ).toBeNull();
+    // Code must be at the START — don't grab an unrelated 3-digit run.
+    expect(
+      failureSignalsFromEvidence({ status: 'build 200 ok' }).httpStatus,
+    ).toBeNull();
   });
 
   it('marks threw when the result status is "error"', () => {

--- a/apps/api/src/integration-platform/utils/task-check-evaluation.signals.spec.ts
+++ b/apps/api/src/integration-platform/utils/task-check-evaluation.signals.spec.ts
@@ -1,0 +1,34 @@
+import { failureSignalsFromEvidence } from './task-check-evaluation';
+
+describe('failureSignalsFromEvidence', () => {
+  it('parses http status from evidence.error like "http_404"', () => {
+    const s = failureSignalsFromEvidence({ error: 'http_404', message: 'not found' });
+    expect(s.httpStatus).toBe(404);
+    expect(s.errorText).toContain('not found');
+    expect(s.threw).toBe(false);
+  });
+
+  it('falls back to numeric evidence.status', () => {
+    expect(failureSignalsFromEvidence({ status: 503 }).httpStatus).toBe(503);
+  });
+
+  it('marks threw when the result status is "error"', () => {
+    expect(failureSignalsFromEvidence({}, 'error').threw).toBe(true);
+  });
+
+  it('prefers message over error for errorText and redacts it', () => {
+    const s = failureSignalsFromEvidence({
+      error: 'http_401',
+      message: 'auth failed for Bearer sk-supersecrettokenvalue123456',
+    });
+    expect(s.errorText).not.toContain('sk-supersecrettokenvalue123456');
+    expect(s.errorText).toContain('auth failed');
+  });
+
+  it('returns empty signals for an evidence-less finding (treated as compliance)', () => {
+    const s = failureSignalsFromEvidence(undefined);
+    expect(s.httpStatus).toBeNull();
+    expect(s.errorText).toBeNull();
+    expect(s.threw).toBe(false);
+  });
+});

--- a/apps/api/src/integration-platform/utils/task-check-evaluation.signals.spec.ts
+++ b/apps/api/src/integration-platform/utils/task-check-evaluation.signals.spec.ts
@@ -2,7 +2,10 @@ import { failureSignalsFromEvidence } from './task-check-evaluation';
 
 describe('failureSignalsFromEvidence', () => {
   it('parses http status from evidence.error like "http_404"', () => {
-    const s = failureSignalsFromEvidence({ error: 'http_404', message: 'not found' });
+    const s = failureSignalsFromEvidence({
+      error: 'http_404',
+      message: 'not found',
+    });
     expect(s.httpStatus).toBe(404);
     expect(s.errorText).toContain('not found');
     expect(s.threw).toBe(false);
@@ -10,6 +13,27 @@ describe('failureSignalsFromEvidence', () => {
 
   it('falls back to numeric evidence.status', () => {
     expect(failureSignalsFromEvidence({ status: 503 }).httpStatus).toBe(503);
+  });
+
+  it('parses spaced/colon HTTP forms so 401/403 are not missed', () => {
+    // These would otherwise default to our_side (held) instead of customer_side.
+    expect(
+      failureSignalsFromEvidence({ message: 'HTTP 401 Unauthorized' })
+        .httpStatus,
+    ).toBe(401);
+    expect(
+      failureSignalsFromEvidence({ error: 'HTTP: 403 Forbidden' }).httpStatus,
+    ).toBe(403);
+    expect(
+      failureSignalsFromEvidence({ message: 'HTTP-429 rate limited' })
+        .httpStatus,
+    ).toBe(429);
+    // A URL must NOT be mistaken for a status.
+    expect(
+      failureSignalsFromEvidence({
+        message: 'fetch https://x.com/v404/p failed',
+      }).httpStatus,
+    ).toBeNull();
   });
 
   it('marks threw when the result status is "error"', () => {

--- a/apps/api/src/integration-platform/utils/task-check-evaluation.signals.spec.ts
+++ b/apps/api/src/integration-platform/utils/task-check-evaluation.signals.spec.ts
@@ -36,6 +36,26 @@ describe('failureSignalsFromEvidence', () => {
     ).toBeNull();
   });
 
+  it('does NOT let an empty message mask the error text', () => {
+    // `msgStr ?? errStr` kept '' (not null) — an empty message hid the error.
+    const s = failureSignalsFromEvidence({
+      error: 'http_500 upstream boom',
+      message: '',
+    });
+    expect(s.errorText).toContain('boom');
+    expect(s.httpStatus).toBe(500);
+  });
+
+  it('parses a STRING evidence.status (e.g. "401", "403 Forbidden")', () => {
+    expect(failureSignalsFromEvidence({ status: '401' }).httpStatus).toBe(401);
+    expect(
+      failureSignalsFromEvidence({ status: '403 Forbidden' }).httpStatus,
+    ).toBe(403);
+    expect(
+      failureSignalsFromEvidence({ status: 'weird' }).httpStatus,
+    ).toBeNull();
+  });
+
   it('marks threw when the result status is "error"', () => {
     expect(failureSignalsFromEvidence({}, 'error').threw).toBe(true);
   });

--- a/apps/api/src/integration-platform/utils/task-check-evaluation.spec.ts
+++ b/apps/api/src/integration-platform/utils/task-check-evaluation.spec.ts
@@ -90,5 +90,16 @@ describe('task-check-evaluation', () => {
     it('null (leave unchanged) when the check evaluated nothing (e.g. all errored)', () => {
       expect(decideTaskStatus(0, 0, 0)).toBeNull();
     });
+    it('NOT done when there are held failures, even with passing results', () => {
+      // (effectiveFailures=0, passing>0, findings adjusted, heldCount=1) → a held
+      // (our-side) check is unresolved; the task must not go done and hide it.
+      expect(decideTaskStatus(0, 5, 0, 1)).toBeNull();
+    });
+    it('still failed when there are real failures regardless of held count', () => {
+      expect(decideTaskStatus(2, 5, 2, 1)).toBe('failed');
+    });
+    it('done as before when nothing is held (heldCount 0)', () => {
+      expect(decideTaskStatus(0, 5, 0, 0)).toBe('done');
+    });
   });
 });

--- a/apps/api/src/integration-platform/utils/task-check-evaluation.spec.ts
+++ b/apps/api/src/integration-platform/utils/task-check-evaluation.spec.ts
@@ -101,5 +101,14 @@ describe('task-check-evaluation', () => {
     it('done as before when nothing is held (heldCount 0)', () => {
       expect(decideTaskStatus(0, 5, 0, 0)).toBe('done');
     });
+    it('returns null (leave unchanged) on a held outcome — a previously-done task stays done', () => {
+      // DELIBERATE: a held check is our-side/transient; the agent re-runs after a
+      // fix and the task reconciles within minutes. We return null (no
+      // transition) rather than pulling a done task out of done — that would show
+      // the customer a regression for OUR bug, which the hold exists to prevent.
+      // There is also no clean "held/checking" task status to move it to.
+      expect(decideTaskStatus(0, 0, 0, 2)).toBeNull();
+      expect(decideTaskStatus(0, 10, 0, 1)).toBeNull();
+    });
   });
 });

--- a/apps/api/src/integration-platform/utils/task-check-evaluation.split.spec.ts
+++ b/apps/api/src/integration-platform/utils/task-check-evaluation.split.spec.ts
@@ -1,0 +1,62 @@
+import {
+  splitFailuresByDisposition,
+  ClassifiableFailure,
+} from './task-check-evaluation';
+
+const f = (over: Partial<ClassifiableFailure>): ClassifiableFailure => ({
+  connectionId: 'icn_1',
+  checkId: 'chk',
+  resourceId: 'res',
+  ...over,
+});
+
+describe('splitFailuresByDisposition', () => {
+  it('keeps a genuine compliance finding (no error signal) as effective', () => {
+    const { effective, held } = splitFailuresByDisposition([f({})]);
+    expect(effective).toHaveLength(1);
+    expect(held).toHaveLength(0);
+  });
+
+  it('holds our-side failures (404 / unhandled endpoint)', () => {
+    const { effective, held } = splitFailuresByDisposition([
+      f({ httpStatus: 404 }),
+      f({ errorText: 'not allowed ... scoped to' }),
+    ]);
+    expect(effective).toHaveLength(0);
+    expect(held).toHaveLength(2);
+  });
+
+  it('holds transient failures (5xx / timeout)', () => {
+    const { held } = splitFailuresByDisposition([
+      f({ httpStatus: 503 }),
+      f({ errorText: 'request timed out' }),
+    ]);
+    expect(held).toHaveLength(2);
+  });
+
+  it('shows proven customer-side failures (401)', () => {
+    const { effective, held } = splitFailuresByDisposition([f({ httpStatus: 401 })]);
+    expect(effective).toHaveLength(1);
+    expect(held).toHaveLength(0);
+  });
+
+  it('splits a mixed batch correctly', () => {
+    const { effective, held } = splitFailuresByDisposition([
+      f({}), // compliance -> effective
+      f({ httpStatus: 401 }), // customer -> effective
+      f({ httpStatus: 404 }), // our-side -> held
+      f({ errorText: 'fetch failed' }), // transient -> held
+    ]);
+    expect(effective).toHaveLength(2);
+    expect(held).toHaveLength(2);
+  });
+
+  it('holds a customer-looking failure when the whole fleet is failing', () => {
+    const { effective, held } = splitFailuresByDisposition(
+      [f({ httpStatus: 403 })],
+      { passing: 0, failing: 6 },
+    );
+    expect(effective).toHaveLength(0);
+    expect(held).toHaveLength(1);
+  });
+});

--- a/apps/api/src/integration-platform/utils/task-check-evaluation.ts
+++ b/apps/api/src/integration-platform/utils/task-check-evaluation.ts
@@ -102,6 +102,39 @@ export function splitFailuresByDisposition(
 }
 
 /**
+ * Decide the per-run status stored on an IntegrationCheckRun. Canonical rule,
+ * shared by ALL run paths (scheduled, manual, and the agent re-run) so a held
+ * run is classified identically everywhere:
+ *   - base: an execution 'error' → 'failed'; otherwise the raw success/failed.
+ *   - DYNAMIC only: an execution error, or a run whose failures are ALL held
+ *     (our-side/transient → no effective failures), becomes 'inconclusive' —
+ *     the self-heal queue, hidden from the customer. Static/AWS keep the base.
+ *
+ * `failures` carries the per-finding signals (from {@link failureSignalsFromEvidence}).
+ */
+export function decideRunStatus(params: {
+  resultStatus: string;
+  failures: ClassifiableFailure[];
+  isDynamic: boolean;
+  fleet?: { passing: number; failing: number } | null;
+}): 'success' | 'failed' | 'inconclusive' {
+  const { resultStatus, failures, isDynamic, fleet } = params;
+  let runStatus: 'success' | 'failed' | 'inconclusive' =
+    resultStatus === 'success' ? 'success' : 'failed';
+  if (isDynamic) {
+    if (resultStatus === 'error') {
+      runStatus = 'inconclusive';
+    } else if (
+      failures.length > 0 &&
+      splitFailuresByDisposition(failures, fleet).effective.length === 0
+    ) {
+      runStatus = 'inconclusive';
+    }
+  }
+  return runStatus;
+}
+
+/**
  * Extract classification signals from a failing finding's evidence. `errorText`
  * is REDACTED of secrets/PII before it leaves this function.
  *

--- a/apps/api/src/integration-platform/utils/task-check-evaluation.ts
+++ b/apps/api/src/integration-platform/utils/task-check-evaluation.ts
@@ -1,4 +1,5 @@
 import { ActiveExceptionSet } from '../../cloud-security/finding-exceptions';
+import { classifyCheckFailure } from '../services/check-failure-classifier';
 
 /** A failing finding, identified the same way an exception is keyed. */
 export interface FailingFinding {
@@ -44,4 +45,57 @@ export function decideTaskStatus(
   if (effectiveFailures > 0) return 'failed';
   if (totalPassing > 0 || totalFindings > 0) return 'done';
   return null;
+}
+
+/** A failing finding plus the signals needed to classify WHY it failed. */
+export interface ClassifiableFailure extends FailingFinding {
+  /** HTTP status the failure carried, if any. */
+  httpStatus?: number | null;
+  /** Error text from the finding's evidence. MUST be pre-redacted of secrets. */
+  errorText?: string | null;
+  /** True if the runtime threw rather than the vendor returning an error. */
+  threw?: boolean;
+}
+
+export interface FailureDisposition {
+  /** Genuine failures — fail the task + show (compliance findings + proven customer-side). */
+  effective: ClassifiableFailure[];
+  /** Held failures — our-side bug / transient. Task NOT failed; surfaced as inconclusive. */
+  held: ClassifiableFailure[];
+}
+
+/**
+ * Split failing findings into those that should fail the task (real compliance
+ * findings + proven customer-side issues) vs those to HOLD as inconclusive
+ * (our-side bug / transient), so a customer never sees a red for our problem.
+ *
+ * For DYNAMIC integrations only — the caller gates this; static/AWS checks keep
+ * their existing behavior. The classifier is conservative (never blames the
+ * customer without proof), so ambiguous failures are held, not shown.
+ *
+ * `fleet` (optional) is the same check's pass/fail counts across the provider's
+ * other active connections — a fleet-wide failure is held even if it looks
+ * customer-like.
+ */
+export function splitFailuresByDisposition(
+  failing: ClassifiableFailure[],
+  fleet?: { passing: number; failing: number } | null,
+): FailureDisposition {
+  const effective: ClassifiableFailure[] = [];
+  const held: ClassifiableFailure[] = [];
+  for (const f of failing) {
+    const { class: cls } = classifyCheckFailure({
+      httpStatus: f.httpStatus,
+      errorText: f.errorText,
+      threw: f.threw,
+      fleet,
+    });
+    if (cls === 'our_side' || cls === 'transient') {
+      held.push(f);
+    } else {
+      // 'compliance' + 'customer_side' → show the customer.
+      effective.push(f);
+    }
+  }
+  return { effective, held };
 }

--- a/apps/api/src/integration-platform/utils/task-check-evaluation.ts
+++ b/apps/api/src/integration-platform/utils/task-check-evaluation.ts
@@ -167,12 +167,18 @@ export function failureSignalsFromEvidence(
   // our_side (held) instead of customer_side (shown). Won't match a URL.
   const m = `${errStr ?? ''} ${msgStr ?? ''}`.match(/\bhttp[\s:_-]*(\d{3})\b/i);
   if (m) httpStatus = Number(m[1]);
-  // e.g. evidence.status === 404
-  if (httpStatus == null && typeof ev.status === 'number') {
-    httpStatus = ev.status;
+  // evidence.status may be a number (404) OR a string ('404', '401 Unauthorized').
+  if (httpStatus == null && ev.status != null) {
+    const n =
+      typeof ev.status === 'number'
+        ? ev.status
+        : Number(String(ev.status).match(/\d{3}/)?.[0]);
+    if (Number.isFinite(n) && n >= 100 && n < 600) httpStatus = n;
   }
 
-  const rawText = msgStr ?? errStr ?? '';
+  // Use the message ONLY when it has content; an empty-string message must not
+  // mask the error text (?? keeps '' because it's not null/undefined).
+  const rawText = msgStr && msgStr.trim() ? msgStr : (errStr ?? '');
   const errorText = rawText ? redactSecrets(rawText) : null;
   const threw = resultStatus === 'error';
 

--- a/apps/api/src/integration-platform/utils/task-check-evaluation.ts
+++ b/apps/api/src/integration-platform/utils/task-check-evaluation.ts
@@ -42,8 +42,16 @@ export function decideTaskStatus(
   effectiveFailures: number,
   totalPassing: number,
   totalFindings: number,
+  heldCount = 0,
 ): 'failed' | 'done' | null {
   if (effectiveFailures > 0) return 'failed';
+  // Held (our-side/transient) failures are UNRESOLVED — the self-heal agent is
+  // still fixing them. Never declare the task done while any check is held, even
+  // if other checks passed; that would hide an unresolved failure behind a green
+  // task. Leave it unchanged (indeterminate) until the held checks actually pass
+  // — the agent's re-run then produces a clean pass and a later run goes done.
+  // heldCount is always 0 for non-dynamic (static/AWS/GCP/Azure), so unchanged.
+  if (heldCount > 0) return null;
   if (totalPassing > 0 || totalFindings > 0) return 'done';
   return null;
 }
@@ -152,11 +160,13 @@ export function failureSignalsFromEvidence(
   const msgStr = typeof ev.message === 'string' ? ev.message : null;
 
   let httpStatus: number | null = null;
-  // e.g. evidence.error === 'http_404'
-  if (errStr) {
-    const m = errStr.match(/http[_-]?(\d{3})/i);
-    if (m) httpStatus = Number(m[1]);
-  }
+  // Search BOTH error and message — the status often lives in the human message
+  // ('HTTP 401 Unauthorized'), not the error code. Tolerate space/colon/_/-
+  // separators so 'http_404', 'HTTP 401', 'HTTP: 403', 'HTTP-429' all parse;
+  // otherwise a customer-actionable 401/403 would be missed and default to
+  // our_side (held) instead of customer_side (shown). Won't match a URL.
+  const m = `${errStr ?? ''} ${msgStr ?? ''}`.match(/\bhttp[\s:_-]*(\d{3})\b/i);
+  if (m) httpStatus = Number(m[1]);
   // e.g. evidence.status === 404
   if (httpStatus == null && typeof ev.status === 'number') {
     httpStatus = ev.status;

--- a/apps/api/src/integration-platform/utils/task-check-evaluation.ts
+++ b/apps/api/src/integration-platform/utils/task-check-evaluation.ts
@@ -1,5 +1,6 @@
 import { ActiveExceptionSet } from '../../cloud-security/finding-exceptions';
 import { classifyCheckFailure } from '../services/check-failure-classifier';
+import { redactSecrets } from './redact-secrets';
 
 /** A failing finding, identified the same way an exception is keyed. */
 export interface FailingFinding {
@@ -98,4 +99,39 @@ export function splitFailuresByDisposition(
     }
   }
   return { effective, held };
+}
+
+/**
+ * Extract classification signals from a failing finding's evidence. `errorText`
+ * is REDACTED of secrets/PII before it leaves this function.
+ *
+ * Defensive about the heterogeneous evidence shapes checks emit: if no signal is
+ * found, returns empty signals → the failure is treated as a genuine compliance
+ * finding (today's behavior), so a check is never wrongly held. `resultStatus`
+ * of 'error' means the check threw → an execution failure.
+ */
+export function failureSignalsFromEvidence(
+  evidence: Record<string, unknown> | null | undefined,
+  resultStatus?: string,
+): { httpStatus: number | null; errorText: string | null; threw: boolean } {
+  const ev = evidence ?? {};
+  const errStr = typeof ev.error === 'string' ? ev.error : null;
+  const msgStr = typeof ev.message === 'string' ? ev.message : null;
+
+  let httpStatus: number | null = null;
+  // e.g. evidence.error === 'http_404'
+  if (errStr) {
+    const m = errStr.match(/http[_-]?(\d{3})/i);
+    if (m) httpStatus = Number(m[1]);
+  }
+  // e.g. evidence.status === 404
+  if (httpStatus == null && typeof ev.status === 'number') {
+    httpStatus = ev.status;
+  }
+
+  const rawText = msgStr ?? errStr ?? '';
+  const errorText = rawText ? redactSecrets(rawText) : null;
+  const threw = resultStatus === 'error';
+
+  return { httpStatus, errorText, threw };
 }

--- a/apps/api/src/integration-platform/utils/task-check-evaluation.ts
+++ b/apps/api/src/integration-platform/utils/task-check-evaluation.ts
@@ -167,12 +167,18 @@ export function failureSignalsFromEvidence(
   // our_side (held) instead of customer_side (shown). Won't match a URL.
   const m = `${errStr ?? ''} ${msgStr ?? ''}`.match(/\bhttp[\s:_-]*(\d{3})\b/i);
   if (m) httpStatus = Number(m[1]);
-  // evidence.status may be a number (404) OR a string ('404', '401 Unauthorized').
+  // evidence.status may be a number (404) OR a status-code string ('404',
+  // '401 Unauthorized'). For strings the code must be at the START (anchored) so
+  // we don't grab an unrelated 3-digit run from arbitrary text (e.g. 'build 200').
   if (httpStatus == null && ev.status != null) {
     const n =
       typeof ev.status === 'number'
         ? ev.status
-        : Number(String(ev.status).match(/\d{3}/)?.[0]);
+        : Number(
+            String(ev.status)
+              .trim()
+              .match(/^(\d{3})\b/)?.[1],
+          );
     if (Number.isFinite(n) && n >= 100 && n < 600) httpStatus = n;
   }
 

--- a/apps/api/src/trigger/integration-platform/run-task-integration-checks.ts
+++ b/apps/api/src/trigger/integration-platform/run-task-integration-checks.ts
@@ -298,10 +298,15 @@ export const runTaskIntegrationChecks = task({
               taskId,
               checkId,
               checkName: checkDef?.name ?? checkId,
-              // A transport blip is our-side/transient. For DYNAMIC providers
-              // hold it as inconclusive (hidden + self-heal queue) so a network
-              // hiccup never shows the customer a red; static/AWS keep 'failed'.
-              status: isDynamic ? 'inconclusive' : 'failed',
+              // A transport blip (Trigger→server) is an execution error, so
+              // route it through the SAME shared rule as every other run: dynamic
+              // → 'inconclusive' (hidden + self-heal queue, so a network hiccup
+              // never shows the customer a red), static/AWS → 'failed'.
+              status: decideRunStatus({
+                resultStatus: 'error',
+                failures: [],
+                isDynamic,
+              }),
               startedAt: new Date(),
               completedAt: new Date(),
               durationMs: 0,

--- a/apps/api/src/trigger/integration-platform/run-task-integration-checks.ts
+++ b/apps/api/src/trigger/integration-platform/run-task-integration-checks.ts
@@ -298,7 +298,10 @@ export const runTaskIntegrationChecks = task({
               taskId,
               checkId,
               checkName: checkDef?.name ?? checkId,
-              status: 'failed',
+              // A transport blip is our-side/transient. For DYNAMIC providers
+              // hold it as inconclusive (hidden + self-heal queue) so a network
+              // hiccup never shows the customer a red; static/AWS keep 'failed'.
+              status: isDynamic ? 'inconclusive' : 'failed',
               startedAt: new Date(),
               completedAt: new Date(),
               durationMs: 0,

--- a/apps/api/src/trigger/integration-platform/run-task-integration-checks.ts
+++ b/apps/api/src/trigger/integration-platform/run-task-integration-checks.ts
@@ -19,7 +19,9 @@ import { loadActiveExceptionSet } from '../../cloud-security/finding-exceptions'
 import {
   countEffectiveFailures,
   decideTaskStatus,
-  type FailingFinding,
+  splitFailuresByDisposition,
+  failureSignalsFromEvidence,
+  type ClassifiableFailure,
 } from '../../integration-platform/utils/task-check-evaluation';
 
 /**
@@ -224,8 +226,9 @@ export const runTaskIntegrationChecks = task({
     let totalPassing = 0;
     let hasExecutionErrors = false;
     // Failing findings (keyed like an exception) so task status can exclude
-    // explicitly-excepted ones below.
-    const failingFindings: FailingFinding[] = [];
+    // explicitly-excepted ones below. Carries redacted error signals so the
+    // self-heal layer can classify our-side failures (dynamic integrations).
+    const failingFindings: ClassifiableFailure[] = [];
 
     // Run only the checks that apply to this task
     try {
@@ -325,6 +328,9 @@ export const runTaskIntegrationChecks = task({
             connectionId,
             checkId: checkResult.checkId,
             resourceId: f.resourceId,
+            // Redacted error signals so the self-heal layer can classify
+            // our-side/transient failures and hold them as inconclusive.
+            ...failureSignalsFromEvidence(f.evidence, checkResult.status),
           });
         }
         if (checkResult.status === 'error') {
@@ -417,14 +423,30 @@ export const runTaskIntegrationChecks = task({
       // the shared helpers). Execution errors don't drive status here; they gate
       // integrationLastRunAt above so the next tick retries.
       const exceptions = await loadActiveExceptionSet(organizationId);
+      // For DYNAMIC integrations, hold our-side/transient failures as
+      // inconclusive: they must not fail the task or send a "task failed" email —
+      // the self-heal layer investigates/fixes them. Static/AWS behavior is
+      // unchanged. Safe degradation: a finding with no readable error signal
+      // classifies as a real (compliance) failure, exactly as today.
+      const statusFailures = isDynamic
+        ? splitFailuresByDisposition(failingFindings).effective
+        : failingFindings;
+      const heldCount = failingFindings.length - statusFailures.length;
+      if (heldCount > 0) {
+        logger.info(
+          `Held ${heldCount} our-side/transient finding(s) as inconclusive for task ${taskId} (not shown as failed)`,
+        );
+      }
       const effectiveFailures = countEffectiveFailures(
-        failingFindings,
+        statusFailures,
         exceptions,
       );
+      // Held findings are indeterminate (like an all-errored run) — they must not
+      // flip the task to "done" either, so exclude them from the finding count.
       const newStatus = decideTaskStatus(
         effectiveFailures,
         totalPassing,
-        totalFindings,
+        totalFindings - heldCount,
       );
 
       // Whether THIS run flipped the task into `failed` (e.g. todo/done →

--- a/apps/api/src/trigger/integration-platform/run-task-integration-checks.ts
+++ b/apps/api/src/trigger/integration-platform/run-task-integration-checks.ts
@@ -362,7 +362,13 @@ export const runTaskIntegrationChecks = task({
               checkResult.result.passingResults.length +
                 checkResult.result.findings.length,
             passedCount: checkResult.result.passingResults.length,
-            failedCount: checkResult.result.findings.length,
+            // A held (inconclusive) run has no CONFIRMED failures — its findings
+            // are our-side/transient, not real fails — so failedCount is 0. The
+            // raw findings still persist as results for the agent to diagnose.
+            failedCount:
+              runStatus === 'inconclusive'
+                ? 0
+                : checkResult.result.findings.length,
             errorMessage: checkResult.error,
             logs: JSON.parse(JSON.stringify(checkResult.result.logs)),
           },

--- a/apps/api/src/trigger/integration-platform/run-task-integration-checks.ts
+++ b/apps/api/src/trigger/integration-platform/run-task-integration-checks.ts
@@ -11,14 +11,12 @@ import {
   runChecksOnServer,
   type RunAllChecksResult,
 } from './run-checks-on-server';
-import {
-  isActiveDynamicProvider,
-  shouldRunOnServer,
-} from './dynamic-provider';
+import { isActiveDynamicProvider, shouldRunOnServer } from './dynamic-provider';
 import { loadActiveExceptionSet } from '../../cloud-security/finding-exceptions';
 import {
   countEffectiveFailures,
   decideTaskStatus,
+  decideRunStatus,
   splitFailuresByDisposition,
   failureSignalsFromEvidence,
   type ClassifiableFailure,
@@ -338,22 +336,15 @@ export const runTaskIntegrationChecks = task({
           hasExecutionErrors = true;
         }
 
-        // Per-check run status. For DYNAMIC integrations a check that failed for
-        // an our-side/transient reason (or threw) is recorded as 'inconclusive'
-        // instead of 'failed' — this is the self-heal agent's work queue.
-        // Static/AWS keep the existing mapping.
-        let runStatus: 'success' | 'failed' | 'inconclusive' =
-          checkResult.status === 'error' ? 'failed' : checkResult.status;
-        if (isDynamic) {
-          if (checkResult.status === 'error') {
-            runStatus = 'inconclusive';
-          } else if (
-            checkFailures.length > 0 &&
-            splitFailuresByDisposition(checkFailures).effective.length === 0
-          ) {
-            runStatus = 'inconclusive';
-          }
-        }
+        // Per-check run status (shared rule). For DYNAMIC integrations a check
+        // that failed for an our-side/transient reason (or threw) is recorded as
+        // 'inconclusive' — the self-heal agent's queue. Static/AWS keep the
+        // base success/failed mapping.
+        const runStatus = decideRunStatus({
+          resultStatus: checkResult.status,
+          failures: checkFailures,
+          isDynamic,
+        });
 
         // Store check run
         const checkRun = await db.integrationCheckRun.create({

--- a/apps/api/src/trigger/integration-platform/run-task-integration-checks.ts
+++ b/apps/api/src/trigger/integration-platform/run-task-integration-checks.ts
@@ -455,6 +455,7 @@ export const runTaskIntegrationChecks = task({
         effectiveFailures,
         totalPassing,
         totalFindings - heldCount,
+        heldCount,
       );
 
       // Whether THIS run flipped the task into `failed` (e.g. todo/done →

--- a/apps/api/src/trigger/integration-platform/run-task-integration-checks.ts
+++ b/apps/api/src/trigger/integration-platform/run-task-integration-checks.ts
@@ -323,18 +323,36 @@ export const runTaskIntegrationChecks = task({
         // exception) so task status can exclude explicitly-excepted ones.
         totalFindings += checkResult.result.findings.length;
         totalPassing += checkResult.result.passingResults.length;
-        for (const f of checkResult.result.findings) {
-          failingFindings.push({
-            connectionId,
-            checkId: checkResult.checkId,
-            resourceId: f.resourceId,
-            // Redacted error signals so the self-heal layer can classify
-            // our-side/transient failures and hold them as inconclusive.
-            ...failureSignalsFromEvidence(f.evidence, checkResult.status),
-          });
-        }
+        // Build this check's failing findings (with redacted signals) once —
+        // reused for the task-level decision and the per-check run status.
+        const checkFailures = checkResult.result.findings.map((f) => ({
+          connectionId,
+          checkId: checkResult.checkId,
+          resourceId: f.resourceId,
+          // Redacted error signals so the self-heal layer can classify
+          // our-side/transient failures and hold them as inconclusive.
+          ...failureSignalsFromEvidence(f.evidence, checkResult.status),
+        }));
+        failingFindings.push(...checkFailures);
         if (checkResult.status === 'error') {
           hasExecutionErrors = true;
+        }
+
+        // Per-check run status. For DYNAMIC integrations a check that failed for
+        // an our-side/transient reason (or threw) is recorded as 'inconclusive'
+        // instead of 'failed' — this is the self-heal agent's work queue.
+        // Static/AWS keep the existing mapping.
+        let runStatus: 'success' | 'failed' | 'inconclusive' =
+          checkResult.status === 'error' ? 'failed' : checkResult.status;
+        if (isDynamic) {
+          if (checkResult.status === 'error') {
+            runStatus = 'inconclusive';
+          } else if (
+            checkFailures.length > 0 &&
+            splitFailuresByDisposition(checkFailures).effective.length === 0
+          ) {
+            runStatus = 'inconclusive';
+          }
         }
 
         // Store check run
@@ -344,8 +362,7 @@ export const runTaskIntegrationChecks = task({
             taskId,
             checkId: checkResult.checkId,
             checkName: checkResult.checkName,
-            status:
-              checkResult.status === 'error' ? 'failed' : checkResult.status,
+            status: runStatus,
             startedAt: new Date(),
             completedAt: new Date(),
             durationMs: checkResult.durationMs,

--- a/packages/db/prisma/migrations/20260625120000_add_dynamic_check_version/migration.sql
+++ b/packages/db/prisma/migrations/20260625120000_add_dynamic_check_version/migration.sql
@@ -16,10 +16,9 @@ CREATE TABLE "DynamicCheckVersion" (
 );
 
 -- CreateIndex
-CREATE INDEX "DynamicCheckVersion_checkId_idx" ON "DynamicCheckVersion"("checkId");
-
--- CreateIndex
-CREATE INDEX "DynamicCheckVersion_createdAt_idx" ON "DynamicCheckVersion"("createdAt");
+-- Composite serves the only read pattern (versions for one check, newest first)
+-- and its leading checkId column also indexes the FK for cascade deletes.
+CREATE INDEX "DynamicCheckVersion_checkId_createdAt_idx" ON "DynamicCheckVersion"("checkId", "createdAt");
 
 -- AddForeignKey
 ALTER TABLE "DynamicCheckVersion" ADD CONSTRAINT "DynamicCheckVersion_checkId_fkey" FOREIGN KEY ("checkId") REFERENCES "DynamicCheck"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/migrations/20260625120000_add_dynamic_check_version/migration.sql
+++ b/packages/db/prisma/migrations/20260625120000_add_dynamic_check_version/migration.sql
@@ -1,0 +1,25 @@
+-- DynamicCheck edit history: a snapshot of a check's logic (definition + variables)
+-- taken before each change, so edits (manual, API, or self-heal agent) can be rolled
+-- back and audited. Additive only — does not alter DynamicCheck or any existing flow.
+
+-- CreateTable
+CREATE TABLE "DynamicCheckVersion" (
+    "id" TEXT NOT NULL DEFAULT generate_prefixed_cuid('dckv'::text),
+    "checkId" TEXT NOT NULL,
+    "definition" JSONB NOT NULL,
+    "variables" JSONB NOT NULL,
+    "source" TEXT NOT NULL DEFAULT 'api',
+    "note" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DynamicCheckVersion_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "DynamicCheckVersion_checkId_idx" ON "DynamicCheckVersion"("checkId");
+
+-- CreateIndex
+CREATE INDEX "DynamicCheckVersion_createdAt_idx" ON "DynamicCheckVersion"("createdAt");
+
+-- AddForeignKey
+ALTER TABLE "DynamicCheckVersion" ADD CONSTRAINT "DynamicCheckVersion_checkId_fkey" FOREIGN KEY ("checkId") REFERENCES "DynamicCheck"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/migrations/20260625130000_add_inconclusive_run_status/migration.sql
+++ b/packages/db/prisma/migrations/20260625130000_add_inconclusive_run_status/migration.sql
@@ -1,0 +1,6 @@
+-- Self-heal layer: a check that fails for a non-customer reason (our bug, a
+-- changed/deprecated vendor endpoint, transient error) is held as 'inconclusive'
+-- rather than shown to the customer as a red 'failed'. Additive enum value only.
+
+-- AlterEnum
+ALTER TYPE "IntegrationRunStatus" ADD VALUE 'inconclusive';

--- a/packages/db/prisma/schema/dynamic-integration.prisma
+++ b/packages/db/prisma/schema/dynamic-integration.prisma
@@ -129,6 +129,7 @@ model DynamicCheckVersion {
 
   createdAt DateTime @default(now())
 
-  @@index([checkId])
-  @@index([createdAt])
+  // Composite serves the only read pattern — listVersions(checkId) ordered by
+  // createdAt desc — and its leading checkId column also covers the FK/cascade.
+  @@index([checkId, createdAt])
 }

--- a/packages/db/prisma/schema/dynamic-integration.prisma
+++ b/packages/db/prisma/schema/dynamic-integration.prisma
@@ -96,7 +96,39 @@ model DynamicCheck {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  /// Edit history (snapshots taken before each change) for rollback + audit
+  versions DynamicCheckVersion[]
+
   @@unique([integrationId, checkSlug])
   @@index([integrationId])
   @@index([isEnabled])
+}
+
+/// Immutable snapshot of a DynamicCheck's logic taken BEFORE each change, so an
+/// edit (manual, via the API, or by the self-heal agent) can be rolled back and
+/// audited. Only the logic-bearing fields are versioned (definition + variables);
+/// rolling back replaces those on the live check.
+model DynamicCheckVersion {
+  id String @id @default(dbgenerated("generate_prefixed_cuid('dckv'::text)"))
+
+  /// The check this snapshot belongs to
+  checkId String
+  check   DynamicCheck @relation(fields: [checkId], references: [id], onDelete: Cascade)
+
+  /// Snapshot of the check's `definition` (the step code) at this version
+  definition Json
+
+  /// Snapshot of the check's `variables` at this version
+  variables Json
+
+  /// What produced this version: 'manual' | 'agent' | 'api' | 'restore' (free-form)
+  source String @default("api")
+
+  /// Optional note describing the change (e.g. agent fix summary). NEVER store secrets here.
+  note String?
+
+  createdAt DateTime @default(now())
+
+  @@index([checkId])
+  @@index([createdAt])
 }

--- a/packages/db/prisma/schema/integration-platform.prisma
+++ b/packages/db/prisma/schema/integration-platform.prisma
@@ -182,6 +182,10 @@ enum IntegrationRunStatus {
   success
   failed
   cancelled
+  /// The check could not be evaluated for a non-customer reason (our bug, a
+  /// changed/deprecated vendor endpoint, or a transient error). Held instead of
+  /// shown as a red "failed" — the self-heal layer investigates/fixes it.
+  inconclusive
 }
 
 /// Stores findings/results from integration syncs


### PR DESCRIPTION
All **`comp`** changes for the dynamic-integration self-heal layer (the agent lands in a separate `comp-private` PR). Rebased onto current `main`. Each piece is additive + tested.

## Goal
Customers never see a red "failed" check when the failure is **our** fault (our bug, a changed/deprecated vendor endpoint). Our-side/transient failures are **held** as `inconclusive` — invisible to the customer, queued for the agent to fix. Only genuine compliance fails and proven customer-side issues show.

## What's in this PR (verified — typecheck clean + ~135 tests, no regressions)
1. **Versioning + rollback** for dynamic check edits (the undo net that makes auto-fix safe).
2. **Failure classifier** — `compliance | transient | customer_side | our_side`; conservative (ambiguous → our_side; fleet-wide → our_side).
3. **`inconclusive` run status + `splitFailuresByDisposition`** — partition failing findings into show vs hold.
4. **Secret redactor + evidence→signals extractor** — error text is redacted of secrets/PII before classification or storage.
5. **Hold wired into BOTH run paths** (scheduled + manual "Run"): our-side/transient dynamic failures no longer fail the task or send the "task failed" email. Held findings are excluded from the "done" path too (indeterminate). **Static/AWS byte-identical; safe degradation: no readable signal → treated as a real failure, exactly as today.**
6. **Held check-runs recorded as `inconclusive`** (per-check) — the agent's work record.
7. **`GET /v1/internal/integration-debug/inconclusive-runs`** — the agent's work queue (held runs + failing results/evidence, filter by provider/org).

## Not in this PR
- **"Checking…" UX** (frontend) — optional polish; the core no-red promise is already met (a held check just leaves the task in its prior status, not red).
- **The agent** — separate `comp-private` PR.

## Verification + caveat
- Typecheck clean for all touched files; existing run-path + controller + internal-debug specs pass (no regressions).
- ⚠️ The end-to-end hold needs a **staging run** before merge — the Trigger.dev pipeline isn't runnable locally. All decision/classification logic is unit-tested; the live wiring is gated to dynamic + degrades safely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PAsijjUQ1bMJuw8NuC1oR