### PR TITLE
fix(auth): disable unused email/password login

### DIFF
--- a/apps/api/src/auth/auth.server.ts
+++ b/apps/api/src/auth/auth.server.ts
@@ -296,8 +296,8 @@ export const auth = betterAuth({
   baseURL: process.env.BASE_URL || 'http://localhost:3333',
   trustedOrigins: getTrustedOrigins(),
   emailAndPassword: {
-    enabled: true,
-    requireEmailVerification: true,
+    // Not used — apps sign in via magic link, email OTP, and OAuth.
+    enabled: false,
   },
   emailVerification: {
     sendOnSignUp: true,


### PR DESCRIPTION
## Hotfix → release

Email/password login isn't offered in any of our apps — we sign in via **magic link, email OTP, and OAuth**. This disables the better-auth email/password endpoints since they aren't part of any product flow.

Branched off **`release`** so the diff is **only** this one-line change — none of the unreleased `main` work ships with it.

```ts
emailAndPassword: {
  enabled: false,
},
```

**Impact:** no user impact (nothing in any UI sets a password; OAuth/magic-link accounts have no password credential; sessions unaffected). Magic link, OTP, and OAuth are unchanged. No DB migration.

On merge, `semantic-release` cuts a patch and back-merges `release` → `main`, so `main` picks this up automatically (the separate main PR can be closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable `better-auth` email/password endpoints in the API since our apps only use magic link, email OTP, and OAuth. No user impact or migrations; sessions unaffected.

<sup>Written for commit a9d887f9a4bf18493403d157c2e6e26897abbec2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

