### PR TITLE
fix(cloud-security): restore Cloud Tests auto-fix (drop unsupported temperature param)

### DIFF
--- a/apps/api/src/cloud-security/ai-remediation.service.spec.ts
+++ b/apps/api/src/cloud-security/ai-remediation.service.spec.ts
@@ -412,8 +412,10 @@ describe('AiRemediationService.refineStepFromError', () => {
     expect(callArgs.prompt).toContain('CreateServiceLinkedRoleCommand');
     // ... and the neighbor step's service so the AI can use cross-step context.
     expect(callArgs.prompt).toContain('guardduty');
-    // Temperature is 0 for deterministic repair.
-    expect(callArgs.temperature).toBe(0);
+    // `temperature` must NOT be sent: claude-opus-4-8 rejects it with a 400
+    // ("temperature is deprecated for this model"), which would make the call
+    // throw and silently degrade auto-fix to manual steps.
+    expect(callArgs.temperature).toBeUndefined();
   });
 });
 
@@ -538,7 +540,7 @@ describe('AiRemediationService.generateFixPlan empty-plan retry', () => {
     generateObjectMock.mockResolvedValueOnce({
       object: basePlan({ canAutoFix: true, fixSteps: [] }),
     });
-    // Second pass (higher temperature): a real plan.
+    // Second pass (re-sample): a real plan.
     generateObjectMock.mockResolvedValueOnce({
       object: basePlan({
         canAutoFix: true,
@@ -566,9 +568,10 @@ describe('AiRemediationService.generateFixPlan empty-plan retry', () => {
     });
 
     expect(generateObjectMock).toHaveBeenCalledTimes(2);
-    // The retry runs at a non-zero temperature so it is a genuinely different sample.
-    expect(generateObjectMock.mock.calls[0][0].temperature).toBe(0);
-    expect(generateObjectMock.mock.calls[1][0].temperature).toBeGreaterThan(0);
+    // Neither call may send `temperature` — claude-opus-4-8 rejects it (400).
+    // The retry is a fresh re-sample (default sampling), not a temperature bump.
+    expect(generateObjectMock.mock.calls[0][0].temperature).toBeUndefined();
+    expect(generateObjectMock.mock.calls[1][0].temperature).toBeUndefined();
     expect(plan.fixSteps).toHaveLength(1);
     expect(plan.fixSteps[0].command).toBe('PutConfigurationRecorderCommand');
   });
@@ -622,7 +625,7 @@ describe('AiRemediationService GCP/Azure empty-plan retry', () => {
     evidence: {},
   };
 
-  it('GCP: retries once at higher temperature when the first plan is empty', async () => {
+  it('GCP: retries once (re-sample) when the first plan is empty, without sending temperature', async () => {
     generateObjectMock.mockResolvedValueOnce({
       object: { canAutoFix: true, fixSteps: [] },
     });
@@ -634,8 +637,8 @@ describe('AiRemediationService GCP/Azure empty-plan retry', () => {
     const plan = await service.generateGcpFixPlan(finding);
 
     expect(generateObjectMock).toHaveBeenCalledTimes(2);
-    expect(generateObjectMock.mock.calls[0][0].temperature).toBe(0);
-    expect(generateObjectMock.mock.calls[1][0].temperature).toBeGreaterThan(0);
+    expect(generateObjectMock.mock.calls[0][0].temperature).toBeUndefined();
+    expect(generateObjectMock.mock.calls[1][0].temperature).toBeUndefined();
     expect(plan.fixSteps).toHaveLength(1);
   });
 
@@ -650,7 +653,7 @@ describe('AiRemediationService GCP/Azure empty-plan retry', () => {
     expect(generateObjectMock).toHaveBeenCalledTimes(1);
   });
 
-  it('Azure: retries once at higher temperature when the first plan is empty', async () => {
+  it('Azure: retries once (re-sample) when the first plan is empty, without sending temperature', async () => {
     generateObjectMock.mockResolvedValueOnce({
       object: { canAutoFix: true, fixSteps: [] },
     });
@@ -662,8 +665,8 @@ describe('AiRemediationService GCP/Azure empty-plan retry', () => {
     const plan = await service.generateAzureFixPlan(finding);
 
     expect(generateObjectMock).toHaveBeenCalledTimes(2);
-    expect(generateObjectMock.mock.calls[0][0].temperature).toBe(0);
-    expect(generateObjectMock.mock.calls[1][0].temperature).toBeGreaterThan(0);
+    expect(generateObjectMock.mock.calls[0][0].temperature).toBeUndefined();
+    expect(generateObjectMock.mock.calls[1][0].temperature).toBeUndefined();
     expect(plan.fixSteps).toHaveLength(1);
   });
 
@@ -676,6 +679,82 @@ describe('AiRemediationService GCP/Azure empty-plan retry', () => {
     await service.generateAzureFixPlan(finding);
 
     expect(generateObjectMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('AiRemediationService MODEL calls omit temperature (opus-4-8 regression)', () => {
+  // Regression for the production bug where auto-fix silently showed manual
+  // "Remediation Steps" for every cloud finding. The remediation model was
+  // bumped to claude-opus-4-8, which rejects the `temperature` parameter with
+  // a 400 ("temperature is deprecated for this model"). Every generateObject
+  // call that passed `temperature` therefore threw, was caught, and fell back
+  // to fallbackPlan() → guidedOnly:true with the verbatim adapter remediation.
+  const generateObjectMock = generateObject as unknown as jest.Mock;
+
+  beforeEach(() => {
+    generateObjectMock.mockReset();
+  });
+
+  it('AWS: generateFixPlan does not send temperature to the model', async () => {
+    generateObjectMock.mockResolvedValueOnce({
+      object: basePlan({
+        fixSteps: [
+          { service: 'cloudtrail', command: 'CreateTrailCommand', params: { Name: 'compai-cloudtrail' }, purpose: 'Create trail' },
+        ],
+      }),
+    });
+
+    await new AiRemediationService().generateFixPlan({
+      title: 'No CloudTrail trails configured',
+      description: 'No CloudTrail trails exist.',
+      severity: 'critical',
+      resourceType: 'AwsCloudTrailTrail',
+      resourceId: 'account-level',
+      remediation: 'Create a multi-region trail using cloudtrail:CreateTrailCommand.',
+      findingKey: 'cloudtrail-no-trails',
+      evidence: { awsAccountId: '123456789012', service: 'CloudTrail' },
+    });
+
+    expect(generateObjectMock).toHaveBeenCalledTimes(1);
+    expect(generateObjectMock.mock.calls[0][0].temperature).toBeUndefined();
+  });
+
+  it('GCP: generateGcpFixPlan does not send temperature to the model', async () => {
+    generateObjectMock.mockResolvedValueOnce({
+      object: { canAutoFix: true, fixSteps: [{ method: 'PATCH' }] },
+    });
+
+    await new AiRemediationService().generateGcpFixPlan({
+      title: 'finding',
+      description: null,
+      severity: 'high',
+      resourceType: 'CloudResource',
+      resourceId: 'r',
+      remediation: null,
+      findingKey: 'fk',
+      evidence: {},
+    });
+
+    expect(generateObjectMock.mock.calls[0][0].temperature).toBeUndefined();
+  });
+
+  it('Azure: generateAzureFixPlan does not send temperature to the model', async () => {
+    generateObjectMock.mockResolvedValueOnce({
+      object: { canAutoFix: true, fixSteps: [{ method: 'PATCH' }] },
+    });
+
+    await new AiRemediationService().generateAzureFixPlan({
+      title: 'finding',
+      description: null,
+      severity: 'high',
+      resourceType: 'CloudResource',
+      resourceId: 'r',
+      remediation: null,
+      findingKey: 'fk',
+      evidence: {},
+    });
+
+    expect(generateObjectMock.mock.calls[0][0].temperature).toBeUndefined();
   });
 });
 

--- a/apps/api/src/cloud-security/ai-remediation.service.ts
+++ b/apps/api/src/cloud-security/ai-remediation.service.ts
@@ -53,19 +53,19 @@ export class AiRemediationService {
   /** Phase 1: Generate initial plan (read steps + preliminary fix plan). */
   async generateFixPlan(finding: FindingContext): Promise<FixPlan> {
     try {
-      let plan = await this.requestFixPlan(finding, 0);
+      let plan = await this.requestFixPlan(finding);
 
       // The model occasionally returns canAutoFix=true with zero fixSteps, or
       // the normalizer strips every step (e.g. unsupported S3 ACL calls). That
       // surfaces to the user as "AI generated an empty fix plan. Cannot
       // proceed." and — combined with plan caching — a Retry that does
-      // nothing. Generation is non-deterministic, so retry ONCE at a higher
-      // temperature to force a genuinely different sample before giving up.
+      // nothing. Generation is non-deterministic, so regenerate ONCE to force a
+      // genuinely different sample before giving up.
       if (plan.canAutoFix && plan.fixSteps.length === 0) {
         this.logger.warn(
-          `Empty fix plan for ${finding.findingKey}; regenerating once at higher temperature`,
+          `Empty fix plan for ${finding.findingKey}; regenerating once`,
         );
-        const retry = await this.requestFixPlan(finding, 0.5);
+        const retry = await this.requestFixPlan(finding);
         // Prefer the retry if it is usable (has steps) OR if it correctly
         // concludes the finding is not auto-fixable — either is better than
         // returning the original empty canAutoFix=true plan (which only yields
@@ -84,16 +84,16 @@ export class AiRemediationService {
   }
 
   /** Single fix-plan generation pass (generate → enrich → normalize). */
-  private async requestFixPlan(
-    finding: FindingContext,
-    temperature: number,
-  ): Promise<FixPlan> {
+  private async requestFixPlan(finding: FindingContext): Promise<FixPlan> {
+    // NOTE: claude-opus-4-8 rejects the `temperature` parameter
+    // ("temperature is deprecated for this model" → 400), which previously
+    // made every plan generation throw and silently fall back to manual
+    // remediation steps. Do not re-add `temperature` to MODEL calls.
     const { object } = await generateObject({
       model: MODEL,
       schema: fixPlanSchema,
       system: SYSTEM_PROMPT,
       prompt: buildFixPlanPrompt(finding),
-      temperature,
     });
 
     this.logger.log(
@@ -133,7 +133,6 @@ IMPORTANT:
 3. ALWAYS overestimate permissions. It is much better to request 5 extra permissions than to fail mid-execution because one was missing.
 
 Generate the complete fix plan with EXACT values from the real AWS state.`,
-        temperature: 0,
       });
 
       this.logger.log(`AI refined plan for ${params.finding.findingKey}`);
@@ -185,7 +184,6 @@ List EVERY IAM action needed. Include:
 - Read permissions needed for validation (e.g., cloudtrail:GetTrailStatus after creating a trail)
 
 OVERESTIMATE. Better to have 5 extra permissions than to miss one.`,
-        temperature: 0,
       });
 
       this.logger.log(
@@ -217,7 +215,6 @@ OVERESTIMATE. Better to have 5 extra permissions than to miss one.`,
           failedStep: params.failedStep,
           roleName: REMEDIATION_ROLE_NAME,
         }),
-        temperature: 0,
       });
 
       const policy = JSON.stringify({
@@ -329,7 +326,6 @@ INSTRUCTIONS:
 3. If the error says "failed to satisfy constraint" or "regular expression pattern", fix the value to match.
 4. Keep the same service and command — do not switch to a different API.
 5. Return a complete AwsCommandStep with all required schema fields.`,
-        temperature: 0,
       });
 
       this.logger.log(
@@ -465,17 +461,17 @@ Produce 3-8 ordered steps. Each step is a single concrete action the customer ca
   async generateGcpFixPlan(finding: FindingContext): Promise<GcpFixPlan> {
     for (let attempt = 0; attempt < 2; attempt++) {
       try {
-        let object = await this.requestGcpFixPlan(finding, 0);
+        let object = await this.requestGcpFixPlan(finding);
 
         // canAutoFix=true with zero fixSteps surfaces as "AI generated an
         // empty fix plan" and (with caching) a Retry that does nothing.
-        // Generation is non-deterministic — retry once at a higher
-        // temperature to force a genuinely different sample.
+        // Generation is non-deterministic — regenerate once to force a
+        // genuinely different sample.
         if (object.canAutoFix && object.fixSteps.length === 0) {
           this.logger.warn(
-            `Empty GCP fix plan for ${finding.findingKey}; regenerating once at higher temperature`,
+            `Empty GCP fix plan for ${finding.findingKey}; regenerating once`,
           );
-          const retry = await this.requestGcpFixPlan(finding, 0.5);
+          const retry = await this.requestGcpFixPlan(finding);
           // Prefer a retry that is usable OR correctly non-auto-fixable —
           // either beats returning the original empty canAutoFix=true plan.
           if (retry.fixSteps.length > 0 || !retry.canAutoFix) object = retry;
@@ -499,14 +495,13 @@ Produce 3-8 ordered steps. Each step is a single concrete action the customer ca
   /** Single GCP fix-plan generation pass. */
   private async requestGcpFixPlan(
     finding: FindingContext,
-    temperature: number,
   ): Promise<GcpFixPlan> {
+    // MODEL (claude-opus-4-8) rejects `temperature` — do not re-add it.
     const { object } = await generateObject({
       model: MODEL,
       schema: gcpFixPlanSchema,
       system: GCP_SYSTEM_PROMPT,
       prompt: buildGcpFixPlanPrompt(finding),
-      temperature,
     });
     return object;
   }
@@ -538,7 +533,6 @@ CRITICAL INSTRUCTIONS:
 6. The "body" field is sent directly as JSON to fetch(). If it contains strings like "enabled for all services" instead of actual JSON, the API will ignore it silently.
 
 Generate the complete fix plan with EXACT JSON values from the real GCP state.`,
-        temperature: 0,
       });
 
       this.logger.log(`GCP AI refined plan for ${params.finding.findingKey}`);
@@ -555,17 +549,17 @@ Generate the complete fix plan with EXACT JSON values from the real GCP state.`,
 
   async generateAzureFixPlan(finding: FindingContext): Promise<AzureFixPlan> {
     try {
-      let object = await this.requestAzureFixPlan(finding, 0);
+      let object = await this.requestAzureFixPlan(finding);
 
       // canAutoFix=true with zero fixSteps surfaces as "AI generated an empty
       // fix plan" and (with caching) a Retry that does nothing. Generation is
-      // non-deterministic — retry once at a higher temperature to force a
-      // genuinely different sample.
+      // non-deterministic — regenerate once to force a genuinely different
+      // sample.
       if (object.canAutoFix && object.fixSteps.length === 0) {
         this.logger.warn(
-          `Empty Azure fix plan for ${finding.findingKey}; regenerating once at higher temperature`,
+          `Empty Azure fix plan for ${finding.findingKey}; regenerating once`,
         );
-        const retry = await this.requestAzureFixPlan(finding, 0.5);
+        const retry = await this.requestAzureFixPlan(finding);
         // Prefer a retry that is usable OR correctly non-auto-fixable —
         // either beats returning the original empty canAutoFix=true plan.
         if (retry.fixSteps.length > 0 || !retry.canAutoFix) object = retry;
@@ -586,14 +580,13 @@ Generate the complete fix plan with EXACT JSON values from the real GCP state.`,
   /** Single Azure fix-plan generation pass. */
   private async requestAzureFixPlan(
     finding: FindingContext,
-    temperature: number,
   ): Promise<AzureFixPlan> {
+    // MODEL (claude-opus-4-8) rejects `temperature` — do not re-add it.
     const { object } = await generateObject({
       model: MODEL,
       schema: azureFixPlanSchema,
       system: AZURE_SYSTEM_PROMPT,
       prompt: buildAzureFixPlanPrompt(finding),
-      temperature,
     });
     return object;
   }
@@ -622,7 +615,6 @@ IMPORTANT:
 3. Make sure all URLs include the correct api-version parameter.
 
 Generate the complete fix plan with EXACT values from the real Azure state.`,
-        temperature: 0,
       });
 
       this.logger.log(`Azure AI refined plan for ${params.finding.findingKey}`);


### PR DESCRIPTION
## Problem

Cloud Tests → auto-fix showed manual **"Remediation Steps"** instead of an **"Apply Fix"** button for every AWS/GCP/Azure finding (reported screenshot: CloudTrail "No CloudTrail trails configured").

**Root cause:** the remediation model was bumped to `claude-opus-4-8` (commit `1b8b3ee8f`, 2026-06-08), which **no longer accepts the `temperature` parameter** and returns:

```
400 invalid_request_error: "temperature is deprecated for this model."
```

Every `generateObject` call in `ai-remediation.service.ts` passed `temperature`, so all fix-plan generation threw, was caught in `generateFixPlan`, and fell back to `fallbackPlan()` → `canAutoFix:false` + `guidedSteps:[finding.remediation]`. The UI renders that as the manual "Remediation Steps" dialog. The fallback masked the failure, so it looked like "auto-fix can't handle this finding" when the AI call was actually erroring on a deprecated param.

## Fix

Remove `temperature` from all 9 `MODEL` (opus-4-8) `generateObject` calls (AWS + GCP + Azure: generate / refine / permission analysis / step repair). The empty-plan retry now re-samples at the model default instead of bumping temperature. The Sonnet `FALLBACK_MODEL` call keeps `temperature` — `claude-sonnet-4-6` and `claude-haiku-4-5` both still accept it.

## Verification (reproduced live against the real API)

- `claude-opus-4-8` + `temperature:0` → **400** (above).
- `claude-opus-4-8` **without** `temperature` → **success**, `canAutoFix:true`, real plan (`CreateBucket → PutPublicAccessBlock → PutBucketPolicy → CreateTrail → StartLogging`).
- Confirmed `sonnet-4-6` and `haiku-4-5` still accept `temperature` (so the Sonnet fallback and the Haiku description service are unaffected).
- `ai-remediation.service.spec.ts`: **26/26 pass**, incl. 3 new regression tests asserting `temperature` is never sent to `MODEL`.
- Typecheck clean for the changed file.

## Scope

Only `apps/api/src/cloud-security/ai-remediation.service.ts` (+ its spec). No version/dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWJZw7nETZu7JHaEdGuGhu

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores Cloud Tests auto-fix by removing the deprecated `temperature` param from `claude-opus-4-8` calls that caused 400s and forced a fallback to manual steps. Users now see “Apply Fix” again for AWS/GCP/Azure findings.

- **Bug Fixes**
  - Removed `temperature` from all `claude-opus-4-8` `generateObject` calls (AWS/GCP/Azure: generate, refine, permissions, step repair).
  - Empty-plan retry now re-samples at model defaults instead of bumping temperature; logs updated to say “regenerating once”.
  - Kept `temperature` for `claude-sonnet-4-6` and `claude-haiku-4-5` fallbacks.
  - Expanded tests to assert `temperature` is never sent to the MODEL across AWS/GCP/Azure paths; all tests pass.

<sup>Written for commit 1cf2269198ae828714babc6bbeeee095186f09b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

