### PR TITLE
feat(people): add "Don't auto-sync" option to employee sync source

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
@@ -53,6 +53,11 @@ import type { MemberWithUser, TaskCompletion, TeamMembersData } from './TeamMemb
 import type { EmployeeSyncConnectionsData } from '../data/queries';
 import { useEmployeeSync } from '../hooks/useEmployeeSync';
 
+// Sentinel value for the "Don't auto-sync" item in the sync-source dropdown.
+// Radix Select items can't have an empty value, so disabling is modeled as a
+// distinct option rather than the absence of a selection.
+const NO_SYNC_VALUE = '__no_sync__';
+
 interface TeamMembersClientProps {
   data: TeamMembersData;
   organizationId: string;
@@ -119,6 +124,7 @@ export function TeamMembersClient({
     selectedProvider,
     isSyncing,
     syncEmployees,
+    setSyncProvider,
     hasAnyConnection,
     getProviderName,
     getProviderLogo,
@@ -135,6 +141,14 @@ export function TeamMembersClient({
     if (result?.success) {
       router.refresh();
     }
+  };
+
+  // Turn off the daily auto-sync without disconnecting the integration (which
+  // would also stop its compliance checks). Clears the org's sync provider so
+  // the scheduled job skips it; already-imported people are left untouched.
+  const handleDisableSync = async () => {
+    if (!selectedProvider) return;
+    await setSyncProvider(null);
   };
 
   const allItems = buildDisplayItems(data);
@@ -358,11 +372,13 @@ export function TeamMembersClient({
             <div className="w-[200px]">
               <Select
                 onValueChange={(value) => {
-                  if (value) {
-                    handleEmployeeSync(
-                      value as 'google-workspace' | 'rippling' | 'jumpcloud',
-                    );
+                  const provider = String(value);
+                  if (!provider) return;
+                  if (provider === NO_SYNC_VALUE) {
+                    handleDisableSync();
+                    return;
                   }
+                  handleEmployeeSync(provider);
                 }}
                 disabled={isSyncing || !canManageMembers}
               >
@@ -488,6 +504,15 @@ export function TeamMembersClient({
                       </div>
                     </SelectItem>
                   ))}
+                <Separator />
+                <SelectItem value={NO_SYNC_VALUE}>
+                  <div className="flex items-center gap-2">
+                    <span>Don&apos;t auto-sync</span>
+                    {!selectedProvider && (
+                      <span className="ml-auto text-xs text-muted-foreground">Active</span>
+                    )}
+                  </div>
+                </SelectItem>
               </SelectContent>
               </Select>
             </div>

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
@@ -133,6 +133,7 @@ export function TeamMembersClient({
 
   const lastSyncAt = employeeSyncData.lastSyncAt;
   const nextSyncAt = employeeSyncData.nextSyncAt;
+  const [isDisablingSync, setIsDisablingSync] = useState(false);
 
   const handleEmployeeSync = async (
     provider: string,
@@ -146,9 +147,16 @@ export function TeamMembersClient({
   // Turn off the daily auto-sync without disconnecting the integration (which
   // would also stop its compliance checks). Clears the org's sync provider so
   // the scheduled job skips it; already-imported people are left untouched.
+  // Sets a busy flag (mirroring isSyncing) so the dropdown is locked while the
+  // request is in flight, preventing an overlapping provider change from racing.
   const handleDisableSync = async () => {
-    if (!selectedProvider) return;
-    await setSyncProvider(null);
+    if (!selectedProvider || isDisablingSync) return;
+    setIsDisablingSync(true);
+    try {
+      await setSyncProvider(null);
+    } finally {
+      setIsDisablingSync(false);
+    }
   };
 
   const allItems = buildDisplayItems(data);
@@ -380,7 +388,7 @@ export function TeamMembersClient({
                   }
                   handleEmployeeSync(provider);
                 }}
-                disabled={isSyncing || !canManageMembers}
+                disabled={isSyncing || isDisablingSync || !canManageMembers}
               >
                 <SelectTrigger>
                   {isSyncing ? (

--- a/apps/app/src/app/(app)/[orgId]/people/all/hooks/useEmployeeSync.test.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/all/hooks/useEmployeeSync.test.ts
@@ -1,0 +1,75 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { EmployeeSyncConnectionsData } from '../data/queries';
+
+vi.mock('@/lib/api-client', () => ({
+  apiClient: { post: vi.fn().mockResolvedValue({ data: { success: true } }) },
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn(), warning: vi.fn() },
+}));
+
+import { apiClient } from '@/lib/api-client';
+import { toast } from 'sonner';
+import { useEmployeeSync } from './useEmployeeSync';
+
+const initialData: EmployeeSyncConnectionsData = {
+  googleWorkspaceConnectionId: null,
+  ripplingConnectionId: null,
+  jumpcloudConnectionId: null,
+  selectedProvider: 'entra-id',
+  lastSyncAt: null,
+  nextSyncAt: null,
+  availableProviders: [
+    {
+      slug: 'entra-id',
+      name: 'Microsoft Entra ID',
+      logoUrl: '',
+      connected: true,
+      connectionId: 'conn_1',
+      lastSyncAt: null,
+      nextSyncAt: null,
+    },
+  ],
+};
+
+const ENDPOINT =
+  '/v1/integrations/sync/employee-sync-provider?organizationId=org_1';
+
+describe('useEmployeeSync.setSyncProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('turns off auto-sync by POSTing provider: null and confirms to the user', async () => {
+    const { result } = renderHook(() =>
+      useEmployeeSync({ organizationId: 'org_1', initialData }),
+    );
+
+    await act(async () => {
+      await result.current.setSyncProvider(null);
+    });
+
+    expect(apiClient.post).toHaveBeenCalledWith(ENDPOINT, { provider: null });
+    expect(toast.success).toHaveBeenCalledWith('Employee auto-sync turned off');
+  });
+
+  it('selects a provider by POSTing its slug', async () => {
+    const { result } = renderHook(() =>
+      useEmployeeSync({ organizationId: 'org_1', initialData }),
+    );
+
+    await act(async () => {
+      await result.current.setSyncProvider('entra-id');
+    });
+
+    expect(apiClient.post).toHaveBeenCalledWith(ENDPOINT, {
+      provider: 'entra-id',
+    });
+    expect(toast.success).toHaveBeenCalledWith(
+      'Microsoft Entra ID set as your employee sync provider',
+    );
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/people/all/hooks/useEmployeeSync.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/all/hooks/useEmployeeSync.ts
@@ -97,6 +97,8 @@ export const useEmployeeSync = ({
           ? PROVIDER_CONFIG[provider as BuiltInSyncProvider].name
           : (availableProviders.find((p) => p.slug === provider)?.name ?? provider);
         toast.success(`${name} set as your employee sync provider`);
+      } else {
+        toast.success('Employee auto-sync turned off');
       }
     } catch (error) {
       toast.error('Failed to set sync provider');


### PR DESCRIPTION
## Problem

CS-576 (re-opened). Customers can pick an employee **sync source** in the People tab, but once selected there is **no way to turn it back off**. The dropdown lists only connected providers and has no "none"/"disable" item; selecting one immediately syncs everyone. The only "off" levers today are:

- **Disconnect the integration** — but that's a soft-delete labelled *"Remove this account and all data"* and, critically, it also stops the integration's **compliance checks** (which the customer wants to keep).
- The email **include/exclude filter** in integration settings — which can *limit* users but has no real "off" (an empty include list silently reverts to "all" by design).

So a customer who wants to **stop the daily auto-sync while staying connected for checks** has no path in the UI.

## Root cause

The capability already exists end-to-end — it was just never wired to a control:

- `POST /v1/integrations/sync/employee-sync-provider` accepts `{ provider: null }` ("pass null to disable employee sync").
- `useEmployeeSync.setSyncProvider(null)` already calls it.
- The daily 7 AM cron (`syncEmployeesSchedule`) only runs for orgs where `employeeSyncProvider` is **not null**.

The People-tab dropdown's `onValueChange` only ever called `syncEmployees(...)`, and the item list contained no "off" option.

## Fix

- Add a **"Don't auto-sync"** item to the sync-source dropdown. Selecting it routes to a disable handler (`setSyncProvider(null)`) instead of running a sync, clearing the org's provider so the scheduled job skips it.
- Already-imported people are left untouched; the integration stays connected (checks keep running).
- The item shows **Active** when no provider is selected, so the off-state is visible/discoverable.
- `setSyncProvider` now confirms the off action with a toast.
- Applies to **every** sync provider (Google Workspace, Rippling, JumpCloud, and dynamic providers like Microsoft Entra ID), not just Entra.
- Permission-gated: the dropdown is disabled unless `canManageMembers`; the API still enforces `integration:update`.

## Not included (intentionally)

"Sync only specific **Entra groups**" — a separate, larger feature that requires editing the shared Entra `syncDefinition` (Graph group-member resolution + a new variable + UI) and is tracked separately. This PR delivers the customer's core "stop the sync completely" ask.

## Tests

- `useEmployeeSync.test.ts`: `setSyncProvider(null)` POSTs `{ provider: null }` and confirms; provider selection POSTs the slug.

Fixes CS-576

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Don’t auto-sync” option to the People tab so orgs can pause daily employee imports without disconnecting the integration. This fulfills the “disable auto-sync” part of Linear CS-576 while keeping compliance checks running.

- **New Features**
  - Added a “Don’t auto-sync” dropdown item that calls `setSyncProvider(null)` so the scheduled job skips the org; existing people remain.
  - Shows “Active” when no provider is selected for a clear off-state.
  - Works for all providers, including dynamic ones (e.g., Microsoft Entra ID).
  - Permission-gated: dropdown disabled unless `canManageMembers`; API enforces `integration:update`.
  - Toast confirms both disabling and provider selection.

- **Bug Fixes**
  - Locked the sync-source dropdown while disabling to prevent races with concurrent provider changes.

<sup>Written for commit 541a72fc107000eaeaa536296a504f8b1fccc71f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

