### PR TITLE
fix(self-heal): refresh manifest cache before persisted re-run

### DIFF
--- a/apps/api/src/integration-platform/services/internal-integration-debug.service.spec.ts
+++ b/apps/api/src/integration-platform/services/internal-integration-debug.service.spec.ts
@@ -12,6 +12,7 @@ jest.mock('@db', () => ({
     },
     integrationOAuthError: { findMany: jest.fn() },
     dynamicIntegration: { findFirst: jest.fn() },
+    task: { findUnique: jest.fn(), updateMany: jest.fn() },
   },
 }));
 
@@ -20,6 +21,7 @@ import { db } from '@db';
 import { InternalIntegrationDebugService } from './internal-integration-debug.service';
 import type { ConnectionCheckRunnerService } from './connection-check-runner.service';
 import type { CheckRunRepository } from '../repositories/check-run.repository';
+import type { DynamicManifestLoaderService } from './dynamic-manifest-loader.service';
 
 const encryptedBlob = {
   encrypted: 'Y2lwaGVydGV4dA==',
@@ -38,15 +40,20 @@ const mockedDb = db as unknown as {
   };
   integrationOAuthError: { findMany: jest.Mock };
   dynamicIntegration: { findFirst: jest.Mock };
+  task: { findUnique: jest.Mock; updateMany: jest.Mock };
 };
 
 const makeService = (
   runner: Partial<ConnectionCheckRunnerService> = {},
   checkRunRepo: Partial<CheckRunRepository> = {},
+  manifestLoader: Partial<DynamicManifestLoaderService> = {
+    loadDynamicManifests: jest.fn().mockResolvedValue(undefined),
+  },
 ) =>
   new InternalIntegrationDebugService(
     runner as ConnectionCheckRunnerService,
     checkRunRepo as CheckRunRepository,
+    manifestLoader as DynamicManifestLoaderService,
   );
 
 describe('InternalIntegrationDebugService', () => {
@@ -471,6 +478,12 @@ describe('InternalIntegrationDebugService', () => {
       complete: jest.fn().mockResolvedValue({}),
     });
 
+    beforeEach(() => {
+      // The persisted re-run validates the taskId belongs to the connection's org
+      // (assertTaskBelongsToOrg). Default the task to the same org as the tests.
+      mockedDb.task.findUnique.mockResolvedValue({ organizationId: 'org_1' });
+    });
+
     it('persists a fresh SUCCESS run when the fixed check now passes', async () => {
       mockedDb.integrationConnection.findUnique.mockResolvedValue({
         organizationId: 'org_1',
@@ -529,6 +542,56 @@ describe('InternalIntegrationDebugService', () => {
         'icr_new',
         expect.objectContaining({ status: 'inconclusive', failedCount: 0 }),
       );
+    });
+
+    it('refreshes the manifest cache BEFORE running (so a just-patched fix is live, not the 60s-stale code)', async () => {
+      mockedDb.integrationConnection.findUnique.mockResolvedValue({
+        organizationId: 'org_1',
+        provider: { slug: 'neon' },
+      });
+      mockedDb.dynamicIntegration.findFirst.mockResolvedValue({ id: 'din_neon' });
+      const runChecks = jest.fn().mockResolvedValue(runResult('success'));
+      const loadDynamicManifests = jest.fn().mockResolvedValue(undefined);
+
+      const service = makeService({ runChecks }, makeRepo(), {
+        loadDynamicManifests,
+      });
+      await service.rerunAndPersistCheck({
+        connectionId: 'icn_1',
+        checkId: 'neon_x',
+        taskId: 'task_1',
+      });
+
+      expect(loadDynamicManifests).toHaveBeenCalledTimes(1);
+      // Refresh MUST happen before the run — otherwise the run executes stale code.
+      expect(loadDynamicManifests.mock.invocationCallOrder[0]).toBeLessThan(
+        runChecks.mock.invocationCallOrder[0],
+      );
+    });
+
+    it('still runs (falls back to cached manifests) when the refresh throws', async () => {
+      mockedDb.integrationConnection.findUnique.mockResolvedValue({
+        organizationId: 'org_1',
+        provider: { slug: 'neon' },
+      });
+      mockedDb.dynamicIntegration.findFirst.mockResolvedValue({ id: 'din_neon' });
+      const runChecks = jest.fn().mockResolvedValue(runResult('success'));
+      const loadDynamicManifests = jest
+        .fn()
+        .mockRejectedValue(new Error('db blip'));
+
+      const service = makeService({ runChecks }, makeRepo(), {
+        loadDynamicManifests,
+      });
+      const out = await service.rerunAndPersistCheck({
+        connectionId: 'icn_1',
+        checkId: 'neon_x',
+        taskId: 'task_1',
+      });
+
+      // Refresh failure is swallowed; the re-run still executes + persists.
+      expect(out.status).toBe('success');
+      expect(runChecks).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/api/src/integration-platform/services/internal-integration-debug.service.ts
+++ b/apps/api/src/integration-platform/services/internal-integration-debug.service.ts
@@ -7,6 +7,7 @@ import {
 } from './connection-check-runner.service';
 import { CheckRunRepository } from '../repositories/check-run.repository';
 import { decideRunStatus } from '../utils/task-check-evaluation';
+import { DynamicManifestLoaderService } from './dynamic-manifest-loader.service';
 
 /**
  * Read-only/diagnostic toolkit for dynamic integrations, used by internal
@@ -32,6 +33,7 @@ export class InternalIntegrationDebugService {
   constructor(
     private readonly runner: ConnectionCheckRunnerService,
     private readonly checkRunRepository: CheckRunRepository,
+    private readonly manifestLoader: DynamicManifestLoaderService,
   ) {}
 
   private isEncryptedData(value: unknown): boolean {
@@ -498,6 +500,23 @@ export class InternalIntegrationDebugService {
       throw new NotFoundException(`Connection ${connectionId} not found`);
     }
     await this.assertTaskBelongsToOrg(taskId, connection.organizationId, connectionId);
+
+    // The runner resolves dynamic check code from the in-memory manifest
+    // registry, which only refreshes from the DB every ~60s. A self-heal re-run
+    // fires seconds after the agent PATCHes a fix, so without a refresh here the
+    // re-run would execute the STALE (pre-fix) code and wrongly re-hold a check
+    // we just fixed. Refresh first so this persisted re-run reflects current DB.
+    // Best-effort: on a transient refresh failure, fall back to the cached
+    // manifests rather than failing the whole re-run.
+    try {
+      await this.manifestLoader.loadDynamicManifests();
+    } catch (err) {
+      this.logger.warn(
+        `Self-heal re-run: manifest refresh failed, using cached manifests: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
 
     // Execute on the real runtime in-process (runChecks never persists).
     const result = await this.runner.runChecks({


### PR DESCRIPTION
## What

A self-heal re-run resolves dynamic check code from the in-memory manifest registry, which only refreshes from the DB every ~60s (`dynamic-manifest-loader.service.ts`). The agent re-runs a check within ~1s of applying a fix, so the persisted re-run executed the **stale, pre-fix code** and re-held a check that had actually been fixed. Result: the fix landed in the DB, but the customer-facing status stayed on "pending" until the next scheduled run (up to a day later).

This refreshes the registry from the DB **before** the persisted re-run, so it always reflects current state. Best-effort — a transient refresh failure falls back to the cached manifests rather than failing the whole re-run.

## Why it matters

This is one of two fixes (the other in the agent repo) for "the agent fixes checks but they never turn green." Live evidence: a check whose code had been corrected still sat in the held queue; re-running it once (with a fresh cache) passed and cleared it. ~40% of the held queue was found to be already-healthy-but-stuck for this class of reason.

## Tests

- `refreshes the manifest cache BEFORE running` — asserts refresh happens before the run.
- `still runs (falls back to cached manifests) when the refresh throws`.
- Adds the missing `db.task` mock so all `rerunAndPersistCheck` tests exercise the org-validation path. Suite: 16/16 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the manifest cache from the DB before a persisted self-heal re-run so the latest dynamic check code is used, preventing fixed checks from being re-held and stuck in “pending”.

- **Bug Fixes**
  - Refresh manifests immediately before the re-run via loadDynamicManifests.
  - Best-effort refresh: on failure, fall back to cached manifests and still re-run.
  - Tests cover refresh-before-run ordering and the fallback; add default `db.task.findUnique` mock for org validation.

<sup>Written for commit 7f8a0a751b6a7943018a1c61128bce72bf942490. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

