### PR TITLE
fix(trust-portal): sync iso 27001 certification mapping with vendor-risk task

### DIFF
--- a/apps/api/src/trust-portal/trust-portal.service.spec.ts
+++ b/apps/api/src/trust-portal/trust-portal.service.spec.ts
@@ -1,0 +1,88 @@
+import { db } from '@db';
+import { TrustPortalService } from './trust-portal.service';
+
+jest.mock('@db', () => ({
+  db: {
+    vendor: {
+      findMany: jest.fn(),
+      update: jest.fn(),
+    },
+    globalVendors: {
+      findUnique: jest.fn(),
+    },
+  },
+  Prisma: {},
+  TrustFramework: {
+    iso_27001: 'iso_27001',
+    iso_42001: 'iso_42001',
+    gdpr: 'gdpr',
+    hipaa: 'hipaa',
+    soc2_type1: 'soc2_type1',
+    soc2_type2: 'soc2_type2',
+    pci_dss: 'pci_dss',
+    nen_7510: 'nen_7510',
+    iso_9001: 'iso_9001',
+  },
+}));
+
+jest.mock('../app/s3', () => ({
+  APP_AWS_ORG_ASSETS_BUCKET: 'org-assets',
+  s3Client: { send: jest.fn() },
+  getSignedUrl: jest.fn(),
+}));
+
+const mockDb = db as unknown as {
+  vendor: { findMany: jest.Mock; update: jest.Mock };
+  globalVendors: { findUnique: jest.Mock };
+};
+
+describe('TrustPortalService getAllVendorsWithSync compliance badges', () => {
+  const service = new TrustPortalService();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // Regression: Scaleway's GlobalVendors record lists "ISO/IEC 27001:2022",
+  // "HDS" and "GDPR Compliance" as verified, but the Trust Centre only showed
+  // GDPR. The "IEC" infix and ":2022" suffix caused the ISO 27001 certification
+  // to be dropped during badge sync, understating the vendor's posture.
+  it('maps "ISO/IEC 27001:2022" to the iso27001 badge alongside gdpr', async () => {
+    const baseVendor = {
+      id: 'vnd_scaleway',
+      name: 'Scaleway',
+      description: null,
+      website: 'scaleway.com',
+      showOnTrustPortal: true,
+      logoUrl: 'https://logo.example/scaleway.png',
+      complianceBadges: null,
+      trustPortalOrder: 0,
+    };
+
+    mockDb.vendor.findMany.mockResolvedValue([baseVendor]);
+    mockDb.globalVendors.findUnique.mockResolvedValue({
+      riskAssessmentData: {
+        certifications: [
+          { type: 'ISO/IEC 27001:2022', status: 'verified' },
+          { type: 'HDS', status: 'verified' },
+          { type: 'GDPR Compliance', status: 'verified' },
+        ],
+      },
+    });
+    mockDb.vendor.update.mockImplementation(
+      async ({ data }: { data: Record<string, unknown> }) => ({
+        ...baseVendor,
+        ...data,
+      }),
+    );
+
+    const result = await service.getAllVendorsWithSync('org_1');
+
+    const badgeTypes = (
+      result[0].complianceBadges as unknown as Array<{ type: string }>
+    ).map((badge) => badge.type);
+
+    expect(badgeTypes).toContain('iso27001');
+    expect(badgeTypes).toContain('gdpr');
+  });
+});

--- a/apps/api/src/trust-portal/trust-portal.service.ts
+++ b/apps/api/src/trust-portal/trust-portal.service.ts
@@ -1950,10 +1950,11 @@ export class TrustPortalService {
 
     if (normalized.includes('soc2') || normalized.includes('soc 2'))
       return 'soc2';
-    if (normalized.includes('iso27001') || normalized.includes('iso 27001'))
-      return 'iso27001';
-    if (normalized.includes('iso42001') || normalized.includes('iso 42001'))
-      return 'iso42001';
+    // Match ISO standards by their number. Vendors write these many ways
+    // ("ISO 27001", "ISO/IEC 27001:2022"), and the "IEC" infix breaks a naive
+    // includes('iso27001') check ("iso27001" is not a substring of "isoiec27001…").
+    if (normalized.includes('27001')) return 'iso27001';
+    if (normalized.includes('42001')) return 'iso42001';
     if (normalized.includes('gdpr')) return 'gdpr';
     if (normalized.includes('hipaa')) return 'hipaa';
     if (
@@ -1964,8 +1965,7 @@ export class TrustPortalService {
       return 'pci_dss';
     if (normalized.includes('nen7510') || normalized.includes('nen 7510'))
       return 'nen7510';
-    if (normalized.includes('iso9001') || normalized.includes('iso 9001'))
-      return 'iso9001';
+    if (normalized.includes('9001')) return 'iso9001';
 
     return null;
   }


### PR DESCRIPTION
## Problem
The Trust Centre subprocessor page shows incomplete compliance badges for Scaleway, displaying only GDPR while missing ISO/IEC 27001 certification that is verified in the Vendors tab. This misleads auditors and prospective customers about the vendor's security posture.

## Root cause
The certification-to-badge mapping in trust-portal.service.ts normalizes cert names by stripping non-alphanumeric chars, turning "ISO/IEC 27001:2022" into "isoiec270012022". The check then looks for 'iso27001' or 'iso 27001' (the latter impossible post-normalization), so the cert is not recognized and gets dropped. The parallel code path in vendor-risk-assessment-task.ts was hardened in April to handle this (bare '27001' substring check), but trust-portal was left behind, creating an asymmetry.

## Fix
Update the mapCertificationToBadgeType logic in trust-portal.service.ts to include a '27001' substring check, matching the vendor-risk-assessment-task implementation. This recognizes the normalized cert string and maps it correctly to the ISO 27001 badge type.

## Explicitly NOT touched
Data in the Vendors tab (Capawesome) remains unchanged. The fix only corrects the mapping logic to properly recognize existing cert data. HDS badge handling is out of scope for this PR.

## Verification
✅ Scaleway vendor card now displays ISO 27001 badge alongside GDPR on Trust Centre Subprocessors page
✅ Badge set matches verified certifications from Vendors tab
✅ No regression on other vendor mappings

Fixes CS-688

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Trust Centre badge mismatch by recognizing ISO/IEC 27001:2022 and similar formats so Scaleway now shows the ISO 27001 badge alongside GDPR. Addresses Linear CS-688.

- **Bug Fixes**
  - Updated `mapCertificationToBadgeType` to detect numeric standards (`27001`, `42001`, `9001`) so variations like "ISO/IEC 27001:2022" map correctly.
  - Added a unit test for the Scaleway scenario to prevent regressions.
  - Synced mapping logic with the vendor risk assessment task for consistency.

<sup>Written for commit 9f944a0df8ea52dcaf209dce3d25ec17bc02b4c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

