### PR TITLE
fix(auth): stop offboarded users from looping into a spurious new org (CS-569)

### DIFF
--- a/apps/api/src/auth/auth.controller.spec.ts
+++ b/apps/api/src/auth/auth.controller.spec.ts
@@ -1,0 +1,105 @@
+const mockUserFindUnique = jest.fn();
+const mockMemberFindMany = jest.fn();
+const mockMemberCount = jest.fn();
+const mockInvitationFindFirst = jest.fn();
+
+jest.mock('@db', () => ({
+  db: {
+    user: { findUnique: (...a: unknown[]) => mockUserFindUnique(...a) },
+    member: {
+      findMany: (...a: unknown[]) => mockMemberFindMany(...a),
+      count: (...a: unknown[]) => mockMemberCount(...a),
+    },
+    invitation: { findFirst: (...a: unknown[]) => mockInvitationFindFirst(...a) },
+  },
+}));
+
+// Both guards import ./auth.server, which validates SECRET_KEY and pulls in
+// better-auth/redis at module load. Stub them so importing the controller is
+// hermetic — the test calls the method directly and never runs the guards.
+jest.mock('./hybrid-auth.guard', () => ({ HybridAuthGuard: class {} }));
+jest.mock('./permission.guard', () => ({
+  PermissionGuard: class {},
+  PERMISSIONS_KEY: 'permissions',
+}));
+
+import { AuthController } from './auth.controller';
+import type { AuthContext } from './types';
+
+const sessionContext = (): AuthContext => ({
+  organizationId: 'org_1',
+  authType: 'session',
+  isApiKey: false,
+  isPlatformAdmin: false,
+  userRoles: null,
+  userId: 'user_1',
+  userEmail: 'user@example.com',
+});
+
+describe('AuthController.getMe — hasInactiveMembership (CS-569)', () => {
+  const controller = new AuthController();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUserFindUnique.mockResolvedValue({
+      id: 'user_1',
+      email: 'user@example.com',
+      name: 'User',
+      image: null,
+      role: 'user',
+    });
+    mockInvitationFindFirst.mockResolvedValue(null);
+  });
+
+  it('returns hasInactiveMembership: false for a genuinely new user (no memberships at all)', async () => {
+    mockMemberFindMany.mockResolvedValue([]);
+    mockMemberCount.mockResolvedValue(0);
+
+    const res = await controller.getMe(sessionContext());
+
+    expect(res.organizations).toEqual([]);
+    expect(res.hasInactiveMembership).toBe(false);
+  });
+
+  it('returns hasInactiveMembership: true for an offboarded user (no active org, only deactivated memberships)', async () => {
+    mockMemberFindMany.mockResolvedValue([]); // no ACTIVE memberships
+    mockMemberCount.mockResolvedValue(1); // one deactivated/inactive membership
+
+    const res = await controller.getMe(sessionContext());
+
+    expect(res.organizations).toEqual([]);
+    expect(res.hasInactiveMembership).toBe(true);
+    // The count that distinguishes "offboarded" from "new" must match
+    // memberships that are deactivated OR no longer active.
+    expect(mockMemberCount).toHaveBeenCalledWith({
+      where: {
+        userId: 'user_1',
+        OR: [{ deactivated: true }, { isActive: false }],
+      },
+    });
+  });
+
+  it('returns hasInactiveMembership: false for an active member', async () => {
+    mockMemberFindMany.mockResolvedValue([
+      {
+        id: 'member_1',
+        role: 'owner',
+        organizationId: 'org_1',
+        organization: {
+          id: 'org_1',
+          name: 'Org',
+          logo: null,
+          onboardingCompleted: true,
+          hasAccess: true,
+          createdAt: new Date(),
+        },
+      },
+    ]);
+    mockMemberCount.mockResolvedValue(0);
+
+    const res = await controller.getMe(sessionContext());
+
+    expect(res.organizations).toHaveLength(1);
+    expect(res.hasInactiveMembership).toBe(false);
+  });
+});

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -35,44 +35,55 @@ export class AuthController {
       return { user: null, organizations: [], pendingInvitation: null };
     }
 
-    const [user, memberships, pendingInvitation] = await Promise.all([
-      db.user.findUnique({
-        where: { id: userId },
-        select: {
-          id: true,
-          email: true,
-          name: true,
-          image: true,
-          role: true,
-        },
-      }),
-      db.member.findMany({
-        where: { userId, isActive: true, deactivated: false },
-        select: {
-          id: true,
-          role: true,
-          organizationId: true,
-          organization: {
-            select: {
-              id: true,
-              name: true,
-              logo: true,
-              onboardingCompleted: true,
-              hasAccess: true,
-              createdAt: true,
+    const [user, memberships, pendingInvitation, inactiveMembershipCount] =
+      await Promise.all([
+        db.user.findUnique({
+          where: { id: userId },
+          select: {
+            id: true,
+            email: true,
+            name: true,
+            image: true,
+            role: true,
+          },
+        }),
+        db.member.findMany({
+          where: { userId, isActive: true, deactivated: false },
+          select: {
+            id: true,
+            role: true,
+            organizationId: true,
+            organization: {
+              select: {
+                id: true,
+                name: true,
+                logo: true,
+                onboardingCompleted: true,
+                hasAccess: true,
+                createdAt: true,
+              },
             },
           },
-        },
-        orderBy: { createdAt: 'desc' },
-      }),
-      db.invitation.findFirst({
-        where: {
-          email: authContext.userEmail ?? '',
-          status: 'pending',
-        },
-        select: { id: true },
-      }),
-    ]);
+          orderBy: { createdAt: 'desc' },
+        }),
+        db.invitation.findFirst({
+          where: {
+            email: authContext.userEmail ?? '',
+            status: 'pending',
+          },
+          select: { id: true },
+        }),
+        // Count memberships that exist but are no longer active (deactivated
+        // or removed). Lets the app tell a genuinely new user (no memberships
+        // at all → onboarding) apart from an offboarded user whose access was
+        // revoked (→ "access removed" instead of a spurious new org). CS-569.
+        db.member.count({
+          where: {
+            userId,
+            OR: [{ deactivated: true }, { isActive: false }],
+          },
+        }),
+      ]);
 
     return {
       user,
@@ -82,6 +93,7 @@ export class AuthController {
         memberId: m.id,
       })),
       pendingInvitation,
+      hasInactiveMembership: inactiveMembershipCount > 0,
     };
   }
 

--- a/apps/app/src/app/(app)/setup/actions/create-organization-minimal.ts
+++ b/apps/app/src/app/(app)/setup/actions/create-organization-minimal.ts
@@ -43,6 +43,36 @@ export const createOrganizationMinimal = authActionClientWithoutOrg
         };
       }
 
+      // CS-569 backstop: never create an org for a user whose only memberships
+      // are deactivated (0 active, >=1 inactive) — that user was offboarded and
+      // the routing layer already sends them to /auth/access-removed. This
+      // guards against a stale/replayed form POST slipping past that redirect
+      // and spawning a spurious empty org. Genuinely new users (no memberships)
+      // and users adding an additional org (have active memberships) pass.
+      const [activeMembershipCount, inactiveMembershipCount] = await Promise.all([
+        db.member.count({
+          where: {
+            userId: session.user.id,
+            isActive: true,
+            deactivated: false,
+          },
+        }),
+        db.member.count({
+          where: {
+            userId: session.user.id,
+            OR: [{ deactivated: true }, { isActive: false }],
+          },
+        }),
+      ]);
+
+      if (activeMembershipCount === 0 && inactiveMembershipCount > 0) {
+        return {
+          success: false,
+          error:
+            'Your access to this organization was removed. Contact your administrator to be re-invited.',
+        };
+      }
+
       // Internal team accounts (verified @trycomp.ai) have access provisioned up front.
       const userEmail = session.user.email;
       const isVerifiedTryCompEmail =

--- a/apps/app/src/app/(app)/setup/route.test.ts
+++ b/apps/app/src/app/(app)/setup/route.test.ts
@@ -1,0 +1,80 @@
+import { vi } from 'vitest';
+
+vi.mock('@/utils/auth', async () => {
+  const { mockAuth } = await import('@/test-utils/mocks/auth');
+  return { auth: mockAuth };
+});
+
+const { mockServerApiGet, mockCreateSetupSession } = vi.hoisted(() => ({
+  mockServerApiGet: vi.fn(),
+  mockCreateSetupSession: vi.fn(async () => ({ id: 'setup_1' })),
+}));
+vi.mock('@/lib/api-server', () => ({ serverApi: { get: mockServerApiGet } }));
+vi.mock('./lib/setup-session', () => ({ createSetupSession: mockCreateSetupSession }));
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { redirect } from 'next/navigation';
+import { GET } from './route';
+import { mockAuthApi, createMockSession, createMockUser } from '@/test-utils/mocks/auth';
+
+const mockRedirect = vi.mocked(redirect);
+
+interface MeData {
+  organizations: unknown[];
+  pendingInvitation: { id: string } | null;
+  hasInactiveMembership?: boolean;
+}
+const mockMe = (data: MeData) => mockServerApiGet.mockResolvedValue({ data, status: 200 });
+const call = (url: string) => GET(new NextRequest(url));
+
+describe('/setup route — CS-569 offboard guard vs invite precedence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateSetupSession.mockResolvedValue({ id: 'setup_1' });
+    mockRedirect.mockImplementation((url: string) => {
+      throw new Error(`REDIRECT:${url}`);
+    });
+    mockAuthApi.getSession.mockResolvedValue({
+      session: createMockSession(),
+      user: createMockUser(),
+    });
+  });
+
+  it('redirects an offboarded user with no invite to access-removed', async () => {
+    mockMe({ organizations: [], pendingInvitation: null, hasInactiveMembership: true });
+
+    await expect(call('http://localhost/setup')).rejects.toThrow('REDIRECT:/auth/access-removed');
+    expect(mockCreateSetupSession).not.toHaveBeenCalled();
+  });
+
+  it('does NOT block an offboarded user arriving via ?inviteCode= (invite handled downstream)', async () => {
+    // Regression (cubic): the guard must not pre-empt the legacy invite entry.
+    mockMe({ organizations: [], pendingInvitation: null, hasInactiveMembership: true });
+
+    await expect(call('http://localhost/setup?inviteCode=inv_abc')).rejects.toThrow(
+      'REDIRECT:/setup/setup_1?inviteCode=inv_abc',
+    );
+    // Guard is skipped entirely when an invite code is present.
+    expect(mockServerApiGet).not.toHaveBeenCalled();
+    expect(mockRedirect).not.toHaveBeenCalledWith('/auth/access-removed');
+  });
+
+  it('routes an offboarded user with a pending invitation to the invite, not access-removed', async () => {
+    mockMe({
+      organizations: [],
+      pendingInvitation: { id: 'inv_xyz' },
+      hasInactiveMembership: true,
+    });
+
+    await expect(call('http://localhost/setup')).rejects.toThrow('REDIRECT:/invite/inv_xyz');
+    expect(mockRedirect).not.toHaveBeenCalledWith('/auth/access-removed');
+  });
+
+  it('lets a genuinely new user through to onboarding', async () => {
+    mockMe({ organizations: [], pendingInvitation: null, hasInactiveMembership: false });
+
+    await expect(call('http://localhost/setup')).rejects.toThrow('REDIRECT:/setup/setup_1');
+    expect(mockCreateSetupSession).toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/app/(app)/setup/route.ts
+++ b/apps/app/src/app/(app)/setup/route.ts
@@ -1,4 +1,5 @@
 import { serverApi } from '@/lib/api-server';
+import { resolveNoActiveOrgRedirect } from '@/lib/no-active-org-redirect';
 import { auth } from '@/utils/auth';
 import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
@@ -20,27 +21,26 @@ export async function GET(request: NextRequest) {
 
   // Invite flows take precedence over the CS-569 offboard guard: a raw
   // ?inviteCode= is turned into /invite/{code} downstream by /setup/[setupId],
-  // so let it flow through untouched rather than pre-empting it here.
-  const hasInviteCode = request.nextUrl.searchParams.has('inviteCode');
-  if (!hasInviteCode) {
+  // so let it flow through untouched rather than pre-empting it here. Matches
+  // the downstream truthy check (an empty ?inviteCode= is not an invite).
+  const inviteCode = request.nextUrl.searchParams.get('inviteCode');
+  if (!inviteCode) {
     // CS-569: guard the onboarding loop at the setup entry too (direct nav or
-    // the create-additional intent). A user with 0 active memberships but >=1
-    // deactivated one was offboarded — never let them create a (spurious) org.
-    // New users (no memberships) and users adding an additional org (have
-    // active memberships) fall through unchanged.
+    // the create-additional intent). Reuse the same decision the landing page
+    // uses so the two can't drift. A non-null target means the user is invited
+    // or offboarded; `null` means a new user (or one with active orgs) who
+    // should fall through to onboarding.
     const meRes = await serverApi.get<{
       organizations: unknown[];
       pendingInvitation: { id: string } | null;
       hasInactiveMembership?: boolean;
     }>('/v1/auth/me');
-    const activeOrgCount = meRes.data?.organizations?.length ?? 0;
-    if (activeOrgCount === 0 && meRes.data?.hasInactiveMembership) {
-      // A pending invitation is the offboarded user's legitimate way back in —
-      // honor it before the access-removed dead-end (mirrors the root page).
-      if (meRes.data?.pendingInvitation) {
-        redirect(`/invite/${meRes.data.pendingInvitation.id}`);
+    const hasActiveOrg = (meRes.data?.organizations?.length ?? 0) > 0;
+    if (!hasActiveOrg) {
+      const target = resolveNoActiveOrgRedirect(meRes.data);
+      if (target) {
+        redirect(target);
       }
-      redirect('/auth/access-removed');
     }
   }
 

--- a/apps/app/src/app/(app)/setup/route.ts
+++ b/apps/app/src/app/(app)/setup/route.ts
@@ -1,3 +1,4 @@
+import { serverApi } from '@/lib/api-server';
 import { auth } from '@/utils/auth';
 import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
@@ -15,6 +16,20 @@ export async function GET(request: NextRequest) {
 
   if (!session?.user?.id) {
     redirect(`/sign-in${queryString}`);
+  }
+
+  // CS-569: guard the onboarding loop at the setup entry too (direct nav or the
+  // create-additional intent). A user with 0 active memberships but >=1
+  // deactivated one was offboarded — never let them create a (spurious) org.
+  // New users (no memberships) and users adding an additional org (have active
+  // memberships) fall through unchanged.
+  const meRes = await serverApi.get<{
+    organizations: unknown[];
+    hasInactiveMembership?: boolean;
+  }>('/v1/auth/me');
+  const activeOrgCount = meRes.data?.organizations?.length ?? 0;
+  if (activeOrgCount === 0 && meRes.data?.hasInactiveMembership) {
+    redirect('/auth/access-removed');
   }
 
   const setupSession = await createSetupSession(session.user.id);

--- a/apps/app/src/app/(app)/setup/route.ts
+++ b/apps/app/src/app/(app)/setup/route.ts
@@ -18,18 +18,30 @@ export async function GET(request: NextRequest) {
     redirect(`/sign-in${queryString}`);
   }
 
-  // CS-569: guard the onboarding loop at the setup entry too (direct nav or the
-  // create-additional intent). A user with 0 active memberships but >=1
-  // deactivated one was offboarded — never let them create a (spurious) org.
-  // New users (no memberships) and users adding an additional org (have active
-  // memberships) fall through unchanged.
-  const meRes = await serverApi.get<{
-    organizations: unknown[];
-    hasInactiveMembership?: boolean;
-  }>('/v1/auth/me');
-  const activeOrgCount = meRes.data?.organizations?.length ?? 0;
-  if (activeOrgCount === 0 && meRes.data?.hasInactiveMembership) {
-    redirect('/auth/access-removed');
+  // Invite flows take precedence over the CS-569 offboard guard: a raw
+  // ?inviteCode= is turned into /invite/{code} downstream by /setup/[setupId],
+  // so let it flow through untouched rather than pre-empting it here.
+  const hasInviteCode = request.nextUrl.searchParams.has('inviteCode');
+  if (!hasInviteCode) {
+    // CS-569: guard the onboarding loop at the setup entry too (direct nav or
+    // the create-additional intent). A user with 0 active memberships but >=1
+    // deactivated one was offboarded — never let them create a (spurious) org.
+    // New users (no memberships) and users adding an additional org (have
+    // active memberships) fall through unchanged.
+    const meRes = await serverApi.get<{
+      organizations: unknown[];
+      pendingInvitation: { id: string } | null;
+      hasInactiveMembership?: boolean;
+    }>('/v1/auth/me');
+    const activeOrgCount = meRes.data?.organizations?.length ?? 0;
+    if (activeOrgCount === 0 && meRes.data?.hasInactiveMembership) {
+      // A pending invitation is the offboarded user's legitimate way back in —
+      // honor it before the access-removed dead-end (mirrors the root page).
+      if (meRes.data?.pendingInvitation) {
+        redirect(`/invite/${meRes.data.pendingInvitation.id}`);
+      }
+      redirect('/auth/access-removed');
+    }
   }
 
   const setupSession = await createSetupSession(session.user.id);

--- a/apps/app/src/app/(public)/auth/access-removed/page.tsx
+++ b/apps/app/src/app/(public)/auth/access-removed/page.tsx
@@ -1,0 +1,34 @@
+import { SignOut } from '@/components/sign-out';
+
+/**
+ * Shown to a signed-in user who has no active organization membership but was
+ * previously a member (all memberships deactivated/removed) — i.e. they were
+ * offboarded. Without this, such a user was silently dropped into onboarding,
+ * which spawned a spurious empty org and locked them into a loop (CS-569).
+ *
+ * The most common cause is a domain change: the old account keeps signing in
+ * after being offboarded. The primary action is therefore "sign out" so they
+ * can sign back in with their current account.
+ */
+export default function AccessRemovedPage() {
+  return (
+    <div className="flex min-h-dvh items-center justify-center p-4">
+      <div className="w-full max-w-lg space-y-6 rounded-lg border p-8 text-center">
+        <div className="space-y-2">
+          <h1 className="text-2xl font-semibold tracking-tight">
+            {'Your access was removed'}
+          </h1>
+          <p className="text-muted-foreground">
+            {
+              'This account is no longer a member of any organization. If your company recently changed email domains or offboarded this account, sign out and sign back in with your current account. Otherwise, contact your administrator to be re-invited.'
+            }
+          </p>
+        </div>
+
+        <div className="flex justify-center">
+          <SignOut asButton />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/app/page.test.tsx
+++ b/apps/app/src/app/page.test.tsx
@@ -1,0 +1,96 @@
+import { vi } from 'vitest';
+
+// Mock the auth module before importing the page so getSession is controllable.
+vi.mock('@/utils/auth', async () => {
+  const { mockAuth } = await import('@/test-utils/mocks/auth');
+  return { auth: mockAuth };
+});
+
+// serverApi.get('/v1/auth/me') drives every routing decision on this page.
+// vi.hoisted so the fn exists when the hoisted vi.mock factory runs.
+const { mockServerApiGet } = vi.hoisted(() => ({ mockServerApiGet: vi.fn() }));
+vi.mock('@/lib/api-server', () => ({
+  serverApi: { get: mockServerApiGet },
+}));
+
+// The page imports `db` from '@db/server' (only used for custom-role
+// resolution, which the zero-org redirect paths never reach). Stub it so the
+// test doesn't pull the real Prisma client.
+vi.mock('@db/server', () => ({ db: {} }));
+
+// '@/lib/permissions' pulls in @trycompai/auth (a built package) and is only
+// used past the zero-org redirects. Stub it so the test stays hermetic.
+vi.mock('@/lib/permissions', () => ({
+  getDefaultRoute: vi.fn(() => '/'),
+  mergePermissions: vi.fn(),
+  resolveBuiltInPermissions: vi.fn(() => ({ permissions: {}, customRoleNames: [] })),
+}));
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { redirect } from 'next/navigation';
+import Page from './page';
+import { mockAuthApi, createMockSession, createMockUser } from '@/test-utils/mocks/auth';
+
+const mockRedirect = vi.mocked(redirect);
+
+interface MeData {
+  organizations: unknown[];
+  pendingInvitation: { id: string } | null;
+  hasInactiveMembership?: boolean;
+}
+
+const mockMe = (data: MeData) => {
+  mockServerApiGet.mockResolvedValue({ data, status: 200 });
+};
+
+describe('RootPage onboarding-loop guard (CS-569)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The real Next.js redirect() throws to halt rendering. Emulate that so
+    // execution stops at the first redirect and we can assert its target.
+    mockRedirect.mockImplementation((url: string) => {
+      throw new Error(`REDIRECT:${url}`);
+    });
+    mockAuthApi.getSession.mockResolvedValue({
+      session: createMockSession(),
+      user: createMockUser(),
+    });
+  });
+
+  it('sends an offboarded user (no active org, has a deactivated membership) to the access-removed page, NOT onboarding', async () => {
+    // This is the bug: without the guard, this user was redirected to /setup,
+    // which silently spawned a spurious empty org and locked them into a loop.
+    mockMe({ organizations: [], pendingInvitation: null, hasInactiveMembership: true });
+
+    await expect(Page({ searchParams: Promise.resolve({}) })).rejects.toThrow(
+      'REDIRECT:/auth/access-removed',
+    );
+
+    expect(mockRedirect).toHaveBeenCalledWith('/auth/access-removed');
+    expect(mockRedirect).not.toHaveBeenCalledWith('/setup');
+  });
+
+  it('still sends a genuinely new user (no memberships at all) to onboarding', async () => {
+    mockMe({ organizations: [], pendingInvitation: null, hasInactiveMembership: false });
+
+    await expect(Page({ searchParams: Promise.resolve({}) })).rejects.toThrow('REDIRECT:/setup');
+
+    expect(mockRedirect).toHaveBeenCalledWith('/setup');
+    expect(mockRedirect).not.toHaveBeenCalledWith('/auth/access-removed');
+  });
+
+  it('prefers a pending invitation over the access-removed page', async () => {
+    mockMe({
+      organizations: [],
+      pendingInvitation: { id: 'inv_abc123' },
+      hasInactiveMembership: true,
+    });
+
+    await expect(Page({ searchParams: Promise.resolve({}) })).rejects.toThrow(
+      'REDIRECT:/invite/inv_abc123',
+    );
+
+    expect(mockRedirect).toHaveBeenCalledWith('/invite/inv_abc123');
+    expect(mockRedirect).not.toHaveBeenCalledWith('/auth/access-removed');
+  });
+});

--- a/apps/app/src/app/page.test.tsx
+++ b/apps/app/src/app/page.test.tsx
@@ -79,6 +79,18 @@ describe('RootPage onboarding-loop guard (CS-569)', () => {
     expect(mockRedirect).not.toHaveBeenCalledWith('/auth/access-removed');
   });
 
+  it('lets an explicit ?inviteCode= win over the offboard guard (hands off to /setup for downstream invite handling)', async () => {
+    // Regression (cubic P2): an offboarded user landing on /?inviteCode=... must
+    // still be able to accept the invite, not be short-circuited to access-removed.
+    mockMe({ organizations: [], pendingInvitation: null, hasInactiveMembership: true });
+
+    await expect(
+      Page({ searchParams: Promise.resolve({ inviteCode: 'inv_abc' }) }),
+    ).rejects.toThrow('REDIRECT:/setup?inviteCode=inv_abc');
+
+    expect(mockRedirect).not.toHaveBeenCalledWith('/auth/access-removed');
+  });
+
   it('prefers a pending invitation over the access-removed page', async () => {
     mockMe({
       organizations: [],

--- a/apps/app/src/app/page.tsx
+++ b/apps/app/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { serverApi } from '@/lib/api-server';
+import { resolveNoActiveOrgRedirect } from '@/lib/no-active-org-redirect';
 import { getDefaultRoute, mergePermissions, resolveBuiltInPermissions } from '@/lib/permissions';
 import { auth } from '@/utils/auth';
 import { db } from '@db/server';
@@ -56,21 +57,13 @@ export default async function RootPage({
 
   const meRes = await serverApi.get<AuthMeResponse>('/v1/auth/me');
   const memberships = meRes.data?.organizations ?? [];
-  const pendingInvitation = meRes.data?.pendingInvitation;
 
   if (memberships.length === 0) {
-    if (pendingInvitation) {
-      return redirect(await buildUrlWithParams(`/invite/${pendingInvitation.id}`));
-    }
-    // CS-569: a user whose only memberships are deactivated (offboarded) has
-    // no active org. Do NOT drop them into onboarding — that silently spawns a
-    // spurious empty org and locks them into an onboarding loop. Tell them
-    // their access was removed instead. Genuinely new users (no memberships at
-    // all) still go to /setup.
-    if (meRes.data?.hasInactiveMembership) {
-      return redirect(await buildUrlWithParams('/auth/access-removed'));
-    }
-    return redirect(await buildUrlWithParams('/setup'));
+    // CS-569: route a user with no active org through the shared decision so
+    // this page and the /setup route can't diverge (invite > offboarded > new).
+    // `null` = genuinely new user → onboarding.
+    const target = resolveNoActiveOrgRedirect(meRes.data);
+    return redirect(await buildUrlWithParams(target ?? '/setup'));
   }
 
   // Always use the org the user last switched to (stored in session)

--- a/apps/app/src/app/page.tsx
+++ b/apps/app/src/app/page.tsx
@@ -15,6 +15,9 @@ interface OrgInfo {
 interface AuthMeResponse {
   organizations: OrgInfo[];
   pendingInvitation: { id: string } | null;
+  // True when the user has memberships that are all deactivated/removed
+  // (i.e. they were offboarded), used to avoid the onboarding loop (CS-569).
+  hasInactiveMembership?: boolean;
 }
 
 export default async function RootPage({
@@ -58,6 +61,14 @@ export default async function RootPage({
   if (memberships.length === 0) {
     if (pendingInvitation) {
       return redirect(await buildUrlWithParams(`/invite/${pendingInvitation.id}`));
+    }
+    // CS-569: a user whose only memberships are deactivated (offboarded) has
+    // no active org. Do NOT drop them into onboarding — that silently spawns a
+    // spurious empty org and locks them into an onboarding loop. Tell them
+    // their access was removed instead. Genuinely new users (no memberships at
+    // all) still go to /setup.
+    if (meRes.data?.hasInactiveMembership) {
+      return redirect(await buildUrlWithParams('/auth/access-removed'));
     }
     return redirect(await buildUrlWithParams('/setup'));
   }

--- a/apps/app/src/app/page.tsx
+++ b/apps/app/src/app/page.tsx
@@ -59,9 +59,16 @@ export default async function RootPage({
   const memberships = meRes.data?.organizations ?? [];
 
   if (memberships.length === 0) {
-    // CS-569: route a user with no active org through the shared decision so
-    // this page and the /setup route can't diverge (invite > offboarded > new).
-    // `null` = genuinely new user → onboarding.
+    // An explicit ?inviteCode= (the user is accepting a specific invitation)
+    // always wins over the offboard guard: hand off to /setup, which preserves
+    // the code and passes it through to /invite downstream. Mirrors the /setup
+    // route precedence so an offboarded user can still accept a valid invite.
+    const inviteCode = (await searchParams)?.inviteCode;
+    if (inviteCode) {
+      return redirect(await buildUrlWithParams('/setup'));
+    }
+    // Otherwise route via the shared decision (pending invite > offboarded >
+    // new user). `null` = genuinely new user → onboarding.
     const target = resolveNoActiveOrgRedirect(meRes.data);
     return redirect(await buildUrlWithParams(target ?? '/setup'));
   }

--- a/apps/app/src/lib/no-active-org-redirect.test.ts
+++ b/apps/app/src/lib/no-active-org-redirect.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { resolveNoActiveOrgRedirect } from './no-active-org-redirect';
+
+describe('resolveNoActiveOrgRedirect (CS-569)', () => {
+  it('routes a pending invitation to the invite — highest precedence', () => {
+    expect(
+      resolveNoActiveOrgRedirect({
+        pendingInvitation: { id: 'inv_1' },
+        hasInactiveMembership: true,
+      }),
+    ).toBe('/invite/inv_1');
+  });
+
+  it('routes an offboarded user (no invite) to access-removed', () => {
+    expect(
+      resolveNoActiveOrgRedirect({ pendingInvitation: null, hasInactiveMembership: true }),
+    ).toBe('/auth/access-removed');
+  });
+
+  it('returns null for a genuinely new user so the caller onboards them', () => {
+    expect(
+      resolveNoActiveOrgRedirect({ pendingInvitation: null, hasInactiveMembership: false }),
+    ).toBeNull();
+  });
+
+  it('is null-safe when the /v1/auth/me payload is missing (degrade to onboarding)', () => {
+    expect(resolveNoActiveOrgRedirect(undefined)).toBeNull();
+    expect(resolveNoActiveOrgRedirect(null)).toBeNull();
+    expect(resolveNoActiveOrgRedirect({})).toBeNull();
+  });
+});

--- a/apps/app/src/lib/no-active-org-redirect.ts
+++ b/apps/app/src/lib/no-active-org-redirect.ts
@@ -1,0 +1,34 @@
+/**
+ * Decides where to send a signed-in user who has **no active organization**.
+ *
+ * This centralizes the CS-569 offboarding-loop guard so the root landing page
+ * (`app/page.tsx`) and the `/setup` entry route can't drift apart — divergent
+ * per-path membership handling is exactly what caused CS-569.
+ *
+ * Precedence:
+ *  1. A pending invitation is always the way in → `/invite/{id}`.
+ *  2. Offboarded (memberships exist but are all deactivated) → `/auth/access-removed`
+ *     (do NOT drop them into onboarding; that spawns a spurious org + loop).
+ *  3. Genuinely new user (no memberships at all) → `null` (caller decides the
+ *     onboarding target).
+ *
+ * Null-safe: a missing `/v1/auth/me` payload is treated as "new user" (`null`),
+ * so a transient API failure degrades to onboarding rather than a dead-end.
+ */
+export function resolveNoActiveOrgRedirect(
+  me:
+    | {
+        pendingInvitation?: { id: string } | null;
+        hasInactiveMembership?: boolean;
+      }
+    | null
+    | undefined,
+): string | null {
+  if (me?.pendingInvitation) {
+    return `/invite/${me.pendingInvitation.id}`;
+  }
+  if (me?.hasInactiveMembership) {
+    return '/auth/access-removed';
+  }
+  return null;
+}


### PR DESCRIPTION
## Problem (CS-569)

When a user is removed/offboarded from their **only** organization, their sole membership is soft-deleted (`deactivated=true, isActive=false`). `GET /v1/auth/me` filters those out, so the app saw **zero organizations** and silently redirected the user to `/setup` (onboarding). Completing onboarding created a brand-new empty org and pointed the session at it, so every subsequent login re-entered onboarding — an **offboarding loop** that spawned throwaway orgs and showed **"Unauthorized"** on the real org.

Root cause: three code paths disagreed on which memberships "count" (`/v1/auth/me` = active & !deactivated; the org layout = !deactivated; the session hook = no filter), and nothing distinguished a **genuinely new user** from an **offboarded** one — so both were dropped into "create a new org."

This was previously only ever resolved with a manual one-time data cleanup (delete the spurious org + clear sessions); the root cause was never fixed in code, so affected users kept re-looping.

## Fix (targeted, additive)

- **`GET /v1/auth/me`** now returns `hasInactiveMembership` so the app can tell an offboarded user (0 active, ≥1 deactivated) apart from a brand-new user (no memberships at all).
- **Landing page** (`page.tsx`) and the **`/setup` entry route** send an offboarded user to a new **`/auth/access-removed`** interstitial instead of onboarding. New users and users adding an *additional* org are unaffected.
- **`createOrganizationMinimal`** refuses to create an org for an offboarded user as a **DB-level backstop** — immune to a transient `/v1/auth/me` failure, so the loop can't be re-created even if the routing guards are bypassed.
- The access-removed page's primary action is **Sign out**, because the common trigger is a domain change where the *old* account keeps signing in after being removed — the user just needs to switch to their current account.

## Tests

- `page.test.tsx` — routing guard: new user → `/setup`; offboarded → `/auth/access-removed`; pending invite still wins.
- `auth.controller.spec.ts` — `hasInactiveMembership` computation (new user / offboarded / active member).

## Known limitation (deliberate)

An offboarded account cannot self-serve create a *new, unrelated* org with the same email — it's directed to contact an admin / sign in with another account. This is rare (a fresh email = a fresh account = unaffected) and can be relaxed later with an explicit "start a new organization" confirmation.

## Not included (needs prod DB — cannot be done from a PR)

The affected customer still has an outstanding spurious org + stale sessions to clean up, and their active account state should be verified. Tracked separately on CS-569.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents offboarded users from entering onboarding and creating a new empty org by detecting inactive memberships and routing them to an access-removed page. Also restores invite-first precedence on the root page and `/setup` so valid invites bypass the guard. Addresses CS-569 and prevents duplicate orgs during domain/owner email migrations.

- **Bug Fixes**
  - `GET /v1/auth/me` now returns `hasInactiveMembership` to distinguish offboarded users (0 active, ≥1 inactive) from new users (no memberships).
  - Root page and `/setup` use invite-first routing: explicit `?inviteCode` or pending invite → invite flow (root passes through to `/setup`, then to `/invite/{id}`); else offboarded → `/auth/access-removed`; else new → `/setup` (empty `?inviteCode=` is ignored).
  - `createOrganizationMinimal` blocks org creation for offboarded users as a DB backstop.
  - Added `/auth/access-removed` page with a primary “Sign out” action.

- **Refactors**
  - Centralized the no-active-org decision in `resolveNoActiveOrgRedirect` to keep root and `/setup` in sync; added tests for the page, route, helper, and `/v1/auth/me`.

<sup>Written for commit ab7ba22ff8be46ba7937bd1c841c30e9058185a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

