### PR TITLE
fix(trust-portal): precise, bounded ISO cert badge matching (cubic review, #3315)

### DIFF
--- a/apps/api/src/trust-portal/trust-portal.service.spec.ts
+++ b/apps/api/src/trust-portal/trust-portal.service.spec.ts
@@ -151,4 +151,27 @@ describe('TrustPortalService getAllVendorsWithSync compliance badges', () => {
     // Sanity check that the sync path still ran and produced real badges.
     expect(badgeTypes).toContain('gdpr');
   });
+
+  // Regression: the ISO number must not match as a prefix of a longer number.
+  // "ISO 90010" normalizes to "iso90010" and would otherwise match iso9001;
+  // only an optional 4-digit year (e.g. ":2015") may follow the standard number.
+  it('does not read "ISO 90010" as the iso9001 badge', async () => {
+    const badgeTypes = await badgeTypesFor([
+      { type: 'ISO 90010', status: 'verified' },
+      { type: 'GDPR Compliance', status: 'verified' },
+    ]);
+
+    expect(badgeTypes).not.toContain('iso9001');
+    expect(badgeTypes).toContain('gdpr');
+  });
+
+  // Real-world boundary: ISO/IEC 27017 (cloud security) shares the "2701"
+  // prefix with 27001 but is a distinct standard and must not earn its badge.
+  it('does not read "ISO/IEC 27017:2015" as the iso27001 badge', async () => {
+    const badgeTypes = await badgeTypesFor([
+      { type: 'ISO/IEC 27017:2015', status: 'verified' },
+    ]);
+
+    expect(badgeTypes).not.toContain('iso27001');
+  });
 });

--- a/apps/api/src/trust-portal/trust-portal.service.spec.ts
+++ b/apps/api/src/trust-portal/trust-portal.service.spec.ts
@@ -43,6 +43,39 @@ describe('TrustPortalService getAllVendorsWithSync compliance badges', () => {
     jest.clearAllMocks();
   });
 
+  // Runs a set of verified certifications through the badge-sync path and
+  // returns the resulting badge types (empty when nothing maps).
+  const badgeTypesFor = async (
+    certifications: Array<{ type: string; status: string }>,
+  ): Promise<string[]> => {
+    const baseVendor = {
+      id: 'vnd_1',
+      name: 'Acme',
+      description: null,
+      website: 'acme.com',
+      showOnTrustPortal: true,
+      logoUrl: 'https://logo.example/acme.png',
+      complianceBadges: null,
+      trustPortalOrder: 0,
+    };
+
+    mockDb.vendor.findMany.mockResolvedValue([baseVendor]);
+    mockDb.globalVendors.findUnique.mockResolvedValue({
+      riskAssessmentData: { certifications },
+    });
+    mockDb.vendor.update.mockImplementation(
+      async ({ data }: { data: Record<string, unknown> }) => ({
+        ...baseVendor,
+        ...data,
+      }),
+    );
+
+    const result = await service.getAllVendorsWithSync('org_1');
+    const badges =
+      (result[0].complianceBadges as unknown as Array<{ type: string }>) ?? [];
+    return badges.map((badge) => badge.type);
+  };
+
   // Regression: Scaleway's GlobalVendors record lists "ISO/IEC 27001:2022",
   // "HDS" and "GDPR Compliance" as verified, but the Trust Centre only showed
   // GDPR. The "IEC" infix and ":2022" suffix caused the ISO 27001 certification
@@ -83,6 +116,39 @@ describe('TrustPortalService getAllVendorsWithSync compliance badges', () => {
     ).map((badge) => badge.type);
 
     expect(badgeTypes).toContain('iso27001');
+    expect(badgeTypes).toContain('gdpr');
+  });
+
+  it('maps "ISO 9001:2015" to the iso9001 badge', async () => {
+    const badgeTypes = await badgeTypesFor([
+      { type: 'ISO 9001:2015', status: 'verified' },
+    ]);
+
+    expect(badgeTypes).toContain('iso9001');
+  });
+
+  // The "IEC" infix must be tolerated for every joint ISO/IEC standard, not
+  // just 27001 — otherwise ISO/IEC 42001 certifications are silently dropped.
+  it('maps "ISO/IEC 42001:2023" to the iso42001 badge', async () => {
+    const badgeTypes = await badgeTypesFor([
+      { type: 'ISO/IEC 42001:2023', status: 'verified' },
+    ]);
+
+    expect(badgeTypes).toContain('iso42001');
+  });
+
+  // Regression: a bare substring match on the digits ("9001") misclassified
+  // unrelated identifiers that merely contain them (e.g. a catalog id "19001")
+  // as ISO 9001, surfacing a certification the vendor never held. The match now
+  // requires the "ISO" prefix, so the digits alone are not enough.
+  it('does not misclassify an unrelated id containing "9001" as iso9001', async () => {
+    const badgeTypes = await badgeTypesFor([
+      { type: 'Catalog 19001', status: 'verified' },
+      { type: 'GDPR Compliance', status: 'verified' },
+    ]);
+
+    expect(badgeTypes).not.toContain('iso9001');
+    // Sanity check that the sync path still ran and produced real badges.
     expect(badgeTypes).toContain('gdpr');
   });
 });

--- a/apps/api/src/trust-portal/trust-portal.service.spec.ts
+++ b/apps/api/src/trust-portal/trust-portal.service.spec.ts
@@ -174,4 +174,30 @@ describe('TrustPortalService getAllVendorsWithSync compliance badges', () => {
 
     expect(badgeTypes).not.toContain('iso27001');
   });
+
+  // ISO/IEC 27018 (PII in the cloud) is another distinct 2701x standard.
+  it('does not read "ISO/IEC 27018:2019" as the iso27001 badge', async () => {
+    const badgeTypes = await badgeTypesFor([
+      { type: 'ISO/IEC 27018:2019', status: 'verified' },
+    ]);
+
+    expect(badgeTypes).not.toContain('iso27001');
+  });
+
+  // Guardrail: a realistic mix of certification names (all carrying the "ISO"
+  // prefix, as produced by the extraction schema) must still map to every badge
+  // — the precision tightening must not drop any legitimate certification.
+  it('maps a realistic mix of certifications without dropping any', async () => {
+    const badgeTypes = await badgeTypesFor([
+      { type: 'SOC 2 Type II', status: 'verified' },
+      { type: 'ISO/IEC 27001:2013', status: 'verified' },
+      { type: 'ISO 9001', status: 'verified' },
+      { type: 'ISO/IEC 42001:2023', status: 'verified' },
+      { type: 'GDPR Compliance', status: 'verified' },
+    ]);
+
+    expect(badgeTypes).toEqual(
+      expect.arrayContaining(['soc2', 'iso27001', 'iso9001', 'iso42001', 'gdpr']),
+    );
+  });
 });

--- a/apps/api/src/trust-portal/trust-portal.service.ts
+++ b/apps/api/src/trust-portal/trust-portal.service.ts
@@ -1954,9 +1954,11 @@ export class TrustPortalService {
     // unrelated ids that merely contain the digits (e.g. a catalog id "19001")
     // aren't misclassified. The optional "iec" handles joint ISO/IEC standards,
     // whose "IEC" infix would otherwise break a naive includes('iso27001') check
-    // ("ISO/IEC 27001:2022" normalizes to "isoiec270012022").
-    if (/iso(?:iec)?27001/.test(normalized)) return 'iso27001';
-    if (/iso(?:iec)?42001/.test(normalized)) return 'iso42001';
+    // ("ISO/IEC 27001:2022" normalizes to "isoiec270012022"). The trailing
+    // "(?:\d{4})?(?!\d)" allows an optional 4-digit year ("...:2022") but forbids
+    // any other trailing digit, so "ISO 90010" is not read as "ISO 9001".
+    if (/iso(?:iec)?27001(?:\d{4})?(?!\d)/.test(normalized)) return 'iso27001';
+    if (/iso(?:iec)?42001(?:\d{4})?(?!\d)/.test(normalized)) return 'iso42001';
     if (normalized.includes('gdpr')) return 'gdpr';
     if (normalized.includes('hipaa')) return 'hipaa';
     if (
@@ -1967,7 +1969,7 @@ export class TrustPortalService {
       return 'pci_dss';
     if (normalized.includes('nen7510') || normalized.includes('nen 7510'))
       return 'nen7510';
-    if (/iso(?:iec)?9001/.test(normalized)) return 'iso9001';
+    if (/iso(?:iec)?9001(?:\d{4})?(?!\d)/.test(normalized)) return 'iso9001';
 
     return null;
   }

--- a/apps/api/src/trust-portal/trust-portal.service.ts
+++ b/apps/api/src/trust-portal/trust-portal.service.ts
@@ -1950,15 +1950,8 @@ export class TrustPortalService {
 
     if (normalized.includes('soc2') || normalized.includes('soc 2'))
       return 'soc2';
-    // Match ISO standards by their number, but require an "iso" prefix so that
-    // unrelated ids that merely contain the digits (e.g. a catalog id "19001")
-    // aren't misclassified. The optional "iec" handles joint ISO/IEC standards,
-    // whose "IEC" infix would otherwise break a naive includes('iso27001') check
-    // ("ISO/IEC 27001:2022" normalizes to "isoiec270012022"). The trailing
-    // "(?:\d{4})?(?!\d)" allows an optional 4-digit year ("...:2022") but forbids
-    // any other trailing digit, so "ISO 90010" is not read as "ISO 9001".
-    if (/iso(?:iec)?27001(?:\d{4})?(?!\d)/.test(normalized)) return 'iso27001';
-    if (/iso(?:iec)?42001(?:\d{4})?(?!\d)/.test(normalized)) return 'iso42001';
+    if (this.matchesIsoStandard(normalized, '27001')) return 'iso27001';
+    if (this.matchesIsoStandard(normalized, '42001')) return 'iso42001';
     if (normalized.includes('gdpr')) return 'gdpr';
     if (normalized.includes('hipaa')) return 'hipaa';
     if (
@@ -1969,9 +1962,33 @@ export class TrustPortalService {
       return 'pci_dss';
     if (normalized.includes('nen7510') || normalized.includes('nen 7510'))
       return 'nen7510';
-    if (/iso(?:iec)?9001(?:\d{4})?(?!\d)/.test(normalized)) return 'iso9001';
+    if (this.matchesIsoStandard(normalized, '9001')) return 'iso9001';
 
     return null;
+  }
+
+  /**
+   * Whether a normalized cert string (lowercased, alphanumerics only) names the
+   * given ISO standard number.
+   *
+   * - Requires an "iso" / "iso iec" prefix, so unrelated ids that merely contain
+   *   the digits ("19001", "127001") are not misclassified.
+   * - The optional "iec" handles joint ISO/IEC standards whose "IEC" infix would
+   *   otherwise break the match ("ISO/IEC 27001:2022" -> "isoiec270012022").
+   * - Allows an optional trailing 4-digit year ("ISO 9001:2015" -> "iso90012015")
+   *   but forbids any other trailing digit, so a longer number is not read as a
+   *   shorter standard ("ISO 90010" is not "ISO 9001", "ISO 27017" is not 27001).
+   *
+   * `standardNumber` is always a hard-coded digit literal — never user input —
+   * so building the RegExp from it carries no injection risk.
+   */
+  private matchesIsoStandard(
+    normalized: string,
+    standardNumber: string,
+  ): boolean {
+    return new RegExp(`iso(?:iec)?${standardNumber}(?:\\d{4})?(?!\\d)`).test(
+      normalized,
+    );
   }
 
   private generateLogoUrl(website: string | null): string | null {

--- a/apps/api/src/trust-portal/trust-portal.service.ts
+++ b/apps/api/src/trust-portal/trust-portal.service.ts
@@ -1950,11 +1950,13 @@ export class TrustPortalService {
 
     if (normalized.includes('soc2') || normalized.includes('soc 2'))
       return 'soc2';
-    // Match ISO standards by their number. Vendors write these many ways
-    // ("ISO 27001", "ISO/IEC 27001:2022"), and the "IEC" infix breaks a naive
-    // includes('iso27001') check ("iso27001" is not a substring of "isoiec27001…").
-    if (normalized.includes('27001')) return 'iso27001';
-    if (normalized.includes('42001')) return 'iso42001';
+    // Match ISO standards by their number, but require an "iso" prefix so that
+    // unrelated ids that merely contain the digits (e.g. a catalog id "19001")
+    // aren't misclassified. The optional "iec" handles joint ISO/IEC standards,
+    // whose "IEC" infix would otherwise break a naive includes('iso27001') check
+    // ("ISO/IEC 27001:2022" normalizes to "isoiec270012022").
+    if (/iso(?:iec)?27001/.test(normalized)) return 'iso27001';
+    if (/iso(?:iec)?42001/.test(normalized)) return 'iso42001';
     if (normalized.includes('gdpr')) return 'gdpr';
     if (normalized.includes('hipaa')) return 'hipaa';
     if (
@@ -1965,7 +1967,7 @@ export class TrustPortalService {
       return 'pci_dss';
     if (normalized.includes('nen7510') || normalized.includes('nen 7510'))
       return 'nen7510';
-    if (normalized.includes('9001')) return 'iso9001';
+    if (/iso(?:iec)?9001/.test(normalized)) return 'iso9001';
 
     return null;
   }


### PR DESCRIPTION
## What
Hardens `mapCertificationToBadgeType` in `trust-portal.service.ts`, resolving two cubic findings on the merged **PR #3315**:

1. **Under-match / wrong prefix** — bare `includes('9001')` matched unrelated ids containing the digits (e.g. a catalog id `19001`).
2. **Over-match** — after requiring the `iso` prefix, `iso9001` was still a prefix of longer numbers, so `ISO 90010` matched ISO 9001.

Both would surface a certification the vendor never held on the public Trust Centre. The same class affected `27001` and `42001`, so all three are fixed together.

## Fix
All three ISO checks go through one bounded helper:

```ts
private matchesIsoStandard(normalized: string, standardNumber: string): boolean {
  return new RegExp(`iso(?:iec)?${standardNumber}(?:\\d{4})?(?!\\d)`).test(normalized);
}
```

- **`iso(?:iec)?`** — requires the ISO prefix (rejects `19001`, `127001`); optional `iec` preserves PR #3315's joint ISO/IEC fix (`"ISO/IEC 27001:2022"` → `"isoiec270012022"`).
- **`(?:\d{4})?(?!\d)`** — allows an optional 4-digit year (`":2015"`, `":2022"`) but forbids any other trailing digit, so a longer number isn't read as a shorter standard (`ISO 90010` ≠ 9001, `ISO 27017`/`27018` ≠ 27001).

The `standardNumber` arg is always a hard-coded digit literal — no injection risk.

## Why this is safe (verified, not assumed)
- **Real data always carries "ISO".** Certification `type` values are AI-extracted names; the extraction schema's own examples are `ISO 27001`, `ISO/IEC 27001:2013`, `ISO 42001`, `ISO 27017`, `ISO 27018`, … Requiring the prefix drops **no** legitimate badge (proven by a 34-case matrix + the test suite).
- **This path is authoritative for display.** `getAllVendorsWithSync` re-derives and **overwrites** `complianceBadges` on read, so the corrected matcher governs what customers see and self-heals stale data.
- **Frontend unaffected.** Emitted type strings are unchanged (`soc2/iso27001/iso42001/gdpr/hipaa/pci_dss/nen7510/iso9001`) and match the `BADGE_ICONS`/`BADGE_LABELS` keys in `TrustPortalVendors.tsx`. Since the matcher now drops unknown certs rather than passing them through, it's strictly safer for rendering.

## Tests (`trust-portal.service.spec.ts`) — 8/8 pass
Positives: `ISO/IEC 27001:2022`, `ISO 9001:2015`, `ISO/IEC 42001:2023`, and a full realistic mix (`SOC 2 Type II` + `ISO/IEC 27001:2013` + `ISO 9001` + `ISO/IEC 42001:2023` + `GDPR`) — nothing dropped.
Negatives: `ISO 90010`, `ISO/IEC 27017:2015`, `ISO/IEC 27018:2019`, `Catalog 19001` — none earn an ISO badge.

## Scope note (honest)
Three sibling mappers exist with the same *latent* bare-`includes` pattern: `vendor-risk-assessment-task.ts`, `trust-portal-deep-scrape-merge.ts` (scan-time writers) and `trust-access.service.ts::extractBadgesFromRiskData` (public fallback, exact-match). They agree with this fix for all real (ISO-prefixed) data, and this path overwrites their output on read, so the customer-facing display is correct. Harmonizing them is a separate, larger change touching the scan pipeline — deliberately **out of scope** here to avoid widening blast radius. Happy to do it as a follow-up.

## Notes
- API typecheck is pre-existing RED on `main` (unrelated spec files); these two files add zero new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZotUzpY9RZt9JDsEJyrWS