### PR TITLE
feat(frameworks): allow editing custom framework name and description

### DIFF
--- a/apps/api/src/frameworks/dto/update-custom-framework.dto.ts
+++ b/apps/api/src/frameworks/dto/update-custom-framework.dto.ts
@@ -1,0 +1,17 @@
+import { IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdateCustomFrameworkDto {
+  @ApiPropertyOptional({ description: 'Framework name', example: 'Internal Controls' })
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(120)
+  name?: string;
+
+  @ApiPropertyOptional({ description: 'Framework description' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  description?: string;
+}

--- a/apps/api/src/frameworks/frameworks.controller.spec.ts
+++ b/apps/api/src/frameworks/frameworks.controller.spec.ts
@@ -41,6 +41,7 @@ describe('FrameworksController', () => {
   const mockService = {
     findAll: jest.fn(),
     findAvailable: jest.fn(),
+    updateCustom: jest.fn(),
     delete: jest.fn(),
     getUpdateStatus: jest.fn(),
     getUpdatePreview: jest.fn(),
@@ -155,6 +156,19 @@ describe('FrameworksController', () => {
       await expect(controller.delete('org_1', 'missing')).rejects.toThrow(
         NotFoundException,
       );
+    });
+  });
+
+  describe('updateCustom', () => {
+    it('should delegate to service and return the updated framework', async () => {
+      const updated = { id: 'cfrm_A', name: 'CSC/CPRT' };
+      mockService.updateCustom.mockResolvedValue(updated);
+
+      const dto = { name: 'CSC/CPRT', description: 'Renamed' };
+      const result = await controller.updateCustom('org_1', 'fi1', dto);
+
+      expect(result).toEqual(updated);
+      expect(service.updateCustom).toHaveBeenCalledWith('fi1', 'org_1', dto);
     });
   });
 

--- a/apps/api/src/frameworks/frameworks.controller.ts
+++ b/apps/api/src/frameworks/frameworks.controller.ts
@@ -5,6 +5,7 @@ import {
   Delete,
   Get,
   Param,
+  Patch,
   Post,
   Query,
   UseGuards,
@@ -12,6 +13,7 @@ import {
 import {
   ApiTags,
   ApiBearerAuth,
+  ApiBody,
   ApiOperation,
   ApiQuery,
 } from '@nestjs/swagger';
@@ -28,6 +30,7 @@ import type { AuthContext as AuthContextType } from '../auth/types';
 import { FrameworksService } from './frameworks.service';
 import { AddFrameworksDto } from './dto/add-frameworks.dto';
 import { CreateCustomFrameworkDto } from './dto/create-custom-framework.dto';
+import { UpdateCustomFrameworkDto } from './dto/update-custom-framework.dto';
 import { CreateCustomRequirementDto } from './dto/create-custom-requirement.dto';
 import { LinkRequirementsDto } from './dto/link-requirements.dto';
 import { LinkControlsDto } from './dto/link-controls.dto';
@@ -142,6 +145,22 @@ export class FrameworksController {
     @Body() dto: CreateCustomFrameworkDto,
   ) {
     return this.frameworksService.createCustom(organizationId, dto);
+  }
+
+  @Patch(':id/custom')
+  @RequirePermission('framework', 'update')
+  @ApiOperation({
+    summary: 'Update a custom framework',
+    description:
+      "Update the name and/or description of an organization's custom framework. Only custom frameworks are editable; platform frameworks return 400.",
+  })
+  @ApiBody({ type: UpdateCustomFrameworkDto })
+  async updateCustom(
+    @OrganizationId() organizationId: string,
+    @Param('id') id: string,
+    @Body() dto: UpdateCustomFrameworkDto,
+  ) {
+    return this.frameworksService.updateCustom(id, organizationId, dto);
   }
 
   @Post(':id/requirements')

--- a/apps/api/src/frameworks/frameworks.service.spec.ts
+++ b/apps/api/src/frameworks/frameworks.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { FrameworksService } from './frameworks.service';
 import { TimelinesService } from '../timelines/timelines.service';
 
@@ -35,6 +35,7 @@ jest.mock('@db', () => ({
     },
     customFramework: {
       findMany: jest.fn(),
+      update: jest.fn(),
     },
   },
   // The frameworks-timeline helper imports FindingType (a Prisma enum) at module
@@ -132,6 +133,71 @@ describe('FrameworksService', () => {
         NotFoundException,
       );
       expect(mockDb.frameworkInstance.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateCustom', () => {
+    it('should update the custom framework name and description', async () => {
+      (mockDb.frameworkInstance.findUnique as jest.Mock).mockResolvedValue({
+        customFrameworkId: 'cfrm_A',
+      });
+      const updated = {
+        id: 'cfrm_A',
+        name: 'CSC/CPRT',
+        description: 'Renamed',
+      };
+      (mockDb.customFramework.update as jest.Mock).mockResolvedValue(updated);
+
+      const result = await service.updateCustom('fi1', 'org_1', {
+        name: 'CSC/CPRT',
+        description: 'Renamed',
+      });
+
+      expect(result).toEqual(updated);
+      expect(mockDb.frameworkInstance.findUnique).toHaveBeenCalledWith({
+        where: { id: 'fi1', organizationId: 'org_1' },
+        select: { customFrameworkId: true },
+      });
+      expect(mockDb.customFramework.update).toHaveBeenCalledWith({
+        where: { id: 'cfrm_A' },
+        data: { name: 'CSC/CPRT', description: 'Renamed' },
+      });
+    });
+
+    it('should only update the fields that are provided', async () => {
+      (mockDb.frameworkInstance.findUnique as jest.Mock).mockResolvedValue({
+        customFrameworkId: 'cfrm_A',
+      });
+      (mockDb.customFramework.update as jest.Mock).mockResolvedValue({});
+
+      await service.updateCustom('fi1', 'org_1', { name: 'Just the name' });
+
+      expect(mockDb.customFramework.update).toHaveBeenCalledWith({
+        where: { id: 'cfrm_A' },
+        data: { name: 'Just the name' },
+      });
+    });
+
+    it('should throw NotFoundException when instance not found', async () => {
+      (mockDb.frameworkInstance.findUnique as jest.Mock).mockResolvedValue(
+        null,
+      );
+
+      await expect(
+        service.updateCustom('missing', 'org_1', { name: 'x' }),
+      ).rejects.toThrow(NotFoundException);
+      expect(mockDb.customFramework.update).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException for a platform framework', async () => {
+      (mockDb.frameworkInstance.findUnique as jest.Mock).mockResolvedValue({
+        customFrameworkId: null,
+      });
+
+      await expect(
+        service.updateCustom('fi_platform', 'org_1', { name: 'x' }),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockDb.customFramework.update).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/frameworks/frameworks.service.ts
+++ b/apps/api/src/frameworks/frameworks.service.ts
@@ -465,6 +465,38 @@ export class FrameworksService {
     });
   }
 
+  async updateCustom(
+    frameworkInstanceId: string,
+    organizationId: string,
+    input: { name?: string; description?: string },
+  ) {
+    const frameworkInstance = await db.frameworkInstance.findUnique({
+      where: { id: frameworkInstanceId, organizationId },
+      select: { customFrameworkId: true },
+    });
+
+    if (!frameworkInstance) {
+      throw new NotFoundException('Framework instance not found');
+    }
+
+    // Only org-authored custom frameworks carry editable metadata. Platform
+    // frameworks derive their name/description from the shared global template.
+    if (!frameworkInstance.customFrameworkId) {
+      throw new BadRequestException('Only custom frameworks can be edited');
+    }
+
+    const data: { name?: string; description?: string } = {};
+    if (input.name !== undefined) data.name = input.name;
+    if (input.description !== undefined) data.description = input.description;
+
+    // Ownership is already enforced by the org-scoped instance lookup above,
+    // so keying the update by the custom framework id is safe.
+    return db.customFramework.update({
+      where: { id: frameworkInstance.customFrameworkId },
+      data,
+    });
+  }
+
   async createRequirement(
     frameworkInstanceId: string,
     organizationId: string,

--- a/apps/app/src/app/(app)/[orgId]/frameworks/[frameworkInstanceId]/components/EditCustomFrameworkSheet.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/frameworks/[frameworkInstanceId]/components/EditCustomFrameworkSheet.test.tsx
@@ -93,4 +93,18 @@ describe('EditCustomFrameworkSheet', () => {
     expect(onUpdated).toHaveBeenCalled();
     expect(onClose).toHaveBeenCalled();
   });
+
+  it('rejects a whitespace-only name and does not submit', async () => {
+    setMockPermissions(ADMIN_PERMISSIONS);
+    renderSheet();
+
+    const user = userEvent.setup();
+    const nameInput = screen.getByDisplayValue('CMMC');
+    await user.clear(nameInput);
+    await user.type(nameInput, '   ');
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    expect(await screen.findByText('Name is required')).toBeInTheDocument();
+    expect(updateCustomFramework).not.toHaveBeenCalled();
+  });
 });

--- a/apps/app/src/app/(app)/[orgId]/frameworks/[frameworkInstanceId]/components/EditCustomFrameworkSheet.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/frameworks/[frameworkInstanceId]/components/EditCustomFrameworkSheet.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  setMockPermissions,
+  ADMIN_PERMISSIONS,
+  AUDITOR_PERMISSIONS,
+  mockHasPermission,
+} from '@/test-utils/mocks/permissions';
+
+vi.mock('@/hooks/use-permissions', () => ({
+  usePermissions: () => ({
+    permissions: {},
+    hasPermission: mockHasPermission,
+  }),
+}));
+
+const updateCustomFramework = vi.fn();
+vi.mock('@/hooks/use-frameworks', () => ({
+  useFrameworks: () => ({ updateCustomFramework }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { EditCustomFrameworkSheet } from './EditCustomFrameworkSheet';
+
+const frameworkInstance = {
+  id: 'frm_1',
+  organizationId: 'org_123',
+  customFrameworkId: 'cfrm_1',
+  customFramework: {
+    id: 'cfrm_1',
+    name: 'CMMC',
+    description: 'Original description',
+  },
+  controls: [],
+} as any;
+
+function renderSheet(overrides: Partial<Record<string, unknown>> = {}) {
+  return render(
+    <EditCustomFrameworkSheet
+      isOpen
+      onClose={vi.fn()}
+      frameworkInstance={frameworkInstance}
+      onUpdated={vi.fn()}
+      {...overrides}
+    />,
+  );
+}
+
+describe('EditCustomFrameworkSheet', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing when the user lacks framework:update', () => {
+    setMockPermissions(AUDITOR_PERMISSIONS);
+    renderSheet();
+    expect(screen.queryByText('Edit Custom Framework')).not.toBeInTheDocument();
+  });
+
+  it('pre-fills the form with the current name and description', () => {
+    setMockPermissions(ADMIN_PERMISSIONS);
+    renderSheet();
+    expect(screen.getByText('Edit Custom Framework')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('CMMC')).toBeInTheDocument();
+    expect(
+      screen.getByDisplayValue('Original description'),
+    ).toBeInTheDocument();
+  });
+
+  it('submits the edited values via updateCustomFramework', async () => {
+    setMockPermissions(ADMIN_PERMISSIONS);
+    updateCustomFramework.mockResolvedValue({});
+    const onClose = vi.fn();
+    const onUpdated = vi.fn();
+    renderSheet({ onClose, onUpdated });
+
+    const user = userEvent.setup();
+    const nameInput = screen.getByDisplayValue('CMMC');
+    await user.clear(nameInput);
+    await user.type(nameInput, 'CSC/CPRT');
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(updateCustomFramework).toHaveBeenCalledWith('frm_1', {
+        name: 'CSC/CPRT',
+        description: 'Original description',
+      });
+    });
+    expect(onUpdated).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/frameworks/[frameworkInstanceId]/components/EditCustomFrameworkSheet.tsx
+++ b/apps/app/src/app/(app)/[orgId]/frameworks/[frameworkInstanceId]/components/EditCustomFrameworkSheet.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { useFrameworks } from '@/hooks/use-frameworks';
+import { usePermissions } from '@/hooks/use-permissions';
+import type { FrameworkInstanceWithControls } from '@/lib/types/framework';
+import {
+  Button,
+  Sheet,
+  SheetBody,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@trycompai/design-system';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@trycompai/ui/form';
+import { Input } from '@trycompai/ui/input';
+import { Textarea } from '@trycompai/ui/textarea';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+import { z } from 'zod';
+
+const schema = z.object({
+  name: z.string().min(1, 'Name is required').max(120),
+  description: z.string().max(2000),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+interface EditCustomFrameworkSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  frameworkInstance: FrameworkInstanceWithControls;
+  onUpdated?: () => void;
+}
+
+export function EditCustomFrameworkSheet({
+  isOpen,
+  onClose,
+  frameworkInstance,
+  onUpdated,
+}: EditCustomFrameworkSheetProps) {
+  const { updateCustomFramework } = useFrameworks();
+  const { hasPermission } = usePermissions();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      name: frameworkInstance.customFramework?.name ?? '',
+      description: frameworkInstance.customFramework?.description ?? '',
+    },
+    mode: 'onChange',
+  });
+
+  // Refresh the form with the latest values each time the sheet opens.
+  useEffect(() => {
+    if (isOpen) {
+      form.reset({
+        name: frameworkInstance.customFramework?.name ?? '',
+        description: frameworkInstance.customFramework?.description ?? '',
+      });
+    }
+  }, [isOpen, frameworkInstance, form]);
+
+  if (!hasPermission('framework', 'update')) return null;
+
+  const handleSubmit = async (values: FormValues) => {
+    if (isSubmitting) return;
+    setIsSubmitting(true);
+    try {
+      await updateCustomFramework(frameworkInstance.id, values);
+      toast.success('Custom framework updated');
+      onUpdated?.();
+      onClose();
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : 'Failed to update framework',
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Sheet open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>Edit Custom Framework</SheetTitle>
+        </SheetHeader>
+        <SheetBody>
+          <Form {...form}>
+            <form
+              onSubmit={form.handleSubmit(handleSubmit)}
+              className="space-y-4"
+            >
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Name</FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        placeholder="Internal Controls Framework"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Description</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        {...field}
+                        className="min-h-[100px]"
+                        placeholder="Describe what this framework covers..."
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <div className="flex justify-end">
+                <Button type="submit" disabled={isSubmitting}>
+                  Save Changes
+                </Button>
+              </div>
+            </form>
+          </Form>
+        </SheetBody>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/app/src/app/(app)/[orgId]/frameworks/[frameworkInstanceId]/components/EditCustomFrameworkSheet.tsx
+++ b/apps/app/src/app/(app)/[orgId]/frameworks/[frameworkInstanceId]/components/EditCustomFrameworkSheet.tsx
@@ -28,7 +28,9 @@ import { toast } from 'sonner';
 import { z } from 'zod';
 
 const schema = z.object({
-  name: z.string().min(1, 'Name is required').max(120),
+  // trim() runs before min(1), so whitespace-only names are rejected and the
+  // stored value is trimmed.
+  name: z.string().trim().min(1, 'Name is required').max(120),
   description: z.string().max(2000),
 });
 

--- a/apps/app/src/app/(app)/[orgId]/frameworks/[frameworkInstanceId]/components/FrameworkDetailContent.tsx
+++ b/apps/app/src/app/(app)/[orgId]/frameworks/[frameworkInstanceId]/components/FrameworkDetailContent.tsx
@@ -15,7 +15,7 @@ import {
   TabsList,
   TabsTrigger,
 } from '@trycompai/design-system';
-import { OverflowMenuVertical, TrashCan } from '@trycompai/design-system/icons';
+import { Edit, OverflowMenuVertical, TrashCan } from '@trycompai/design-system/icons';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -26,6 +26,7 @@ import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { Suspense, useCallback, useMemo, useState } from 'react';
 import { AddCustomRequirementSheet } from './AddCustomRequirementSheet';
+import { EditCustomFrameworkSheet } from './EditCustomFrameworkSheet';
 import { FrameworkControls } from './FrameworkControls';
 import { FrameworkControlsGrouped } from './FrameworkControlsGrouped';
 import { FrameworkDeleteDialog } from './FrameworkDeleteDialog';
@@ -58,9 +59,10 @@ export function FrameworkDetailContent({
   const { hasPermission, permissions } = usePermissions();
   const complianceTimelineEnabled = useFeatureFlag('is-timeline-enabled');
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [editSheetOpen, setEditSheetOpen] = useState(false);
   const [dropdownOpen, setDropdownOpen] = useState(false);
 
-  const { data } = useFrameworkInstance<any>(frameworkInstanceId, {
+  const { data, mutate } = useFrameworkInstance<any>(frameworkInstanceId, {
     fallbackData: initialFramework,
   });
   const framework = data ?? initialFramework;
@@ -126,6 +128,10 @@ export function FrameworkDetailContent({
   const requirementsCount = requirementDefinitions.length;
 
   const canDeleteFramework = hasPermission('framework', 'delete');
+  // Only org-authored custom frameworks have editable name/description; platform
+  // frameworks inherit theirs from the shared global template.
+  const canEditCustomFramework =
+    !!framework.customFramework && hasPermission('framework', 'update');
 
   return (
     <Tabs value={activeTab} onValueChange={handleTabChange}>
@@ -145,7 +151,7 @@ export function FrameworkDetailContent({
               <>
                 <LinkRequirementSheet frameworkInstanceId={frameworkInstanceId} />
                 <AddCustomRequirementSheet frameworkInstanceId={frameworkInstanceId} />
-                {canDeleteFramework && (
+                {(canEditCustomFramework || canDeleteFramework) && (
                   <DropdownMenu open={dropdownOpen} onOpenChange={setDropdownOpen}>
                     <DropdownMenuTrigger asChild>
                       <Button size="sm" variant="ghost">
@@ -153,16 +159,29 @@ export function FrameworkDetailContent({
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
-                      <DropdownMenuItem
-                        onClick={() => {
-                          setDropdownOpen(false);
-                          setDeleteDialogOpen(true);
-                        }}
-                        className="text-destructive focus:text-destructive"
-                      >
-                        <TrashCan size={16} className="mr-2" />
-                        Delete Framework
-                      </DropdownMenuItem>
+                      {canEditCustomFramework && (
+                        <DropdownMenuItem
+                          onClick={() => {
+                            setDropdownOpen(false);
+                            setEditSheetOpen(true);
+                          }}
+                        >
+                          <Edit size={16} className="mr-2" />
+                          Edit Framework
+                        </DropdownMenuItem>
+                      )}
+                      {canDeleteFramework && (
+                        <DropdownMenuItem
+                          onClick={() => {
+                            setDropdownOpen(false);
+                            setDeleteDialogOpen(true);
+                          }}
+                          className="text-destructive focus:text-destructive"
+                        >
+                          <TrashCan size={16} className="mr-2" />
+                          Delete Framework
+                        </DropdownMenuItem>
+                      )}
                     </DropdownMenuContent>
                   </DropdownMenu>
                 )}
@@ -264,6 +283,15 @@ export function FrameworkDetailContent({
         onClose={() => setDeleteDialogOpen(false)}
         frameworkInstance={frameworkInstanceWithControls}
       />
+
+      {canEditCustomFramework && (
+        <EditCustomFrameworkSheet
+          isOpen={editSheetOpen}
+          onClose={() => setEditSheetOpen(false)}
+          frameworkInstance={frameworkInstanceWithControls}
+          onUpdated={() => mutate()}
+        />
+      )}
     </Tabs>
   );
 }

--- a/apps/app/src/hooks/use-frameworks.ts
+++ b/apps/app/src/hooks/use-frameworks.ts
@@ -66,6 +66,20 @@ export function useFrameworks(options?: UseFrameworksOptions) {
     return response.data;
   };
 
+  const updateCustomFramework = async (
+    id: string,
+    input: { name?: string; description?: string },
+  ) => {
+    const response = await apiClient.patch<{
+      id: string;
+      name: string;
+      description: string;
+    }>(`/v1/frameworks/${id}/custom`, input);
+    if (response.error) throw new Error(response.error);
+    await mutate();
+    return response.data;
+  };
+
   const deleteFramework = async (id: string) => {
     const previous = frameworks;
     await mutate(
@@ -89,6 +103,7 @@ export function useFrameworks(options?: UseFrameworksOptions) {
     mutate,
     addFrameworks,
     createCustomFramework,
+    updateCustomFramework,
     deleteFramework,
   };
 }


### PR DESCRIPTION
## Problem

Customers can **create** and **delete** custom frameworks, but there is no way to **edit** a custom framework's title or description after creation. (Reported: a customer has three custom frameworks all showing the same "CMMC" name and needs to rename them individually.)

The gap was end-to-end: no update endpoint, no `updateCustomFramework` hook, no edit UI. The DB already supports it (`CustomFramework.name` / `description` are plain editable fields).

## What changed

**API** (`apps/api/src/frameworks/`)
- `PATCH /v1/frameworks/:id/custom` (`@RequirePermission('framework','update')`) + `UpdateCustomFrameworkDto` (`name?`, `description?`).
- `updateCustom` service method: resolves the framework instance **org-scoped** (404 if missing), rejects **platform** frameworks (`400` — their name/description come from the shared global template, not per-org), then updates the org's `CustomFramework`.
- Endpoint follows the MCP/OpenAPI contract: class DTO with both `@ApiPropertyOptional` + class-validator stacks, `@ApiBody`, and a summary + ≤240-char description.

**App** (`apps/app/src/app/(app)/[orgId]/frameworks/`)
- `updateCustomFramework` added to the `useFrameworks` hook.
- New `EditCustomFrameworkSheet` — controlled, pre-filled, gated on `framework:update`.
- "Edit Framework" item added to the framework detail overflow menu (`FrameworkDetailContent`), shown **only for custom frameworks** with `framework:update`. Revalidates the instance on save.
- Trust Portal reflects the new name automatically (the portal reads `CustomFramework.name` over HTTP).

## Scope notes
- **Name + description only** (version left untouched, per request).
- Only org-authored custom frameworks are editable; platform frameworks are unaffected.
- No DB migration.

## Tests
- **Service**: success, partial update, 404 (missing instance), 400 (platform framework). ✅ pass
- **Controller**: delegation test (mirrors the existing `delete` test).
- **Frontend**: `EditCustomFrameworkSheet` — permission gating (null render without `framework:update`), prefill, and submit. ✅ 3/3 pass
- Typecheck clean for all changed files (both `@trycompai/api` and `@trycompai/app`).

## Reviewer notes (pre-existing, not introduced here)
- `apps/api` and `apps/app` typechecks are already red on `main` in unrelated spec files; none of my files error.
- The `frameworks.controller.spec.ts` **file** doesn't load in a fresh local worktree due to a pre-existing Prisma 7 + jest module-resolution issue in the shared `@db` import chain (all ~15 tests in the file, not just mine); it runs in CI. The service tests fully cover the logic.
- `FrameworkOverview.test.tsx` has one pre-existing failure — that component is dead code (only its own test imports it); byte-identical to `main`, untouched here.
- **Follow-up:** `packages/docs/openapi.json` should be regenerated so the new endpoint surfaces in the hosted MCP. I verified locally that it produces a correct `UpdateCustomFrameworkDto` schema and valid SEO metadata, but did not commit the regenerated spec because the committed spec is already stale on `main` (a full regen would bundle unrelated drift). Note: the local generator (`gen-openapi.spec.ts`) currently fails to load due to an unrelated `@inference/tracing` ESM import — separate infra issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jXBJKNd7CYdUxf44DsKba

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the ability to rename and update the description of custom frameworks, with a new edit UI and API. Also trims and rejects whitespace-only names to prevent blank-looking titles.

- **New Features**
  - API: `PATCH /v1/frameworks/:id/custom` (`framework:update`). Validates optional `name` and `description`; 404 if instance not found; 400 for platform frameworks; updates only provided fields.
  - App: `useFrameworks.updateCustomFramework`. New `EditCustomFrameworkSheet` (prefilled, permission-gated) and “Edit Framework” menu item for custom frameworks. Revalidates on save; Trust Portal reflects new name.

- **Bug Fixes**
  - App: Trim `name` and reject whitespace-only values in `EditCustomFrameworkSheet`; adds a regression test.

<sup>Written for commit 8db8ac5dfd84988ab2bd39961b1f1c7190598429. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

