### PR TITLE
fix(frameworks): reject null fields and empty payload on custom framework update

### DIFF
--- a/apps/api/src/frameworks/dto/update-custom-framework.dto.spec.ts
+++ b/apps/api/src/frameworks/dto/update-custom-framework.dto.spec.ts
@@ -1,0 +1,46 @@
+import { plainToInstance } from 'class-transformer';
+import { validate, type ValidationError } from 'class-validator';
+import { UpdateCustomFrameworkDto } from './update-custom-framework.dto';
+
+function propsWithErrors(errors: ValidationError[]): string[] {
+  return errors.map((e) => e.property);
+}
+
+async function validatePayload(payload: Record<string, unknown>) {
+  const dto = plainToInstance(UpdateCustomFrameworkDto, payload);
+  return validate(dto, { whitelist: true, forbidNonWhitelisted: true });
+}
+
+describe('UpdateCustomFrameworkDto', () => {
+  it('accepts a name-only payload', async () => {
+    expect(await validatePayload({ name: 'Internal Controls' })).toHaveLength(0);
+  });
+
+  it('accepts a description-only payload', async () => {
+    expect(await validatePayload({ description: 'Covers X' })).toHaveLength(0);
+  });
+
+  it('accepts an empty payload (field-level; empty PATCH is rejected in the service)', async () => {
+    expect(await validatePayload({})).toHaveLength(0);
+  });
+
+  it('rejects an explicit null name', async () => {
+    const errors = await validatePayload({ name: null });
+    expect(propsWithErrors(errors)).toContain('name');
+  });
+
+  it('rejects an explicit null description', async () => {
+    const errors = await validatePayload({ description: null });
+    expect(propsWithErrors(errors)).toContain('description');
+  });
+
+  it('rejects a non-string name', async () => {
+    const errors = await validatePayload({ name: 42 });
+    expect(propsWithErrors(errors)).toContain('name');
+  });
+
+  it('rejects an empty-string name (MinLength)', async () => {
+    const errors = await validatePayload({ name: '' });
+    expect(propsWithErrors(errors)).toContain('name');
+  });
+});

--- a/apps/api/src/frameworks/dto/update-custom-framework.dto.ts
+++ b/apps/api/src/frameworks/dto/update-custom-framework.dto.ts
@@ -1,16 +1,19 @@
-import { IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+import { IsString, MaxLength, MinLength, ValidateIf } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class UpdateCustomFrameworkDto {
+  // ValidateIf (rather than @IsOptional) only skips validation when the field is
+  // omitted (undefined). An explicit `null` still runs @IsString and is rejected
+  // with a 400, instead of slipping through to a non-null DB column.
   @ApiPropertyOptional({ description: 'Framework name', example: 'Internal Controls' })
-  @IsOptional()
+  @ValidateIf((_, value) => value !== undefined)
   @IsString()
   @MinLength(1)
   @MaxLength(120)
   name?: string;
 
   @ApiPropertyOptional({ description: 'Framework description' })
-  @IsOptional()
+  @ValidateIf((_, value) => value !== undefined)
   @IsString()
   @MaxLength(2000)
   description?: string;

--- a/apps/api/src/frameworks/frameworks.service.spec.ts
+++ b/apps/api/src/frameworks/frameworks.service.spec.ts
@@ -178,6 +178,14 @@ describe('FrameworksService', () => {
       });
     });
 
+    it('should throw BadRequestException when no fields are provided', async () => {
+      await expect(
+        service.updateCustom('fi1', 'org_1', {}),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockDb.frameworkInstance.findUnique).not.toHaveBeenCalled();
+      expect(mockDb.customFramework.update).not.toHaveBeenCalled();
+    });
+
     it('should throw NotFoundException when instance not found', async () => {
       (mockDb.frameworkInstance.findUnique as jest.Mock).mockResolvedValue(
         null,

--- a/apps/api/src/frameworks/frameworks.service.ts
+++ b/apps/api/src/frameworks/frameworks.service.ts
@@ -470,6 +470,15 @@ export class FrameworksService {
     organizationId: string,
     input: { name?: string; description?: string },
   ) {
+    const data: { name?: string; description?: string } = {};
+    if (input.name !== undefined) data.name = input.name;
+    if (input.description !== undefined) data.description = input.description;
+
+    // Reject an empty PATCH up front instead of issuing a no-op write.
+    if (Object.keys(data).length === 0) {
+      throw new BadRequestException('No fields to update');
+    }
+
     const frameworkInstance = await db.frameworkInstance.findUnique({
       where: { id: frameworkInstanceId, organizationId },
       select: { customFrameworkId: true },
@@ -484,10 +493,6 @@ export class FrameworksService {
     if (!frameworkInstance.customFrameworkId) {
       throw new BadRequestException('Only custom frameworks can be edited');
     }
-
-    const data: { name?: string; description?: string } = {};
-    if (input.name !== undefined) data.name = input.name;
-    if (input.description !== undefined) data.description = input.description;
 
     // Ownership is already enforced by the org-scoped instance lookup above,
     // so keying the update by the custom framework id is safe.


### PR DESCRIPTION
Follow-up to #3319 (now merged) — addresses the two cubic findings on the custom-framework edit endpoint (`PATCH /v1/frameworks/:id/custom`). Diff is only the 4 fix files.

## Fixes

**1. `null` fields bypassed validation → DB error (cubic P2, real bug)**
`@IsOptional()` skips validation for `null` *and* `undefined`, so `PATCH { "name": null }` passed validation, then `input.name !== undefined` was `true` for `null`, so `data.name = null` reached Prisma and failed against the non-null column (500).
→ Both fields now use `@ValidateIf((_, value) => value !== undefined)`: an omitted field stays optional, but an explicit `null` runs `@IsString` and is rejected with a **400**.

**2. Empty payload issued a no-op write (cubic P1)**
An empty `data: {}` is a valid Prisma no-op (bumps `updatedAt`) rather than a runtime error, but issuing a pointless write for a content-free PATCH is wrong.
→ Added an up-front guard: if neither field is provided, throw `BadRequestException('No fields to update')` before any DB work.

## Tests
- **New DTO spec** (`update-custom-framework.dto.spec.ts`): rejects `null` name/description, non-string, and empty-string name; accepts name-only, description-only, and empty payloads at the field level.
- **Service spec**: new empty-payload guard test (400, no DB calls).
- Service spec 22 passed (only the 2 pre-existing `findOne` isolation failures remain — unrelated). Typecheck clean for all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jXBJKNd7CYdUxf44DsKba

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix validation in the custom framework update endpoint. We now reject explicit nulls and empty PATCH payloads with 400 to prevent DB errors and no-op writes.

- **Bug Fixes**
  - DTO: replaced `@IsOptional` with `@ValidateIf((_, v) => v !== undefined)` on `name` and `description` so explicit `null` values run string/length checks and are rejected.
  - Service: if neither field is provided, throw `BadRequestException('No fields to update')` before any DB calls on `PATCH /v1/frameworks/:id/custom`.

<sup>Written for commit 26bafcbcae59fdb9cf66c76d5dbb51a3d44d0233. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

