### PR TITLE
fix(integrations): use catalog-defined field names for fivetran basic auth

### DIFF
--- a/apps/api/src/integration-platform/services/basic-auth-credential-fields.spec.ts
+++ b/apps/api/src/integration-platform/services/basic-auth-credential-fields.spec.ts
@@ -1,0 +1,39 @@
+import type { BasicAuthConfig } from '@trycompai/integration-platform';
+import { buildBasicAuthCredentialFields } from './basic-auth-credential-fields';
+
+describe('buildBasicAuthCredentialFields', () => {
+  it('maps usernameField/passwordField to labeled fields (Fivetran api_key/api_secret)', () => {
+    const config: BasicAuthConfig = {
+      usernameField: 'api_key',
+      passwordField: 'api_secret',
+    };
+
+    const fields = buildBasicAuthCredentialFields(config);
+
+    // Ids must equal the config field names so the runtime finds them when
+    // building the Basic auth header; labels must read as API Key / API Secret.
+    expect(fields).toEqual([
+      {
+        id: 'api_key',
+        label: 'API Key',
+        type: 'text',
+        required: true,
+        placeholder: 'Enter API Key',
+      },
+      {
+        id: 'api_secret',
+        label: 'API Secret',
+        type: 'password',
+        required: true,
+        placeholder: 'Enter API Secret',
+      },
+    ]);
+  });
+
+  it('falls back to generic username/password when field names are unset', () => {
+    const fields = buildBasicAuthCredentialFields({} as BasicAuthConfig);
+
+    expect(fields.map((f) => f.id)).toEqual(['username', 'password']);
+    expect(fields.map((f) => f.label)).toEqual(['Username', 'Password']);
+  });
+});

--- a/apps/api/src/integration-platform/services/basic-auth-credential-fields.ts
+++ b/apps/api/src/integration-platform/services/basic-auth-credential-fields.ts
@@ -1,0 +1,58 @@
+import type {
+  BasicAuthConfig,
+  CredentialField,
+} from '@trycompai/integration-platform';
+
+/**
+ * Turn a credential field name into a human-readable label.
+ * e.g. "api_key" → "API Key", "api_secret" → "API Secret", "username" → "Username".
+ */
+function humanizeFieldName(fieldName: string): string {
+  return fieldName
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map((word) =>
+      word.toLowerCase() === 'api'
+        ? 'API'
+        : word.charAt(0).toUpperCase() + word.slice(1),
+    )
+    .join(' ');
+}
+
+/**
+ * Build the credential form fields for a Basic-auth integration from its auth
+ * config.
+ *
+ * The field ids MUST equal the config's `usernameField`/`passwordField` so the
+ * values the customer enters are stored under the same keys the runtime reads
+ * when it builds the `Authorization: Basic` header (see runtime/check-context.ts).
+ * Fivetran, for example, maps Basic auth to `api_key`/`api_secret` — without
+ * these synthesized fields the connect form falls back to generic
+ * `username`/`password` ids, the runtime looks up the never-set real field names
+ * and sends `Basic base64(":")`, and every check fails with a 401.
+ */
+export function buildBasicAuthCredentialFields(
+  config: BasicAuthConfig,
+): CredentialField[] {
+  const usernameField = config.usernameField || 'username';
+  const passwordField = config.passwordField || 'password';
+  const usernameLabel = humanizeFieldName(usernameField);
+  const passwordLabel = humanizeFieldName(passwordField);
+
+  return [
+    {
+      id: usernameField,
+      label: usernameLabel,
+      type: 'text',
+      required: true,
+      placeholder: `Enter ${usernameLabel}`,
+    },
+    {
+      id: passwordField,
+      label: passwordLabel,
+      type: 'password',
+      required: true,
+      placeholder: `Enter ${passwordLabel}`,
+    },
+  ];
+}

--- a/apps/api/src/integration-platform/services/dynamic-manifest-loader.service.ts
+++ b/apps/api/src/integration-platform/services/dynamic-manifest-loader.service.ts
@@ -20,6 +20,7 @@ import {
   DynamicIntegrationRepository,
   type DynamicIntegrationWithChecks,
 } from '../repositories/dynamic-integration.repository';
+import { buildBasicAuthCredentialFields } from './basic-auth-credential-fields';
 import type { DynamicCheck } from '@db';
 
 @Injectable()
@@ -153,6 +154,15 @@ export class DynamicManifestLoaderService
     > | null;
     const syncVariables = syncDef?.variables as CheckVariable[] | undefined;
 
+    // Basic-auth integrations declare their credential field names (e.g. Fivetran
+    // maps Basic auth to api_key/api_secret) but ship no credentialFields. Synthesize
+    // them so the connect form labels the inputs correctly and — critically — stores
+    // the values under the same keys the runtime reads to build the Basic header.
+    const credentialFields =
+      auth.type === 'basic'
+        ? buildBasicAuthCredentialFields(auth.config)
+        : undefined;
+
     return {
       id: integration.slug,
       name: integration.name,
@@ -164,6 +174,7 @@ export class DynamicManifestLoaderService
       baseUrl: integration.baseUrl ?? undefined,
       defaultHeaders:
         (integration.defaultHeaders as Record<string, string>) ?? undefined,
+      credentialFields,
       capabilities:
         (integration.capabilities as unknown as IntegrationCapability[]) ?? [
           'checks',

--- a/apps/app/src/components/integrations/ConnectIntegrationDialog.test.tsx
+++ b/apps/app/src/components/integrations/ConnectIntegrationDialog.test.tsx
@@ -59,6 +59,29 @@ const mockProviders = [
     ],
     supportsMultipleConnections: true,
   },
+  {
+    // Basic-auth provider whose catalog maps the two fields to API Key / API Secret
+    // (the backend synthesizes these credentialFields from usernameField/passwordField).
+    id: 'fivetran',
+    authType: 'basic',
+    credentialFields: [
+      {
+        id: 'api_key',
+        label: 'API Key',
+        type: 'text',
+        required: true,
+        placeholder: 'Enter API Key',
+      },
+      {
+        id: 'api_secret',
+        label: 'API Secret',
+        type: 'password',
+        required: true,
+        placeholder: 'Enter API Secret',
+      },
+    ],
+    supportsMultipleConnections: false,
+  },
 ];
 
 vi.mock('@/hooks/use-integration-platform', () => ({
@@ -263,5 +286,32 @@ describe('ConnectIntegrationDialog permission gating', () => {
     setMockPermissions(ADMIN_PERMISSIONS);
     render(<ConnectIntegrationDialog {...defaultProps} open={false} />);
     expect(screen.queryByTestId('dialog')).not.toBeInTheDocument();
+  });
+});
+
+describe('ConnectIntegrationDialog basic auth credential labels', () => {
+  const fivetranProps = {
+    ...defaultProps,
+    integrationId: 'fivetran',
+    integrationName: 'Fivetran',
+    integrationLogoUrl: 'https://example.com/fivetran.png',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setMockPermissions(ADMIN_PERMISSIONS);
+  });
+
+  // Regression: Fivetran uses Basic auth but the two fields are API Key / API Secret.
+  // The form used to hardcode generic Username/Password ids+labels, so customers saw
+  // the wrong labels AND their creds were stored under username/password while the
+  // runtime read api_key/api_secret → empty Basic header → 401 on every check.
+  it('labels basic-auth fields from the catalog (API Key / API Secret), not generic Username / Password', () => {
+    render(<ConnectIntegrationDialog {...fivetranProps} />);
+
+    expect(screen.getByText('API Key')).toBeInTheDocument();
+    expect(screen.getByText('API Secret')).toBeInTheDocument();
+    expect(screen.queryByText('Username')).not.toBeInTheDocument();
+    expect(screen.queryByText('Password')).not.toBeInTheDocument();
   });
 });

--- a/apps/app/src/components/integrations/ConnectIntegrationDialog.tsx
+++ b/apps/app/src/components/integrations/ConnectIntegrationDialog.tsx
@@ -176,6 +176,13 @@ export function ConnectIntegrationDialog({
 
   const allFields = useMemo(() => {
     if (authType === 'basic') {
+      // Prefer the catalog-defined fields (e.g. Fivetran's api_key/api_secret) so the
+      // inputs are labeled correctly and the values are stored under the keys the
+      // runtime reads to build the Basic auth header. Fall back to generic
+      // username/password only when the provider ships no credential fields.
+      if (credentialFields.length > 0) {
+        return credentialFields;
+      }
       return [
         {
           id: 'username',


### PR DESCRIPTION
## Problem

Fivetran integration displays generic "Username" and "Password" labels for API credentials instead of "API Key" and "API Secret". This misleads users into entering wrong credentials (e.g., Entra login details). Auth checks then fail silently connection shows "on" but checks error with auth failures.

## Root cause

ConnectIntegrationDialog.tsx hardcodes username/password field ids and labels for basic auth, ignoring the catalog definition. Meanwhile check-context.ts reads credentials['api_key'] and ['api_secret']. The field names never align, so the Basic auth header gets empty values and requests to api.fivetran.com/v1/users fail.

The catalog JSON already has the correct field names (api_key, api_secret) and setup instructions. The bug is in the UI layer and auth synthesis, not the manifest.

## Fix

Remove the hardcoded basic auth branch in ConnectIntegrationDialog.tsx. Instead, synthesize credentialFields from the catalog's usernameField and passwordField definitions. This makes field ids and labels derive from the catalog, aligning with what check-context.ts reads.

Changes:
- dynamic-manifest-loader: generate credentialFields for basic auth from usernameField/passwordField
- ConnectIntegrationDialog.tsx: drop hardcoded branch, use synthesized fields
- Backward compatible: default basic integrations unchanged; affected customer reconnects once

## Explicitly NOT touched

- Fivetran catalog JSON (already correct)
- credential-vault or remap logic
- oauth controller or other auth flows
- any customer data or account setup

## Verification

✅ Fivetran integration now shows "API Key" and "API Secret" labels
✅ check-context.ts reads credentials['api_key'] and ['api_secret'] correctly
✅ Basic auth header is populated with user input
✅ Existing default basic auth integrations render unchanged
✅ Manual test: reconnected fivetran connector, checks pass against api.fivetran.com

Fixes CS-690

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CS-690 by using catalog-defined field names for Basic auth so Fivetran shows “API Key” and “API Secret” and the runtime reads the same keys, preventing silent auth failures.

- **Bug Fixes**
  - Backend: synthesize Basic auth `credentialFields` from catalog `usernameField`/`passwordField` via `buildBasicAuthCredentialFields` (with humanized labels) in the dynamic manifest loader.
  - Frontend: `ConnectIntegrationDialog` prefers catalog-provided fields for Basic auth; falls back to generic only if none exist.
  - Tests: added API and UI tests to verify `api_key`/`api_secret` labels and fallback to username/password.

- **Migration**
  - Existing Fivetran connections: reconnect once to save credentials under `api_key`/`api_secret`.

<sup>Written for commit 21259bc4cbf975f1b1c9ac348f96ac52cf71e712. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

