### PR TITLE
fix(frameworks): trim custom framework name/description in update DTO

### DIFF
--- a/apps/api/src/frameworks/dto/update-custom-framework.dto.spec.ts
+++ b/apps/api/src/frameworks/dto/update-custom-framework.dto.spec.ts
@@ -11,6 +11,10 @@ async function validatePayload(payload: Record<string, unknown>) {
   return validate(dto, { whitelist: true, forbidNonWhitelisted: true });
 }
 
+function transform(payload: Record<string, unknown>) {
+  return plainToInstance(UpdateCustomFrameworkDto, payload);
+}
+
 describe('UpdateCustomFrameworkDto', () => {
   it('accepts a name-only payload', async () => {
     expect(await validatePayload({ name: 'Internal Controls' })).toHaveLength(0);
@@ -42,5 +46,22 @@ describe('UpdateCustomFrameworkDto', () => {
   it('rejects an empty-string name (MinLength)', async () => {
     const errors = await validatePayload({ name: '' });
     expect(propsWithErrors(errors)).toContain('name');
+  });
+
+  it('rejects a whitespace-only name (trimmed to empty)', async () => {
+    const errors = await validatePayload({ name: '   ' });
+    expect(propsWithErrors(errors)).toContain('name');
+  });
+
+  it('trims surrounding whitespace from a valid name', async () => {
+    const payload = { name: '  Internal Controls  ' };
+    expect(await validatePayload(payload)).toHaveLength(0);
+    expect(transform(payload).name).toBe('Internal Controls');
+  });
+
+  it('trims the description', async () => {
+    expect(transform({ description: '  Covers X  ' }).description).toBe(
+      'Covers X',
+    );
   });
 });

--- a/apps/api/src/frameworks/dto/update-custom-framework.dto.ts
+++ b/apps/api/src/frameworks/dto/update-custom-framework.dto.ts
@@ -1,5 +1,13 @@
 import { IsString, MaxLength, MinLength, ValidateIf } from 'class-validator';
+import { Transform } from 'class-transformer';
 import { ApiPropertyOptional } from '@nestjs/swagger';
+
+// Trim strings so a whitespace-only value collapses to '' and is rejected by
+// MinLength. Guard on typeof so null/non-strings pass through unchanged and are
+// still rejected by @IsString (using value?.trim() would turn null into
+// undefined, which ValidateIf would then treat as an omitted field).
+const trimIfString = ({ value }: { value: unknown }) =>
+  typeof value === 'string' ? value.trim() : value;
 
 export class UpdateCustomFrameworkDto {
   // ValidateIf (rather than @IsOptional) only skips validation when the field is
@@ -7,6 +15,7 @@ export class UpdateCustomFrameworkDto {
   // with a 400, instead of slipping through to a non-null DB column.
   @ApiPropertyOptional({ description: 'Framework name', example: 'Internal Controls' })
   @ValidateIf((_, value) => value !== undefined)
+  @Transform(trimIfString)
   @IsString()
   @MinLength(1)
   @MaxLength(120)
@@ -14,6 +23,7 @@ export class UpdateCustomFrameworkDto {
 
   @ApiPropertyOptional({ description: 'Framework description' })
   @ValidateIf((_, value) => value !== undefined)
+  @Transform(trimIfString)
   @IsString()
   @MaxLength(2000)
   description?: string;


### PR DESCRIPTION
Addresses the cubic finding on `apps/api/src/frameworks/dto/update-custom-framework.dto.ts`: `@MinLength(1)` accepted **whitespace-only** names (`"   "` has length ≥ 1), so a blank-looking title could be persisted via a **direct API call** — the UI already trims (from #3319), but the API did not.

## Fix
Added a class-transformer `@Transform` that trims strings before validation, so a whitespace-only value collapses to `''` and `@MinLength(1)` rejects it (400). Applied to `name` and `description` (description trimmed for consistent data hygiene; it has no min-length so an all-whitespace description just becomes empty).

### Deliberate deviation from cubic's suggestion
Cubic suggested `@Transform(({ value }) => value?.trim())`. I used a **typeof-guarded** transform instead:

```ts
const trimIfString = ({ value }) => typeof value === 'string' ? value.trim() : value;
```

`value?.trim()` coerces `null → undefined`, which `@ValidateIf((_, v) => v !== undefined)` would then treat as an *omitted* field — silently undoing the explicit `null`-rejection added in #3323. The guarded version trims strings but leaves `null`/non-strings for `@IsString` to reject with a 400.

## Tests
`update-custom-framework.dto.spec.ts` extended — now 10/10 pass:
- rejects whitespace-only name (trimmed → empty → MinLength)
- trims surrounding whitespace from a valid name / description
- still rejects `null`, non-string, and empty-string name (unchanged behavior)

Typecheck clean.

## Note — same gap on the create path
`CreateCustomFrameworkDto` and `CreateCustomFrameworkSheet` have the identical whitespace gap (neither trims). I scoped this PR to cubic's exact finding (update DTO). Happy to send a small follow-up to bring the create path to parity — just say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jXBJKNd7CYdUxf44DsKba

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trim `name` and `description` in `UpdateCustomFrameworkDto` so whitespace-only names are rejected and surrounding spaces are removed before validation. This prevents blank-looking titles from being saved via direct API calls.

- **Bug Fixes**
  - Added `class-transformer` `@Transform` to trim strings before `@MinLength`/`@IsString`.
  - Guarded transform avoids `null` → `undefined`, preserving rejection of `null` and non-strings.
  - Extended tests to cover whitespace-only rejection and trimming behavior.

<sup>Written for commit dcf3dc156022026d8e4a64c760d8874342ad0061. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

