### PR TITLE
feat(people): redesign TASKS column with per-requirement status rows

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/people/all/components/MemberRow.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/MemberRow.test.tsx
@@ -86,29 +86,29 @@ describe('MemberRow device status', () => {
     vi.clearAllMocks();
   });
 
-  it('shows "Device 0/1" when deviceStatus is not-installed', () => {
+  it('shows Device as Missing when deviceStatus is not-installed', () => {
     renderMemberRow('not-installed');
-    expect(screen.getByText('Device 0/1')).toBeInTheDocument();
+    expect(screen.getByTestId('requirement-Device')).toHaveTextContent('Missing');
   });
 
-  it('shows dash when deviceStatus is omitted (no compliance obligation)', () => {
+  it('shows no device row when deviceStatus is omitted (no compliance obligation)', () => {
     renderMemberRow();
-    expect(screen.queryByText(/^Device /)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('requirement-Device')).not.toBeInTheDocument();
   });
 
-  it('shows "Device 1/1" when deviceStatus is compliant', () => {
+  it('shows Device as Done when deviceStatus is compliant', () => {
     renderMemberRow('compliant');
-    expect(screen.getByText('Device 1/1')).toBeInTheDocument();
+    expect(screen.getByTestId('requirement-Device')).toHaveTextContent('Done');
   });
 
-  it('shows "Device 0/1" when deviceStatus is non-compliant', () => {
+  it('shows Device as Missing when deviceStatus is non-compliant', () => {
     renderMemberRow('non-compliant');
-    expect(screen.getByText('Device 0/1')).toBeInTheDocument();
+    expect(screen.getByTestId('requirement-Device')).toHaveTextContent('Missing');
   });
 
-  it('shows "Device 0/1" when deviceStatus is stale', () => {
+  it('shows Device as Missing when deviceStatus is stale', () => {
     renderMemberRow('stale');
-    expect(screen.getByText('Device 0/1')).toBeInTheDocument();
+    expect(screen.getByTestId('requirement-Device')).toHaveTextContent('Missing');
   });
 
   it('does not show device status for platform admin', () => {
@@ -134,7 +134,7 @@ describe('MemberRow device status', () => {
       </table>,
     );
 
-    expect(screen.queryByText(/^Device /)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('requirement-Device')).not.toBeInTheDocument();
   });
 
   it('does not show device status for deactivated member', () => {
@@ -160,7 +160,7 @@ describe('MemberRow device status', () => {
       </table>,
     );
 
-    expect(screen.queryByText(/^Device /)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('requirement-Device')).not.toBeInTheDocument();
   });
 
   it('does not show device status for member without compliance obligation (e.g. auditor)', () => {
@@ -186,7 +186,7 @@ describe('MemberRow device status', () => {
       </table>,
     );
 
-    expect(screen.queryByText(/^Device /)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('requirement-Device')).not.toBeInTheDocument();
   });
 
   it('still shows device status for member with compliance obligation', () => {
@@ -212,7 +212,7 @@ describe('MemberRow device status', () => {
       </table>,
     );
 
-    expect(screen.getByText('Device 1/1')).toBeInTheDocument();
+    expect(screen.getByTestId('requirement-Device')).toHaveTextContent('Done');
   });
 
   it('hides the background-check task counter and verified tick when bypassed', () => {
@@ -240,7 +240,7 @@ describe('MemberRow device status', () => {
       </table>,
     );
 
-    expect(screen.queryByText(/background check/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('requirement-Background')).not.toBeInTheDocument();
     expect(
       screen.queryByLabelText('Employee has completed a background check'),
     ).not.toBeInTheDocument();
@@ -273,7 +273,7 @@ describe('MemberRow device status', () => {
       </table>,
     );
 
-    expect(screen.queryByText(/background check/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('requirement-Background')).not.toBeInTheDocument();
     expect(
       screen.queryByLabelText('Employee has completed a background check'),
     ).not.toBeInTheDocument();

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/MemberRow.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/MemberRow.tsx
@@ -25,7 +25,6 @@ import {
   DropdownMenuTrigger,
   HStack,
   Label,
-  Skeleton,
   TableCell,
   TableRow,
   Text,
@@ -43,6 +42,7 @@ import { toast } from 'sonner';
 import { BackgroundCheckVerifiedTick } from '../../components/BackgroundCheckVerifiedTick';
 import { MultiRoleCombobox } from './MultiRoleCombobox';
 import { RemoveDeviceAlert } from './RemoveDeviceAlert';
+import { TaskRequirements, type TaskRequirementItem } from './TaskRequirements';
 import { RemoveMemberAlert } from './RemoveMemberAlert';
 import type { CustomRoleOption } from './MultiRoleCombobox';
 import type { BackgroundCheckStatus, MemberWithUser, TaskCompletion } from './TeamMembers';
@@ -99,20 +99,6 @@ function isBackgroundCheckComplete(status?: BackgroundCheckStatus): boolean {
   return status === 'completed' || status === 'completed_with_flags';
 }
 
-interface TaskCountItem {
-  label: string;
-  completed: number;
-  total: number;
-}
-
-function TaskCountLabel({ item }: { item: TaskCountItem }) {
-  return (
-    <Text size="xs" variant="muted">
-      {item.label} {item.completed}/{item.total}
-    </Text>
-  );
-}
-
 export function MemberRow({
   member,
   onRemove,
@@ -157,13 +143,14 @@ export function MemberRow({
   const hasCompletedBackgroundCheck = isBackgroundCheckComplete(backgroundCheckStatus);
   const memberExempt = member.backgroundCheckExempt === true;
   const shouldShowTaskRequirements = !isPlatformAdmin && !isDeactivated;
-  const taskItems: TaskCountItem[] = [];
+  const taskItems: TaskRequirementItem[] = [];
 
   if (taskCompletion) {
     taskItems.push({
       label: 'Policies',
       completed: taskCompletion.policies.completed,
       total: taskCompletion.policies.total,
+      kind: 'count',
     });
 
     if (taskCompletion.training.total > 0) {
@@ -171,6 +158,7 @@ export function MemberRow({
         label: 'Training',
         completed: taskCompletion.training.completed,
         total: taskCompletion.training.total,
+        kind: 'count',
       });
     }
 
@@ -179,30 +167,30 @@ export function MemberRow({
         label: 'HIPAA',
         completed: taskCompletion.hipaa.completed,
         total: taskCompletion.hipaa.total,
+        kind: 'binary',
       });
     }
   }
 
-  if (shouldShowTaskRequirements && (deviceStatus || isDeviceStatusLoading)) {
+  if (shouldShowTaskRequirements && deviceStatus) {
     taskItems.push({
       label: 'Device',
       completed: deviceStatus === 'compliant' ? 1 : 0,
       total: 1,
+      kind: 'binary',
     });
   }
 
   if (shouldShowTaskRequirements && backgroundCheckStepEnabled && !memberExempt && !isAuditorOnly) {
     taskItems.push({
-      label: 'Background check',
+      label: 'Background',
       completed: hasCompletedBackgroundCheck ? 1 : 0,
       total: 1,
+      kind: 'binary',
     });
   }
 
-  const visibleTaskTotal = taskItems.reduce((sum, item) => sum + item.total, 0);
-  const visibleTaskCompleted = taskItems.reduce((sum, item) => sum + item.completed, 0);
-  const taskProgressPercent =
-    visibleTaskTotal > 0 ? Math.round((visibleTaskCompleted / visibleTaskTotal) * 100) : 0;
+  const isDeviceLoadingRow = shouldShowTaskRequirements && isDeviceStatusLoading && !deviceStatus;
 
   const handleEditRolesClick = () => {
     setSelectedRoles(parseRoles(member.role));
@@ -353,30 +341,7 @@ export function MemberRow({
 
         {/* TASKS */}
         <TableCell>
-          {taskItems.length > 0 ? (
-            <div className="min-w-64 max-w-sm">
-              <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
-                <div
-                  className="h-full bg-primary transition-all"
-                  style={{ width: `${taskProgressPercent}%` }}
-                />
-              </div>
-              <div className="mt-1 flex flex-wrap gap-x-2 gap-y-0.5">
-                {taskItems.map((item) => (
-                  <TaskCountLabel key={item.label} item={item} />
-                ))}
-                {shouldShowTaskRequirements && isDeviceStatusLoading && (
-                  <div className="h-3 w-16">
-                    <Skeleton style={{ height: '100%', width: '100%' }} />
-                  </div>
-                )}
-              </div>
-            </div>
-          ) : (
-            <Text size="sm" variant="muted">
-              —
-            </Text>
-          )}
+          <TaskRequirements items={taskItems} showLoadingRow={isDeviceLoadingRow} />
         </TableCell>
 
         {/* ACTIONS */}

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/MemberRowBackgroundCheck.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/MemberRowBackgroundCheck.test.tsx
@@ -74,12 +74,12 @@ function renderRow({
 describe('MemberRow background check status', () => {
   it('shows background check as incomplete in the tasks column', () => {
     renderRow({ backgroundCheckStatus: 'invited' });
-    expect(screen.getByText('Background check 0/1')).toBeInTheDocument();
+    expect(screen.getByTestId('requirement-Background')).toHaveTextContent('Missing');
   });
 
   it('shows background check as complete in the tasks column', () => {
     renderRow({ backgroundCheckStatus: 'completed_with_flags' });
-    expect(screen.getByText('Background check 1/1')).toBeInTheDocument();
+    expect(screen.getByTestId('requirement-Background')).toHaveTextContent('Done');
     expect(screen.getByLabelText('Employee has completed a background check')).toBeInTheDocument();
   });
 
@@ -90,6 +90,6 @@ describe('MemberRow background check status', () => {
 
   it('does not show background check tracking for auditor-only members', () => {
     renderRow({ backgroundCheckStatus: 'invited', role: 'auditor' });
-    expect(screen.queryByText(/Background check/)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('requirement-Background')).not.toBeInTheDocument();
   });
 });

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TaskRequirements.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TaskRequirements.test.tsx
@@ -51,6 +51,12 @@ describe('TaskRequirements', () => {
 
   it('shows a loading placeholder when showLoadingRow is set with no items', () => {
     render(<TaskRequirements items={[]} showLoadingRow />);
+    expect(screen.getByTestId('task-requirements-loading')).toBeInTheDocument();
     expect(screen.queryByText('—')).not.toBeInTheDocument();
+  });
+
+  it('shows no loading placeholder when showLoadingRow is not set', () => {
+    render(<TaskRequirements items={[count('Policies', 1, 3)]} />);
+    expect(screen.queryByTestId('task-requirements-loading')).not.toBeInTheDocument();
   });
 });

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TaskRequirements.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TaskRequirements.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { TaskRequirements, type TaskRequirementItem } from './TaskRequirements';
+
+const count = (
+  label: string,
+  completed: number,
+  total: number,
+): TaskRequirementItem => ({ label, completed, total, kind: 'count' });
+
+const binary = (label: string, completed: number): TaskRequirementItem => ({
+  label,
+  completed,
+  total: 1,
+  kind: 'binary',
+});
+
+describe('TaskRequirements', () => {
+  it('renders a dash when there are no items and nothing loading', () => {
+    render(<TaskRequirements items={[]} />);
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('renders count requirements as "x/y"', () => {
+    render(<TaskRequirements items={[count('Policies', 24, 33)]} />);
+    const row = screen.getByTestId('requirement-Policies');
+    expect(row).toHaveTextContent('Policies');
+    expect(row).toHaveTextContent('24/33');
+  });
+
+  it('renders a complete binary requirement as Done', () => {
+    render(<TaskRequirements items={[binary('Background', 1)]} />);
+    expect(screen.getByTestId('requirement-Background')).toHaveTextContent('Done');
+  });
+
+  it('renders an incomplete binary requirement as Missing', () => {
+    render(<TaskRequirements items={[binary('Device', 0)]} />);
+    expect(screen.getByTestId('requirement-Device')).toHaveTextContent('Missing');
+  });
+
+  it('renders each requirement on its own row', () => {
+    render(
+      <TaskRequirements
+        items={[count('Policies', 33, 33), count('Training', 5, 5), binary('Background', 1)]}
+      />,
+    );
+    expect(screen.getByTestId('requirement-Policies')).toBeInTheDocument();
+    expect(screen.getByTestId('requirement-Training')).toBeInTheDocument();
+    expect(screen.getByTestId('requirement-Background')).toBeInTheDocument();
+  });
+
+  it('shows a loading placeholder when showLoadingRow is set with no items', () => {
+    render(<TaskRequirements items={[]} showLoadingRow />);
+    expect(screen.queryByText('—')).not.toBeInTheDocument();
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TaskRequirements.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TaskRequirements.tsx
@@ -74,7 +74,7 @@ export function TaskRequirements({
         <TaskRequirementRow key={item.label} item={item} />
       ))}
       {showLoadingRow && (
-        <div className="h-3 w-16">
+        <div className="h-3 w-16" data-testid="task-requirements-loading">
           <Skeleton style={{ height: '100%', width: '100%' }} />
         </div>
       )}

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TaskRequirements.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TaskRequirements.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { Badge, Skeleton, Text } from '@trycompai/design-system';
+
+export interface TaskRequirementItem {
+  label: string;
+  completed: number;
+  total: number;
+  /** 'count' renders "x/y" + a progress bar; 'binary' renders a Done/Missing badge. */
+  kind: 'count' | 'binary';
+}
+
+function TaskRequirementRow({ item }: { item: TaskRequirementItem }) {
+  const { label, completed, total, kind } = item;
+  const isComplete = total > 0 && completed >= total;
+
+  return (
+    <div className="flex items-center gap-2" data-testid={`requirement-${label}`}>
+      <div className="w-24 shrink-0">
+        <Text size="xs" variant="muted">
+          {label}
+        </Text>
+      </div>
+
+      {kind === 'binary' ? (
+        <Badge variant={isComplete ? 'accent' : 'secondary'}>
+          {isComplete ? 'Done' : 'Missing'}
+        </Badge>
+      ) : (
+        <>
+          <div className="w-11 shrink-0">
+            <Text size="xs" variant={isComplete ? 'success' : completed > 0 ? 'warning' : 'muted'}>
+              {completed}/{total}
+            </Text>
+          </div>
+          <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-muted">
+            <div
+              className="h-full bg-primary transition-all"
+              style={{
+                width: `${total > 0 ? Math.min(100, Math.round((completed / total) * 100)) : 0}%`,
+              }}
+            />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Per-employee requirement rollup shown in the People list TASKS column.
+ * Each requirement is on its own row: fractional requirements (policies, training)
+ * show a count + progress bar; binary requirements (HIPAA, device, background)
+ * show a Done/Missing badge.
+ */
+export function TaskRequirements({
+  items,
+  showLoadingRow = false,
+}: {
+  items: TaskRequirementItem[];
+  showLoadingRow?: boolean;
+}) {
+  if (items.length === 0 && !showLoadingRow) {
+    return (
+      <Text size="sm" variant="muted">
+        —
+      </Text>
+    );
+  }
+
+  return (
+    <div className="flex min-w-56 max-w-sm flex-col gap-1">
+      {items.map((item) => (
+        <TaskRequirementRow key={item.label} item={item} />
+      ))}
+      {showLoadingRow && (
+        <div className="h-3 w-16">
+          <Skeleton style={{ height: '100%', width: '100%' }} />
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Redesigns the People list's TASKS column from a collapsed composite progress bar + wall of gray text into a scannable per-requirement list:

- Each requirement on its own row (vertical stack, aligned label column)
- Fractional requirements (Policies, Training) → count + mini progress bar, color-coded (green = complete, amber = partial, muted = none)
- Binary requirements (HIPAA, Device, Background check) → **Done** / **Missing** badge
- All colors via design-system `Text`/`Badge` variants — no custom CSS

| Before | After |
|---|---|
| One composite bar + `Policies 0/33 Training 0/5 HIPAA 0/1 Device 0/1 Background check 0/1` in wrapping gray text | One row per requirement: `Policies 24/33 ▓▓▓░`, `Background [Done]` |

## Why

Admins couldn't tell at a glance *which* requirement a person is missing — the single bar collapsed everything, and the per-item counts were unscannable gray text.

## Implementation

- Extracted rendering into `TaskRequirements.tsx` (MemberRow was over the 300-line limit)
- Device row now waits for device status to load instead of flashing "Missing"
- Label shortened `Background check` → `Background`

## Tests

- 6 new `TaskRequirements` tests; 15 existing MemberRow/background-check tests updated to the new rendering (behavior-based via `data-testid`)
- Typecheck clean on changed files (app-wide typecheck failures are pre-existing on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EP8KdCURe23QJ9oXd9ZJ3M

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the People TASKS column into a per‑requirement list with clear statuses, replacing the single progress bar. This makes it easy to see exactly what each person is missing at a glance.

- **New Features**
  - One row per requirement with aligned labels.
  - Fractional items show x/y + mini bar; binary items show Done/Missing badges (HIPAA, Device, Background).
  - Uses `@trycompai/design-system` `Text`/`Badge`; label shortened to “Background”. Device waits for status and shows a small loading placeholder; added `data-testid` for the loading skeleton and tests assert its presence. Extracted `TaskRequirements.tsx` with focused tests.

<sup>Written for commit 80100a46d72a7a04c28b23055fcb31e349986ebd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

