### PR TITLE
feat(people): per-employee 2FA status from a selected integration source

### DIFF
--- a/.claude/skills/check-results-service/SKILL.md
+++ b/.claude/skills/check-results-service/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: check-results-service
+description: How to reuse ANY integration check's results in a feature via the universal CheckResultsService (apps/api integration-platform). Use whenever a feature needs data produced by an integration check — "show 2FA status on People", "surface AWS S3 findings in X", "reuse a check's results", "per-user/per-resource results from a connected integration", "which integrations feed task T". Read this BEFORE writing your own IntegrationCheckResult / CheckRunRepository query — don't hand-roll it.
+---
+
+# CheckResultsService — reuse any integration check's results
+
+## The one idea
+
+Integration checks (2FA, AWS S3 encryption, device posture, …) all write per-resource
+results to one table (`IntegrationCheckResult`). **`CheckResultsService` is the single,
+universal, read-only way to get those results into any feature.** It is deliberately
+**feature-agnostic**: it fetches results and hands them back in a stable envelope, and it
+does **not** know or care what the data means.
+
+> **Service = fetch the results (generic). Feature = interpret + map + present.**
+
+If you're about to query `IntegrationCheckResult` or `CheckRunRepository` directly from a
+new feature — stop. Use this service instead.
+
+- Service: `apps/api/src/integration-platform/services/check-results.service.ts`
+- Exported from `IntegrationPlatformModule` — inject it into any feature module.
+- Reference consumer (copy this): the 2FA feature — `two-factor-source.controller.ts`.
+
+## When to use it
+
+Use it whenever a feature needs the output of an integration check:
+- "Show each employee's 2FA status on the People tab" (the current consumer)
+- "Surface which S3 buckets failed encryption inside feature X"
+- "Show device compliance per user from the MDM check"
+- "List which connected integrations can supply data for task T"
+
+## The API (3 methods)
+
+```ts
+// 1. Discover sources: which connected integrations can feed a task, + connection state.
+listSourcesBoundToTask(organizationId, taskTemplateId): Promise<CheckSourceInfo[]>
+
+// 2. The primitive: full results of a check's latest REAL run for ONE connection.
+getLatestResultsByCheck({ organizationId, connectionId, checkId, resourceType? }): Promise<CheckResultRow[]>
+
+// 3. Convenience: results for a task-bound check from a chosen source (provider slug).
+//    Resolves task -> check and slug -> connection for you.
+getLatestResultsForTask({ organizationId, taskTemplateId, sourceSlug, resourceType? }): Promise<CheckResultRow[]>
+```
+
+Notes:
+- "Latest REAL run" = newest run that isn't `inconclusive`/held and whose connection isn't
+  disconnected. Held runs (our-side self-heal) never leak to a feature.
+- No row cap — you get the full result set (unlike the 30-row task-history display).
+- `resourceType` filters rows (e.g. `'user'`, `'bucket'`). Omit to get all.
+- Empty array = "no data" (source not bound/connected, or never really ran). Never throws
+  for "no results".
+
+## The envelope you get back
+
+```ts
+interface CheckResultRow {
+  resourceId: string;      // provider-native id: email (2FA), bucket ARN (S3), repo, …
+  resourceType: string;    // 'user' | 'bucket' | …
+  passed: boolean;         // did this resource pass the check
+  title: string;
+  description: string | null;
+  evidence: Prisma.JsonValue;  // ← check-SPECIFIC payload. The service does NOT interpret it.
+  collectedAt: Date;
+  runId: string;
+  connectionId: string;
+}
+```
+
+**The `evidence` rule (important):** the envelope is universal; the check-specific data lives
+in `evidence` as raw JSON. The service never types or interprets it. **Your feature validates
+`evidence` at its own edge with a zod schema** and reads only the fields it understands:
+
+```ts
+const TwoFaEvidence = z.object({ isEnrolledIn2Sv: z.boolean() });
+const parsed = TwoFaEvidence.safeParse(row.evidence);
+// use parsed.data.isEnrolledIn2Sv — never `as any`
+```
+
+For a simple pass/fail feature you often don't even need `evidence` — just use `row.passed`
+and `row.resourceId` (that's all 2FA needs).
+
+## How to add a NEW consumer (step by step)
+
+Say a feature wants "which AWS S3 buckets failed encryption":
+
+1. Inject the service: add `CheckResultsService` to your feature's constructor (the module
+   already exports it; import `IntegrationPlatformModule` if your module doesn't already).
+2. Get results with the primitive (S3 usually spans many AWS connections, so you may loop
+   connections from `listSourcesBoundToTask` or your own connection lookup):
+   ```ts
+   const rows = await this.checkResults.getLatestResultsByCheck({
+     organizationId,
+     connectionId,
+     checkId: 'aws-s3-encryption',   // the check's manifest id
+     resourceType: 'bucket',
+   });
+   ```
+   …or, if your feature lets the user PICK a source for a task (like 2FA does), use
+   `getLatestResultsForTask` with the task template id and the chosen `sourceSlug`.
+3. Interpret in YOUR feature: map `resourceId`/`passed`, validate `evidence` with zod, shape
+   the response your UI needs. **Do not** add feature logic to the service.
+4. Test with the service mocked (see `two-factor-source.controller.spec.ts`).
+
+## Worked example — the 2FA feature (reference implementation)
+
+The People-tab 2FA column is consumer #1. Study it end to end:
+
+- `two-factor-source.controller.ts`
+  - `available-2fa-sources` → `listSourcesBoundToTask(org, TASK_TEMPLATES.twoFactorAuth)`
+  - `two-factor-statuses` → `getLatestResultsForTask({ org, taskTemplateId: twoFactorAuth,
+    sourceSlug: org.twoFactorSource, resourceType: 'user' })`, then maps `resourceId`→email
+    (lowercased) and `passed`→`enabled`/`missing`. Emails with no row are resolved to
+    "Not provided" on the client, never a false "missing".
+- The controller owns the 2FA-specific bits (the `Organization.twoFactorSource` column, the
+  enabled/missing interpretation). The generic fetch is all in the service.
+
+## Rules / do & don't
+
+- ✅ DO put every "read a check's results" path through this service.
+- ✅ DO validate `evidence` with zod in your feature. No `as any`.
+- ✅ DO treat an empty array as "no data / not provided" — never a failure.
+- ❌ DON'T query `IntegrationCheckResult` / `CheckRunRepository` directly from a feature.
+- ❌ DON'T add feature-specific interpretation (enabled/missing, domain mapping) to the
+  service — it must stay universal and read-only.
+- ❌ DON'T assume a source produces per-`user` (or email-keyed) rows — that's per-check. If a
+  chosen source's check emits a different `resourceType` or a non-mappable `resourceId`, your
+  feature should degrade gracefully (e.g. "Not provided"), not crash.
+
+## Source selection is NOT part of this service
+
+Which integration an org uses for a purpose (e.g. `Organization.twoFactorSource`) is
+feature-owned config, mirroring `employeeSyncProvider` / `deviceSyncProvider`. Add a column
+per feature. (If a 3rd/4th feature needs it, consider generalizing selection then — not
+before.)

--- a/.claude/skills/responsive-ui/SKILL.md
+++ b/.claude/skills/responsive-ui/SKILL.md
@@ -24,13 +24,38 @@ A change is NOT done until you have reasoned through (or better, viewed via the
 `webapp-testing` skill / browser dev tools) what it looks like at 375, 768, 1280,
 and 1920. If you only checked one width, you checked none.
 
+## Works WITH the design system — precedence rules
+
+This skill layers on top of the `ui` skill; **where they touch, the design-system
+rules win**. Responsiveness is achieved THROUGH the DS, never around it:
+
+- **Never put responsive classes (or any `className`) on DS components**
+  (`Text`, `Stack`, `HStack`, `Badge`, `Button`, …) — they don't accept it. Put
+  breakpoint utilities on a wrapper `<div>` (the `ui` skill's "Layout with Wrapper
+  Divs" pattern):
+  ```tsx
+  // ✅ breakpoints on the wrapper, DS component untouched
+  <div className="hidden sm:block"><Badge variant="outline">Active</Badge></div>
+  // ❌ className on a DS component
+  <Badge className="hidden sm:block">Active</Badge>
+  ```
+- **Reach for DS layout primitives first** (`PageLayout`, `Stack`, `HStack`,
+  `Section`) — they carry responsive spacing already. Raw responsive divs are for
+  what the primitives don't cover, not a replacement for them.
+- **Arbitrary pixel values stay an anti-pattern** (`w-[847px]` ❌ — per the `ui`
+  skill). Prefer the standard Tailwind scale (`max-w-sm`, `w-48`, `max-w-xs`). A
+  fixed control width like `w-[200px]` is acceptable ONLY when it matches an
+  established pattern already used on that surface, and it must still carry a
+  responsive strategy (see below).
+
 ## Non-negotiables
 
 1. **The page body never scrolls horizontally.** Wide content (tables, code, diagrams)
    scrolls inside its own container, never the page.
-2. **No fixed pixel width without a responsive strategy.** A bare `w-[200px]` is only
+2. **No fixed width without a responsive strategy.** A fixed-width control is only
    acceptable if the element hides, shrinks, or wraps on smaller screens
-   (`hidden sm:block`, `w-full md:w-[200px]`, or a wrapping parent).
+   (`hidden sm:block`, `w-full md:max-w-xs`, or a wrapping parent) — with the
+   breakpoint classes on a wrapper div, never on a DS component.
 3. **Touch targets** on mobile: interactive elements ≥40px tall; don't rely on hover
    for anything essential (no hover on touch devices).
 4. **Test with real content lengths** — long names, emails, 33-item counts. Use

--- a/.claude/skills/responsive-ui/SKILL.md
+++ b/.claude/skills/responsive-ui/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: responsive-ui
+description: MANDATORY for any UI work in apps/app, apps/portal, or packages/design-system — every component, page, or layout change must work on mobile (~375px), tablet (~768px), desktop (~1280px), and large desktop (~1920px) BY DEFAULT, without being asked. Read this before writing or editing any JSX/TSX that renders visible UI. Triggers on: new component, page, layout, table, toolbar, form, modal/sheet, dashboard, "build UI", "add a column", "add a filter", any styling change.
+---
+
+# Responsive UI — default, not a feature request
+
+## The rule
+
+**Every UI change ships working at all four device classes. Nobody has to ask.**
+
+| Device | Test width | Tailwind context |
+|---|---|---|
+| Mobile | 375px | base (no prefix) |
+| Tablet | 768px | `md:` |
+| Desktop | 1280px | `xl:` |
+| Large desktop | 1920px | beyond `2xl:` |
+
+Tailwind is **mobile-first**: unprefixed classes are the mobile layout; prefixes add
+behavior at wider screens (`sm:` 640, `md:` 768, `lg:` 1024, `xl:` 1280, `2xl:` 1536).
+Write the mobile layout first, then widen — not the other way around.
+
+A change is NOT done until you have reasoned through (or better, viewed via the
+`webapp-testing` skill / browser dev tools) what it looks like at 375, 768, 1280,
+and 1920. If you only checked one width, you checked none.
+
+## Non-negotiables
+
+1. **The page body never scrolls horizontally.** Wide content (tables, code, diagrams)
+   scrolls inside its own container, never the page.
+2. **No fixed pixel width without a responsive strategy.** A bare `w-[200px]` is only
+   acceptable if the element hides, shrinks, or wraps on smaller screens
+   (`hidden sm:block`, `w-full md:w-[200px]`, or a wrapping parent).
+3. **Touch targets** on mobile: interactive elements ≥40px tall; don't rely on hover
+   for anything essential (no hover on touch devices).
+4. **Test with real content lengths** — long names, emails, 33-item counts. Use
+   `truncate` / `min-w-0` on flex children that hold text.
+5. **Large desktops:** content must not stretch into unreadable full-width lines —
+   cap with `max-w-*` containers where the layout doesn't already.
+
+## Repo patterns (use these, don't invent)
+
+- **Tables**: the design-system `Table` already wraps rows in `overflow-x-auto` —
+  wide tables scroll horizontally inside themselves on mobile. That is the accepted
+  pattern for dense admin tables. Do NOT try to reflow table columns per breakpoint;
+  do keep cells reasonable (`min-w-* max-w-*` on cell content is fine).
+- **Toolbars / filter rows**: primary control (search) is `w-full md:max-w-[300px]`;
+  secondary controls (filters, source selectors) collapse on phones with
+  `hidden sm:block`. Example: the People tab toolbar in
+  `apps/app/.../people/all/components/TeamMembersClient.tsx`.
+- **Page shells**: use design-system `PageLayout` / `Stack` / `HStack` — they carry
+  the responsive spacing; don't rebuild them with raw divs.
+- **Grids**: `grid-cols-1 md:grid-cols-2 xl:grid-cols-3` style progressions — never a
+  fixed column count for all widths.
+- **Sheets/Modals**: design-system `Sheet`/`Dialog` are responsive already; don't fix
+  their widths with arbitrary values.
+- **Images/logos**: constrain (`max-w-full`, explicit small sizes); never let an
+  image force layout width.
+
+## Checklist before "done" (run mentally or in the browser)
+
+- [ ] 375px — nothing overflows the viewport; controls usable or intentionally hidden; text truncates instead of breaking layout
+- [ ] 768px — secondary controls visible; layout uses available width sensibly
+- [ ] 1280px — the intended "design" width; matches mockups
+- [ ] 1920px — no absurdly stretched content; whitespace balanced
+- [ ] Long content (names, emails, high counts) doesn't break any of the above
+- [ ] Tests: if a component hides/reflows per breakpoint in a way that matters, its test asserts the class contract (e.g. `hidden sm:block`)
+
+## When you can skip a width
+
+Admin-only dense screens (e.g. internal tooling) may treat mobile as "usable via
+horizontal scroll" rather than fully reflowed — but that must be a conscious choice
+following the existing pattern of that page, never an accident of not checking.

--- a/.claude/skills/ui/SKILL.md
+++ b/.claude/skills/ui/SKILL.md
@@ -135,3 +135,12 @@ import { Plus, X } from 'lucide-react';
 <div className="bg-[#059669]">                // Hardcoded colors
 <div className="w-[847px]">                   // Arbitrary values
 ```
+
+## Responsive (MANDATORY — read the `responsive-ui` skill)
+
+Every UI change must work on mobile (375px), tablet (768px), desktop (1280px), and
+large desktop (1920px) **by default — nobody has to ask**. Tailwind is mobile-first:
+write the base (mobile) layout, widen with `sm:`/`md:`/`lg:`/`xl:`. No fixed pixel
+widths without a responsive strategy (`hidden sm:block`, `w-full md:w-[...]`, or a
+wrapping parent). Wide tables scroll inside the DS `Table` (`overflow-x-auto`), never
+the page. Full rules + repo patterns + checklist: `.claude/skills/responsive-ui/SKILL.md`.

--- a/.claude/skills/ui/SKILL.md
+++ b/.claude/skills/ui/SKILL.md
@@ -140,7 +140,9 @@ import { Plus, X } from 'lucide-react';
 
 Every UI change must work on mobile (375px), tablet (768px), desktop (1280px), and
 large desktop (1920px) **by default — nobody has to ask**. Tailwind is mobile-first:
-write the base (mobile) layout, widen with `sm:`/`md:`/`lg:`/`xl:`. No fixed pixel
-widths without a responsive strategy (`hidden sm:block`, `w-full md:w-[...]`, or a
-wrapping parent). Wide tables scroll inside the DS `Table` (`overflow-x-auto`), never
-the page. Full rules + repo patterns + checklist: `.claude/skills/responsive-ui/SKILL.md`.
+write the base (mobile) layout, widen with `sm:`/`md:`/`lg:`/`xl:`. No fixed widths
+without a responsive strategy (`hidden sm:block`, `w-full md:max-w-xs`, or a wrapping
+parent). All the rules above still apply: breakpoint classes go on wrapper divs, never
+on DS components, and arbitrary pixel values remain an anti-pattern. Wide tables scroll
+inside the DS `Table` (`overflow-x-auto`), never the page. Full rules + repo patterns +
+checklist: `.claude/skills/responsive-ui/SKILL.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ Every customer-facing API endpoint MUST have:
 - **DS components that do NOT accept `className`**: `Text`, `Stack`, `HStack`, `Badge`, `Button` — wrap in `<div>` for custom styling
 - **Layout**: Use `PageLayout`, `PageHeader`, `Stack`, `HStack`, `Section`, `SettingGroup`
 - **Patterns**: Sheet (`Sheet > SheetContent > SheetHeader + SheetBody`), Drawer, Collapsible
+- **Responsive (MANDATORY)**: every UI change must work on mobile (375px), tablet (768px), desktop (1280px), and large desktop (1920px) by default — no one has to ask. See the `responsive-ui` skill for breakpoints, repo patterns, and the checklist.
 - **After editing any frontend component**: Run the `audit-design-system` skill to catch `@trycompai/ui` or `lucide-react` imports that should be migrated
 
 ## Data Fetching

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -126,6 +126,10 @@ const module = await Test.createTestingModule({
 - Use Prisma via `@trycompai/db`
 - Always scope queries by `organizationId` for multi-tenancy
 - Use transactions for operations that modify multiple records
+- **Reusing an integration check's results in a feature?** Use `CheckResultsService`
+  (`integration-platform/services/check-results.service.ts`) — the universal, read-only way
+  to get any check's per-resource results. Do NOT query `IntegrationCheckResult` /
+  `CheckRunRepository` directly from a feature. See the `check-results-service` skill.
 
 ### Gotchas
 

--- a/apps/api/src/integration-platform/controllers/two-factor-source.controller.spec.ts
+++ b/apps/api/src/integration-platform/controllers/two-factor-source.controller.spec.ts
@@ -178,6 +178,32 @@ describe('TwoFactorSourceController.getTwoFactorStatuses', () => {
     });
   });
 
+  it('resolves conflicting rows for one email deterministically — a fail always wins', async () => {
+    mockOrgFindUnique.mockResolvedValue({ twoFactorSource: 'google-workspace' });
+    mockCheckResults.listSourcesBoundToTask.mockResolvedValue([
+      source('google-workspace', true),
+    ]);
+
+    // Same email with pass+fail rows, in BOTH orders — result must not depend
+    // on iteration order.
+    for (const rows of [
+      [
+        { resourceId: 'dup@x.com', passed: true },
+        { resourceId: 'dup@x.com', passed: false },
+      ],
+      [
+        { resourceId: 'dup@x.com', passed: false },
+        { resourceId: 'dup@x.com', passed: true },
+      ],
+    ]) {
+      mockCheckResults.getLatestResultsForTask.mockResolvedValue(rows);
+      const result = await makeController().getTwoFactorStatuses(ORG);
+      expect(result.statuses).toEqual([
+        { email: 'dup@x.com', status: 'missing' },
+      ]);
+    }
+  });
+
   it('returns empty statuses when the source has no results', async () => {
     mockOrgFindUnique.mockResolvedValue({ twoFactorSource: 'google-workspace' });
     mockCheckResults.getLatestResultsForTask.mockResolvedValue([]);

--- a/apps/api/src/integration-platform/controllers/two-factor-source.controller.spec.ts
+++ b/apps/api/src/integration-platform/controllers/two-factor-source.controller.spec.ts
@@ -124,6 +124,25 @@ describe('TwoFactorSourceController.setTwoFactorSource', () => {
       data: { twoFactorSource: null },
     });
   });
+
+  it('maps a missing org row (P2025) to 404 instead of a 500', async () => {
+    mockOrgUpdate.mockRejectedValue(
+      Object.assign(new Error('No record found'), { code: 'P2025' }),
+    );
+
+    await expect(
+      makeController().setTwoFactorSource(ORG, { provider: null }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('rethrows non-P2025 update errors untouched', async () => {
+    const dbError = new Error('connection lost');
+    mockOrgUpdate.mockRejectedValue(dbError);
+
+    await expect(
+      makeController().setTwoFactorSource(ORG, { provider: null }),
+    ).rejects.toBe(dbError);
+  });
 });
 
 describe('TwoFactorSourceController.getAvailableTwoFactorSources', () => {
@@ -150,6 +169,13 @@ describe('TwoFactorSourceController.getTwoFactorStatuses', () => {
       statuses: [],
     });
     expect(mockCheckResults.getLatestResultsForTask).not.toHaveBeenCalled();
+  });
+
+  it('404s on a missing org instead of reporting unconfigured', async () => {
+    mockOrgFindUnique.mockResolvedValue(null);
+    await expect(
+      makeController().getTwoFactorStatuses(ORG),
+    ).rejects.toMatchObject({ status: 404 });
   });
 
   it('maps the service results to lowercased email + enabled/missing', async () => {

--- a/apps/api/src/integration-platform/controllers/two-factor-source.controller.spec.ts
+++ b/apps/api/src/integration-platform/controllers/two-factor-source.controller.spec.ts
@@ -1,0 +1,235 @@
+import { HttpException } from '@nestjs/common';
+
+jest.mock('@db', () => ({
+  db: {
+    organization: { findUnique: jest.fn(), update: jest.fn() },
+    integrationConnection: { findFirst: jest.fn() },
+  },
+}));
+
+jest.mock('@trycompai/integration-platform', () => {
+  const actual = jest.requireActual<
+    typeof import('@trycompai/integration-platform')
+  >('@trycompai/integration-platform');
+  return {
+    ...actual,
+    registry: { getActiveManifests: jest.fn() },
+  };
+});
+
+// Break the ESM better-auth import chain pulled in via HybridAuthGuard.
+jest.mock('@trycompai/auth', () => ({
+  statement: { integration: ['create', 'read', 'update', 'delete'] },
+  BUILT_IN_ROLE_PERMISSIONS: {},
+}));
+jest.mock('../../auth/auth.server', () => ({
+  auth: { api: { getSession: jest.fn() } },
+}));
+
+import { db } from '@db';
+import { registry, TASK_TEMPLATES } from '@trycompai/integration-platform';
+import { TwoFactorSourceController } from './two-factor-source.controller';
+
+const mockGetActiveManifests = (
+  registry as unknown as { getActiveManifests: jest.Mock }
+).getActiveManifests;
+const mockOrgFindUnique = (
+  db.organization as unknown as { findUnique: jest.Mock }
+).findUnique;
+const mockOrgUpdate = (db.organization as unknown as { update: jest.Mock })
+  .update;
+const mockConnFindFirst = (
+  db.integrationConnection as unknown as { findFirst: jest.Mock }
+).findFirst;
+
+// Build a manifest whose check is bound to the 2FA task.
+function boundManifest(id: string, name = id) {
+  return {
+    id,
+    name,
+    logoUrl: null,
+    checks: [{ id: 'two-factor-auth', taskMapping: TASK_TEMPLATES.twoFactorAuth }],
+  };
+}
+// A manifest with a check NOT bound to the 2FA task.
+function unboundManifest(id: string) {
+  return {
+    id,
+    name: id,
+    logoUrl: null,
+    checks: [{ id: 'other', taskMapping: TASK_TEMPLATES.codeChanges }],
+  };
+}
+
+const mockConnRepo = { findBySlugAndOrg: jest.fn() };
+const mockCheckRunRepo = { findLatestUserResultsByConnectionAndCheck: jest.fn() };
+
+function makeController() {
+  return new TwoFactorSourceController(
+    mockConnRepo as never,
+    mockCheckRunRepo as never,
+  );
+}
+
+const ORG = 'org_1';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('TwoFactorSourceController.getTwoFactorSource', () => {
+  it('returns the configured provider', async () => {
+    mockOrgFindUnique.mockResolvedValue({ twoFactorSource: 'google-workspace' });
+    const result = await makeController().getTwoFactorSource(ORG);
+    expect(result).toEqual({ provider: 'google-workspace' });
+  });
+
+  it('throws when the org does not exist', async () => {
+    mockOrgFindUnique.mockResolvedValue(null);
+    await expect(makeController().getTwoFactorSource(ORG)).rejects.toBeInstanceOf(
+      HttpException,
+    );
+  });
+});
+
+describe('TwoFactorSourceController.setTwoFactorSource', () => {
+  it('rejects a blank/whitespace provider with 400', async () => {
+    await expect(
+      makeController().setTwoFactorSource(ORG, { provider: '   ' }),
+    ).rejects.toBeInstanceOf(HttpException);
+    expect(mockOrgUpdate).not.toHaveBeenCalled();
+  });
+
+  it('rejects a provider not bound to the 2FA task', async () => {
+    mockGetActiveManifests.mockReturnValue([boundManifest('google-workspace')]);
+    await expect(
+      makeController().setTwoFactorSource(ORG, { provider: 'slack' }),
+    ).rejects.toBeInstanceOf(HttpException);
+    expect(mockOrgUpdate).not.toHaveBeenCalled();
+  });
+
+  it('rejects a bound provider that is not connected', async () => {
+    mockGetActiveManifests.mockReturnValue([boundManifest('google-workspace')]);
+    mockConnRepo.findBySlugAndOrg.mockResolvedValue(null);
+    await expect(
+      makeController().setTwoFactorSource(ORG, { provider: 'google-workspace' }),
+    ).rejects.toBeInstanceOf(HttpException);
+    expect(mockOrgUpdate).not.toHaveBeenCalled();
+  });
+
+  it('sets a valid, connected, bound provider', async () => {
+    mockGetActiveManifests.mockReturnValue([boundManifest('google-workspace')]);
+    mockConnRepo.findBySlugAndOrg.mockResolvedValue({
+      id: 'conn_1',
+      status: 'active',
+    });
+    mockOrgUpdate.mockResolvedValue({});
+
+    const result = await makeController().setTwoFactorSource(ORG, {
+      provider: 'google-workspace',
+    });
+
+    expect(result).toEqual({ success: true, provider: 'google-workspace' });
+    expect(mockOrgUpdate).toHaveBeenCalledWith({
+      where: { id: ORG },
+      data: { twoFactorSource: 'google-workspace' },
+    });
+  });
+
+  it('clears the source when provider is null', async () => {
+    mockOrgUpdate.mockResolvedValue({});
+    const result = await makeController().setTwoFactorSource(ORG, {
+      provider: null,
+    });
+    expect(result).toEqual({ success: true, provider: null });
+    expect(mockOrgUpdate).toHaveBeenCalledWith({
+      where: { id: ORG },
+      data: { twoFactorSource: null },
+    });
+  });
+});
+
+describe('TwoFactorSourceController.getAvailableTwoFactorSources', () => {
+  it('returns only manifests bound to the 2FA task, with connection state', async () => {
+    mockGetActiveManifests.mockReturnValue([
+      boundManifest('google-workspace', 'Google Workspace'),
+      unboundManifest('slack'),
+      boundManifest('github', 'GitHub'),
+    ]);
+    mockConnFindFirst.mockImplementation(
+      (args: { where: { provider: { slug: string } } }) =>
+        args.where.provider.slug === 'google-workspace'
+          ? Promise.resolve({ id: 'conn_1', lastSyncAt: null, nextSyncAt: null })
+          : Promise.resolve(null),
+    );
+
+    const { providers } = await makeController().getAvailableTwoFactorSources(ORG);
+
+    expect(providers.map((p) => p.slug)).toEqual(['google-workspace', 'github']);
+    expect(providers.find((p) => p.slug === 'google-workspace')?.connected).toBe(
+      true,
+    );
+    expect(providers.find((p) => p.slug === 'github')?.connected).toBe(false);
+  });
+});
+
+describe('TwoFactorSourceController.getTwoFactorStatuses', () => {
+  it('returns unconfigured when no source is set', async () => {
+    mockOrgFindUnique.mockResolvedValue({ twoFactorSource: null });
+    const result = await makeController().getTwoFactorStatuses(ORG);
+    expect(result).toEqual({ configured: false, source: null, statuses: [] });
+  });
+
+  it('maps latest-run results to lowercased email + enabled/missing', async () => {
+    mockOrgFindUnique.mockResolvedValue({ twoFactorSource: 'google-workspace' });
+    mockGetActiveManifests.mockReturnValue([boundManifest('google-workspace')]);
+    mockConnRepo.findBySlugAndOrg.mockResolvedValue({
+      id: 'conn_1',
+      status: 'active',
+    });
+    mockCheckRunRepo.findLatestUserResultsByConnectionAndCheck.mockResolvedValue({
+      run: { id: 'run_1' },
+      results: [
+        { resourceId: 'Alice@X.com', passed: true },
+        { resourceId: 'bob@x.com', passed: false },
+      ],
+    });
+
+    const result = await makeController().getTwoFactorStatuses(ORG);
+
+    expect(
+      mockCheckRunRepo.findLatestUserResultsByConnectionAndCheck,
+    ).toHaveBeenCalledWith({
+      connectionId: 'conn_1',
+      checkId: 'two-factor-auth',
+      organizationId: ORG,
+    });
+    expect(result).toEqual({
+      configured: true,
+      source: 'google-workspace',
+      statuses: [
+        { email: 'alice@x.com', status: 'enabled' },
+        { email: 'bob@x.com', status: 'missing' },
+      ],
+    });
+  });
+
+  it('returns empty statuses when the source has no real run', async () => {
+    mockOrgFindUnique.mockResolvedValue({ twoFactorSource: 'google-workspace' });
+    mockGetActiveManifests.mockReturnValue([boundManifest('google-workspace')]);
+    mockConnRepo.findBySlugAndOrg.mockResolvedValue({
+      id: 'conn_1',
+      status: 'active',
+    });
+    mockCheckRunRepo.findLatestUserResultsByConnectionAndCheck.mockResolvedValue(
+      null,
+    );
+
+    const result = await makeController().getTwoFactorStatuses(ORG);
+    expect(result).toEqual({
+      configured: true,
+      source: 'google-workspace',
+      statuses: [],
+    });
+  });
+});

--- a/apps/api/src/integration-platform/controllers/two-factor-source.controller.spec.ts
+++ b/apps/api/src/integration-platform/controllers/two-factor-source.controller.spec.ts
@@ -50,6 +50,9 @@ const ORG = 'org_1';
 
 beforeEach(() => {
   jest.clearAllMocks();
+  // Default: the org exists (individual tests override to simulate a stale/
+  // deleted org context).
+  mockOrgFindUnique.mockResolvedValue({ id: ORG, twoFactorSource: null });
 });
 
 describe('TwoFactorSourceController.getTwoFactorSource', () => {
@@ -123,6 +126,20 @@ describe('TwoFactorSourceController.setTwoFactorSource', () => {
       where: { id: ORG },
       data: { twoFactorSource: null },
     });
+  });
+
+  it('returns 404 (not 400 "not connected") when setting a provider for a missing org', async () => {
+    mockOrgFindUnique.mockResolvedValue(null);
+    // Even with sources resolvable, the missing org must win with a 404 —
+    // a dead org's empty connection list must not surface as a 400.
+    mockCheckResults.listSourcesBoundToTask.mockResolvedValue([
+      source('google-workspace', false),
+    ]);
+
+    await expect(
+      makeController().setTwoFactorSource(ORG, { provider: 'google-workspace' }),
+    ).rejects.toMatchObject({ status: 404 });
+    expect(mockOrgUpdate).not.toHaveBeenCalled();
   });
 
   it('maps a missing org row (P2025) to 404 instead of a 500', async () => {

--- a/apps/api/src/integration-platform/controllers/two-factor-source.controller.spec.ts
+++ b/apps/api/src/integration-platform/controllers/two-factor-source.controller.spec.ts
@@ -3,19 +3,8 @@ import { HttpException } from '@nestjs/common';
 jest.mock('@db', () => ({
   db: {
     organization: { findUnique: jest.fn(), update: jest.fn() },
-    integrationConnection: { findFirst: jest.fn() },
   },
 }));
-
-jest.mock('@trycompai/integration-platform', () => {
-  const actual = jest.requireActual<
-    typeof import('@trycompai/integration-platform')
-  >('@trycompai/integration-platform');
-  return {
-    ...actual,
-    registry: { getActiveManifests: jest.fn() },
-  };
-});
 
 // Break the ESM better-auth import chain pulled in via HybridAuthGuard.
 jest.mock('@trycompai/auth', () => ({
@@ -27,48 +16,34 @@ jest.mock('../../auth/auth.server', () => ({
 }));
 
 import { db } from '@db';
-import { registry, TASK_TEMPLATES } from '@trycompai/integration-platform';
 import { TwoFactorSourceController } from './two-factor-source.controller';
 
-const mockGetActiveManifests = (
-  registry as unknown as { getActiveManifests: jest.Mock }
-).getActiveManifests;
 const mockOrgFindUnique = (
   db.organization as unknown as { findUnique: jest.Mock }
 ).findUnique;
 const mockOrgUpdate = (db.organization as unknown as { update: jest.Mock })
   .update;
-const mockConnFindFirst = (
-  db.integrationConnection as unknown as { findFirst: jest.Mock }
-).findFirst;
 
-// Build a manifest whose check is bound to the 2FA task.
-function boundManifest(id: string, name = id) {
-  return {
-    id,
-    name,
-    logoUrl: null,
-    checks: [{ id: 'two-factor-auth', taskMapping: TASK_TEMPLATES.twoFactorAuth }],
-  };
-}
-// A manifest with a check NOT bound to the 2FA task.
-function unboundManifest(id: string) {
-  return {
-    id,
-    name: id,
-    logoUrl: null,
-    checks: [{ id: 'other', taskMapping: TASK_TEMPLATES.codeChanges }],
-  };
-}
-
-const mockConnRepo = { findBySlugAndOrg: jest.fn() };
-const mockCheckRunRepo = { findLatestUserResultsByConnectionAndCheck: jest.fn() };
+const mockCheckResults = {
+  listSourcesBoundToTask: jest.fn(),
+  getLatestResultsForTask: jest.fn(),
+};
 
 function makeController() {
-  return new TwoFactorSourceController(
-    mockConnRepo as never,
-    mockCheckRunRepo as never,
-  );
+  return new TwoFactorSourceController(mockCheckResults as never);
+}
+
+function source(slug: string, connected: boolean, name = slug) {
+  return {
+    slug,
+    name,
+    logoUrl: null,
+    checkId: 'two-factor-auth',
+    connected,
+    connectionId: connected ? `conn_${slug}` : null,
+    lastSyncAt: null,
+    nextSyncAt: null,
+  };
 }
 
 const ORG = 'org_1';
@@ -80,8 +55,9 @@ beforeEach(() => {
 describe('TwoFactorSourceController.getTwoFactorSource', () => {
   it('returns the configured provider', async () => {
     mockOrgFindUnique.mockResolvedValue({ twoFactorSource: 'google-workspace' });
-    const result = await makeController().getTwoFactorSource(ORG);
-    expect(result).toEqual({ provider: 'google-workspace' });
+    expect(await makeController().getTwoFactorSource(ORG)).toEqual({
+      provider: 'google-workspace',
+    });
   });
 
   it('throws when the org does not exist', async () => {
@@ -101,7 +77,9 @@ describe('TwoFactorSourceController.setTwoFactorSource', () => {
   });
 
   it('rejects a provider not bound to the 2FA task', async () => {
-    mockGetActiveManifests.mockReturnValue([boundManifest('google-workspace')]);
+    mockCheckResults.listSourcesBoundToTask.mockResolvedValue([
+      source('google-workspace', true),
+    ]);
     await expect(
       makeController().setTwoFactorSource(ORG, { provider: 'slack' }),
     ).rejects.toBeInstanceOf(HttpException);
@@ -109,8 +87,9 @@ describe('TwoFactorSourceController.setTwoFactorSource', () => {
   });
 
   it('rejects a bound provider that is not connected', async () => {
-    mockGetActiveManifests.mockReturnValue([boundManifest('google-workspace')]);
-    mockConnRepo.findBySlugAndOrg.mockResolvedValue(null);
+    mockCheckResults.listSourcesBoundToTask.mockResolvedValue([
+      source('google-workspace', false),
+    ]);
     await expect(
       makeController().setTwoFactorSource(ORG, { provider: 'google-workspace' }),
     ).rejects.toBeInstanceOf(HttpException);
@@ -118,11 +97,9 @@ describe('TwoFactorSourceController.setTwoFactorSource', () => {
   });
 
   it('sets a valid, connected, bound provider', async () => {
-    mockGetActiveManifests.mockReturnValue([boundManifest('google-workspace')]);
-    mockConnRepo.findBySlugAndOrg.mockResolvedValue({
-      id: 'conn_1',
-      status: 'active',
-    });
+    mockCheckResults.listSourcesBoundToTask.mockResolvedValue([
+      source('google-workspace', true),
+    ]);
     mockOrgUpdate.mockResolvedValue({});
 
     const result = await makeController().setTwoFactorSource(ORG, {
@@ -150,60 +127,47 @@ describe('TwoFactorSourceController.setTwoFactorSource', () => {
 });
 
 describe('TwoFactorSourceController.getAvailableTwoFactorSources', () => {
-  it('returns only manifests bound to the 2FA task, with connection state', async () => {
-    mockGetActiveManifests.mockReturnValue([
-      boundManifest('google-workspace', 'Google Workspace'),
-      unboundManifest('slack'),
-      boundManifest('github', 'GitHub'),
+  it('returns bound sources with connection state (without the internal checkId)', async () => {
+    mockCheckResults.listSourcesBoundToTask.mockResolvedValue([
+      source('google-workspace', true, 'Google Workspace'),
+      source('github', false, 'GitHub'),
     ]);
-    mockConnFindFirst.mockImplementation(
-      (args: { where: { provider: { slug: string } } }) =>
-        args.where.provider.slug === 'google-workspace'
-          ? Promise.resolve({ id: 'conn_1', lastSyncAt: null, nextSyncAt: null })
-          : Promise.resolve(null),
-    );
 
     const { providers } = await makeController().getAvailableTwoFactorSources(ORG);
 
     expect(providers.map((p) => p.slug)).toEqual(['google-workspace', 'github']);
-    expect(providers.find((p) => p.slug === 'google-workspace')?.connected).toBe(
-      true,
-    );
-    expect(providers.find((p) => p.slug === 'github')?.connected).toBe(false);
+    expect(providers[0]).not.toHaveProperty('checkId');
+    expect(providers[0].connected).toBe(true);
   });
 });
 
 describe('TwoFactorSourceController.getTwoFactorStatuses', () => {
   it('returns unconfigured when no source is set', async () => {
     mockOrgFindUnique.mockResolvedValue({ twoFactorSource: null });
-    const result = await makeController().getTwoFactorStatuses(ORG);
-    expect(result).toEqual({ configured: false, source: null, statuses: [] });
+    expect(await makeController().getTwoFactorStatuses(ORG)).toEqual({
+      configured: false,
+      source: null,
+      statuses: [],
+    });
+    expect(mockCheckResults.getLatestResultsForTask).not.toHaveBeenCalled();
   });
 
-  it('maps latest-run results to lowercased email + enabled/missing', async () => {
+  it('maps the service results to lowercased email + enabled/missing', async () => {
     mockOrgFindUnique.mockResolvedValue({ twoFactorSource: 'google-workspace' });
-    mockGetActiveManifests.mockReturnValue([boundManifest('google-workspace')]);
-    mockConnRepo.findBySlugAndOrg.mockResolvedValue({
-      id: 'conn_1',
-      status: 'active',
-    });
-    mockCheckRunRepo.findLatestUserResultsByConnectionAndCheck.mockResolvedValue({
-      run: { id: 'run_1' },
-      results: [
-        { resourceId: 'Alice@X.com', passed: true },
-        { resourceId: 'bob@x.com', passed: false },
-      ],
-    });
+    mockCheckResults.getLatestResultsForTask.mockResolvedValue([
+      { resourceId: 'Alice@X.com', passed: true },
+      { resourceId: 'bob@x.com', passed: false },
+    ]);
 
     const result = await makeController().getTwoFactorStatuses(ORG);
 
-    expect(
-      mockCheckRunRepo.findLatestUserResultsByConnectionAndCheck,
-    ).toHaveBeenCalledWith({
-      connectionId: 'conn_1',
-      checkId: 'two-factor-auth',
-      organizationId: ORG,
-    });
+    expect(mockCheckResults.getLatestResultsForTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: ORG,
+        sourceSlug: 'google-workspace',
+        resourceType: 'user',
+      }),
+    );
     expect(result).toEqual({
       configured: true,
       source: 'google-workspace',
@@ -214,19 +178,11 @@ describe('TwoFactorSourceController.getTwoFactorStatuses', () => {
     });
   });
 
-  it('returns empty statuses when the source has no real run', async () => {
+  it('returns empty statuses when the source has no results', async () => {
     mockOrgFindUnique.mockResolvedValue({ twoFactorSource: 'google-workspace' });
-    mockGetActiveManifests.mockReturnValue([boundManifest('google-workspace')]);
-    mockConnRepo.findBySlugAndOrg.mockResolvedValue({
-      id: 'conn_1',
-      status: 'active',
-    });
-    mockCheckRunRepo.findLatestUserResultsByConnectionAndCheck.mockResolvedValue(
-      null,
-    );
+    mockCheckResults.getLatestResultsForTask.mockResolvedValue([]);
 
-    const result = await makeController().getTwoFactorStatuses(ORG);
-    expect(result).toEqual({
+    expect(await makeController().getTwoFactorStatuses(ORG)).toEqual({
       configured: true,
       source: 'google-workspace',
       statuses: [],

--- a/apps/api/src/integration-platform/controllers/two-factor-source.controller.ts
+++ b/apps/api/src/integration-platform/controllers/two-factor-source.controller.ts
@@ -129,10 +129,19 @@ export class TwoFactorSourceController {
       }
     }
 
-    await db.organization.update({
-      where: { id: organizationId },
-      data: { twoFactorSource: provider },
-    });
+    try {
+      await db.organization.update({
+        where: { id: organizationId },
+        data: { twoFactorSource: provider },
+      });
+    } catch (err) {
+      // Stale/deleted org context: Prisma throws P2025 on a missing row — map
+      // it to the same 404 as this controller's other org lookups, not a 500.
+      if ((err as { code?: string }).code === 'P2025') {
+        throw new HttpException('Organization not found', HttpStatus.NOT_FOUND);
+      }
+      throw err;
+    }
 
     this.logger.log(
       `Set 2FA source to ${provider ?? 'none'} for org ${organizationId}`,
@@ -180,7 +189,12 @@ export class TwoFactorSourceController {
       where: { id: organizationId },
       select: { twoFactorSource: true },
     });
-    const source = org?.twoFactorSource ?? null;
+    // Missing org context is an error, not "unconfigured" — keep it distinct
+    // so callers never mistake invalid context for a valid empty state.
+    if (!org) {
+      throw new HttpException('Organization not found', HttpStatus.NOT_FOUND);
+    }
+    const source = org.twoFactorSource ?? null;
     if (!source) {
       return { configured: false, source: null, statuses: [] };
     }

--- a/apps/api/src/integration-platform/controllers/two-factor-source.controller.ts
+++ b/apps/api/src/integration-platform/controllers/two-factor-source.controller.ts
@@ -109,6 +109,19 @@ export class TwoFactorSourceController {
     }
     const provider = rawProvider ? rawProvider.trim() : null;
 
+    // The org row must exist before any provider semantics are evaluated, so a
+    // stale/deleted org context always yields this endpoint's 404 contract
+    // (otherwise a dead org's empty connection list reads as a 400
+    // "not connected"). The P2025 catch below only covers a deletion racing
+    // the update itself.
+    const org = await db.organization.findUnique({
+      where: { id: organizationId },
+      select: { id: true },
+    });
+    if (!org) {
+      throw new HttpException('Organization not found', HttpStatus.NOT_FOUND);
+    }
+
     if (provider) {
       const sources = await this.checkResults.listSourcesBoundToTask(
         organizationId,

--- a/apps/api/src/integration-platform/controllers/two-factor-source.controller.ts
+++ b/apps/api/src/integration-platform/controllers/two-factor-source.controller.ts
@@ -193,11 +193,15 @@ export class TwoFactorSourceController {
       resourceType: 'user',
     });
 
-    // Dedupe by lowercased email (results aren't ordered; last row wins).
+    // Dedupe by lowercased email. Result rows carry no ordering, so conflict
+    // resolution must not depend on iteration order: a failing row always wins
+    // (compliance-conservative — if any row says the user lacks 2FA, show
+    // missing; never upgrade back to enabled).
     const byEmail = new Map<string, 'enabled' | 'missing'>();
     for (const result of results) {
       const email = result.resourceId.toLowerCase().trim();
       if (!email) continue;
+      if (byEmail.get(email) === 'missing') continue;
       byEmail.set(email, result.passed ? 'enabled' : 'missing');
     }
     const statuses = Array.from(byEmail, ([email, status]) => ({

--- a/apps/api/src/integration-platform/controllers/two-factor-source.controller.ts
+++ b/apps/api/src/integration-platform/controllers/two-factor-source.controller.ts
@@ -1,0 +1,250 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  HttpException,
+  HttpStatus,
+  Logger,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBody,
+  ApiOperation,
+  ApiPropertyOptional,
+  ApiSecurity,
+  ApiTags,
+} from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+import { db } from '@db';
+import {
+  registry,
+  TASK_TEMPLATES,
+  type IntegrationManifest,
+} from '@trycompai/integration-platform';
+import { HybridAuthGuard } from '../../auth/hybrid-auth.guard';
+import { PermissionGuard } from '../../auth/permission.guard';
+import { RequirePermission } from '../../auth/require-permission.decorator';
+import { OrganizationId } from '../../auth/auth-context.decorator';
+import { ConnectionRepository } from '../repositories/connection.repository';
+import { CheckRunRepository } from '../repositories/check-run.repository';
+
+/** The check on a manifest that feeds the 2FA evidence task, if any. */
+function twoFactorCheckOf(manifest: IntegrationManifest) {
+  return (
+    manifest.checks?.find(
+      (check) => check.taskMapping === TASK_TEMPLATES.twoFactorAuth,
+    ) ?? null
+  );
+}
+
+/**
+ * Every active manifest — codebase OR dynamic — whose check is bound to the 2FA
+ * task. Dynamic manifests are merged into the same registry, so this is uniformly
+ * universal: any integration that ships a 2FA check becomes an eligible source
+ * with zero per-integration wiring.
+ */
+function manifestsWithTwoFactorCheck(): IntegrationManifest[] {
+  return registry.getActiveManifests().filter((m) => !!twoFactorCheckOf(m));
+}
+
+// Body for POST /v1/integrations/sync/two-factor-source. Pass a provider slug to
+// set the org's 2FA source, or null/omit to clear it. Class (not inline type) so
+// swagger + the ValidationPipe whitelist accept it.
+class SetTwoFactorSourceDto {
+  // UI sends organizationId in the body; ignored by the handler (derived from auth).
+  @ApiPropertyOptional({
+    description:
+      'Auto-resolved from your API key / session. You can omit this; it is ignored by the server.',
+  })
+  @IsOptional()
+  @IsString()
+  organizationId?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Provider slug whose 2FA check feeds the People-tab 2FA column (must have a check bound to the 2FA task — call available-2fa-sources for options). Pass null or omit to clear the source.',
+    example: 'google-workspace',
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString()
+  provider?: string | null;
+}
+
+@Controller({ path: 'integrations/sync', version: '1' })
+@ApiTags('Integrations')
+@UseGuards(HybridAuthGuard, PermissionGuard)
+@ApiSecurity('apikey')
+export class TwoFactorSourceController {
+  private readonly logger = new Logger(TwoFactorSourceController.name);
+
+  constructor(
+    private readonly connectionRepository: ConnectionRepository,
+    private readonly checkRunRepo: CheckRunRepository,
+  ) {}
+
+  /**
+   * Get the currently configured 2FA source provider.
+   */
+  @Get('two-factor-source')
+  @ApiOperation({ summary: 'Get the configured 2FA source provider' })
+  @RequirePermission('integration', 'read')
+  async getTwoFactorSource(@OrganizationId() organizationId: string) {
+    const org = await db.organization.findUnique({
+      where: { id: organizationId },
+      select: { twoFactorSource: true },
+    });
+    if (!org) {
+      throw new HttpException('Organization not found', HttpStatus.NOT_FOUND);
+    }
+    return { provider: org.twoFactorSource };
+  }
+
+  /**
+   * Set (or clear) the org's 2FA source provider.
+   */
+  @Post('two-factor-source')
+  @ApiOperation({ summary: 'Set the 2FA source provider' })
+  @ApiBody({ type: SetTwoFactorSourceDto })
+  @RequirePermission('integration', 'update')
+  async setTwoFactorSource(
+    @OrganizationId() organizationId: string,
+    @Body() body: SetTwoFactorSourceDto,
+  ) {
+    // Only an explicit string (set) or null (clear) are valid. Reject anything
+    // else — non-string, or blank/whitespace — with a 400 rather than silently
+    // coercing it to null and clearing the org's configured source.
+    const rawProvider = body.provider;
+    if (
+      rawProvider !== null &&
+      rawProvider !== undefined &&
+      (typeof rawProvider !== 'string' || rawProvider.trim().length === 0)
+    ) {
+      throw new HttpException(
+        'provider must be a non-empty string or null',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+    const provider = rawProvider ? rawProvider.trim() : null;
+
+    if (provider) {
+      const validProviders = manifestsWithTwoFactorCheck().map((m) => m.id);
+      if (!validProviders.includes(provider)) {
+        throw new HttpException(
+          `Invalid 2FA source. Must be one of: ${validProviders.join(', ')}`,
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      const connection = await this.connectionRepository.findBySlugAndOrg(
+        provider,
+        organizationId,
+      );
+      if (!connection || connection.status !== 'active') {
+        throw new HttpException(
+          `Provider ${provider} is not connected`,
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+    }
+
+    await db.organization.update({
+      where: { id: organizationId },
+      data: { twoFactorSource: provider },
+    });
+
+    this.logger.log(
+      `Set 2FA source to ${provider ?? 'none'} for org ${organizationId}`,
+    );
+    return { success: true, provider };
+  }
+
+  /**
+   * List integrations that can supply per-user 2FA status (all bound to the 2FA
+   * task), with each one's connection state for this org.
+   */
+  @Get('available-2fa-sources')
+  @ApiOperation({ summary: 'List integrations that can supply per-user 2FA status' })
+  @RequirePermission('integration', 'read')
+  async getAvailableTwoFactorSources(@OrganizationId() organizationId: string) {
+    const sources = manifestsWithTwoFactorCheck();
+    const providers = await Promise.all(
+      sources.map(async (m) => {
+        const connection = await db.integrationConnection.findFirst({
+          where: { organizationId, status: 'active', provider: { slug: m.id } },
+          select: { id: true, lastSyncAt: true, nextSyncAt: true },
+        });
+        return {
+          slug: m.id,
+          name: m.name,
+          logoUrl: m.logoUrl,
+          connected: !!connection,
+          connectionId: connection?.id ?? null,
+          lastSyncAt: connection?.lastSyncAt?.toISOString() ?? null,
+          nextSyncAt: connection?.nextSyncAt?.toISOString() ?? null,
+        };
+      }),
+    );
+    return { providers };
+  }
+
+  /**
+   * Per-user 2FA status from the configured source's latest real check run.
+   *
+   * Returns only emails that had a result row; the People tab resolves any
+   * member without a matching row to "Not provided". Emails are lowercased to
+   * match the (lowercased) member emails on the join.
+   */
+  @Get('two-factor-statuses')
+  @ApiOperation({ summary: 'Per-user 2FA status from the configured source' })
+  @RequirePermission('integration', 'read')
+  async getTwoFactorStatuses(@OrganizationId() organizationId: string) {
+    const org = await db.organization.findUnique({
+      where: { id: organizationId },
+      select: { twoFactorSource: true },
+    });
+    const source = org?.twoFactorSource ?? null;
+    if (!source) {
+      return { configured: false, source: null, statuses: [] };
+    }
+
+    const manifest = manifestsWithTwoFactorCheck().find((m) => m.id === source);
+    const check = manifest ? twoFactorCheckOf(manifest) : null;
+    if (!check) {
+      // Source no longer offers a 2FA check (removed/disabled) — treat as unset.
+      return { configured: false, source, statuses: [] };
+    }
+
+    const connection = await this.connectionRepository.findBySlugAndOrg(
+      source,
+      organizationId,
+    );
+    if (!connection) {
+      return { configured: true, source, statuses: [] };
+    }
+
+    const latest = await this.checkRunRepo.findLatestUserResultsByConnectionAndCheck({
+      connectionId: connection.id,
+      checkId: check.id,
+      organizationId,
+    });
+    if (!latest) {
+      return { configured: true, source, statuses: [] };
+    }
+
+    // Dedupe by lowercased email (results aren't ordered; last row wins).
+    const byEmail = new Map<string, 'enabled' | 'missing'>();
+    for (const result of latest.results) {
+      const email = result.resourceId.toLowerCase().trim();
+      if (!email) continue;
+      byEmail.set(email, result.passed ? 'enabled' : 'missing');
+    }
+    const statuses = Array.from(byEmail, ([email, status]) => ({
+      email,
+      status,
+    }));
+
+    return { configured: true, source, statuses };
+  }
+}

--- a/apps/api/src/integration-platform/controllers/two-factor-source.controller.ts
+++ b/apps/api/src/integration-platform/controllers/two-factor-source.controller.ts
@@ -17,36 +17,12 @@ import {
 } from '@nestjs/swagger';
 import { IsOptional, IsString } from 'class-validator';
 import { db } from '@db';
-import {
-  registry,
-  TASK_TEMPLATES,
-  type IntegrationManifest,
-} from '@trycompai/integration-platform';
+import { TASK_TEMPLATES } from '@trycompai/integration-platform';
 import { HybridAuthGuard } from '../../auth/hybrid-auth.guard';
 import { PermissionGuard } from '../../auth/permission.guard';
 import { RequirePermission } from '../../auth/require-permission.decorator';
 import { OrganizationId } from '../../auth/auth-context.decorator';
-import { ConnectionRepository } from '../repositories/connection.repository';
-import { CheckRunRepository } from '../repositories/check-run.repository';
-
-/** The check on a manifest that feeds the 2FA evidence task, if any. */
-function twoFactorCheckOf(manifest: IntegrationManifest) {
-  return (
-    manifest.checks?.find(
-      (check) => check.taskMapping === TASK_TEMPLATES.twoFactorAuth,
-    ) ?? null
-  );
-}
-
-/**
- * Every active manifest — codebase OR dynamic — whose check is bound to the 2FA
- * task. Dynamic manifests are merged into the same registry, so this is uniformly
- * universal: any integration that ships a 2FA check becomes an eligible source
- * with zero per-integration wiring.
- */
-function manifestsWithTwoFactorCheck(): IntegrationManifest[] {
-  return registry.getActiveManifests().filter((m) => !!twoFactorCheckOf(m));
-}
+import { CheckResultsService } from '../services/check-results.service';
 
 // Body for POST /v1/integrations/sync/two-factor-source. Pass a provider slug to
 // set the org's 2FA source, or null/omit to clear it. Class (not inline type) so
@@ -63,7 +39,7 @@ class SetTwoFactorSourceDto {
 
   @ApiPropertyOptional({
     description:
-      'Provider slug whose 2FA check feeds the People-tab 2FA column (must have a check bound to the 2FA task — call available-2fa-sources for options). Pass null or omit to clear the source.',
+      'Provider slug whose 2FA check feeds the People-tab 2FA column (must be bound to the 2FA task — call available-2fa-sources for options). Pass null or omit to clear the source.',
     example: 'google-workspace',
     nullable: true,
   })
@@ -72,6 +48,14 @@ class SetTwoFactorSourceDto {
   provider?: string | null;
 }
 
+/**
+ * 2FA source configuration + per-employee 2FA status for the People tab.
+ *
+ * This controller owns only the 2FA-SPECIFIC concerns: the org's chosen source
+ * (`Organization.twoFactorSource`) and the enabled/missing interpretation. All
+ * the generic "read an integration check's results" work is delegated to
+ * {@link CheckResultsService} — it is consumer #1 of that universal service.
+ */
 @Controller({ path: 'integrations/sync', version: '1' })
 @ApiTags('Integrations')
 @UseGuards(HybridAuthGuard, PermissionGuard)
@@ -79,10 +63,7 @@ class SetTwoFactorSourceDto {
 export class TwoFactorSourceController {
   private readonly logger = new Logger(TwoFactorSourceController.name);
 
-  constructor(
-    private readonly connectionRepository: ConnectionRepository,
-    private readonly checkRunRepo: CheckRunRepository,
-  ) {}
+  constructor(private readonly checkResults: CheckResultsService) {}
 
   /**
    * Get the currently configured 2FA source provider.
@@ -129,19 +110,18 @@ export class TwoFactorSourceController {
     const provider = rawProvider ? rawProvider.trim() : null;
 
     if (provider) {
-      const validProviders = manifestsWithTwoFactorCheck().map((m) => m.id);
-      if (!validProviders.includes(provider)) {
+      const sources = await this.checkResults.listSourcesBoundToTask(
+        organizationId,
+        TASK_TEMPLATES.twoFactorAuth,
+      );
+      const source = sources.find((s) => s.slug === provider);
+      if (!source) {
         throw new HttpException(
-          `Invalid 2FA source. Must be one of: ${validProviders.join(', ')}`,
+          `Invalid 2FA source. Must be one of: ${sources.map((s) => s.slug).join(', ')}`,
           HttpStatus.BAD_REQUEST,
         );
       }
-
-      const connection = await this.connectionRepository.findBySlugAndOrg(
-        provider,
-        organizationId,
-      );
-      if (!connection || connection.status !== 'active') {
+      if (!source.connected) {
         throw new HttpException(
           `Provider ${provider} is not connected`,
           HttpStatus.BAD_REQUEST,
@@ -168,24 +148,20 @@ export class TwoFactorSourceController {
   @ApiOperation({ summary: 'List integrations that can supply per-user 2FA status' })
   @RequirePermission('integration', 'read')
   async getAvailableTwoFactorSources(@OrganizationId() organizationId: string) {
-    const sources = manifestsWithTwoFactorCheck();
-    const providers = await Promise.all(
-      sources.map(async (m) => {
-        const connection = await db.integrationConnection.findFirst({
-          where: { organizationId, status: 'active', provider: { slug: m.id } },
-          select: { id: true, lastSyncAt: true, nextSyncAt: true },
-        });
-        return {
-          slug: m.id,
-          name: m.name,
-          logoUrl: m.logoUrl,
-          connected: !!connection,
-          connectionId: connection?.id ?? null,
-          lastSyncAt: connection?.lastSyncAt?.toISOString() ?? null,
-          nextSyncAt: connection?.nextSyncAt?.toISOString() ?? null,
-        };
-      }),
+    const sources = await this.checkResults.listSourcesBoundToTask(
+      organizationId,
+      TASK_TEMPLATES.twoFactorAuth,
     );
+    // Expose only what the selector needs (drop the internal checkId).
+    const providers = sources.map((s) => ({
+      slug: s.slug,
+      name: s.name,
+      logoUrl: s.logoUrl,
+      connected: s.connected,
+      connectionId: s.connectionId,
+      lastSyncAt: s.lastSyncAt,
+      nextSyncAt: s.nextSyncAt,
+    }));
     return { providers };
   }
 
@@ -209,33 +185,17 @@ export class TwoFactorSourceController {
       return { configured: false, source: null, statuses: [] };
     }
 
-    const manifest = manifestsWithTwoFactorCheck().find((m) => m.id === source);
-    const check = manifest ? twoFactorCheckOf(manifest) : null;
-    if (!check) {
-      // Source no longer offers a 2FA check (removed/disabled) — treat as unset.
-      return { configured: false, source, statuses: [] };
-    }
-
-    const connection = await this.connectionRepository.findBySlugAndOrg(
-      source,
+    // Delegate the generic fetch; interpret 'user' rows here (2FA's concern).
+    const results = await this.checkResults.getLatestResultsForTask({
       organizationId,
-    );
-    if (!connection) {
-      return { configured: true, source, statuses: [] };
-    }
-
-    const latest = await this.checkRunRepo.findLatestUserResultsByConnectionAndCheck({
-      connectionId: connection.id,
-      checkId: check.id,
-      organizationId,
+      taskTemplateId: TASK_TEMPLATES.twoFactorAuth,
+      sourceSlug: source,
+      resourceType: 'user',
     });
-    if (!latest) {
-      return { configured: true, source, statuses: [] };
-    }
 
     // Dedupe by lowercased email (results aren't ordered; last row wins).
     const byEmail = new Map<string, 'enabled' | 'missing'>();
-    for (const result of latest.results) {
+    for (const result of results) {
       const email = result.resourceId.toLowerCase().trim();
       if (!email) continue;
       byEmail.set(email, result.passed ? 'enabled' : 'missing');

--- a/apps/api/src/integration-platform/integration-platform.module.ts
+++ b/apps/api/src/integration-platform/integration-platform.module.ts
@@ -14,6 +14,7 @@ import { VariablesController } from './controllers/variables.controller';
 import { TaskIntegrationsController } from './controllers/task-integrations.controller';
 import { WebhookController } from './controllers/webhook.controller';
 import { SyncController } from './controllers/sync.controller';
+import { TwoFactorSourceController } from './controllers/two-factor-source.controller';
 import { ServicesController } from './controllers/services.controller';
 import { CredentialVaultService } from './services/credential-vault.service';
 import { ConnectionService } from './services/connection.service';
@@ -54,6 +55,7 @@ import { GenericDeviceSyncService } from './services/generic-device-sync.service
     TaskIntegrationsController,
     WebhookController,
     SyncController,
+    TwoFactorSourceController,
     ServicesController,
   ],
   providers: [

--- a/apps/api/src/integration-platform/integration-platform.module.ts
+++ b/apps/api/src/integration-platform/integration-platform.module.ts
@@ -38,6 +38,7 @@ import { DynamicCheckRepository } from './repositories/dynamic-check.repository'
 import { IntegrationSyncLoggerService } from './services/integration-sync-logger.service';
 import { GenericEmployeeSyncService } from './services/generic-employee-sync.service';
 import { GenericDeviceSyncService } from './services/generic-device-sync.service';
+import { CheckResultsService } from './services/check-results.service';
 
 @Module({
   imports: [AuthModule, forwardRef(() => CloudSecurityModule)],
@@ -73,6 +74,7 @@ import { GenericDeviceSyncService } from './services/generic-device-sync.service
     IntegrationSyncLoggerService,
     GenericEmployeeSyncService,
     GenericDeviceSyncService,
+    CheckResultsService,
     // Repositories
     ProviderRepository,
     ConnectionRepository,
@@ -90,6 +92,9 @@ import { GenericDeviceSyncService } from './services/generic-device-sync.service
     OAuthCredentialsService,
     AutoCheckRunnerService,
     DynamicManifestLoaderService,
+    // Universal, feature-agnostic access to integration check results. Any
+    // feature module that needs to reuse check output injects this.
+    CheckResultsService,
   ],
 })
 export class IntegrationPlatformModule {}

--- a/apps/api/src/integration-platform/repositories/check-run.repository.spec.ts
+++ b/apps/api/src/integration-platform/repositories/check-run.repository.spec.ts
@@ -295,12 +295,13 @@ describe('CheckRunRepository.countExceptedFailures', () => {
   });
 });
 
-describe('CheckRunRepository.findLatestUserResultsByConnectionAndCheck', () => {
+describe('CheckRunRepository.findLatestResultsByConnectionAndCheck', () => {
   const repo = new CheckRunRepository();
   const params = {
     connectionId: 'conn_1',
     checkId: 'two-factor-auth',
     organizationId: 'org_1',
+    resourceType: 'user',
   };
 
   beforeEach(() => {
@@ -310,7 +311,7 @@ describe('CheckRunRepository.findLatestUserResultsByConnectionAndCheck', () => {
   it('returns null and never loads results when there is no real run', async () => {
     mockFindFirst.mockResolvedValue(null);
 
-    const result = await repo.findLatestUserResultsByConnectionAndCheck(params);
+    const result = await repo.findLatestResultsByConnectionAndCheck(params);
 
     expect(result).toBeNull();
     expect(mockResultFindMany).not.toHaveBeenCalled();
@@ -320,7 +321,7 @@ describe('CheckRunRepository.findLatestUserResultsByConnectionAndCheck', () => {
     mockFindFirst.mockResolvedValue({ id: 'run_1' });
     mockResultFindMany.mockResolvedValue([]);
 
-    await repo.findLatestUserResultsByConnectionAndCheck(params);
+    await repo.findLatestResultsByConnectionAndCheck(params);
 
     expect(mockFindFirst).toHaveBeenCalledWith({
       where: {
@@ -337,7 +338,7 @@ describe('CheckRunRepository.findLatestUserResultsByConnectionAndCheck', () => {
     });
   });
 
-  it('loads the FULL per-user result set for the latest run — no take cap', async () => {
+  it('loads the FULL result set for the latest run — no take cap — filtered by resourceType', async () => {
     mockFindFirst.mockResolvedValue({ id: 'run_1' });
     const rows = [
       { id: 'icx_1', resourceId: 'a@x.com', passed: true },
@@ -345,13 +346,28 @@ describe('CheckRunRepository.findLatestUserResultsByConnectionAndCheck', () => {
     ];
     mockResultFindMany.mockResolvedValue(rows);
 
-    const result = await repo.findLatestUserResultsByConnectionAndCheck(params);
+    const result = await repo.findLatestResultsByConnectionAndCheck(params);
 
     expect(mockResultFindMany).toHaveBeenCalledWith({
       where: { checkRunId: 'run_1', resourceType: 'user' },
     });
-    // Every user must map to a member — the 30-row display cap is NOT reused.
+    // Every resource must map to a domain entity — the 30-row display cap is NOT reused.
     expect(mockResultFindMany.mock.calls[0][0].take).toBeUndefined();
     expect(result).toEqual({ run: { id: 'run_1' }, results: rows });
+  });
+
+  it('omits the resourceType filter when not provided (loads all rows)', async () => {
+    mockFindFirst.mockResolvedValue({ id: 'run_1' });
+    mockResultFindMany.mockResolvedValue([]);
+
+    await repo.findLatestResultsByConnectionAndCheck({
+      connectionId: 'conn_1',
+      checkId: 'aws-s3-encryption',
+      organizationId: 'org_1',
+    });
+
+    expect(mockResultFindMany).toHaveBeenCalledWith({
+      where: { checkRunId: 'run_1' },
+    });
   });
 });

--- a/apps/api/src/integration-platform/repositories/check-run.repository.spec.ts
+++ b/apps/api/src/integration-platform/repositories/check-run.repository.spec.ts
@@ -3,9 +3,11 @@ jest.mock('@db', () => ({
     integrationCheckRun: {
       groupBy: jest.fn(),
       findMany: jest.fn(),
+      findFirst: jest.fn(),
     },
     integrationCheckResult: {
       count: jest.fn(),
+      findMany: jest.fn(),
     },
   },
 }));
@@ -24,6 +26,12 @@ const mockFindMany = mockedCheckRun.findMany;
 const mockResultCount = (
   db.integrationCheckResult as unknown as { count: jest.Mock }
 ).count;
+const mockFindFirst = (
+  db.integrationCheckRun as unknown as { findFirst: jest.Mock }
+).findFirst;
+const mockResultFindMany = (
+  db.integrationCheckResult as unknown as { findMany: jest.Mock }
+).findMany;
 
 function makeRun(opts: {
   id: string;
@@ -284,5 +292,66 @@ describe('CheckRunRepository.countExceptedFailures', () => {
         resourceId: { in: ['b1', 'b2'] },
       },
     });
+  });
+});
+
+describe('CheckRunRepository.findLatestUserResultsByConnectionAndCheck', () => {
+  const repo = new CheckRunRepository();
+  const params = {
+    connectionId: 'conn_1',
+    checkId: 'two-factor-auth',
+    organizationId: 'org_1',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns null and never loads results when there is no real run', async () => {
+    mockFindFirst.mockResolvedValue(null);
+
+    const result = await repo.findLatestUserResultsByConnectionAndCheck(params);
+
+    expect(result).toBeNull();
+    expect(mockResultFindMany).not.toHaveBeenCalled();
+  });
+
+  it('scopes the run to org + connection + check, excluding held runs and disconnected connections', async () => {
+    mockFindFirst.mockResolvedValue({ id: 'run_1' });
+    mockResultFindMany.mockResolvedValue([]);
+
+    await repo.findLatestUserResultsByConnectionAndCheck(params);
+
+    expect(mockFindFirst).toHaveBeenCalledWith({
+      where: {
+        connectionId: 'conn_1',
+        checkId: 'two-factor-auth',
+        // Held (inconclusive) runs must never surface to the customer.
+        status: { not: 'inconclusive' },
+        connection: {
+          organizationId: 'org_1',
+          status: { not: 'disconnected' },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  });
+
+  it('loads the FULL per-user result set for the latest run — no take cap', async () => {
+    mockFindFirst.mockResolvedValue({ id: 'run_1' });
+    const rows = [
+      { id: 'icx_1', resourceId: 'a@x.com', passed: true },
+      { id: 'icx_2', resourceId: 'b@x.com', passed: false },
+    ];
+    mockResultFindMany.mockResolvedValue(rows);
+
+    const result = await repo.findLatestUserResultsByConnectionAndCheck(params);
+
+    expect(mockResultFindMany).toHaveBeenCalledWith({
+      where: { checkRunId: 'run_1', resourceType: 'user' },
+    });
+    // Every user must map to a member — the 30-row display cap is NOT reused.
+    expect(mockResultFindMany.mock.calls[0][0].take).toBeUndefined();
+    expect(result).toEqual({ run: { id: 'run_1' }, results: rows });
   });
 });

--- a/apps/api/src/integration-platform/repositories/check-run.repository.ts
+++ b/apps/api/src/integration-platform/repositories/check-run.repository.ts
@@ -302,6 +302,42 @@ export class CheckRunRepository {
   }
 
   /**
+   * Latest per-USER results for a (connection, check), scoped to an org.
+   *
+   * Used by the People-tab 2FA column: returns the full, untruncated set of
+   * `resourceType='user'` results from the connection's most recent REAL run
+   * (never `inconclusive`/held, never a disconnected connection). Unlike the
+   * task-run-history read, there is NO `take` cap — every user must map to a
+   * member, so the 30-row display sample ({@link DISPLAY_RESULTS_PER_RUN}) is
+   * deliberately not reused here. Returns null when the source has no real run.
+   */
+  async findLatestUserResultsByConnectionAndCheck({
+    connectionId,
+    checkId,
+    organizationId,
+  }: {
+    connectionId: string;
+    checkId: string;
+    organizationId: string;
+  }) {
+    const run = await db.integrationCheckRun.findFirst({
+      where: {
+        connectionId,
+        checkId,
+        status: { not: 'inconclusive' },
+        connection: { organizationId, status: { not: 'disconnected' } },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+    if (!run) return null;
+
+    const results = await db.integrationCheckResult.findMany({
+      where: { checkRunId: run.id, resourceType: 'user' },
+    });
+    return { run, results };
+  }
+
+  /**
    * Get check runs for a connection
    */
   async findByConnection(connectionId: string, limit = 20) {

--- a/apps/api/src/integration-platform/repositories/check-run.repository.ts
+++ b/apps/api/src/integration-platform/repositories/check-run.repository.ts
@@ -302,23 +302,27 @@ export class CheckRunRepository {
   }
 
   /**
-   * Latest per-USER results for a (connection, check), scoped to an org.
+   * Full results of a (connection, check)'s most recent REAL run, scoped to an
+   * org. "Real" = never `inconclusive`/held, never a disconnected connection.
    *
-   * Used by the People-tab 2FA column: returns the full, untruncated set of
-   * `resourceType='user'` results from the connection's most recent REAL run
-   * (never `inconclusive`/held, never a disconnected connection). Unlike the
-   * task-run-history read, there is NO `take` cap — every user must map to a
-   * member, so the 30-row display sample ({@link DISPLAY_RESULTS_PER_RUN}) is
-   * deliberately not reused here. Returns null when the source has no real run.
+   * This is the generic read behind {@link CheckResultsService} — any feature
+   * reusing check results goes through that service, not this method directly.
+   * Unlike the task-run-history read there is NO `take` cap: a consumer that
+   * maps every resource (e.g. one member per user row) needs the full set, so
+   * the 30-row display sample ({@link DISPLAY_RESULTS_PER_RUN}) is deliberately
+   * not reused here. Pass `resourceType` to load only rows of that kind (e.g.
+   * `'user'`); omit it to load all. Returns null when there is no real run.
    */
-  async findLatestUserResultsByConnectionAndCheck({
+  async findLatestResultsByConnectionAndCheck({
     connectionId,
     checkId,
     organizationId,
+    resourceType,
   }: {
     connectionId: string;
     checkId: string;
     organizationId: string;
+    resourceType?: string;
   }) {
     const run = await db.integrationCheckRun.findFirst({
       where: {
@@ -332,7 +336,10 @@ export class CheckRunRepository {
     if (!run) return null;
 
     const results = await db.integrationCheckResult.findMany({
-      where: { checkRunId: run.id, resourceType: 'user' },
+      where: {
+        checkRunId: run.id,
+        ...(resourceType ? { resourceType } : {}),
+      },
     });
     return { run, results };
   }

--- a/apps/api/src/integration-platform/repositories/connection.repository.ts
+++ b/apps/api/src/integration-platform/repositories/connection.repository.ts
@@ -61,6 +61,50 @@ export class ConnectionRepository {
     return this.findByProviderAndOrg(provider.id, organizationId);
   }
 
+  /**
+   * Active connections for a set of provider slugs, keyed by slug, in ONE query.
+   * When a provider has several active connections (e.g. AWS multi-account) the
+   * newest wins. Slugs with no active connection are simply absent from the map.
+   */
+  async findActiveBySlugsAndOrg(
+    providerSlugs: string[],
+    organizationId: string,
+  ): Promise<
+    Map<string, { id: string; lastSyncAt: Date | null; nextSyncAt: Date | null }>
+  > {
+    if (providerSlugs.length === 0) return new Map();
+
+    const connections = await db.integrationConnection.findMany({
+      where: {
+        organizationId,
+        status: 'active',
+        provider: { slug: { in: providerSlugs } },
+      },
+      select: {
+        id: true,
+        lastSyncAt: true,
+        nextSyncAt: true,
+        provider: { select: { slug: true } },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    const bySlug = new Map<
+      string,
+      { id: string; lastSyncAt: Date | null; nextSyncAt: Date | null }
+    >();
+    for (const connection of connections) {
+      if (!bySlug.has(connection.provider.slug)) {
+        bySlug.set(connection.provider.slug, {
+          id: connection.id,
+          lastSyncAt: connection.lastSyncAt,
+          nextSyncAt: connection.nextSyncAt,
+        });
+      }
+    }
+    return bySlug;
+  }
+
   async findByOrganization(
     organizationId: string,
   ): Promise<IntegrationConnection[]> {

--- a/apps/api/src/integration-platform/services/README-check-results.md
+++ b/apps/api/src/integration-platform/services/README-check-results.md
@@ -1,0 +1,39 @@
+# CheckResultsService — reuse any integration check's results
+
+`CheckResultsService` is the **single, universal, read-only** way for any feature to consume
+the output of an integration check (2FA, AWS S3, device posture, …). It fetches per-resource
+results and returns them in a stable, feature-agnostic envelope. It does **not** interpret
+the data — that's the feature's job.
+
+> Service = fetch results (generic). Feature = interpret + map + present.
+
+**Full usage map, examples, and rules:** see the `check-results-service` skill
+(`.claude/skills/check-results-service/SKILL.md`).
+
+## 30-second version
+
+```ts
+// inject CheckResultsService (exported by IntegrationPlatformModule), then:
+
+// which connected integrations can feed a task, + connection state
+await checkResults.listSourcesBoundToTask(orgId, TASK_TEMPLATES.twoFactorAuth);
+
+// full results of a check's latest real run for one connection
+await checkResults.getLatestResultsByCheck({ organizationId, connectionId, checkId, resourceType });
+
+// results for a task-bound check from a chosen source (resolves task->check, slug->connection)
+await checkResults.getLatestResultsForTask({ organizationId, taskTemplateId, sourceSlug, resourceType });
+```
+
+Each row is `{ resourceId, resourceType, passed, title, description, evidence, collectedAt,
+runId, connectionId }`. The check-specific payload is `evidence` (raw JSON) — **validate it
+with zod in your feature**; the service never types it. Empty array = "no data" (never throws).
+
+## Don't
+
+- Don't query `IntegrationCheckResult` / `CheckRunRepository` directly from a feature — use this service.
+- Don't add feature-specific interpretation to the service — keep it universal and read-only.
+
+## Reference consumer
+
+The People-tab 2FA column: `../controllers/two-factor-source.controller.ts`.

--- a/apps/api/src/integration-platform/services/check-results.service.spec.ts
+++ b/apps/api/src/integration-platform/services/check-results.service.spec.ts
@@ -1,0 +1,193 @@
+jest.mock('@db', () => ({
+  db: { integrationConnection: { findFirst: jest.fn() } },
+}));
+
+jest.mock('@trycompai/integration-platform', () => {
+  const actual = jest.requireActual<
+    typeof import('@trycompai/integration-platform')
+  >('@trycompai/integration-platform');
+  return {
+    ...actual,
+    registry: { getActiveManifests: jest.fn() },
+  };
+});
+
+import { db } from '@db';
+import { registry, TASK_TEMPLATES } from '@trycompai/integration-platform';
+import { CheckResultsService } from './check-results.service';
+
+const mockGetActiveManifests = (
+  registry as unknown as { getActiveManifests: jest.Mock }
+).getActiveManifests;
+const mockConnFindFirst = (
+  db.integrationConnection as unknown as { findFirst: jest.Mock }
+).findFirst;
+
+const mockCheckRunRepo = { findLatestResultsByConnectionAndCheck: jest.fn() };
+const mockConnRepo = { findBySlugAndOrg: jest.fn() };
+
+function makeService() {
+  return new CheckResultsService(
+    mockCheckRunRepo as never,
+    mockConnRepo as never,
+  );
+}
+
+function boundManifest(id: string, name = id) {
+  return {
+    id,
+    name,
+    logoUrl: null,
+    checks: [{ id: 'two-factor-auth', taskMapping: TASK_TEMPLATES.twoFactorAuth }],
+  };
+}
+function unboundManifest(id: string) {
+  return {
+    id,
+    name: id,
+    logoUrl: null,
+    checks: [{ id: 'other', taskMapping: TASK_TEMPLATES.codeChanges }],
+  };
+}
+
+const ORG = 'org_1';
+const TWO_FA = TASK_TEMPLATES.twoFactorAuth;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('CheckResultsService.listSourcesBoundToTask', () => {
+  it('returns only manifests bound to the task, with connection state + checkId', async () => {
+    mockGetActiveManifests.mockReturnValue([
+      boundManifest('google-workspace', 'Google Workspace'),
+      unboundManifest('slack'),
+      boundManifest('github', 'GitHub'),
+    ]);
+    mockConnFindFirst.mockImplementation(
+      (args: { where: { provider: { slug: string } } }) =>
+        args.where.provider.slug === 'google-workspace'
+          ? Promise.resolve({ id: 'c1', lastSyncAt: null, nextSyncAt: null })
+          : Promise.resolve(null),
+    );
+
+    const sources = await makeService().listSourcesBoundToTask(ORG, TWO_FA);
+
+    expect(sources.map((s) => s.slug)).toEqual(['google-workspace', 'github']);
+    const gws = sources.find((s) => s.slug === 'google-workspace');
+    expect(gws).toMatchObject({
+      connected: true,
+      connectionId: 'c1',
+      checkId: 'two-factor-auth',
+    });
+    expect(sources.find((s) => s.slug === 'github')?.connected).toBe(false);
+  });
+});
+
+describe('CheckResultsService.getLatestResultsByCheck', () => {
+  it('maps repo rows into the generic envelope (evidence passed through untouched)', async () => {
+    const collectedAt = new Date('2026-01-01T00:00:00Z');
+    mockCheckRunRepo.findLatestResultsByConnectionAndCheck.mockResolvedValue({
+      run: { id: 'run_1' },
+      results: [
+        {
+          resourceId: 'a@x.com',
+          resourceType: 'user',
+          passed: true,
+          title: 'Has 2FA',
+          description: null,
+          evidence: { isEnrolledIn2Sv: true },
+          collectedAt,
+        },
+      ],
+    });
+
+    const rows = await makeService().getLatestResultsByCheck({
+      organizationId: ORG,
+      connectionId: 'conn_1',
+      checkId: 'two-factor-auth',
+      resourceType: 'user',
+    });
+
+    expect(rows).toEqual([
+      {
+        resourceId: 'a@x.com',
+        resourceType: 'user',
+        passed: true,
+        title: 'Has 2FA',
+        description: null,
+        evidence: { isEnrolledIn2Sv: true },
+        collectedAt,
+        runId: 'run_1',
+        connectionId: 'conn_1',
+      },
+    ]);
+  });
+
+  it('returns [] when there is no real run', async () => {
+    mockCheckRunRepo.findLatestResultsByConnectionAndCheck.mockResolvedValue(
+      null,
+    );
+    const rows = await makeService().getLatestResultsByCheck({
+      organizationId: ORG,
+      connectionId: 'conn_1',
+      checkId: 'two-factor-auth',
+    });
+    expect(rows).toEqual([]);
+  });
+});
+
+describe('CheckResultsService.getLatestResultsForTask', () => {
+  it('resolves task->check and slug->connection, then fetches results', async () => {
+    mockGetActiveManifests.mockReturnValue([boundManifest('google-workspace')]);
+    mockConnRepo.findBySlugAndOrg.mockResolvedValue({
+      id: 'conn_1',
+      status: 'active',
+    });
+    mockCheckRunRepo.findLatestResultsByConnectionAndCheck.mockResolvedValue({
+      run: { id: 'run_1' },
+      results: [],
+    });
+
+    await makeService().getLatestResultsForTask({
+      organizationId: ORG,
+      taskTemplateId: TWO_FA,
+      sourceSlug: 'google-workspace',
+      resourceType: 'user',
+    });
+
+    expect(
+      mockCheckRunRepo.findLatestResultsByConnectionAndCheck,
+    ).toHaveBeenCalledWith({
+      connectionId: 'conn_1',
+      checkId: 'two-factor-auth',
+      organizationId: ORG,
+      resourceType: 'user',
+    });
+  });
+
+  it('returns [] when the source is not bound to the task', async () => {
+    mockGetActiveManifests.mockReturnValue([]);
+    const rows = await makeService().getLatestResultsForTask({
+      organizationId: ORG,
+      taskTemplateId: TWO_FA,
+      sourceSlug: 'google-workspace',
+    });
+    expect(rows).toEqual([]);
+    expect(mockConnRepo.findBySlugAndOrg).not.toHaveBeenCalled();
+  });
+
+  it('returns [] when the source has no connection', async () => {
+    mockGetActiveManifests.mockReturnValue([boundManifest('google-workspace')]);
+    mockConnRepo.findBySlugAndOrg.mockResolvedValue(null);
+    const rows = await makeService().getLatestResultsForTask({
+      organizationId: ORG,
+      taskTemplateId: TWO_FA,
+      sourceSlug: 'google-workspace',
+    });
+    expect(rows).toEqual([]);
+    expect(
+      mockCheckRunRepo.findLatestResultsByConnectionAndCheck,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/integration-platform/services/check-results.service.spec.ts
+++ b/apps/api/src/integration-platform/services/check-results.service.spec.ts
@@ -1,6 +1,4 @@
-jest.mock('@db', () => ({
-  db: { integrationConnection: { findFirst: jest.fn() } },
-}));
+jest.mock('@db', () => ({ db: {} }));
 
 jest.mock('@trycompai/integration-platform', () => {
   const actual = jest.requireActual<
@@ -12,19 +10,18 @@ jest.mock('@trycompai/integration-platform', () => {
   };
 });
 
-import { db } from '@db';
 import { registry, TASK_TEMPLATES } from '@trycompai/integration-platform';
 import { CheckResultsService } from './check-results.service';
 
 const mockGetActiveManifests = (
   registry as unknown as { getActiveManifests: jest.Mock }
 ).getActiveManifests;
-const mockConnFindFirst = (
-  db.integrationConnection as unknown as { findFirst: jest.Mock }
-).findFirst;
 
 const mockCheckRunRepo = { findLatestResultsByConnectionAndCheck: jest.fn() };
-const mockConnRepo = { findBySlugAndOrg: jest.fn() };
+const mockConnRepo = {
+  findBySlugAndOrg: jest.fn(),
+  findActiveBySlugsAndOrg: jest.fn(),
+};
 
 function makeService() {
   return new CheckResultsService(
@@ -64,15 +61,19 @@ describe('CheckResultsService.listSourcesBoundToTask', () => {
       unboundManifest('slack'),
       boundManifest('github', 'GitHub'),
     ]);
-    mockConnFindFirst.mockImplementation(
-      (args: { where: { provider: { slug: string } } }) =>
-        args.where.provider.slug === 'google-workspace'
-          ? Promise.resolve({ id: 'c1', lastSyncAt: null, nextSyncAt: null })
-          : Promise.resolve(null),
+    mockConnRepo.findActiveBySlugsAndOrg.mockResolvedValue(
+      new Map([
+        ['google-workspace', { id: 'c1', lastSyncAt: null, nextSyncAt: null }],
+      ]),
     );
 
     const sources = await makeService().listSourcesBoundToTask(ORG, TWO_FA);
 
+    // One batched lookup for all bound slugs — not one query per manifest.
+    expect(mockConnRepo.findActiveBySlugsAndOrg).toHaveBeenCalledWith(
+      ['google-workspace', 'github'],
+      ORG,
+    );
     expect(sources.map((s) => s.slug)).toEqual(['google-workspace', 'github']);
     const gws = sources.find((s) => s.slug === 'google-workspace');
     expect(gws).toMatchObject({

--- a/apps/api/src/integration-platform/services/check-results.service.ts
+++ b/apps/api/src/integration-platform/services/check-results.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@nestjs/common';
-import { db } from '@db';
 import type { Prisma } from '@db';
 import {
   registry,
+  type IntegrationCheck,
   type IntegrationManifest,
   type TaskTemplateId,
 } from '@trycompai/integration-platform';
@@ -65,28 +65,21 @@ export class CheckResultsService {
     private readonly connectionRepository: ConnectionRepository,
   ) {}
 
-  /** The check on a manifest bound to a task template, if any. */
-  private checkBoundToTask(
-    manifest: IntegrationManifest,
-    taskTemplateId: TaskTemplateId,
-  ) {
-    return (
-      manifest.checks?.find((check) => check.taskMapping === taskTemplateId) ??
-      null
-    );
-  }
-
   /**
-   * Every active manifest — codebase OR dynamic — whose check is bound to a task
-   * template. Dynamic manifests are merged into the same registry, so this is
-   * uniformly universal.
+   * Every active manifest — codebase OR dynamic — paired with its check bound to
+   * the task template. Dynamic manifests are merged into the same registry, so
+   * this is uniformly universal. Pairing (instead of re-finding the check later)
+   * lets the type system carry the "bound check exists" guarantee.
    */
-  private manifestsBoundToTask(
+  private boundPairsForTask(
     taskTemplateId: TaskTemplateId,
-  ): IntegrationManifest[] {
-    return registry
-      .getActiveManifests()
-      .filter((m) => !!this.checkBoundToTask(m, taskTemplateId));
+  ): Array<{ manifest: IntegrationManifest; check: IntegrationCheck }> {
+    return registry.getActiveManifests().flatMap((manifest) => {
+      const check = manifest.checks?.find(
+        (c) => c.taskMapping === taskTemplateId,
+      );
+      return check ? [{ manifest, check }] : [];
+    });
   }
 
   /**
@@ -99,26 +92,26 @@ export class CheckResultsService {
     organizationId: string,
     taskTemplateId: TaskTemplateId,
   ): Promise<CheckSourceInfo[]> {
-    const manifests = this.manifestsBoundToTask(taskTemplateId);
-    return Promise.all(
-      manifests.map(async (m) => {
-        const check = this.checkBoundToTask(m, taskTemplateId);
-        const connection = await db.integrationConnection.findFirst({
-          where: { organizationId, status: 'active', provider: { slug: m.id } },
-          select: { id: true, lastSyncAt: true, nextSyncAt: true },
-        });
-        return {
-          slug: m.id,
-          name: m.name,
-          logoUrl: m.logoUrl ?? null,
-          checkId: check?.id ?? '',
-          connected: !!connection,
-          connectionId: connection?.id ?? null,
-          lastSyncAt: connection?.lastSyncAt?.toISOString() ?? null,
-          nextSyncAt: connection?.nextSyncAt?.toISOString() ?? null,
-        };
-      }),
-    );
+    const pairs = this.boundPairsForTask(taskTemplateId);
+    const connectionsBySlug =
+      await this.connectionRepository.findActiveBySlugsAndOrg(
+        pairs.map((p) => p.manifest.id),
+        organizationId,
+      );
+
+    return pairs.map(({ manifest, check }) => {
+      const connection = connectionsBySlug.get(manifest.id);
+      return {
+        slug: manifest.id,
+        name: manifest.name,
+        logoUrl: manifest.logoUrl ?? null,
+        checkId: check.id,
+        connected: !!connection,
+        connectionId: connection?.id ?? null,
+        lastSyncAt: connection?.lastSyncAt?.toISOString() ?? null,
+        nextSyncAt: connection?.nextSyncAt?.toISOString() ?? null,
+      };
+    });
   }
 
   /**
@@ -172,13 +165,10 @@ export class CheckResultsService {
     sourceSlug: string;
     resourceType?: string;
   }): Promise<CheckResultRow[]> {
-    const manifest = this.manifestsBoundToTask(taskTemplateId).find(
-      (m) => m.id === sourceSlug,
+    const pair = this.boundPairsForTask(taskTemplateId).find(
+      (p) => p.manifest.id === sourceSlug,
     );
-    const check = manifest
-      ? this.checkBoundToTask(manifest, taskTemplateId)
-      : null;
-    if (!check) return [];
+    if (!pair) return [];
 
     const connection = await this.connectionRepository.findBySlugAndOrg(
       sourceSlug,
@@ -189,7 +179,7 @@ export class CheckResultsService {
     return this.getLatestResultsByCheck({
       organizationId,
       connectionId: connection.id,
-      checkId: check.id,
+      checkId: pair.check.id,
       resourceType,
     });
   }

--- a/apps/api/src/integration-platform/services/check-results.service.ts
+++ b/apps/api/src/integration-platform/services/check-results.service.ts
@@ -1,0 +1,196 @@
+import { Injectable } from '@nestjs/common';
+import { db } from '@db';
+import type { Prisma } from '@db';
+import {
+  registry,
+  type IntegrationManifest,
+  type TaskTemplateId,
+} from '@trycompai/integration-platform';
+import { CheckRunRepository } from '../repositories/check-run.repository';
+import { ConnectionRepository } from '../repositories/connection.repository';
+
+/**
+ * One row of an integration check's output, in a stable, FEATURE-AGNOSTIC shape.
+ *
+ * The envelope (resourceId/passed/etc.) is universal across every check. The
+ * check-SPECIFIC payload lives in `evidence` (raw JSON) — this service does NOT
+ * interpret it. Each consuming feature validates `evidence` at its own edge
+ * (e.g. with a zod schema) and reads only the fields it understands.
+ */
+export interface CheckResultRow {
+  /** Provider-native identifier for the resource (email, bucket ARN, repo, …). */
+  resourceId: string;
+  /** Kind of resource the check produced (e.g. 'user', 'bucket'). */
+  resourceType: string;
+  /** Whether this resource passed the check. */
+  passed: boolean;
+  title: string;
+  description: string | null;
+  /** Check-specific payload — interpret this in the feature, never here. */
+  evidence: Prisma.JsonValue;
+  collectedAt: Date;
+  runId: string;
+  connectionId: string;
+}
+
+/** A connected integration that can supply results for a given task. */
+export interface CheckSourceInfo {
+  slug: string;
+  name: string;
+  logoUrl: string | null;
+  /** The check on this source bound to the requested task. */
+  checkId: string;
+  connected: boolean;
+  connectionId: string | null;
+  lastSyncAt: string | null;
+  nextSyncAt: string | null;
+}
+
+/**
+ * Universal, read-only access to integration CHECK RESULTS.
+ *
+ * The single reuse point for any feature that wants to consume the output of an
+ * integration check — 2FA today, background checks / device posture / S3 config
+ * tomorrow. It is deliberately feature-agnostic: it fetches results and returns
+ * them in a stable envelope, and it does NOT know or care what the data means.
+ * Interpretation, domain mapping, and presentation are the feature's job.
+ *
+ * See `apps/api/src/integration-platform/services/README-check-results.md`
+ * (and the `check-results-service` skill) for the usage map + examples.
+ */
+@Injectable()
+export class CheckResultsService {
+  constructor(
+    private readonly checkRunRepo: CheckRunRepository,
+    private readonly connectionRepository: ConnectionRepository,
+  ) {}
+
+  /** The check on a manifest bound to a task template, if any. */
+  private checkBoundToTask(
+    manifest: IntegrationManifest,
+    taskTemplateId: TaskTemplateId,
+  ) {
+    return (
+      manifest.checks?.find((check) => check.taskMapping === taskTemplateId) ??
+      null
+    );
+  }
+
+  /**
+   * Every active manifest — codebase OR dynamic — whose check is bound to a task
+   * template. Dynamic manifests are merged into the same registry, so this is
+   * uniformly universal.
+   */
+  private manifestsBoundToTask(
+    taskTemplateId: TaskTemplateId,
+  ): IntegrationManifest[] {
+    return registry
+      .getActiveManifests()
+      .filter((m) => !!this.checkBoundToTask(m, taskTemplateId));
+  }
+
+  /**
+   * List the integrations that can supply results for a task in this org, with
+   * each one's connection state. Use this to build a "source" selector or to
+   * discover what's available. Returns ALL bound integrations (connected or not)
+   * so the caller can decide how to present unconnected ones.
+   */
+  async listSourcesBoundToTask(
+    organizationId: string,
+    taskTemplateId: TaskTemplateId,
+  ): Promise<CheckSourceInfo[]> {
+    const manifests = this.manifestsBoundToTask(taskTemplateId);
+    return Promise.all(
+      manifests.map(async (m) => {
+        const check = this.checkBoundToTask(m, taskTemplateId);
+        const connection = await db.integrationConnection.findFirst({
+          where: { organizationId, status: 'active', provider: { slug: m.id } },
+          select: { id: true, lastSyncAt: true, nextSyncAt: true },
+        });
+        return {
+          slug: m.id,
+          name: m.name,
+          logoUrl: m.logoUrl ?? null,
+          checkId: check?.id ?? '',
+          connected: !!connection,
+          connectionId: connection?.id ?? null,
+          lastSyncAt: connection?.lastSyncAt?.toISOString() ?? null,
+          nextSyncAt: connection?.nextSyncAt?.toISOString() ?? null,
+        };
+      }),
+    );
+  }
+
+  /**
+   * The primitive: full results of a specific check's latest real run for a
+   * specific connection. Everything else composes from this. Pass `resourceType`
+   * to load only rows of that kind. Returns [] when the check has never really run.
+   */
+  async getLatestResultsByCheck({
+    organizationId,
+    connectionId,
+    checkId,
+    resourceType,
+  }: {
+    organizationId: string;
+    connectionId: string;
+    checkId: string;
+    resourceType?: string;
+  }): Promise<CheckResultRow[]> {
+    const latest = await this.checkRunRepo.findLatestResultsByConnectionAndCheck(
+      { connectionId, checkId, organizationId, resourceType },
+    );
+    if (!latest) return [];
+
+    return latest.results.map((r) => ({
+      resourceId: r.resourceId,
+      resourceType: r.resourceType,
+      passed: r.passed,
+      title: r.title,
+      description: r.description,
+      evidence: r.evidence,
+      collectedAt: r.collectedAt,
+      runId: latest.run.id,
+      connectionId,
+    }));
+  }
+
+  /**
+   * Convenience: results for a task-bound check from a chosen source (provider
+   * slug). Resolves task -> check and slug -> connection, then fetches the
+   * latest real run. Returns [] when the source isn't bound/connected or has no
+   * real run. This is what a "pick a source, show its results" feature uses.
+   */
+  async getLatestResultsForTask({
+    organizationId,
+    taskTemplateId,
+    sourceSlug,
+    resourceType,
+  }: {
+    organizationId: string;
+    taskTemplateId: TaskTemplateId;
+    sourceSlug: string;
+    resourceType?: string;
+  }): Promise<CheckResultRow[]> {
+    const manifest = this.manifestsBoundToTask(taskTemplateId).find(
+      (m) => m.id === sourceSlug,
+    );
+    const check = manifest
+      ? this.checkBoundToTask(manifest, taskTemplateId)
+      : null;
+    if (!check) return [];
+
+    const connection = await this.connectionRepository.findBySlugAndOrg(
+      sourceSlug,
+      organizationId,
+    );
+    if (!connection) return [];
+
+    return this.getLatestResultsByCheck({
+      organizationId,
+      connectionId: connection.id,
+      checkId: check.id,
+      resourceType,
+    });
+  }
+}

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/MemberRow.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/MemberRow.test.tsx
@@ -278,4 +278,91 @@ describe('MemberRow device status', () => {
       screen.queryByLabelText('Employee has completed a background check'),
     ).not.toBeInTheDocument();
   });
+
+  it('hides the Policies row when there are no required policies (0/0 is not-applicable)', () => {
+    render(
+      <table>
+        <tbody>
+          <MemberRow
+            member={baseMember}
+            onRemove={noop}
+            onRemoveDevice={noop}
+            onUpdateRole={noop}
+            onReactivate={noop}
+            canEdit={false}
+            isCurrentUserOwner={false}
+            taskCompletion={{
+              completed: 0,
+              total: 0,
+              policies: { completed: 0, total: 0 },
+              training: { completed: 0, total: 0 },
+            }}
+          />
+        </tbody>
+      </table>,
+    );
+
+    expect(screen.queryByTestId('requirement-Policies')).not.toBeInTheDocument();
+  });
+});
+
+describe('MemberRow 2FA status', () => {
+  function render2fa({
+    member = baseMember,
+    twoFactorStatus,
+  }: {
+    member?: MemberWithUser;
+    twoFactorStatus?: 'enabled' | 'missing' | 'not-provided';
+  }) {
+    return render(
+      <table>
+        <tbody>
+          <MemberRow
+            member={member}
+            onRemove={noop}
+            onRemoveDevice={noop}
+            onUpdateRole={noop}
+            onReactivate={noop}
+            canEdit={false}
+            isCurrentUserOwner={false}
+            twoFactorStatus={twoFactorStatus}
+          />
+        </tbody>
+      </table>,
+    );
+  }
+
+  it('shows no 2FA row when no source is configured (status undefined)', () => {
+    render2fa({});
+    expect(screen.queryByTestId('requirement-2FA')).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ['enabled', 'Done'],
+    ['missing', 'Missing'],
+    ['not-provided', 'Not provided'],
+  ] as const)('renders %s as "%s"', (status, text) => {
+    render2fa({ twoFactorStatus: status });
+    expect(screen.getByTestId('requirement-2FA')).toHaveTextContent(text);
+  });
+
+  it('shows the 2FA row even for platform admins (2FA applies to all members)', () => {
+    const adminMember = {
+      ...baseMember,
+      user: { ...baseMember.user, role: 'admin' as const },
+    } as MemberWithUser;
+
+    render2fa({ member: adminMember, twoFactorStatus: 'enabled' });
+    expect(screen.getByTestId('requirement-2FA')).toHaveTextContent('Done');
+  });
+
+  it('hides the 2FA row for deactivated members', () => {
+    const deactivatedMember = {
+      ...baseMember,
+      deactivated: true,
+    } as MemberWithUser;
+
+    render2fa({ member: deactivatedMember, twoFactorStatus: 'missing' });
+    expect(screen.queryByTestId('requirement-2FA')).not.toBeInTheDocument();
+  });
 });

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/MemberRow.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/MemberRow.tsx
@@ -45,7 +45,12 @@ import { RemoveDeviceAlert } from './RemoveDeviceAlert';
 import { TaskRequirements, type TaskRequirementItem } from './TaskRequirements';
 import { RemoveMemberAlert } from './RemoveMemberAlert';
 import type { CustomRoleOption } from './MultiRoleCombobox';
-import type { BackgroundCheckStatus, MemberWithUser, TaskCompletion } from './TeamMembers';
+import type {
+  BackgroundCheckStatus,
+  MemberWithUser,
+  TaskCompletion,
+  TwoFactorStatus,
+} from './TeamMembers';
 
 interface MemberRowProps {
   member: MemberWithUser;
@@ -62,6 +67,8 @@ interface MemberRowProps {
   isDeviceStatusLoading?: boolean;
   backgroundCheckStatus?: BackgroundCheckStatus;
   backgroundCheckStepEnabled?: boolean;
+  /** From the org's configured 2FA source; absent when no source is configured. */
+  twoFactorStatus?: TwoFactorStatus;
 }
 
 function getInitials(name?: string | null, email?: string | null): string {
@@ -114,6 +121,7 @@ export function MemberRow({
   isDeviceStatusLoading = false,
   backgroundCheckStatus,
   backgroundCheckStepEnabled = true,
+  twoFactorStatus,
 }: MemberRowProps) {
   const { orgId } = useParams<{ orgId: string }>();
 
@@ -146,12 +154,16 @@ export function MemberRow({
   const taskItems: TaskRequirementItem[] = [];
 
   if (taskCompletion) {
-    taskItems.push({
-      label: 'Policies',
-      completed: taskCompletion.policies.completed,
-      total: taskCompletion.policies.total,
-      kind: 'count',
-    });
+    // total === 0 means "nothing to complete" (e.g. no required policies) —
+    // that's not-applicable, not incomplete, so no row at all.
+    if (taskCompletion.policies.total > 0) {
+      taskItems.push({
+        label: 'Policies',
+        completed: taskCompletion.policies.completed,
+        total: taskCompletion.policies.total,
+        kind: 'count',
+      });
+    }
 
     if (taskCompletion.training.total > 0) {
       taskItems.push({
@@ -187,6 +199,24 @@ export function MemberRow({
       completed: hasCompletedBackgroundCheck ? 1 : 0,
       total: 1,
       kind: 'binary',
+    });
+  }
+
+  // 2FA applies to EVERY non-deactivated member (platform admins included),
+  // unlike the compliance-scoped rows above. Absent status = no 2FA source
+  // configured for the org, so no row.
+  if (!isDeactivated && twoFactorStatus) {
+    taskItems.push({
+      label: '2FA',
+      completed: twoFactorStatus === 'enabled' ? 1 : 0,
+      total: 1,
+      kind: 'binary',
+      state:
+        twoFactorStatus === 'enabled'
+          ? 'done'
+          : twoFactorStatus === 'missing'
+            ? 'missing'
+            : 'not-provided',
     });
   }
 

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TaskRequirements.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TaskRequirements.test.tsx
@@ -53,4 +53,24 @@ describe('TaskRequirements', () => {
     render(<TaskRequirements items={[]} showLoadingRow />);
     expect(screen.queryByText('—')).not.toBeInTheDocument();
   });
+
+  it('renders an explicit not-provided state distinctly from Missing', () => {
+    render(
+      <TaskRequirements
+        items={[{ label: '2FA', completed: 0, total: 1, kind: 'binary', state: 'not-provided' }]}
+      />,
+    );
+    const row = screen.getByTestId('requirement-2FA');
+    expect(row).toHaveTextContent('Not provided');
+    expect(row).not.toHaveTextContent('Missing');
+  });
+
+  it('lets an explicit state override the completed/total derivation', () => {
+    render(
+      <TaskRequirements
+        items={[{ label: '2FA', completed: 0, total: 1, kind: 'binary', state: 'done' }]}
+      />,
+    );
+    expect(screen.getByTestId('requirement-2FA')).toHaveTextContent('Done');
+  });
 });

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TaskRequirements.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TaskRequirements.tsx
@@ -6,13 +6,21 @@ export interface TaskRequirementItem {
   label: string;
   completed: number;
   total: number;
-  /** 'count' renders "x/y" + a progress bar; 'binary' renders a Done/Missing badge. */
+  /** 'count' renders "x/y" + a progress bar; 'binary' renders a status badge. */
   kind: 'count' | 'binary';
+  /**
+   * Explicit badge state for binary requirements whose status comes from an
+   * external source (e.g. 2FA). 'not-provided' = the source had no data for
+   * this member — distinct from 'missing' (an explicit failure). When omitted,
+   * the state derives from completed/total.
+   */
+  state?: 'done' | 'missing' | 'not-provided';
 }
 
 function TaskRequirementRow({ item }: { item: TaskRequirementItem }) {
   const { label, completed, total, kind } = item;
   const isComplete = total > 0 && completed >= total;
+  const state = item.state ?? (isComplete ? 'done' : 'missing');
 
   return (
     <div className="flex items-center gap-2" data-testid={`requirement-${label}`}>
@@ -23,9 +31,13 @@ function TaskRequirementRow({ item }: { item: TaskRequirementItem }) {
       </div>
 
       {kind === 'binary' ? (
-        <Badge variant={isComplete ? 'accent' : 'secondary'}>
-          {isComplete ? 'Done' : 'Missing'}
-        </Badge>
+        state === 'not-provided' ? (
+          <Badge variant="outline">Not provided</Badge>
+        ) : (
+          <Badge variant={state === 'done' ? 'accent' : 'secondary'}>
+            {state === 'done' ? 'Done' : 'Missing'}
+          </Badge>
+        )
       ) : (
         <>
           <div className="w-11 shrink-0">

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TaskRequirements.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TaskRequirements.tsx
@@ -6,7 +6,7 @@ export interface TaskRequirementItem {
   label: string;
   completed: number;
   total: number;
-  /** 'count' renders "x/y" + a progress bar; 'binary' renders a status badge. */
+  /** 'count' renders a colored "x/y"; 'binary' renders a status badge. */
   kind: 'count' | 'binary';
   /**
    * Explicit badge state for binary requirements whose status comes from an
@@ -39,23 +39,14 @@ function TaskRequirementRow({ item }: { item: TaskRequirementItem }) {
           </Badge>
         )
       ) : (
-        <>
-          {/* pl-1.5 matches the Badge's inner padding so counts and badge text
-              share one vertical line across rows. */}
-          <div className="w-11 shrink-0 pl-1.5">
-            <Text size="xs" variant={isComplete ? 'success' : completed > 0 ? 'warning' : 'muted'}>
-              {completed}/{total}
-            </Text>
-          </div>
-          <div className="h-1 w-20 shrink-0 overflow-hidden rounded-full bg-muted">
-            <div
-              className="h-full bg-primary transition-all"
-              style={{
-                width: `${total > 0 ? Math.min(100, Math.round((completed / total) * 100)) : 0}%`,
-              }}
-            />
-          </div>
-        </>
+        // pl-1.5 matches the Badge's inner padding so counts and badge text
+        // share one vertical line across rows. The colored count alone carries
+        // the state (green done / amber partial / muted none) — no bar needed.
+        <div className="pl-1.5">
+          <Text size="xs" variant={isComplete ? 'success' : completed > 0 ? 'warning' : 'muted'}>
+            {completed}/{total}
+          </Text>
+        </div>
       )}
     </div>
   );
@@ -64,7 +55,7 @@ function TaskRequirementRow({ item }: { item: TaskRequirementItem }) {
 /**
  * Per-employee requirement rollup shown in the People list TASKS column.
  * Each requirement is on its own row: fractional requirements (policies, training)
- * show a count + progress bar; binary requirements (HIPAA, device, background)
+ * show a colored count; binary requirements (HIPAA, device, background)
  * show a Done/Missing badge.
  */
 export function TaskRequirements({
@@ -83,8 +74,8 @@ export function TaskRequirements({
   }
 
   return (
-    // Content-sized: label (w-24) + count (w-11) + bar (w-20) — no stretching,
-    // so the column stays compact regardless of table width.
+    // Content-sized (w-max): label column + value only — the column stays
+    // compact regardless of table width.
     <div className="flex w-max flex-col gap-0.5">
       {items.map((item) => (
         <TaskRequirementRow key={item.label} item={item} />

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TaskRequirements.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TaskRequirements.tsx
@@ -40,12 +40,14 @@ function TaskRequirementRow({ item }: { item: TaskRequirementItem }) {
         )
       ) : (
         <>
-          <div className="w-11 shrink-0">
+          {/* pl-1.5 matches the Badge's inner padding so counts and badge text
+              share one vertical line across rows. */}
+          <div className="w-11 shrink-0 pl-1.5">
             <Text size="xs" variant={isComplete ? 'success' : completed > 0 ? 'warning' : 'muted'}>
               {completed}/{total}
             </Text>
           </div>
-          <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-muted">
+          <div className="h-1 w-20 shrink-0 overflow-hidden rounded-full bg-muted">
             <div
               className="h-full bg-primary transition-all"
               style={{
@@ -81,7 +83,9 @@ export function TaskRequirements({
   }
 
   return (
-    <div className="flex min-w-56 max-w-sm flex-col gap-1">
+    // Content-sized: label (w-24) + count (w-11) + bar (w-20) — no stretching,
+    // so the column stays compact regardless of table width.
+    <div className="flex w-max flex-col gap-0.5">
       {items.map((item) => (
         <TaskRequirementRow key={item.label} item={item} />
       ))}

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembers.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembers.tsx
@@ -7,8 +7,13 @@ import { db } from '@db/server';
 import { getEmployeeSyncConnections } from '../data/queries';
 import { TeamMembersClient } from './TeamMembersClient';
 import type { BackgroundCheckStatus } from '../../[employeeId]/components/backgroundCheckTypes';
+import {
+  buildTwoFactorStatusMap,
+  type TwoFactorStatusesResponse,
+} from './two-factor-status-map';
 
 export type { BackgroundCheckStatus };
+export type { TwoFactorStatus } from './two-factor-status-map';
 
 export interface MemberWithUser extends Member {
   user: User;
@@ -54,12 +59,15 @@ export async function TeamMembers(props: TeamMembersProps) {
     return null;
   }
 
-  // Fetch members and invitations from API
-  const [membersRes, invitationsRes] = await Promise.all([
+  // Fetch members, invitations, and 2FA statuses from API
+  const [membersRes, invitationsRes, twoFactorRes] = await Promise.all([
     serverApi.get<{ data: MemberWithUser[]; count: number }>(
       '/v1/people?includeDeactivated=true',
     ),
     serverApi.get<{ data: Invitation[] }>('/v1/auth/invitations'),
+    serverApi.get<TwoFactorStatusesResponse>(
+      '/v1/integrations/sync/two-factor-statuses',
+    ),
   ]);
 
   const members: MemberWithUser[] = Array.isArray(membersRes.data?.data)
@@ -70,6 +78,13 @@ export async function TeamMembers(props: TeamMembersProps) {
     : [];
 
   const data: TeamMembersData = { members, pendingInvitations };
+
+  // Empty when no 2FA source is configured (or the fetch failed) — rows then
+  // show no 2FA entry rather than a wrong one.
+  const twoFactorStatusMap = buildTwoFactorStatusMap(
+    members,
+    twoFactorRes.data ?? undefined,
+  );
 
   // Fetch employee sync connections server-side
   const employeeSyncData = await getEmployeeSyncConnections(organizationId);
@@ -165,6 +180,7 @@ export async function TeamMembers(props: TeamMembersProps) {
       taskCompletionMap={taskCompletionMap}
       complianceMemberIds={complianceMemberIds}
       backgroundCheckStepEnabled={backgroundCheckStepEnabled}
+      twoFactorStatusMap={twoFactorStatusMap}
     />
   );
 }

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
@@ -48,7 +48,13 @@ import { buildDisplayItems, filterDisplayItems } from './filter-members';
 import { computeDeviceStatusMap } from './compute-device-status-map';
 import { MemberRow } from './MemberRow';
 import { PendingInvitationRow } from './PendingInvitationRow';
-import type { MemberWithUser, TaskCompletion, TeamMembersData } from './TeamMembers';
+import { TwoFactorSourceSelector } from './TwoFactorSourceSelector';
+import type {
+  MemberWithUser,
+  TaskCompletion,
+  TeamMembersData,
+  TwoFactorStatus,
+} from './TeamMembers';
 
 import type { EmployeeSyncConnectionsData } from '../data/queries';
 import { useEmployeeSync } from '../hooks/useEmployeeSync';
@@ -63,6 +69,7 @@ interface TeamMembersClientProps {
   taskCompletionMap: Record<string, TaskCompletion>;
   complianceMemberIds: string[];
   backgroundCheckStepEnabled: boolean;
+  twoFactorStatusMap: Record<string, TwoFactorStatus>;
 }
 
 export function TeamMembersClient({
@@ -74,6 +81,7 @@ export function TeamMembersClient({
   taskCompletionMap,
   complianceMemberIds,
   backgroundCheckStepEnabled,
+  twoFactorStatusMap,
 }: TeamMembersClientProps) {
   const { agentDevices, isLoading: isAgentDevicesLoading } = useAgentDevices();
   const { fleetHosts, isLoading: isFleetHostsLoading } = useFleetHosts();
@@ -493,6 +501,7 @@ export function TeamMembersClient({
             </div>
           </div>
         )}
+        <TwoFactorSourceSelector />
       </div>
 
       {/* Table */}
@@ -556,6 +565,7 @@ export function TeamMembersClient({
                     (item as MemberWithUser).backgroundCheckRequests?.[0]?.status
                   }
                   backgroundCheckStepEnabled={backgroundCheckStepEnabled}
+                  twoFactorStatus={twoFactorStatusMap[(item as MemberWithUser).id]}
                 />
               ) : (
                 <PendingInvitationRow

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.test.tsx
@@ -71,6 +71,14 @@ describe('TwoFactorSourceSelector — RBAC gating', () => {
     );
   });
 
+  it('collapses on mobile like the other secondary toolbar controls (hidden sm:block)', () => {
+    mockHasPermission.mockReturnValue(true);
+
+    const { container } = render(<TwoFactorSourceSelector />);
+
+    expect(container.firstElementChild).toHaveClass('hidden', 'sm:block');
+  });
+
   it('renders nothing when no bound integration is connected', () => {
     mockHasPermission.mockReturnValue(true);
     mockUse2faSource.mockReturnValue({

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.test.tsx
@@ -79,6 +79,20 @@ describe('TwoFactorSourceSelector — RBAC gating', () => {
     expect(container.firstElementChild).toHaveClass('hidden', 'sm:block');
   });
 
+  it('renders nothing while the source/selection are still loading (no placeholder flash)', () => {
+    mockHasPermission.mockReturnValue(true);
+    mockUse2faSource.mockReturnValue({
+      selectedSource: null,
+      isLoading: true,
+      availableSources: [source],
+      setSource: vi.fn(),
+      hasAnyConnection: true,
+    });
+
+    const { container } = render(<TwoFactorSourceSelector />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
   it('renders nothing when no bound integration is connected', () => {
     mockHasPermission.mockReturnValue(true);
     mockUse2faSource.mockReturnValue({

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TwoFactorSourceSelector } from './TwoFactorSourceSelector';
+import type { TwoFactorSourceProviderInfo } from '../hooks/use2faSource';
+
+const { mockHasPermission, mockUse2faSource } = vi.hoisted(() => ({
+  mockHasPermission: vi.fn(),
+  mockUse2faSource: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ orgId: 'org_1' }),
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+vi.mock('@/hooks/use-permissions', () => ({
+  usePermissions: () => ({ hasPermission: mockHasPermission }),
+}));
+
+vi.mock('../hooks/use2faSource', () => ({
+  use2faSource: (opts: { organizationId: string; enabled?: boolean }) =>
+    mockUse2faSource(opts),
+}));
+
+const source: TwoFactorSourceProviderInfo = {
+  slug: 'google-workspace',
+  name: 'Google Workspace',
+  logoUrl: 'https://example.com/gws.png',
+  connected: true,
+  connectionId: 'icn_1',
+  lastSyncAt: null,
+  nextSyncAt: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUse2faSource.mockReturnValue({
+    selectedSource: 'google-workspace',
+    isLoading: false,
+    availableSources: [source],
+    setSource: vi.fn(),
+    hasAnyConnection: true,
+  });
+});
+
+describe('TwoFactorSourceSelector — RBAC gating', () => {
+  it('renders the selector for a user with integration:update', () => {
+    mockHasPermission.mockImplementation(
+      (resource: string, action: string) =>
+        resource === 'integration' && action === 'update',
+    );
+
+    render(<TwoFactorSourceSelector />);
+
+    expect(screen.getByText('Google Workspace')).toBeInTheDocument();
+    // Hook is enabled (and therefore allowed to hit the 2FA-source APIs).
+    expect(mockUse2faSource).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: true }),
+    );
+  });
+
+  it('renders nothing for a user without integration:update and disables the hook', () => {
+    mockHasPermission.mockReturnValue(false);
+
+    const { container } = render(<TwoFactorSourceSelector />);
+
+    expect(container).toBeEmptyDOMElement();
+    // The hook must be disabled so no 2FA-source API is called without permission.
+    expect(mockUse2faSource).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+
+  it('renders nothing when no bound integration is connected', () => {
+    mockHasPermission.mockReturnValue(true);
+    mockUse2faSource.mockReturnValue({
+      selectedSource: null,
+      isLoading: false,
+      availableSources: [{ ...source, connected: false, connectionId: null }],
+      setSource: vi.fn(),
+      hasAnyConnection: false,
+    });
+
+    const { container } = render(<TwoFactorSourceSelector />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.tsx
@@ -28,10 +28,18 @@ export function TwoFactorSourceSelector() {
   // Selecting a source is an integration:update action. Gate the hook itself so
   // users without the permission never hit any 2FA-source API.
   const canManage = hasPermission('integration', 'update');
-  const { selectedSource, availableSources, setSource, hasAnyConnection } =
-    use2faSource({ organizationId: orgId, enabled: canManage });
+  const {
+    selectedSource,
+    availableSources,
+    setSource,
+    hasAnyConnection,
+    isLoading,
+  } = use2faSource({ organizationId: orgId, enabled: canManage });
 
-  if (!canManage || !hasAnyConnection) {
+  // Wait for BOTH the available sources and the current selection before
+  // rendering, so the trigger never flashes the placeholder while the saved
+  // selection is still resolving.
+  if (!canManage || isLoading || !hasAnyConnection) {
     return null;
   }
 

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.tsx
@@ -49,7 +49,11 @@ export function TwoFactorSourceSelector() {
   };
 
   return (
-    <div className="w-[200px]">
+    // hidden sm:block matches the other secondary toolbar controls (status/role/
+    // date filters): config actions collapse on phones, where the toolbar row
+    // doesn't wrap. The per-member 2FA status stays visible at every width via
+    // the table's own horizontal scroll.
+    <div className="hidden w-[200px] sm:block">
       <Select
         value={selectedSource ?? NONE_VALUE}
         onValueChange={(value) => {

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import Image from 'next/image';
+import { useParams, useRouter } from 'next/navigation';
+
+import { usePermissions } from '@/hooks/use-permissions';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@trycompai/design-system';
+
+import { use2faSource } from '../hooks/use2faSource';
+
+const NONE_VALUE = 'none';
+
+/**
+ * Picks which connected integration (bound to the 2FA evidence task) supplies
+ * the per-employee 2FA column. Hidden for users without integration:update and
+ * for orgs with no eligible connected integration.
+ */
+export function TwoFactorSourceSelector() {
+  const { orgId } = useParams<{ orgId: string }>();
+  const router = useRouter();
+  const { hasPermission } = usePermissions();
+  // Selecting a source is an integration:update action. Gate the hook itself so
+  // users without the permission never hit any 2FA-source API.
+  const canManage = hasPermission('integration', 'update');
+  const { selectedSource, availableSources, setSource, hasAnyConnection } =
+    use2faSource({ organizationId: orgId, enabled: canManage });
+
+  if (!canManage || !hasAnyConnection) {
+    return null;
+  }
+
+  const connectedSources = availableSources.filter((p) => p.connected);
+  const selected = connectedSources.find((p) => p.slug === selectedSource);
+
+  const handleSourceChange = async (value: string) => {
+    const provider = value === NONE_VALUE ? null : value;
+    if (provider === selectedSource) return;
+    const ok = await setSource(provider);
+    if (ok) {
+      // The 2FA column is server-computed; refresh so it reflects the new source.
+      router.refresh();
+    }
+  };
+
+  return (
+    <div className="w-[200px]">
+      <Select
+        value={selectedSource ?? NONE_VALUE}
+        onValueChange={(value) => {
+          if (value) void handleSourceChange(value);
+        }}
+      >
+        <SelectTrigger>
+          {selected ? (
+            <div className="flex items-center gap-2">
+              {selected.logoUrl && (
+                <Image
+                  src={selected.logoUrl}
+                  alt={selected.name}
+                  width={16}
+                  height={16}
+                  className="rounded-sm"
+                  unoptimized
+                />
+              )}
+              <span className="truncate">{selected.name}</span>
+            </div>
+          ) : (
+            <SelectValue placeholder="2FA source" />
+          )}
+        </SelectTrigger>
+        <SelectContent>
+          <div className="px-2 py-1.5 text-xs text-muted-foreground">
+            Shows each person&apos;s 2FA status from this integration
+          </div>
+          <SelectItem value={NONE_VALUE}>No 2FA source</SelectItem>
+          {connectedSources.map((p) => (
+            <SelectItem key={p.slug} value={p.slug}>
+              {p.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/two-factor-status-map.test.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/two-factor-status-map.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { buildTwoFactorStatusMap } from './two-factor-status-map';
+
+const members = [
+  { id: 'mem_1', user: { email: 'Alice@X.com' } },
+  { id: 'mem_2', user: { email: 'bob@x.com' } },
+  { id: 'mem_3', user: { email: 'carol@x.com' } },
+  { id: 'mem_4', user: { email: null } },
+];
+
+describe('buildTwoFactorStatusMap', () => {
+  it('returns an empty map when no source is configured', () => {
+    expect(
+      buildTwoFactorStatusMap(members, {
+        configured: false,
+        source: null,
+        statuses: [],
+      }),
+    ).toEqual({});
+  });
+
+  it('returns an empty map when the response is missing (fetch failed)', () => {
+    expect(buildTwoFactorStatusMap(members, undefined)).toEqual({});
+  });
+
+  it('joins by email case-insensitively and resolves absence to not-provided', () => {
+    const map = buildTwoFactorStatusMap(members, {
+      configured: true,
+      source: 'google-workspace',
+      statuses: [
+        { email: 'alice@x.com', status: 'enabled' },
+        { email: 'BOB@x.com', status: 'missing' },
+      ],
+    });
+
+    expect(map).toEqual({
+      mem_1: 'enabled', // matched despite different casing on both sides
+      mem_2: 'missing',
+      mem_3: 'not-provided', // no result row for this member
+      mem_4: 'not-provided', // member without an email can never match
+    });
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/two-factor-status-map.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/two-factor-status-map.ts
@@ -1,0 +1,34 @@
+export type TwoFactorStatus = 'enabled' | 'missing' | 'not-provided';
+
+/** Shape of GET /v1/integrations/sync/two-factor-statuses. */
+export interface TwoFactorStatusesResponse {
+  configured: boolean;
+  source: string | null;
+  statuses: Array<{ email: string; status: 'enabled' | 'missing' }>;
+}
+
+/**
+ * Join the 2FA source's per-email results onto members by lowercased email.
+ *
+ * Returns an empty map when no 2FA source is configured (callers render no 2FA
+ * row at all). A member with no matching result row gets 'not-provided' —
+ * absence means the source had no data for them, which must never read as an
+ * explicit 'missing' failure.
+ */
+export function buildTwoFactorStatusMap(
+  members: Array<{ id: string; user: { email: string | null } }>,
+  response: TwoFactorStatusesResponse | undefined,
+): Record<string, TwoFactorStatus> {
+  if (!response?.configured) return {};
+
+  const byEmail = new Map(
+    response.statuses.map((s) => [s.email.toLowerCase().trim(), s.status]),
+  );
+
+  const map: Record<string, TwoFactorStatus> = {};
+  for (const member of members) {
+    const email = member.user.email?.toLowerCase().trim();
+    map[member.id] = (email && byEmail.get(email)) || 'not-provided';
+  }
+  return map;
+}

--- a/apps/app/src/app/(app)/[orgId]/people/all/hooks/use2faSource.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/all/hooks/use2faSource.ts
@@ -26,6 +26,7 @@ interface Use2faSourceOptions {
 interface Use2faSourceReturn {
   selectedSource: string | null;
   isLoading: boolean;
+  error?: string;
   availableSources: TwoFactorSourceProviderInfo[];
   setSource: (provider: string | null) => Promise<boolean>;
   hasAnyConnection: boolean;
@@ -39,9 +40,12 @@ export function use2faSource({
   organizationId,
   enabled = true,
 }: Use2faSourceOptions): Use2faSourceReturn {
-  const { data: sourceData, mutate: mutateSource } = useSWR<{
-    provider: string | null;
-  }>(
+  const {
+    data: sourceData,
+    error: sourceError,
+    isLoading: isLoadingSource,
+    mutate: mutateSource,
+  } = useSWR<{ provider: string | null }>(
     enabled
       ? `/v1/integrations/sync/two-factor-source?organizationId=${organizationId}`
       : null,
@@ -52,9 +56,11 @@ export function use2faSource({
     },
   );
 
-  const { data: availableData, isLoading } = useSWR<{
-    providers: TwoFactorSourceProviderInfo[];
-  }>(
+  const {
+    data: availableData,
+    error: availableError,
+    isLoading: isLoadingAvailable,
+  } = useSWR<{ providers: TwoFactorSourceProviderInfo[] }>(
     enabled
       ? `/v1/integrations/sync/available-2fa-sources?organizationId=${organizationId}`
       : null,
@@ -97,9 +103,15 @@ export function use2faSource({
     }
   };
 
+  const fetchError = sourceError ?? availableError;
+
   return {
     selectedSource,
-    isLoading,
+    // Both requests feed the selector; report loading until BOTH settle so
+    // consumers never render a half-resolved state (e.g. sources without the
+    // current selection).
+    isLoading: isLoadingSource || isLoadingAvailable,
+    error: fetchError instanceof Error ? fetchError.message : undefined,
     availableSources,
     setSource,
     hasAnyConnection: availableSources.some((p) => p.connected),

--- a/apps/app/src/app/(app)/[orgId]/people/all/hooks/use2faSource.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/all/hooks/use2faSource.ts
@@ -1,0 +1,107 @@
+'use client';
+
+import { apiClient } from '@/lib/api-client';
+import { toast } from 'sonner';
+import useSWR from 'swr';
+
+export interface TwoFactorSourceProviderInfo {
+  slug: string;
+  name: string;
+  logoUrl: string | null;
+  connected: boolean;
+  connectionId: string | null;
+  lastSyncAt: string | null;
+  nextSyncAt: string | null;
+}
+
+interface Use2faSourceOptions {
+  organizationId: string;
+  /**
+   * When false, the hook makes no API calls (used to fully disable it for users
+   * who lack the integration:update permission, so no 2FA-source API is hit).
+   */
+  enabled?: boolean;
+}
+
+interface Use2faSourceReturn {
+  selectedSource: string | null;
+  isLoading: boolean;
+  availableSources: TwoFactorSourceProviderInfo[];
+  setSource: (provider: string | null) => Promise<boolean>;
+  hasAnyConnection: boolean;
+}
+
+/**
+ * The org's 2FA source: which connected integration (bound to the 2FA evidence
+ * task) supplies the per-employee 2FA column on the People tab.
+ */
+export function use2faSource({
+  organizationId,
+  enabled = true,
+}: Use2faSourceOptions): Use2faSourceReturn {
+  const { data: sourceData, mutate: mutateSource } = useSWR<{
+    provider: string | null;
+  }>(
+    enabled
+      ? `/v1/integrations/sync/two-factor-source?organizationId=${organizationId}`
+      : null,
+    async (url: string) => {
+      const res = await apiClient.get<{ provider: string | null }>(url);
+      if (res.error) throw new Error(res.error);
+      return res.data as { provider: string | null };
+    },
+  );
+
+  const { data: availableData, isLoading } = useSWR<{
+    providers: TwoFactorSourceProviderInfo[];
+  }>(
+    enabled
+      ? `/v1/integrations/sync/available-2fa-sources?organizationId=${organizationId}`
+      : null,
+    async (url: string) => {
+      const res = await apiClient.get<{
+        providers: TwoFactorSourceProviderInfo[];
+      }>(url);
+      if (res.error) throw new Error(res.error);
+      return res.data as { providers: TwoFactorSourceProviderInfo[] };
+    },
+  );
+
+  const selectedSource = sourceData?.provider ?? null;
+  const availableSources = Array.isArray(availableData?.providers)
+    ? availableData.providers
+    : [];
+
+  const setSource = async (provider: string | null): Promise<boolean> => {
+    try {
+      const response = await apiClient.post(
+        `/v1/integrations/sync/two-factor-source?organizationId=${organizationId}`,
+        { provider },
+      );
+      if (response.error) {
+        toast.error('Failed to set 2FA source');
+        return false;
+      }
+
+      mutateSource({ provider }, false);
+
+      if (provider) {
+        const name =
+          availableSources.find((p) => p.slug === provider)?.name ?? provider;
+        toast.success(`${name} set as your 2FA source`);
+      }
+      return true;
+    } catch {
+      toast.error('Failed to set 2FA source');
+      return false;
+    }
+  };
+
+  return {
+    selectedSource,
+    isLoading,
+    availableSources,
+    setSource,
+    hasAnyConnection: availableSources.some((p) => p.connected),
+  };
+}

--- a/packages/db/prisma/migrations/20260701120000_add_two_factor_source/migration.sql
+++ b/packages/db/prisma/migrations/20260701120000_add_two_factor_source/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."Organization" ADD COLUMN     "twoFactorSource" TEXT;

--- a/packages/db/prisma/schema/organization.prisma
+++ b/packages/db/prisma/schema/organization.prisma
@@ -29,6 +29,10 @@ model Organization {
   // When set, the scheduled sync will import devices from this provider
   deviceSyncProvider String?
 
+  // 2FA source provider (e.g., 'google-workspace')
+  // When set, the People tab reads per-user 2FA status from this integration's latest check run
+  twoFactorSource String?
+
   apiKeys                            ApiKey[]
   mcpOrgBindings                     McpOrgBinding[]
   auditLog                           AuditLog[]


### PR DESCRIPTION
## What

Adds a per-employee **2FA** row to the People list's TASKS column, sourced from whichever connected integration the org selects as its "2FA source". Stacked on #3332.

- **2FA source selector** in the People toolbar (mirrors the employee/device sync-source pattern): lists connected integrations whose check is bound to the 2FA evidence task — codebase **and** dynamic integrations, via the shared registry
- Each person's row shows **Done** / **Missing** / **Not provided** from the source's latest real check run, joined by email
- **Not provided** = the source had no data for that member — absence never reads as an explicit failure

## Universal `CheckResultsService`

The generic fetch lives in a new feature-agnostic, read-only service (`apps/api/.../services/check-results.service.ts`) — the single reuse point for any feature that consumes integration check results:

- `listSourcesBoundToTask(orgId, taskTemplateId)` — which connected integrations feed a task
- `getLatestResultsByCheck(...)` / `getLatestResultsForTask(...)` — full results of the latest real (non-held) run, stable envelope, `evidence` left as raw JSON for features to validate

The 2FA controller is consumer #1: it owns only `Organization.twoFactorSource` and the enabled/missing interpretation. Agent/dev docs: `check-results-service` skill + `README-check-results.md` + `apps/api/CLAUDE.md` pointer.

## Implementation

- DB: `Organization.twoFactorSource String?` + migration
- API: `TwoFactorSourceController` — GET/POST `two-factor-source`, GET `available-2fa-sources`, GET `two-factor-statuses`; all `@RequirePermission`-gated (`integration` read/update)
- Repo: `CheckRunRepository.findLatestResultsByConnectionAndCheck` (latest non-inconclusive run, full result set — deliberately not the 30-row display sample); `ConnectionRepository.findActiveBySlugsAndOrg` (batched slug lookup)
- Frontend: `use2faSource` hook + `TwoFactorSourceSelector` (RBAC-gated, hidden when no eligible connection); server-side email join in `TeamMembers.tsx`; `TaskRequirements` gains a `not-provided` state
- Also hides 0/0 count rows (nothing-to-complete renders as not-applicable, not incomplete)

## Notes

- Google Workspace is the first source with full per-user coverage; other bound sources appear in the selector and degrade gracefully to "Not provided" where per-user email-keyed data isn't available
- 2FA applies to all non-deactivated members (including admins), unlike the compliance-scoped rows

## Tests

- API: 29 (service + controller + repository), incl. RBAC-rejection and no-real-run paths
- App: 66 passing across TaskRequirements / MemberRow / selector / email-join (3 pre-existing `InviteMembersModal` failures reproduce on base — jsdom `ResizeObserver`, unrelated)
- Typecheck clean on all changed files in both apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EP8KdCURe23QJ9oXd9ZJ3M

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-employee 2FA status to the People list from a selected integration source and adds a universal `CheckResultsService` to reuse integration check results. Also tightens the TASKS scorecard and removes the mini progress bar for a cleaner, aligned column.

- **New Features**
  - People: 2FA row in TASKS shows Done/Missing/Not provided; applies to all non‑deactivated members; joined by email.
  - 2FA source selector in the toolbar; RBAC‑gated; hidden if none connected; collapses on mobile; no placeholder flash.
  - API: GET/POST `two-factor-source`, GET `available-2fa-sources`, GET `two-factor-statuses` (permission‑gated: `integration` read/update).
  - DB: `Organization.twoFactorSource` (+ migration).
  - UI: hide “0/0” policy rows; compact TASKS scorecard with aligned counts/badges and colored counts only (mini bar removed).

- **Refactors**
  - Added `CheckResultsService`: `listSourcesBoundToTask`, `getLatestResultsByCheck`, `getLatestResultsForTask`; stable envelope with raw `evidence`.
  - Repos: `findLatestResultsByConnectionAndCheck` (latest non‑inconclusive, optional `resourceType`, no row cap); `findActiveBySlugsAndOrg` (batched lookup).
  - 2FA statuses: deterministic email dedup (fail wins); client joins case‑insensitively; absence → Not provided.
  - Hook: `use2faSource` reports loading across both requests, surfaces errors, and waits before rendering.
  - Error handling: POST `two-factor-source` now checks org existence before provider validation and maps missing org to 404 (also maps Prisma P2025); GET `two-factor-statuses` 404s on missing org.
  - Docs/tests: `check-results-service` README/skill + `responsive-ui` skill; controller/service/repo + UI tests.

<sup>Written for commit 21e2befd5d035152a16605729e14e580638aded2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

