### PR TITLE
fix(people): label the toolbar source selects and stop date-chip wrapping

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
@@ -386,7 +386,9 @@ export function TeamMembersClient({
         {hasAnyConnection && (
           <div className="flex items-end gap-2">
             <div className="flex w-[200px] flex-col gap-1">
-              <span className="text-xs text-muted-foreground">Sync source</span>
+              <span id="employee-sync-source-label" className="text-xs text-muted-foreground">
+                Sync source
+              </span>
               <Select
                 onValueChange={(value) => {
                   const provider = String(value);
@@ -399,7 +401,7 @@ export function TeamMembersClient({
                 }}
                 disabled={isSyncing || isDisablingSync || !canManageMembers}
               >
-                <SelectTrigger>
+                <SelectTrigger aria-labelledby="employee-sync-source-label">
                   {isSyncing ? (
                     <>
                       <InProgress size={16} className="mr-2 animate-spin" />

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
@@ -308,7 +308,7 @@ export function TeamMembersClient({
   return (
     <Stack gap="4">
       {/* Search and Filters */}
-      <div className="flex items-center gap-4">
+      <div className="flex items-end gap-4">
         <div className="w-full md:max-w-[300px]">
           <InputGroup>
             <InputGroupAddon>
@@ -384,8 +384,9 @@ export function TeamMembersClient({
           onClear={() => { setOffboardFrom(undefined); setOffboardTo(undefined); setPage(1); }}
         />
         {hasAnyConnection && (
-          <div className="flex items-center gap-2">
-            <div className="w-[200px]">
+          <div className="flex items-end gap-2">
+            <div className="flex w-[200px] flex-col gap-1">
+              <span className="text-xs text-muted-foreground">Sync source</span>
               <Select
                 onValueChange={(value) => {
                   const provider = String(value);
@@ -705,7 +706,7 @@ function DateRangeFilter({
     <div className="hidden sm:block">
       <Popover open={open} onOpenChange={handleOpenChange}>
         <PopoverTrigger>
-          <div className="border-border bg-background hover:bg-muted flex h-8 items-center gap-2 rounded-md border px-3 text-xs transition-colors cursor-pointer">
+          <div className="border-border bg-background hover:bg-muted flex h-8 items-center gap-2 whitespace-nowrap rounded-md border px-3 text-xs transition-colors cursor-pointer">
             <CalendarIcon size={13} className="text-muted-foreground" />
             <span className="text-muted-foreground">{label}</span>
             <span className="font-medium">·</span>

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.test.tsx
@@ -53,6 +53,8 @@ describe('TwoFactorSourceSelector — RBAC gating', () => {
     render(<TwoFactorSourceSelector />);
 
     expect(screen.getByText('Google Workspace')).toBeInTheDocument();
+    // The label above the select is what tells users what this control is for.
+    expect(screen.getByText('2FA source')).toBeInTheDocument();
     // Hook is enabled (and therefore allowed to hit the 2FA-source APIs).
     expect(mockUse2faSource).toHaveBeenCalledWith(
       expect.objectContaining({ enabled: true }),

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.test.tsx
@@ -53,8 +53,15 @@ describe('TwoFactorSourceSelector — RBAC gating', () => {
     render(<TwoFactorSourceSelector />);
 
     expect(screen.getByText('Google Workspace')).toBeInTheDocument();
-    // The label above the select is what tells users what this control is for.
-    expect(screen.getByText('2FA source')).toBeInTheDocument();
+    // The label above the select is what tells users what this control is for —
+    // and it must be programmatically tied to the trigger for screen readers.
+    expect(screen.getByText('2FA source')).toHaveAttribute(
+      'id',
+      'two-factor-source-label',
+    );
+    expect(
+      screen.getByRole('combobox', { name: '2FA source' }),
+    ).toBeInTheDocument();
     // Hook is enabled (and therefore allowed to hit the 2FA-source APIs).
     expect(mockUse2faSource).toHaveBeenCalledWith(
       expect.objectContaining({ enabled: true }),

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.tsx
@@ -9,7 +9,6 @@ import {
   SelectContent,
   SelectItem,
   SelectTrigger,
-  SelectValue,
 } from '@trycompai/design-system';
 
 import { use2faSource } from '../hooks/use2faSource';
@@ -62,7 +61,9 @@ export function TwoFactorSourceSelector() {
     // doesn't wrap. The per-member 2FA status stays visible at every width via
     // the table's own horizontal scroll.
     <div className="hidden w-[200px] sm:block">
-      <Select
+      <div className="flex flex-col gap-1">
+        <span className="text-xs text-muted-foreground">2FA source</span>
+        <Select
         value={selectedSource ?? NONE_VALUE}
         onValueChange={(value) => {
           if (value) void handleSourceChange(value);
@@ -84,7 +85,7 @@ export function TwoFactorSourceSelector() {
               <span className="truncate">{selected.name}</span>
             </div>
           ) : (
-            <SelectValue placeholder="2FA source" />
+            <span className="text-muted-foreground">None</span>
           )}
         </SelectTrigger>
         <SelectContent>
@@ -98,7 +99,8 @@ export function TwoFactorSourceSelector() {
             </SelectItem>
           ))}
         </SelectContent>
-      </Select>
+        </Select>
+      </div>
     </div>
   );
 }

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.tsx
@@ -62,14 +62,16 @@ export function TwoFactorSourceSelector() {
     // the table's own horizontal scroll.
     <div className="hidden w-[200px] sm:block">
       <div className="flex flex-col gap-1">
-        <span className="text-xs text-muted-foreground">2FA source</span>
+        <span id="two-factor-source-label" className="text-xs text-muted-foreground">
+          2FA source
+        </span>
         <Select
         value={selectedSource ?? NONE_VALUE}
         onValueChange={(value) => {
           if (value) void handleSourceChange(value);
         }}
       >
-        <SelectTrigger>
+        <SelectTrigger aria-labelledby="two-factor-source-label">
           {selected ? (
             <div className="flex items-center gap-2">
               {selected.logoUrl && (


### PR DESCRIPTION
## What

Small UX polish on the People toolbar, following up on #3333:

- **Labels above both source selects** — "2FA source" and "Sync source". A bare select showing `none` or `Google` gave users no clue what it configures.
- **2FA select shows a muted "None"** when unset, instead of leaking the raw item value.
- **Toolbar bottom-aligns** (`items-end`) so the newly labeled selects line up with the unlabeled search/filters.
- **Date chips get `whitespace-nowrap`** — "Any time" no longer wraps onto two lines inside the Onboarded/Offboarded chips.

| Before | After |
|---|---|
| `[none ▾]` (what is this?) · `Any`↵`time` | `2FA source` label + `[None ▾]` · `Any time` on one line |

## Tests

- Selector tests extended to assert the label renders; 5/5 pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EP8KdCURe23QJ9oXd9ZJ3M

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds '2FA source' and 'Sync source' labels to the People toolbar selects, tied to their triggers so screen readers announce the names, and shows a muted "None" when 2FA is unset. Bottom-aligns the toolbar and keeps date chips on one line to stop "Any time" from wrapping.

<sup>Written for commit 59cdce7919df39e98082661643fadbfaef7e9e95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

