### PR TITLE
style(people): brand-green counts and inline chip labels for source selects

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TaskRequirements.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TaskRequirements.tsx
@@ -43,7 +43,9 @@ function TaskRequirementRow({ item }: { item: TaskRequirementItem }) {
         // share one vertical line across rows. The colored count alone carries
         // the state (green done / amber partial / muted none) — no bar needed.
         <div className="pl-1.5">
-          <Text size="xs" variant={isComplete ? 'success' : completed > 0 ? 'warning' : 'muted'}>
+          {/* 'primary' = the brand green — matches the Done badge (accent),
+              unlike the DS 'success' variant which is a different green. */}
+          <Text size="xs" variant={isComplete ? 'primary' : completed > 0 ? 'warning' : 'muted'}>
             {completed}/{total}
           </Text>
         </div>

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
@@ -308,7 +308,7 @@ export function TeamMembersClient({
   return (
     <Stack gap="4">
       {/* Search and Filters */}
-      <div className="flex items-end gap-4">
+      <div className="flex items-center gap-4">
         <div className="w-full md:max-w-[300px]">
           <InputGroup>
             <InputGroupAddon>
@@ -384,11 +384,8 @@ export function TeamMembersClient({
           onClear={() => { setOffboardFrom(undefined); setOffboardTo(undefined); setPage(1); }}
         />
         {hasAnyConnection && (
-          <div className="flex items-end gap-2">
-            <div className="flex w-[200px] flex-col gap-1">
-              <span id="employee-sync-source-label" className="text-xs text-muted-foreground">
-                Sync source
-              </span>
+          <div className="flex items-center gap-2">
+            <div className="w-fit max-w-[300px]">
               <Select
                 onValueChange={(value) => {
                   const provider = String(value);
@@ -401,29 +398,36 @@ export function TeamMembersClient({
                 }}
                 disabled={isSyncing || isDisablingSync || !canManageMembers}
               >
-                <SelectTrigger aria-labelledby="employee-sync-source-label">
-                  {isSyncing ? (
-                    <>
-                      <InProgress size={16} className="mr-2 animate-spin" />
-                      Syncing...
-                    </>
-                  ) : selectedProvider ? (
-                    <div className="flex items-center gap-2">
-                      {getProviderLogo(selectedProvider) && (
-                        <Image
-                          src={getProviderLogo(selectedProvider)}
-                          alt={getProviderName(selectedProvider)}
-                          width={16}
-                          height={16}
-                          className="rounded-sm"
-                          unoptimized
-                        />
-                      )}
-                      <span className="truncate">{getProviderName(selectedProvider)}</span>
-                    </div>
-                  ) : (
-                    <SelectValue placeholder="Select sync source" />
-                  )}
+                <SelectTrigger aria-label="Sync source">
+                  {/* Inline "Sync source ·" prefix mirrors the date chips;
+                      the aria-label names the combobox for screen readers
+                      (comboboxes don't take their name from contents). */}
+                  <div className="flex items-center gap-2 whitespace-nowrap">
+                    <span className="text-muted-foreground">Sync source</span>
+                    <span className="font-medium">·</span>
+                    {isSyncing ? (
+                      <>
+                        <InProgress size={16} className="animate-spin" />
+                        Syncing...
+                      </>
+                    ) : selectedProvider ? (
+                      <>
+                        {getProviderLogo(selectedProvider) && (
+                          <Image
+                            src={getProviderLogo(selectedProvider)}
+                            alt=""
+                            width={16}
+                            height={16}
+                            className="rounded-sm"
+                            unoptimized
+                          />
+                        )}
+                        <span className="truncate">{getProviderName(selectedProvider)}</span>
+                      </>
+                    ) : (
+                      <span className="text-muted-foreground">None</span>
+                    )}
+                  </div>
                 </SelectTrigger>
               <SelectContent>
                 <div className="px-2 py-1.5 text-xs text-muted-foreground space-y-1">

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
@@ -398,12 +398,12 @@ export function TeamMembersClient({
                 }}
                 disabled={isSyncing || isDisablingSync || !canManageMembers}
               >
-                <SelectTrigger aria-label="Sync source">
-                  {/* Inline "Sync source ·" prefix mirrors the date chips;
+                <SelectTrigger aria-label="Sync people from">
+                  {/* Inline "Sync people from ·" prefix mirrors the date chips;
                       the aria-label names the combobox for screen readers
                       (comboboxes don't take their name from contents). */}
                   <div className="flex items-center gap-2 whitespace-nowrap">
-                    <span className="text-muted-foreground">Sync source</span>
+                    <span className="text-muted-foreground">Sync people from</span>
                     <span className="font-medium">·</span>
                     {isSyncing ? (
                       <>

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.test.tsx
@@ -53,10 +53,10 @@ describe('TwoFactorSourceSelector — RBAC gating', () => {
     render(<TwoFactorSourceSelector />);
 
     expect(screen.getByText('Google Workspace')).toBeInTheDocument();
-    // The inline "2FA source ·" prefix tells users what the control is for and
+    // The inline "2FA status from ·" prefix tells users what the control is for and
     // makes it part of the trigger's accessible name for screen readers.
     expect(
-      screen.getByRole('combobox', { name: /2FA source/ }),
+      screen.getByRole('combobox', { name: /2FA status from/ }),
     ).toBeInTheDocument();
     // Hook is enabled (and therefore allowed to hit the 2FA-source APIs).
     expect(mockUse2faSource).toHaveBeenCalledWith(

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.test.tsx
@@ -53,14 +53,10 @@ describe('TwoFactorSourceSelector — RBAC gating', () => {
     render(<TwoFactorSourceSelector />);
 
     expect(screen.getByText('Google Workspace')).toBeInTheDocument();
-    // The label above the select is what tells users what this control is for —
-    // and it must be programmatically tied to the trigger for screen readers.
-    expect(screen.getByText('2FA source')).toHaveAttribute(
-      'id',
-      'two-factor-source-label',
-    );
+    // The inline "2FA source ·" prefix tells users what the control is for and
+    // makes it part of the trigger's accessible name for screen readers.
     expect(
-      screen.getByRole('combobox', { name: '2FA source' }),
+      screen.getByRole('combobox', { name: /2FA source/ }),
     ).toBeInTheDocument();
     // Hook is enabled (and therefore allowed to hit the 2FA-source APIs).
     expect(mockUse2faSource).toHaveBeenCalledWith(

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.tsx
@@ -59,36 +59,39 @@ export function TwoFactorSourceSelector() {
     // hidden sm:block matches the other secondary toolbar controls (status/role/
     // date filters): config actions collapse on phones, where the toolbar row
     // doesn't wrap. The per-member 2FA status stays visible at every width via
-    // the table's own horizontal scroll.
-    <div className="hidden w-[200px] sm:block">
-      <div className="flex flex-col gap-1">
-        <span id="two-factor-source-label" className="text-xs text-muted-foreground">
-          2FA source
-        </span>
-        <Select
+    // the table's own horizontal scroll. The inline "2FA source ·" prefix inside
+    // the trigger mirrors the Onboarded/Offboarded chips.
+    <div className="hidden w-fit max-w-[280px] sm:block">
+      <Select
         value={selectedSource ?? NONE_VALUE}
         onValueChange={(value) => {
           if (value) void handleSourceChange(value);
         }}
       >
-        <SelectTrigger aria-labelledby="two-factor-source-label">
-          {selected ? (
-            <div className="flex items-center gap-2">
-              {selected.logoUrl && (
-                <Image
-                  src={selected.logoUrl}
-                  alt={selected.name}
-                  width={16}
-                  height={16}
-                  className="rounded-sm"
-                  unoptimized
-                />
-              )}
-              <span className="truncate">{selected.name}</span>
-            </div>
-          ) : (
-            <span className="text-muted-foreground">None</span>
-          )}
+        {/* combobox takes its accessible name from author attrs only — the
+            inline prefix text alone can't name it, hence the aria-label. */}
+        <SelectTrigger aria-label="2FA source">
+          <div className="flex items-center gap-2 whitespace-nowrap">
+            <span className="text-muted-foreground">2FA source</span>
+            <span className="font-medium">·</span>
+            {selected ? (
+              <>
+                {selected.logoUrl && (
+                  <Image
+                    src={selected.logoUrl}
+                    alt=""
+                    width={16}
+                    height={16}
+                    className="rounded-sm"
+                    unoptimized
+                  />
+                )}
+                <span className="truncate">{selected.name}</span>
+              </>
+            ) : (
+              <span className="text-muted-foreground">None</span>
+            )}
+          </div>
         </SelectTrigger>
         <SelectContent>
           <div className="px-2 py-1.5 text-xs text-muted-foreground">
@@ -101,8 +104,7 @@ export function TwoFactorSourceSelector() {
             </SelectItem>
           ))}
         </SelectContent>
-        </Select>
-      </div>
+      </Select>
     </div>
   );
 }

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.tsx
@@ -70,9 +70,9 @@ export function TwoFactorSourceSelector() {
       >
         {/* combobox takes its accessible name from author attrs only — the
             inline prefix text alone can't name it, hence the aria-label. */}
-        <SelectTrigger aria-label="2FA source">
+        <SelectTrigger aria-label="2FA status from">
           <div className="flex items-center gap-2 whitespace-nowrap">
-            <span className="text-muted-foreground">2FA source</span>
+            <span className="text-muted-foreground">2FA status from</span>
             <span className="font-medium">·</span>
             {selected ? (
               <>
@@ -95,9 +95,9 @@ export function TwoFactorSourceSelector() {
         </SelectTrigger>
         <SelectContent>
           <div className="px-2 py-1.5 text-xs text-muted-foreground">
-            Shows each person&apos;s 2FA status from this integration
+            Shows each person&apos;s 2FA status from the selected integration&apos;s latest check
           </div>
-          <SelectItem value={NONE_VALUE}>No 2FA source</SelectItem>
+          <SelectItem value={NONE_VALUE}>Don&apos;t show 2FA status</SelectItem>
           {connectedSources.map((p) => (
             <SelectItem key={p.slug} value={p.slug}>
               {p.name}


### PR DESCRIPTION
## What

Two visual refinements to the People toolbar and TASKS scorecard, following #3336:

- **Complete counts now use the brand green** (`primary`) — they previously used the design-system `success` variant, which is a *different* green than the Done badges sitting right next to them. Counts and badges now match.
- **"Sync source ·" / "2FA source ·" render inline inside their select triggers**, matching the Onboarded/Offboarded chip pattern — single-height toolbar, uniform grammar (replaces the stacked labels from #3336). The selects size to content with a max-width cap.

## Accessibility note

The `combobox` role takes its accessible name from author attributes only — inline text can't name it — so both triggers carry explicit `aria-label`s. The test asserts the accessible name resolves (`getByRole('combobox', { name: /2FA source/ })`).

## Tests

14/14 across TaskRequirements + selector; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EP8KdCURe23QJ9oXd9ZJ3M

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies People toolbar visuals and copy: completion counts use the brand green, and the sync/2FA source selects use inline sentence chips (“Sync people from · …”, “2FA status from · …”) for a single-height toolbar.

- **Refactors**
  - Switch counts to `primary` brand green to match Done badges.
  - Center toolbar items; size selects with `w-fit` and a max width.
  - Inline sentence chips replace labels; `aria-label`s name the comboboxes.
  - Provider logos use empty `alt`; clear option is “Don’t show 2FA status”.
  - Dropdown hint clarifies it uses the selected integration’s latest check.
  - Tests updated to assert the new accessible names.

<sup>Written for commit 341f5405c6795af628b0f16678b1bc6d451c646d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

