### PR TITLE
style(people): uniform labels above every toolbar control

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
@@ -308,7 +308,7 @@ export function TeamMembersClient({
   return (
     <Stack gap="4">
       {/* Search and Filters */}
-      <div className="flex items-center gap-4">
+      <div className="flex items-end gap-4">
         <div className="w-full md:max-w-[300px]">
           <InputGroup>
             <InputGroupAddon>
@@ -322,7 +322,10 @@ export function TeamMembersClient({
           </InputGroup>
         </div>
         {/* Status Filter Select */}
-        <div className="hidden w-[140px] sm:block">
+        <div className="hidden w-[140px] flex-col gap-1 sm:flex">
+          <span id="people-status-filter-label" className="text-xs text-muted-foreground">
+            Status
+          </span>
           <Select
             value={statusFilter || undefined}
             onValueChange={(value) => {
@@ -330,7 +333,7 @@ export function TeamMembersClient({
               setPage(1);
             }}
           >
-            <SelectTrigger>
+            <SelectTrigger aria-labelledby="people-status-filter-label">
               <SelectValue placeholder="Active">
                 {hasOffboardFilter && !statusFilter
                   ? 'All People'
@@ -346,7 +349,10 @@ export function TeamMembersClient({
           </Select>
         </div>
         {/* Role Filter Select */}
-        <div className="hidden w-[180px] sm:block">
+        <div className="hidden w-[180px] flex-col gap-1 sm:flex">
+          <span id="people-role-filter-label" className="text-xs text-muted-foreground">
+            Role
+          </span>
           <Select
             value={roleFilter || undefined}
             onValueChange={(value) => {
@@ -354,7 +360,7 @@ export function TeamMembersClient({
               setPage(1);
             }}
           >
-            <SelectTrigger>
+            <SelectTrigger aria-labelledby="people-role-filter-label">
               <SelectValue placeholder="All Roles">
                 {{ owner: 'Owner', admin: 'Admin', auditor: 'Auditor', employee: 'Employee', contractor: 'Contractor' }[roleFilter] ?? 'All Roles'}
               </SelectValue>
@@ -384,8 +390,11 @@ export function TeamMembersClient({
           onClear={() => { setOffboardFrom(undefined); setOffboardTo(undefined); setPage(1); }}
         />
         {hasAnyConnection && (
-          <div className="flex items-center gap-2">
-            <div className="w-fit max-w-[300px]">
+          <div className="flex items-end gap-2">
+            <div className="flex w-[200px] flex-col gap-1">
+              <span id="employee-sync-source-label" className="text-xs text-muted-foreground">
+                Sync people from
+              </span>
               <Select
                 onValueChange={(value) => {
                   const provider = String(value);
@@ -398,36 +407,29 @@ export function TeamMembersClient({
                 }}
                 disabled={isSyncing || isDisablingSync || !canManageMembers}
               >
-                <SelectTrigger aria-label="Sync people from">
-                  {/* Inline "Sync people from ·" prefix mirrors the date chips;
-                      the aria-label names the combobox for screen readers
-                      (comboboxes don't take their name from contents). */}
-                  <div className="flex items-center gap-2 whitespace-nowrap">
-                    <span className="text-muted-foreground">Sync people from</span>
-                    <span className="font-medium">·</span>
-                    {isSyncing ? (
-                      <>
-                        <InProgress size={16} className="animate-spin" />
-                        Syncing...
-                      </>
-                    ) : selectedProvider ? (
-                      <>
-                        {getProviderLogo(selectedProvider) && (
-                          <Image
-                            src={getProviderLogo(selectedProvider)}
-                            alt=""
-                            width={16}
-                            height={16}
-                            className="rounded-sm"
-                            unoptimized
-                          />
-                        )}
-                        <span className="truncate">{getProviderName(selectedProvider)}</span>
-                      </>
-                    ) : (
-                      <span className="text-muted-foreground">None</span>
-                    )}
-                  </div>
+                <SelectTrigger aria-labelledby="employee-sync-source-label">
+                  {isSyncing ? (
+                    <>
+                      <InProgress size={16} className="mr-2 animate-spin" />
+                      Syncing...
+                    </>
+                  ) : selectedProvider ? (
+                    <div className="flex items-center gap-2">
+                      {getProviderLogo(selectedProvider) && (
+                        <Image
+                          src={getProviderLogo(selectedProvider)}
+                          alt=""
+                          width={16}
+                          height={16}
+                          className="rounded-sm"
+                          unoptimized
+                        />
+                      )}
+                      <span className="truncate">{getProviderName(selectedProvider)}</span>
+                    </div>
+                  ) : (
+                    <span className="text-muted-foreground">None</span>
+                  )}
                 </SelectTrigger>
               <SelectContent>
                 <div className="px-2 py-1.5 text-xs text-muted-foreground space-y-1">
@@ -708,14 +710,17 @@ function DateRangeFilter({
         ? `Until ${format(to, 'MMM d, yyyy')}`
         : 'Any time';
 
+  const labelId = `people-${label.toLowerCase()}-filter-label`;
+
   return (
-    <div className="hidden sm:block">
+    <div className="hidden flex-col gap-1 sm:flex">
+      <span id={labelId} className="text-xs text-muted-foreground">
+        {label}
+      </span>
       <Popover open={open} onOpenChange={handleOpenChange}>
-        <PopoverTrigger>
+        <PopoverTrigger aria-labelledby={labelId}>
           <div className="border-border bg-background hover:bg-muted flex h-8 items-center gap-2 whitespace-nowrap rounded-md border px-3 text-xs transition-colors cursor-pointer">
             <CalendarIcon size={13} className="text-muted-foreground" />
-            <span className="text-muted-foreground">{label}</span>
-            <span className="font-medium">·</span>
             <span className="font-medium">{displayLabel}</span>
             <ChevronDown size={12} className="text-muted-foreground" />
           </div>

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.test.tsx
@@ -81,7 +81,7 @@ describe('TwoFactorSourceSelector — RBAC gating', () => {
 
     const { container } = render(<TwoFactorSourceSelector />);
 
-    expect(container.firstElementChild).toHaveClass('hidden', 'sm:block');
+    expect(container.firstElementChild).toHaveClass('hidden', 'sm:flex');
   });
 
   it('renders nothing while the source/selection are still loading (no placeholder flash)', () => {

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.tsx
@@ -56,42 +56,39 @@ export function TwoFactorSourceSelector() {
   };
 
   return (
-    // hidden sm:block matches the other secondary toolbar controls (status/role/
-    // date filters): config actions collapse on phones, where the toolbar row
-    // doesn't wrap. The per-member 2FA status stays visible at every width via
-    // the table's own horizontal scroll. The inline "2FA source ·" prefix inside
-    // the trigger mirrors the Onboarded/Offboarded chips.
-    <div className="hidden w-fit max-w-[280px] sm:block">
+    // hidden sm:flex matches the other toolbar controls: config actions
+    // collapse on phones, where the toolbar row doesn't wrap. The per-member
+    // 2FA status stays visible at every width via the table's own horizontal
+    // scroll. Label above the input, uniform with the rest of the toolbar;
+    // aria-labelledby names the combobox (the role ignores content for names).
+    <div className="hidden w-[200px] flex-col gap-1 sm:flex">
+      <span id="two-factor-source-label" className="text-xs text-muted-foreground">
+        2FA status from
+      </span>
       <Select
         value={selectedSource ?? NONE_VALUE}
         onValueChange={(value) => {
           if (value) void handleSourceChange(value);
         }}
       >
-        {/* combobox takes its accessible name from author attrs only — the
-            inline prefix text alone can't name it, hence the aria-label. */}
-        <SelectTrigger aria-label="2FA status from">
-          <div className="flex items-center gap-2 whitespace-nowrap">
-            <span className="text-muted-foreground">2FA status from</span>
-            <span className="font-medium">·</span>
-            {selected ? (
-              <>
-                {selected.logoUrl && (
-                  <Image
-                    src={selected.logoUrl}
-                    alt=""
-                    width={16}
-                    height={16}
-                    className="rounded-sm"
-                    unoptimized
-                  />
-                )}
-                <span className="truncate">{selected.name}</span>
-              </>
-            ) : (
-              <span className="text-muted-foreground">None</span>
-            )}
-          </div>
+        <SelectTrigger aria-labelledby="two-factor-source-label">
+          {selected ? (
+            <div className="flex items-center gap-2">
+              {selected.logoUrl && (
+                <Image
+                  src={selected.logoUrl}
+                  alt=""
+                  width={16}
+                  height={16}
+                  className="rounded-sm"
+                  unoptimized
+                />
+              )}
+              <span className="truncate">{selected.name}</span>
+            </div>
+          ) : (
+            <span className="text-muted-foreground">None</span>
+          )}
         </SelectTrigger>
         <SelectContent>
           <div className="px-2 py-1.5 text-xs text-muted-foreground">


### PR DESCRIPTION
## What

The inline chip labels from #3337 read badly in practice. This switches the whole People toolbar to ONE consistent pattern — a small muted label above each control:

```
Status        Role         Onboarded      Offboarded     Sync people from      2FA status from
[Active ▾]    [All Roles ▾] [📅 Any time ▾] [📅 Any time ▾] [🟢 Google Workspace ▾] [None ▾]
```

- **Status / Role** get labels (previously value-only selects)
- **Onboarded / Offboarded** labels move above; the chips show just the value ("Any time" / date range)
- **Sync people from / 2FA status from** return to label-above with value-only triggers
- Search stays unlabeled; toolbar bottom-aligns so all control boxes sit on one line

## Accessibility

Every combobox/popover trigger is `aria-labelledby` its visible label (comboboxes don't take accessible names from content).

## Tests

32/32 across selector/TaskRequirements/MemberRow; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EP8KdCURe23QJ9oXd9ZJ3M

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the People toolbar to a single pattern: a small muted label above each control, with value-only triggers. Aligns the toolbar bottoms and improves accessibility via `aria-labelledby` on all combobox and date controls.

- **Refactors**
  - Adds labels for Status, Role, Onboarded, Offboarded, Sync people from, and 2FA status from; search stays unlabeled.
  - Triggers show only the selected value (or “None”); sync shows a spinner with “Syncing...” and provider/2FA selectors render logo + name.
  - Switches control containers to hidden `sm:flex` with vertical label stacks; toolbar uses bottom alignment so controls sit on one line; tests updated accordingly.

<sup>Written for commit 9ff4d054e1b7d39da5a9caddc5fbd37ee87c3979. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

