### PR TITLE
style(people): Sync settings popover + toolbar layout per Linear/Stripe convention

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
@@ -374,7 +374,7 @@ export function TeamMembersClient({
           <PopoverTrigger>
             <div className="border-border bg-background hover:bg-muted flex h-8 cursor-pointer items-center gap-2 whitespace-nowrap rounded-md border px-3 text-sm transition-colors">
               <SettingsAdjust size={16} className="text-muted-foreground" />
-              Data sources
+              Sync settings
             </div>
           </PopoverTrigger>
           <PopoverContent align="end" style={{ width: 'auto' }}>

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
@@ -375,22 +375,18 @@ export function TeamMembersClient({
           </PopoverTrigger>
           <PopoverContent align="end" style={{ width: 'auto' }}>
             <div className="flex w-[280px] flex-col gap-4 p-1.5">
-              {/* Fresh orgs have nothing to configure yet — teach instead of
-                  showing an empty popover. */}
-              {!hasAnyConnection && (
-                <div className="flex flex-col gap-2 py-1">
-                  <span className="text-sm font-medium">No integrations connected</span>
-                  <span className="text-xs text-muted-foreground">
-                    Data sources appear here once you connect an integration.
-                  </span>
-                  <Link
-                    href={`/${organizationId}/integrations`}
-                    className="text-xs font-medium text-primary hover:underline"
-                  >
-                    Browse integrations →
-                  </Link>
-                </div>
-              )}
+        {!hasAnyConnection && (
+          <div className="flex w-full flex-col gap-1">
+            <span className="text-xs text-muted-foreground">Sync people from</span>
+            <Link
+              href={`/${organizationId}/integrations`}
+              className="border-border text-muted-foreground hover:bg-muted flex h-8 items-center justify-between rounded-md border border-dashed px-3 text-sm transition-colors"
+            >
+              Connect an integration
+              <span aria-hidden>→</span>
+            </Link>
+          </div>
+        )}
         {hasAnyConnection && (
           <div className="flex w-full">
             <div className="flex w-full flex-col gap-1">

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
@@ -330,7 +330,10 @@ export function TeamMembersClient({
   return (
     <Stack gap="4">
       {/* Search and Filters */}
-      <div className="flex items-end gap-4">
+      {/* Left = query (search, filters); right = view configuration (data
+          sources) — the Linear/Stripe toolbar convention. */}
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex min-w-0 flex-1 items-center gap-3">
         <div className="w-full md:max-w-[300px]">
           <InputGroup>
             <InputGroupAddon>
@@ -364,6 +367,7 @@ export function TeamMembersClient({
           onOffboardApply={(from, to) => { setOffboardFrom(from); setOffboardTo(to); setPage(1); }}
           onOffboardClear={() => { setOffboardFrom(undefined); setOffboardTo(undefined); setPage(1); }}
         />
+        </div>
         {/* Source settings (sync / 2FA) — settings, not filters, so they get
             their own compact popover, symmetric with the Filters button. */}
         <Popover>

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { toast } from 'sonner';
@@ -374,6 +375,23 @@ export function TeamMembersClient({
           </PopoverTrigger>
           <PopoverContent align="end" style={{ width: 'auto' }}>
             <div className="flex w-[280px] flex-col gap-4 p-1.5">
+              {/* Fresh orgs have nothing to configure yet — teach instead of
+                  showing an empty popover. */}
+              {!hasAnyConnection && (
+                <div className="flex flex-col gap-2 py-1">
+                  <span className="text-sm font-medium">No integrations connected</span>
+                  <span className="text-xs text-muted-foreground">
+                    Connect an integration like Google Workspace to sync your
+                    team automatically and show each person&apos;s 2FA status.
+                  </span>
+                  <Link
+                    href={`/${organizationId}/integrations`}
+                    className="text-xs font-medium text-primary hover:underline"
+                  >
+                    Browse integrations →
+                  </Link>
+                </div>
+              )}
         {hasAnyConnection && (
           <div className="flex w-full">
             <div className="flex w-full flex-col gap-1">

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
@@ -21,6 +21,9 @@ import {
   InputGroup,
   InputGroupAddon,
   InputGroupInput,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
   Select,
   SelectContent,
   SelectItem,
@@ -34,7 +37,7 @@ import {
   TableHeader,
   TableRow,
 } from '@trycompai/design-system';
-import { InProgress, Search } from '@trycompai/design-system/icons';
+import { InProgress, Search, SettingsAdjust } from '@trycompai/design-system/icons';
 
 import { apiClient } from '@/lib/api-client';
 import { useMemo } from 'react';
@@ -360,9 +363,20 @@ export function TeamMembersClient({
           onOffboardApply={(from, to) => { setOffboardFrom(from); setOffboardTo(to); setPage(1); }}
           onOffboardClear={() => { setOffboardFrom(undefined); setOffboardTo(undefined); setPage(1); }}
         />
+        {/* Source settings (sync / 2FA) — settings, not filters, so they get
+            their own compact popover, symmetric with the Filters button. */}
+        <Popover>
+          <PopoverTrigger>
+            <div className="border-border bg-background hover:bg-muted flex h-8 cursor-pointer items-center gap-2 whitespace-nowrap rounded-md border px-3 text-sm transition-colors">
+              <SettingsAdjust size={16} className="text-muted-foreground" />
+              Sources
+            </div>
+          </PopoverTrigger>
+          <PopoverContent align="end" style={{ width: 'auto' }}>
+            <div className="flex w-[280px] flex-col gap-4 p-1.5">
         {hasAnyConnection && (
-          <div className="flex items-end gap-2">
-            <div className="flex w-[200px] flex-col gap-1">
+          <div className="flex w-full">
+            <div className="flex w-full flex-col gap-1">
               <span id="employee-sync-source-label" className="text-xs text-muted-foreground">
                 Sync people from
               </span>
@@ -515,6 +529,9 @@ export function TeamMembersClient({
           </div>
         )}
         <TwoFactorSourceSelector />
+            </div>
+          </PopoverContent>
+        </Popover>
       </div>
 
       {/* Table */}

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
@@ -381,8 +381,7 @@ export function TeamMembersClient({
                 <div className="flex flex-col gap-2 py-1">
                   <span className="text-sm font-medium">No integrations connected</span>
                   <span className="text-xs text-muted-foreground">
-                    Connect an integration like Google Workspace to sync your
-                    team automatically and show each person&apos;s 2FA status.
+                    Data sources appear here once you connect an integration.
                   </span>
                   <Link
                     href={`/${organizationId}/integrations`}

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
@@ -369,7 +369,7 @@ export function TeamMembersClient({
           <PopoverTrigger>
             <div className="border-border bg-background hover:bg-muted flex h-8 cursor-pointer items-center gap-2 whitespace-nowrap rounded-md border px-3 text-sm transition-colors">
               <SettingsAdjust size={16} className="text-muted-foreground" />
-              Sources
+              Data sources
             </div>
           </PopoverTrigger>
           <PopoverContent align="end" style={{ width: 'auto' }}>

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.test.tsx
@@ -76,12 +76,12 @@ describe('TwoFactorSourceSelector — RBAC gating', () => {
     );
   });
 
-  it('collapses on mobile like the other secondary toolbar controls (hidden sm:block)', () => {
+  it('fills the Sources popover width (visible at every breakpoint inside it)', () => {
     mockHasPermission.mockReturnValue(true);
 
     const { container } = render(<TwoFactorSourceSelector />);
 
-    expect(container.firstElementChild).toHaveClass('hidden', 'sm:flex');
+    expect(container.firstElementChild).toHaveClass('flex', 'w-full');
   });
 
   it('renders nothing while the source/selection are still loading (no placeholder flash)', () => {

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.test.tsx
@@ -8,6 +8,12 @@ const { mockHasPermission, mockUse2faSource } = vi.hoisted(() => ({
   mockUse2faSource: vi.fn(),
 }));
 
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...rest }: { children: React.ReactNode; href: string }) => (
+    <a href={href} {...rest}>{children}</a>
+  ),
+}));
+
 vi.mock('next/navigation', () => ({
   useParams: () => ({ orgId: 'org_1' }),
   useRouter: () => ({ refresh: vi.fn() }),
@@ -98,7 +104,7 @@ describe('TwoFactorSourceSelector — RBAC gating', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('renders nothing when no bound integration is connected', () => {
+  it('shows a labeled connect prompt when no bound integration is connected', () => {
     mockHasPermission.mockReturnValue(true);
     mockUse2faSource.mockReturnValue({
       selectedSource: null,
@@ -108,7 +114,11 @@ describe('TwoFactorSourceSelector — RBAC gating', () => {
       hasAnyConnection: false,
     });
 
-    const { container } = render(<TwoFactorSourceSelector />);
-    expect(container).toBeEmptyDOMElement();
+    render(<TwoFactorSourceSelector />);
+    expect(screen.getByText('2FA status from')).toBeInTheDocument();
+    expect(screen.getByText('Connect an integration')).toHaveAttribute(
+      'href',
+      '/org_1/integrations',
+    );
   });
 });

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 
 import { usePermissions } from '@/hooks/use-permissions';
@@ -38,8 +39,25 @@ export function TwoFactorSourceSelector() {
   // Wait for BOTH the available sources and the current selection before
   // rendering, so the trigger never flashes the placeholder while the saved
   // selection is still resolving.
-  if (!canManage || isLoading || !hasAnyConnection) {
+  if (!canManage || isLoading) {
     return null;
+  }
+
+  // Empty slot instead of nothing: the labeled placeholder shows exactly what
+  // this setting is and how to unlock it.
+  if (!hasAnyConnection) {
+    return (
+      <div className="flex w-full flex-col gap-1">
+        <span className="text-xs text-muted-foreground">2FA status from</span>
+        <Link
+          href={`/${orgId}/integrations`}
+          className="border-border text-muted-foreground hover:bg-muted flex h-8 items-center justify-between rounded-md border border-dashed px-3 text-sm transition-colors"
+        >
+          Connect an integration
+          <span aria-hidden>→</span>
+        </Link>
+      </div>
+    );
   }
 
   const connectedSources = availableSources.filter((p) => p.connected);

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.tsx
@@ -56,12 +56,10 @@ export function TwoFactorSourceSelector() {
   };
 
   return (
-    // hidden sm:flex matches the other toolbar controls: config actions
-    // collapse on phones, where the toolbar row doesn't wrap. The per-member
-    // 2FA status stays visible at every width via the table's own horizontal
-    // scroll. Label above the input, uniform with the rest of the toolbar;
-    // aria-labelledby names the combobox (the role ignores content for names).
-    <div className="hidden w-[200px] flex-col gap-1 sm:flex">
+    // Renders inside the toolbar's Sources popover, so it fills the popover
+    // width and stays reachable at every breakpoint. aria-labelledby names the
+    // combobox (the role ignores content for accessible names).
+    <div className="flex w-full flex-col gap-1">
       <span id="two-factor-source-label" className="text-xs text-muted-foreground">
         2FA status from
       </span>


### PR DESCRIPTION
## What

Toolbar UX rework for the People list, iterated locally with Tofik before this PR:

```
[ 🔍 Search people… ]  [ 🜄 Filters ] [chips…]              [ ⚙ Sync settings ]
└────────── query: what am I looking at ─────────┘          └─ configuration ─┘
```

- **Sync settings popover**: the two source selects ("Sync people from", "2FA status from") move out of the toolbar into a compact popover button — they're settings, not filters. Symmetric with the Filters button; also reachable on mobile now (inline they were hidden below `sm`).
- **Toolbar split**: search + Filters (+ active-filter chips) group left; Sync settings sits alone on the right — the Linear/Stripe convention separating query controls from view configuration.
- **Structural empty state**: a fresh org with no integrations no longer sees an empty popover — each setting renders as a labeled placeholder slot with a dashed "Connect an integration →" row deep-linking to the Integrations page. The empty state IS the real UI, unfilled, so users see exactly what can appear there.
- Naming iterated: Sources → Data sources → **Sync settings** (intent-revealing, matches the product's existing sync vocabulary, no collision with the People Settings tab).

## Tests

- Selector tests updated for the popover home + the new connect-prompt empty state (asserts label + deep-link href)
- 8 passing across selector/filters; typecheck clean

## Review notes

- The 2FA selector's empty slot and the sync empty slot are independent — an org with only one capability connected sees one real select + one connect prompt.
- Verified locally by Tofik (hot-reload review on this branch) before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EP8KdCURe23QJ9oXd9ZJ3M

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the People data-source selectors into a compact "Sync settings" popover and splits the toolbar to separate query controls from configuration. This clarifies the UI and makes sync settings accessible on mobile.

- **New Features**
  - Added a "Sync settings" popover with "Sync people from" and "2FA status from"; shows labeled empty slots with a dashed "Connect an integration →" link when no integrations are connected.
  - Toolbar split: search + Filters (and chips) on the left; "Sync settings" on the right, following the Linear/Stripe convention.
  - `TwoFactorSourceSelector` now fills the popover width at all breakpoints and renders a labeled connect prompt when no 2FA source is available; tests updated to cover labels and deep-link hrefs.

<sup>Written for commit 1d1246a3540e368e452b2cc2dd6a4b0acf682b58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

