### PR TITLE
improvement(people): restore portaled dropdowns for in-popover selects

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/people/all/components/PeopleFilters.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/PeopleFilters.tsx
@@ -125,7 +125,7 @@ export function PeopleFilters({
                       ] ?? 'Active')}
                 </SelectValue>
               </SelectTrigger>
-              <SelectContent portal={false}>
+              <SelectContent>
                 <SelectItem value="all">All People</SelectItem>
                 <SelectItem value="active">Active</SelectItem>
                 <SelectItem value="pending">Pending</SelectItem>
@@ -146,7 +146,7 @@ export function PeopleFilters({
                   ] ?? 'All Roles'}
                 </SelectValue>
               </SelectTrigger>
-              <SelectContent portal={false}>
+              <SelectContent>
                 <SelectItem value="all">All Roles</SelectItem>
                 <SelectItem value="owner">Owner</SelectItem>
                 <SelectItem value="admin">Admin</SelectItem>

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
@@ -433,7 +433,7 @@ export function TeamMembersClient({
                     <span className="text-muted-foreground">Not syncing</span>
                   )}
                 </SelectTrigger>
-              <SelectContent portal={false}>
+              <SelectContent>
                 <div className="px-2 py-1.5 text-xs text-muted-foreground space-y-1">
                   {selectedProvider ? (
                     <>

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.tsx
@@ -106,7 +106,7 @@ export function TwoFactorSourceSelector() {
             <span className="text-muted-foreground">Not shown</span>
           )}
         </SelectTrigger>
-        <SelectContent portal={false}>
+        <SelectContent>
           <div className="px-2 py-1.5 text-xs text-muted-foreground">
             Where each person&apos;s 2FA status comes from
           </div>


### PR DESCRIPTION
## Urgent-ish: reverts a UI breakage merged in #3344

The `portal={false}` change in #3344 (meant to fix the extra-click-to-dismiss quirk) breaks the selects inside Sync settings/Filters: on mousedown the inline dropdown mis-positions far right and stretches the page width. Verified locally by Tofik.

This restores the portaled dropdowns for all four in-popover selects. The original minor quirk returns (after closing an open select, the popover takes one extra click to dismiss) — that needs a proper fix at the design-system layer (popover dismiss detection vs. nested portals), not at the call site.

Everything else from #3344 (logos, labels, copy) is untouched and stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EP8KdCURe23QJ9oXd9ZJ3M

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores portaled dropdowns for in-popover selects in People views to fix mis-positioned menus that stretched the page width.

- **Bug Fixes**
  - Re-enable portal on `SelectContent` in `PeopleFilters`, `TeamMembersClient`, and `TwoFactorSourceSelector`.
  - Fixes dropdown opening off-screen and expanding layout inside popovers.
  - Known quirk: popover requires one extra click to dismiss after closing a select; to be addressed in the design system.

<sup>Written for commit ec7cad708233af112aa51abe935f5a92fbb945f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

