### PR TITLE
fix(people): 2FA select now dismisses cleanly (match the sync select pattern)

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.tsx
@@ -81,10 +81,13 @@ export function TwoFactorSourceSelector() {
       <span id="two-factor-source-label" className="text-xs text-muted-foreground">
         2FA status
       </span>
+      {/* Uncontrolled on purpose — mirrors the (working) people-sync select.
+          A controlled value re-renders mid-dismissal when SWR revalidates,
+          which breaks the parent popover's outside-click tracking. */}
       <Select
-        value={selectedSource ?? NONE_VALUE}
         onValueChange={(value) => {
-          if (value) void handleSourceChange(value);
+          const provider = String(value);
+          if (provider) void handleSourceChange(provider);
         }}
       >
         <SelectTrigger aria-labelledby="two-factor-source-label">
@@ -127,6 +130,9 @@ export function TwoFactorSourceSelector() {
                   />
                 )}
                 {p.name}
+                {selectedSource === p.slug && (
+                  <span className="ml-auto text-xs text-muted-foreground">Active</span>
+                )}
               </div>
             </SelectItem>
           ))}

--- a/apps/app/src/app/(app)/[orgId]/people/all/hooks/use2faSource.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/all/hooks/use2faSource.ts
@@ -54,6 +54,7 @@ export function use2faSource({
       if (res.error) throw new Error(res.error);
       return res.data as { provider: string | null };
     },
+    { revalidateOnFocus: false },
   );
 
   const {
@@ -71,6 +72,7 @@ export function use2faSource({
       if (res.error) throw new Error(res.error);
       return res.data as { providers: TwoFactorSourceProviderInfo[] };
     },
+    { revalidateOnFocus: false },
   );
 
   const selectedSource = sourceData?.provider ?? null;


### PR DESCRIPTION
## The finding (credit: Tofik's comparative testing)

Inside Sync settings, the **People** select dismissed cleanly, but the **2FA status** select left the popover needing one extra click. The difference between the two implementations:

- People select: **uncontrolled** (no `value` prop) → stable through the dismissal sequence ✅
- 2FA select: **controlled** (`value` from SWR-backed state) → re-renders mid-dismissal when SWR updates, orphaning the popover's outside-click tracking ❌

## Fix

Mirror the proven pattern exactly:
- 2FA `Select` is now uncontrolled; the trigger already rendered its own display, and the selected item gets a manual muted "Active" marker (same as the sync dropdown)
- `use2faSource`'s two SWR calls no longer revalidate on window focus (stabilizer against mid-interaction re-renders)

No portal changes — dropdowns stay portaled (the #3345 revert stands).

## Tests
5/5 selector tests, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EP8KdCURe23QJ9oXd9ZJ3M

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the 2FA status select in People so the popover dismisses cleanly, matching the sync select.

Made the `Select` uncontrolled, disabled SWR `revalidateOnFocus`, and added an "Active" marker for the current provider; no portal changes.

<sup>Written for commit b3f5b2afc20ea834794697eb916efe7170b728ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

