### PR TITLE
fix(people): polish the redesigned People tab (requirement columns, filters, per-employee 2FA)

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TeamMembersClient.tsx
@@ -409,7 +409,7 @@ export function TeamMembersClient({
                 }}
                 disabled={isSyncing || isDisablingSync || !canManageMembers}
               >
-                <SelectTrigger aria-labelledby="employee-sync-source-label">
+                <SelectTrigger aria-label="Sync people from">
                   {isSyncing ? (
                     <>
                       <InProgress size={16} className="mr-2 animate-spin" />

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/TwoFactorSourceSelector.tsx
@@ -90,7 +90,7 @@ export function TwoFactorSourceSelector() {
           if (provider) void handleSourceChange(provider);
         }}
       >
-        <SelectTrigger aria-labelledby="two-factor-source-label">
+        <SelectTrigger aria-label="2FA status from">
           {selected ? (
             <div className="flex items-center gap-2">
               {selected.logoUrl && (


### PR DESCRIPTION
Small follow-up to the People tab release (v3.96.0).

**Actual change (2 lines):** the Sync settings selects get descriptive screen-reader names ("Sync people from" / "2FA status from") — the shortened visible labels ("People" / "2FA status") were too terse as accessible names.

**Note for the merger:** squash-merge; the title is written to be the v3.96.1 changelog line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EP8KdCURe23QJ9oXd9ZJ3M