### PR TITLE
feat(trust): add setting to show/hide the Security Questionnaire on the public trust portal

### DIFF
--- a/apps/api/src/trust-portal/dto/update-security-questionnaire.dto.ts
+++ b/apps/api/src/trust-portal/dto/update-security-questionnaire.dto.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const UpdateSecurityQuestionnaireSchema = z.object({
+  enabled: z.boolean(),
+});
+
+export type UpdateSecurityQuestionnaireDto = z.infer<
+  typeof UpdateSecurityQuestionnaireSchema
+>;

--- a/apps/api/src/trust-portal/trust-access.controller.ts
+++ b/apps/api/src/trust-portal/trust-access.controller.ts
@@ -680,6 +680,37 @@ export class TrustAccessController {
     return this.trustAccessService.getPublicOverview(friendlyUrl);
   }
 
+  @Get(':friendlyUrl/security-questionnaire')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Get Security Questionnaire visibility for a trust portal',
+    description:
+      "Whether the org offers the AI-assisted Security Questionnaire on its public trust portal. Defaults to enabled when the portal can't be resolved.",
+  })
+  @ApiParam({
+    name: 'friendlyUrl',
+    description: 'Trust Portal friendly URL or Organization ID',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Security Questionnaire visibility retrieved successfully',
+    schema: {
+      type: 'object',
+      properties: {
+        enabled: { type: 'boolean' },
+      },
+    },
+  })
+  async getPublicSecurityQuestionnaire(
+    @Param('friendlyUrl') friendlyUrl: string,
+  ) {
+    const enabled =
+      await this.trustAccessService.getPublicSecurityQuestionnaireEnabled(
+        friendlyUrl,
+      );
+    return { enabled };
+  }
+
   @Get(':friendlyUrl/custom-links')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({

--- a/apps/api/src/trust-portal/trust-access.security-questionnaire.service.spec.ts
+++ b/apps/api/src/trust-portal/trust-access.security-questionnaire.service.spec.ts
@@ -1,0 +1,68 @@
+import { db } from '@db';
+import { TrustAccessService } from './trust-access.service';
+
+jest.mock('@db', () => ({
+  db: {
+    trust: {
+      findFirst: jest.fn(),
+    },
+  },
+  Prisma: {},
+  TrustFramework: {},
+}));
+
+jest.mock('../app/s3', () => ({
+  APP_AWS_ORG_ASSETS_BUCKET: 'org-assets',
+  s3Client: { send: jest.fn() },
+  getSignedUrl: jest.fn(),
+}));
+
+const mockDb = db as unknown as {
+  trust: { findFirst: jest.Mock };
+};
+
+describe('TrustAccessService.getPublicSecurityQuestionnaireEnabled', () => {
+  const service = new TrustAccessService(
+    {} as any,
+    {} as any,
+    {} as any,
+    {} as any,
+    {} as any,
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('resolves by friendlyUrl OR organizationId', async () => {
+    mockDb.trust.findFirst.mockResolvedValue({
+      securityQuestionnaireEnabled: false,
+    });
+
+    const result = await service.getPublicSecurityQuestionnaireEnabled('acme');
+
+    expect(result).toBe(false);
+    expect(mockDb.trust.findFirst).toHaveBeenCalledWith({
+      where: { OR: [{ friendlyUrl: 'acme' }, { organizationId: 'acme' }] },
+      select: { securityQuestionnaireEnabled: true },
+    });
+  });
+
+  it('returns true when the flag is enabled', async () => {
+    mockDb.trust.findFirst.mockResolvedValue({
+      securityQuestionnaireEnabled: true,
+    });
+
+    await expect(
+      service.getPublicSecurityQuestionnaireEnabled('acme'),
+    ).resolves.toBe(true);
+  });
+
+  it('defaults to enabled when the portal cannot be resolved', async () => {
+    mockDb.trust.findFirst.mockResolvedValue(null);
+
+    await expect(
+      service.getPublicSecurityQuestionnaireEnabled('unknown'),
+    ).resolves.toBe(true);
+  });
+});

--- a/apps/api/src/trust-portal/trust-access.security-questionnaire.service.spec.ts
+++ b/apps/api/src/trust-portal/trust-access.security-questionnaire.service.spec.ts
@@ -4,7 +4,7 @@ import { TrustAccessService } from './trust-access.service';
 jest.mock('@db', () => ({
   db: {
     trust: {
-      findFirst: jest.fn(),
+      findUnique: jest.fn(),
     },
   },
   Prisma: {},
@@ -18,7 +18,7 @@ jest.mock('../app/s3', () => ({
 }));
 
 const mockDb = db as unknown as {
-  trust: { findFirst: jest.Mock };
+  trust: { findUnique: jest.Mock };
 };
 
 describe('TrustAccessService.getPublicSecurityQuestionnaireEnabled', () => {
@@ -34,22 +34,38 @@ describe('TrustAccessService.getPublicSecurityQuestionnaireEnabled', () => {
     jest.clearAllMocks();
   });
 
-  it('resolves by friendlyUrl OR organizationId', async () => {
-    mockDb.trust.findFirst.mockResolvedValue({
+  it('resolves by friendlyUrl first', async () => {
+    mockDb.trust.findUnique.mockResolvedValue({
       securityQuestionnaireEnabled: false,
     });
 
     const result = await service.getPublicSecurityQuestionnaireEnabled('acme');
 
     expect(result).toBe(false);
-    expect(mockDb.trust.findFirst).toHaveBeenCalledWith({
-      where: { OR: [{ friendlyUrl: 'acme' }, { organizationId: 'acme' }] },
+    expect(mockDb.trust.findUnique).toHaveBeenCalledTimes(1);
+    expect(mockDb.trust.findUnique).toHaveBeenNthCalledWith(1, {
+      where: { friendlyUrl: 'acme' },
+      select: { securityQuestionnaireEnabled: true },
+    });
+  });
+
+  it('falls back to organizationId when friendlyUrl does not match', async () => {
+    mockDb.trust.findUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ securityQuestionnaireEnabled: false });
+
+    const result =
+      await service.getPublicSecurityQuestionnaireEnabled('org_123');
+
+    expect(result).toBe(false);
+    expect(mockDb.trust.findUnique).toHaveBeenNthCalledWith(2, {
+      where: { organizationId: 'org_123' },
       select: { securityQuestionnaireEnabled: true },
     });
   });
 
   it('returns true when the flag is enabled', async () => {
-    mockDb.trust.findFirst.mockResolvedValue({
+    mockDb.trust.findUnique.mockResolvedValue({
       securityQuestionnaireEnabled: true,
     });
 
@@ -59,7 +75,7 @@ describe('TrustAccessService.getPublicSecurityQuestionnaireEnabled', () => {
   });
 
   it('defaults to enabled when the portal cannot be resolved', async () => {
-    mockDb.trust.findFirst.mockResolvedValue(null);
+    mockDb.trust.findUnique.mockResolvedValue(null);
 
     await expect(
       service.getPublicSecurityQuestionnaireEnabled('unknown'),

--- a/apps/api/src/trust-portal/trust-access.service.ts
+++ b/apps/api/src/trust-portal/trust-access.service.ts
@@ -2740,21 +2740,9 @@ export class TrustAccessService {
   async getPublicSecurityQuestionnaireEnabled(
     friendlyUrl: string,
   ): Promise<boolean> {
-    // Resolve by friendlyUrl first, then fall back to organizationId — mirrors
-    // getPublicFavicon. Two findUnique calls on unique columns give explicit
-    // precedence (friendlyUrl wins), so an org whose friendlyUrl happens to
-    // equal another org's id can't shadow that org's setting.
-    let trust = await db.trust.findUnique({
-      where: { friendlyUrl },
-      select: { securityQuestionnaireEnabled: true },
+    const trust = await this.resolveTrustByFriendlyUrl(friendlyUrl, {
+      securityQuestionnaireEnabled: true,
     });
-
-    if (!trust) {
-      trust = await db.trust.findUnique({
-        where: { organizationId: friendlyUrl },
-        select: { securityQuestionnaireEnabled: true },
-      });
-    }
 
     return trust?.securityQuestionnaireEnabled ?? true;
   }
@@ -2784,18 +2772,29 @@ export class TrustAccessService {
     });
   }
 
-  async getPublicFavicon(friendlyUrl: string): Promise<string | null> {
-    let trust = await db.trust.findUnique({
-      where: { friendlyUrl },
-      select: { favicon: true },
-    });
-
-    if (!trust) {
-      trust = await db.trust.findUnique({
+  /**
+   * Resolve a Trust by friendlyUrl, falling back to organizationId — the public
+   * portal passes either. Two findUnique calls on unique columns give explicit
+   * precedence (friendlyUrl wins), so an org whose friendlyUrl happens to equal
+   * another org's id can't shadow it. Shared by the public read endpoints.
+   */
+  private async resolveTrustByFriendlyUrl<S extends Prisma.TrustSelect>(
+    friendlyUrl: string,
+    select: S,
+  ): Promise<Prisma.TrustGetPayload<{ select: S }> | null> {
+    return (
+      (await db.trust.findUnique({ where: { friendlyUrl }, select })) ??
+      (await db.trust.findUnique({
         where: { organizationId: friendlyUrl },
-        select: { favicon: true },
-      });
-    }
+        select,
+      }))
+    );
+  }
+
+  async getPublicFavicon(friendlyUrl: string): Promise<string | null> {
+    const trust = await this.resolveTrustByFriendlyUrl(friendlyUrl, {
+      favicon: true,
+    });
 
     if (!trust?.favicon) {
       return null;

--- a/apps/api/src/trust-portal/trust-access.service.ts
+++ b/apps/api/src/trust-portal/trust-access.service.ts
@@ -1531,7 +1531,9 @@ export class TrustAccessService {
     };
   }
 
-  private async getTrustBrandingByOrganizationId(organizationId: string): Promise<{
+  private async getTrustBrandingByOrganizationId(
+    organizationId: string,
+  ): Promise<{
     friendlyUrl: string;
     faviconUrl: string | null;
     securityQuestionnaireEnabled: boolean;
@@ -2733,12 +2735,21 @@ export class TrustAccessService {
   async getPublicSecurityQuestionnaireEnabled(
     friendlyUrl: string,
   ): Promise<boolean> {
-    const trust = await db.trust.findFirst({
-      where: {
-        OR: [{ friendlyUrl }, { organizationId: friendlyUrl }],
-      },
+    // Resolve by friendlyUrl first, then fall back to organizationId — mirrors
+    // getPublicFavicon. Two findUnique calls on unique columns give explicit
+    // precedence (friendlyUrl wins), so an org whose friendlyUrl happens to
+    // equal another org's id can't shadow that org's setting.
+    let trust = await db.trust.findUnique({
+      where: { friendlyUrl },
       select: { securityQuestionnaireEnabled: true },
     });
+
+    if (!trust) {
+      trust = await db.trust.findUnique({
+        where: { organizationId: friendlyUrl },
+        select: { securityQuestionnaireEnabled: true },
+      });
+    }
 
     return trust?.securityQuestionnaireEnabled ?? true;
   }

--- a/apps/api/src/trust-portal/trust-access.service.ts
+++ b/apps/api/src/trust-portal/trust-access.service.ts
@@ -1524,18 +1524,25 @@ export class TrustAccessService {
       organizationName: grant.accessRequest.organization.name,
       friendlyUrl: branding.friendlyUrl,
       faviconUrl: branding.faviconUrl,
+      securityQuestionnaireEnabled: branding.securityQuestionnaireEnabled,
       expiresAt: grant.expiresAt,
       subjectEmail: grant.subjectEmail,
       ndaPdfUrl,
     };
   }
 
-  private async getTrustBrandingByOrganizationId(
-    organizationId: string,
-  ): Promise<{ friendlyUrl: string; faviconUrl: string | null }> {
+  private async getTrustBrandingByOrganizationId(organizationId: string): Promise<{
+    friendlyUrl: string;
+    faviconUrl: string | null;
+    securityQuestionnaireEnabled: boolean;
+  }> {
     const trust = await db.trust.findUnique({
       where: { organizationId },
-      select: { friendlyUrl: true, favicon: true },
+      select: {
+        friendlyUrl: true,
+        favicon: true,
+        securityQuestionnaireEnabled: true,
+      },
     });
 
     const friendlyUrl = trust?.friendlyUrl ?? organizationId;
@@ -1543,7 +1550,11 @@ export class TrustAccessService {
       ? await this.getFaviconSignedUrl(trust.favicon)
       : null;
 
-    return { friendlyUrl, faviconUrl };
+    return {
+      friendlyUrl,
+      faviconUrl,
+      securityQuestionnaireEnabled: trust?.securityQuestionnaireEnabled ?? true,
+    };
   }
 
   private async getFaviconSignedUrl(
@@ -2711,6 +2722,25 @@ export class TrustAccessService {
       title: trust.overviewTitle,
       content: trust.overviewContent,
     };
+  }
+
+  /**
+   * Whether the public trust portal should offer the AI-assisted Security
+   * Questionnaire. The public portal passes either the friendly URL or the
+   * organization ID, so we resolve on both. Defaults to enabled when the portal
+   * can't be resolved so the questionnaire never disappears by accident.
+   */
+  async getPublicSecurityQuestionnaireEnabled(
+    friendlyUrl: string,
+  ): Promise<boolean> {
+    const trust = await db.trust.findFirst({
+      where: {
+        OR: [{ friendlyUrl }, { organizationId: friendlyUrl }],
+      },
+      select: { securityQuestionnaireEnabled: true },
+    });
+
+    return trust?.securityQuestionnaireEnabled ?? true;
   }
 
   async getPublicCustomLinks(friendlyUrl: string) {

--- a/apps/api/src/trust-portal/trust-portal.controller.ts
+++ b/apps/api/src/trust-portal/trust-portal.controller.ts
@@ -56,6 +56,8 @@ import {
 } from './dto/trust-custom-link.dto';
 import type { UpdateTrustOverviewDto } from './dto/update-trust-overview.dto';
 import { UpdateTrustOverviewSchema } from './dto/update-trust-overview.dto';
+import type { UpdateSecurityQuestionnaireDto } from './dto/update-security-questionnaire.dto';
+import { UpdateSecurityQuestionnaireSchema } from './dto/update-security-questionnaire.dto';
 import { UpdateAllowedEmailsDto } from './dto/update-allowed-emails.dto';
 import type { UpdateVendorTrustSettingsDto } from './dto/trust-vendor.dto';
 import { UpdateVendorTrustSettingsSchema } from './dto/trust-vendor.dto';
@@ -418,6 +420,35 @@ export class TrustPortalController {
     @Body() body: Record<string, boolean | string | undefined>,
   ) {
     return this.trustPortalService.updateFrameworks(organizationId, body);
+  }
+
+  @Put('settings/security-questionnaire')
+  @RequirePermission('trust', 'update')
+  @ApiOperation({
+    summary: 'Show or hide the Security Questionnaire on the public trust portal',
+  })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['enabled'],
+      properties: {
+        enabled: {
+          type: 'boolean',
+          description:
+            'When false, the Security Questionnaire is hidden from the public trust portal.',
+        },
+      },
+    },
+  })
+  async updateSecurityQuestionnaire(
+    @OrganizationId() organizationId: string,
+    @Body(new ZodValidationPipe(UpdateSecurityQuestionnaireSchema))
+    body: UpdateSecurityQuestionnaireDto,
+  ) {
+    return this.trustPortalService.updateSecurityQuestionnaireEnabled(
+      organizationId,
+      body.enabled,
+    );
   }
 
   @Get('custom-frameworks')

--- a/apps/api/src/trust-portal/trust-portal.security-questionnaire.service.spec.ts
+++ b/apps/api/src/trust-portal/trust-portal.security-questionnaire.service.spec.ts
@@ -1,0 +1,68 @@
+import { NotFoundException } from '@nestjs/common';
+import { db } from '@db';
+import { TrustPortalService } from './trust-portal.service';
+
+jest.mock('@db', () => ({
+  db: {
+    trust: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+  Prisma: {},
+  TrustFramework: {},
+}));
+
+jest.mock('../app/s3', () => ({
+  APP_AWS_ORG_ASSETS_BUCKET: 'org-assets',
+  s3Client: { send: jest.fn() },
+  getSignedUrl: jest.fn(),
+}));
+
+const mockDb = db as unknown as {
+  trust: { findUnique: jest.Mock; update: jest.Mock };
+};
+
+describe('TrustPortalService.updateSecurityQuestionnaireEnabled', () => {
+  const service = new TrustPortalService();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('persists the flag when the trust portal exists', async () => {
+    mockDb.trust.findUnique.mockResolvedValue({ organizationId: 'org_1' });
+    mockDb.trust.update.mockResolvedValue({
+      organizationId: 'org_1',
+      securityQuestionnaireEnabled: false,
+    });
+
+    await service.updateSecurityQuestionnaireEnabled('org_1', false);
+
+    expect(mockDb.trust.update).toHaveBeenCalledWith({
+      where: { organizationId: 'org_1' },
+      data: { securityQuestionnaireEnabled: false },
+    });
+  });
+
+  it('re-enables the questionnaire when set to true', async () => {
+    mockDb.trust.findUnique.mockResolvedValue({ organizationId: 'org_1' });
+    mockDb.trust.update.mockResolvedValue({});
+
+    await service.updateSecurityQuestionnaireEnabled('org_1', true);
+
+    expect(mockDb.trust.update).toHaveBeenCalledWith({
+      where: { organizationId: 'org_1' },
+      data: { securityQuestionnaireEnabled: true },
+    });
+  });
+
+  it('throws NotFound and does not write when the trust portal is missing', async () => {
+    mockDb.trust.findUnique.mockResolvedValue(null);
+
+    await expect(
+      service.updateSecurityQuestionnaireEnabled('org_missing', false),
+    ).rejects.toBeInstanceOf(NotFoundException);
+    expect(mockDb.trust.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/trust-portal/trust-portal.service.ts
+++ b/apps/api/src/trust-portal/trust-portal.service.ts
@@ -1475,6 +1475,24 @@ export class TrustPortalService {
     });
   }
 
+  async updateSecurityQuestionnaireEnabled(
+    organizationId: string,
+    enabled: boolean,
+  ) {
+    const trust = await db.trust.findUnique({
+      where: { organizationId },
+    });
+
+    if (!trust) {
+      throw new NotFoundException('Trust portal not found');
+    }
+
+    return db.trust.update({
+      where: { organizationId },
+      data: { securityQuestionnaireEnabled: enabled },
+    });
+  }
+
   async getOverview(organizationId: string) {
     const trust = await db.trust.findUnique({
       where: { organizationId },
@@ -1730,6 +1748,8 @@ export class TrustPortalService {
       overviewTitle: trust.overviewTitle ?? null,
       overviewContent: trust.overviewContent ?? defaultOverviewContent,
       showOverview: trust.showOverview ?? false,
+      // Security questionnaire visibility on the public portal
+      securityQuestionnaireEnabled: trust.securityQuestionnaireEnabled ?? true,
       // Favicon
       faviconUrl,
       // Organization data

--- a/apps/app/src/app/(app)/[orgId]/trust/page.tsx
+++ b/apps/app/src/app/(app)/[orgId]/trust/page.tsx
@@ -158,6 +158,7 @@ export default async function TrustPage({ params }: { params: Promise<{ orgId: s
         vendors={vendors}
         customFrameworks={customFrameworks}
         faviconUrl={settings?.faviconUrl ?? null}
+        securityQuestionnaireEnabled={settings?.securityQuestionnaireEnabled ?? true}
       />
     </PageLayout>
   );

--- a/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/TrustPortalQuestionnaire.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/TrustPortalQuestionnaire.test.tsx
@@ -1,11 +1,11 @@
-import { act, fireEvent, render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-  setMockPermissions,
   ADMIN_PERMISSIONS,
   AUDITOR_PERMISSIONS,
   mockHasPermission,
+  setMockPermissions,
 } from '@/test-utils/mocks/permissions';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockUpdate } = vi.hoisted(() => ({ mockUpdate: vi.fn() }));
 
@@ -86,5 +86,21 @@ describe('TrustPortalQuestionnaire', () => {
       fireEvent.click(screen.getByText('Visible'));
     });
     expect(mockUpdate).toHaveBeenCalledWith(true);
+  });
+
+  it('exposes the active state to assistive tech via aria-pressed', () => {
+    setMockPermissions(ADMIN_PERMISSIONS);
+    render(<TrustPortalQuestionnaire initialEnabled={true} orgId="org-1" />);
+    expect(screen.getByText('Visible').closest('button')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByText('Hidden').closest('button')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('resyncs local state when initialEnabled changes', () => {
+    setMockPermissions(ADMIN_PERMISSIONS);
+    const { rerender } = render(<TrustPortalQuestionnaire initialEnabled={true} orgId="org-1" />);
+    expect(screen.getByText('Visible').closest('button')).toHaveAttribute('aria-pressed', 'true');
+
+    rerender(<TrustPortalQuestionnaire initialEnabled={false} orgId="org-1" />);
+    expect(screen.getByText('Hidden').closest('button')).toHaveAttribute('aria-pressed', 'true');
   });
 });

--- a/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/TrustPortalQuestionnaire.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/TrustPortalQuestionnaire.test.tsx
@@ -61,7 +61,7 @@ describe('TrustPortalQuestionnaire', () => {
     expect(screen.getByText('Hidden').closest('button')).toBeDisabled();
   });
 
-  it('saves disabled=false when an admin clicks Hidden', async () => {
+  it('saves enabled=false when an admin clicks Hidden', async () => {
     setMockPermissions(ADMIN_PERMISSIONS);
     render(<TrustPortalQuestionnaire {...defaultProps} />);
     await act(async () => {

--- a/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/TrustPortalQuestionnaire.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/TrustPortalQuestionnaire.test.tsx
@@ -1,0 +1,90 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  setMockPermissions,
+  ADMIN_PERMISSIONS,
+  AUDITOR_PERMISSIONS,
+  mockHasPermission,
+} from '@/test-utils/mocks/permissions';
+
+const { mockUpdate } = vi.hoisted(() => ({ mockUpdate: vi.fn() }));
+
+vi.mock('@/hooks/use-permissions', () => ({
+  usePermissions: () => ({
+    permissions: {},
+    hasPermission: mockHasPermission,
+  }),
+}));
+
+vi.mock('@/hooks/use-trust-portal-settings', () => ({
+  useTrustPortalSettings: () => ({
+    updateSecurityQuestionnaireEnabled: mockUpdate,
+  }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@trycompai/design-system/icons', () => ({
+  View: () => <span data-testid="view-icon" />,
+  ViewOff: () => <span data-testid="view-off-icon" />,
+}));
+
+import { TrustPortalQuestionnaire } from './TrustPortalQuestionnaire';
+
+describe('TrustPortalQuestionnaire', () => {
+  const defaultProps = { initialEnabled: true, orgId: 'org-1' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpdate.mockResolvedValue(undefined);
+  });
+
+  it('renders explanatory copy regardless of permissions', () => {
+    setMockPermissions({});
+    render(<TrustPortalQuestionnaire {...defaultProps} />);
+    expect(screen.getByText(/receive AI-assisted answers/i)).toBeInTheDocument();
+  });
+
+  it('enables the toggle buttons when the user has trust:update', () => {
+    setMockPermissions(ADMIN_PERMISSIONS);
+    render(<TrustPortalQuestionnaire {...defaultProps} />);
+    expect(screen.getByText('Visible').closest('button')).not.toBeDisabled();
+    expect(screen.getByText('Hidden').closest('button')).not.toBeDisabled();
+  });
+
+  it('disables the toggle buttons when the user lacks trust:update', () => {
+    setMockPermissions(AUDITOR_PERMISSIONS);
+    render(<TrustPortalQuestionnaire {...defaultProps} />);
+    expect(screen.getByText('Visible').closest('button')).toBeDisabled();
+    expect(screen.getByText('Hidden').closest('button')).toBeDisabled();
+  });
+
+  it('saves disabled=false when an admin clicks Hidden', async () => {
+    setMockPermissions(ADMIN_PERMISSIONS);
+    render(<TrustPortalQuestionnaire {...defaultProps} />);
+    await act(async () => {
+      fireEvent.click(screen.getByText('Hidden'));
+    });
+    expect(mockUpdate).toHaveBeenCalledWith(false);
+  });
+
+  it('does not call the API when a read-only user clicks Hidden', async () => {
+    setMockPermissions(AUDITOR_PERMISSIONS);
+    render(<TrustPortalQuestionnaire {...defaultProps} />);
+    await act(async () => {
+      fireEvent.click(screen.getByText('Hidden'));
+    });
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('saves enabled=true when an admin re-enables a hidden questionnaire', async () => {
+    setMockPermissions(ADMIN_PERMISSIONS);
+    render(<TrustPortalQuestionnaire initialEnabled={false} orgId="org-1" />);
+    await act(async () => {
+      fireEvent.click(screen.getByText('Visible'));
+    });
+    expect(mockUpdate).toHaveBeenCalledWith(true);
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/TrustPortalQuestionnaire.tsx
+++ b/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/TrustPortalQuestionnaire.tsx
@@ -3,7 +3,7 @@
 import { usePermissions } from '@/hooks/use-permissions';
 import { useTrustPortalSettings } from '@/hooks/use-trust-portal-settings';
 import { View, ViewOff } from '@trycompai/design-system/icons';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 
 interface TrustPortalQuestionnaireProps {
@@ -11,15 +11,18 @@ interface TrustPortalQuestionnaireProps {
   orgId: string;
 }
 
-export function TrustPortalQuestionnaire({
-  initialEnabled,
-  orgId,
-}: TrustPortalQuestionnaireProps) {
+export function TrustPortalQuestionnaire({ initialEnabled, orgId }: TrustPortalQuestionnaireProps) {
   const { hasPermission } = usePermissions();
   const canUpdate = hasPermission('trust', 'update');
   const { updateSecurityQuestionnaireEnabled } = useTrustPortalSettings();
   const [enabled, setEnabled] = useState(initialEnabled);
   const [isSaving, setIsSaving] = useState(false);
+
+  // Resync when the server-provided value changes (e.g. parent refetch), so the
+  // toggle never reflects stale visibility.
+  useEffect(() => {
+    setEnabled(initialEnabled);
+  }, [initialEnabled]);
 
   const handleToggleChange = async (checked: boolean) => {
     if (!canUpdate || checked === enabled || isSaving) return;
@@ -51,6 +54,7 @@ export function TrustPortalQuestionnaire({
             type="button"
             onClick={() => handleToggleChange(true)}
             disabled={!canUpdate || isSaving}
+            aria-pressed={enabled}
             className={`flex items-center gap-1 px-2 py-1 font-medium transition-colors ${canUpdate ? 'cursor-pointer' : 'cursor-default opacity-70'} ${
               enabled
                 ? 'bg-primary/10 text-primary dark:brightness-175'
@@ -64,6 +68,7 @@ export function TrustPortalQuestionnaire({
             type="button"
             onClick={() => handleToggleChange(false)}
             disabled={!canUpdate || isSaving}
+            aria-pressed={!enabled}
             className={`flex items-center gap-1 px-2 py-1 font-medium transition-colors ${canUpdate ? 'cursor-pointer' : 'cursor-default opacity-70'} ${
               !enabled
                 ? 'bg-orange-100 text-orange-600 dark:bg-orange-950/30 dark:text-orange-400'
@@ -79,13 +84,13 @@ export function TrustPortalQuestionnaire({
       <div className="space-y-2">
         <h3 className="text-lg font-medium">Security Questionnaire</h3>
         <p className="text-sm text-muted-foreground">
-          When visible, visitors to your public trust portal can submit a security
-          questionnaire and receive AI-assisted answers drawn from your policy library.
+          When visible, visitors to your public trust portal can submit a security questionnaire and
+          receive AI-assisted answers drawn from your policy library.
         </p>
         <p className="text-sm text-muted-foreground">
-          Hide it if you'd rather review answers before they reach customers — hiding removes
-          the questionnaire button from your trust portal and the questionnaire tab from the
-          access area, so questionnaires can no longer be started from the portal.
+          Hide it if you'd rather review answers before they reach customers — hiding removes the
+          questionnaire button from your trust portal and the questionnaire tab from the access
+          area, so questionnaires can no longer be started from the portal.
         </p>
       </div>
     </div>

--- a/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/TrustPortalQuestionnaire.tsx
+++ b/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/TrustPortalQuestionnaire.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { usePermissions } from '@/hooks/use-permissions';
+import { useTrustPortalSettings } from '@/hooks/use-trust-portal-settings';
+import { View, ViewOff } from '@trycompai/design-system/icons';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+interface TrustPortalQuestionnaireProps {
+  initialEnabled: boolean;
+  orgId: string;
+}
+
+export function TrustPortalQuestionnaire({
+  initialEnabled,
+  orgId,
+}: TrustPortalQuestionnaireProps) {
+  const { hasPermission } = usePermissions();
+  const canUpdate = hasPermission('trust', 'update');
+  const { updateSecurityQuestionnaireEnabled } = useTrustPortalSettings();
+  const [enabled, setEnabled] = useState(initialEnabled);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleToggleChange = async (checked: boolean) => {
+    if (!canUpdate || checked === enabled || isSaving) return;
+    // Optimistically flip, revert if the save fails.
+    const previous = enabled;
+    setEnabled(checked);
+    setIsSaving(true);
+    try {
+      await updateSecurityQuestionnaireEnabled(checked);
+      toast.success(
+        checked
+          ? 'Security Questionnaire is now visible on your trust portal'
+          : 'Security Questionnaire is now hidden from your trust portal',
+      );
+    } catch {
+      setEnabled(previous);
+      toast.error('Failed to update Security Questionnaire visibility');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Visibility Toggle */}
+      <div className="flex justify-start">
+        <div className="inline-flex rounded-md overflow-hidden text-xs">
+          <button
+            type="button"
+            onClick={() => handleToggleChange(true)}
+            disabled={!canUpdate || isSaving}
+            className={`flex items-center gap-1 px-2 py-1 font-medium transition-colors ${canUpdate ? 'cursor-pointer' : 'cursor-default opacity-70'} ${
+              enabled
+                ? 'bg-primary/10 text-primary dark:brightness-175'
+                : 'bg-muted/50 text-muted-foreground hover:bg-muted'
+            }`}
+          >
+            <View size={12} />
+            Visible
+          </button>
+          <button
+            type="button"
+            onClick={() => handleToggleChange(false)}
+            disabled={!canUpdate || isSaving}
+            className={`flex items-center gap-1 px-2 py-1 font-medium transition-colors ${canUpdate ? 'cursor-pointer' : 'cursor-default opacity-70'} ${
+              !enabled
+                ? 'bg-orange-100 text-orange-600 dark:bg-orange-950/30 dark:text-orange-400'
+                : 'bg-muted/50 text-muted-foreground hover:bg-muted'
+            }`}
+          >
+            <ViewOff size={12} />
+            Hidden
+          </button>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <h3 className="text-lg font-medium">Security Questionnaire</h3>
+        <p className="text-sm text-muted-foreground">
+          When visible, visitors to your public trust portal can submit a security
+          questionnaire and receive AI-assisted answers drawn from your policy library.
+        </p>
+        <p className="text-sm text-muted-foreground">
+          Hide it if you'd rather review answers before they reach customers — hiding removes
+          the questionnaire button from your trust portal and the questionnaire tab from the
+          access area, so questionnaires can no longer be started from the portal.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/TrustPortalSwitch.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/TrustPortalSwitch.test.tsx
@@ -245,6 +245,7 @@ describe('TrustPortalSwitch permission gating', () => {
     customLinks: [],
     vendors: [],
     customFrameworks: [],
+    securityQuestionnaireEnabled: true,
   };
 
   beforeEach(() => {

--- a/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/TrustPortalSwitch.tsx
+++ b/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/TrustPortalSwitch.tsx
@@ -21,6 +21,7 @@ import { TrustPortalBrandingSettings } from './TrustPortalBrandingSettings';
 import { TrustPortalCustomLinks } from './TrustPortalCustomLinks';
 import { TrustPortalFaqBuilder } from './TrustPortalFaqBuilder';
 import { TrustPortalOverview } from './TrustPortalOverview';
+import { TrustPortalQuestionnaire } from './TrustPortalQuestionnaire';
 import { TrustPortalVendors } from './TrustPortalVendors';
 
 // Client-side form schema (includes all fields for form state)
@@ -170,6 +171,7 @@ export function TrustPortalSwitch({
   vendors,
   customFrameworks,
   faviconUrl,
+  securityQuestionnaireEnabled,
 }: {
   enabled: boolean;
   slug: string;
@@ -221,6 +223,7 @@ export function TrustPortalSwitch({
   vendors: TrustVendor[];
   customFrameworks: TrustCustomFrameworkItem[];
   faviconUrl?: string | null;
+  securityQuestionnaireEnabled: boolean;
 }) {
   const { hasPermission } = usePermissions();
   const canUpdate = hasPermission('trust', 'update');
@@ -486,6 +489,7 @@ export function TrustPortalSwitch({
             <TabsTrigger value="links">Links</TabsTrigger>
             <TabsTrigger value="faq">FAQ</TabsTrigger>
             <TabsTrigger value="documents">Documents</TabsTrigger>
+            <TabsTrigger value="questionnaire">Questionnaire</TabsTrigger>
           </TabsList>
 
           {/* Compliance Frameworks Tab */}
@@ -1022,6 +1026,16 @@ export function TrustPortalSwitch({
                 organizationId={orgId}
                 enabled={true}
                 documents={additionalDocuments}
+              />
+            </div>
+          </TabsContent>
+
+          {/* Security Questionnaire Tab */}
+          <TabsContent value="questionnaire">
+            <div className="pt-6">
+              <TrustPortalQuestionnaire
+                initialEnabled={securityQuestionnaireEnabled}
+                orgId={orgId}
               />
             </div>
           </TabsContent>

--- a/apps/app/src/hooks/use-trust-portal-settings.ts
+++ b/apps/app/src/hooks/use-trust-portal-settings.ts
@@ -201,6 +201,17 @@ export function useTrustPortalSettings() {
     [api],
   );
 
+  const updateSecurityQuestionnaireEnabled = useCallback(
+    async (enabled: boolean) => {
+      const response = await api.put('/v1/trust-portal/settings/security-questionnaire', {
+        enabled,
+      });
+      if (response.error) throw new Error(response.error);
+      return response.data;
+    },
+    [api],
+  );
+
   const updateVendorTrustSettings = useCallback(
     async (vendorId: string, data: VendorTrustSettingsData) => {
       const response = await api.post(`/v1/trust-portal/vendors/${vendorId}/trust-settings`, data);
@@ -289,6 +300,7 @@ export function useTrustPortalSettings() {
     uploadCustomFrameworkBadge,
     removeCustomFrameworkBadge,
     saveOverview,
+    updateSecurityQuestionnaireEnabled,
     updateVendorTrustSettings,
     updateAllowedDomains,
     updateAllowedEmails,

--- a/packages/db/prisma/migrations/20260706120000_add_trust_security_questionnaire_enabled/migration.sql
+++ b/packages/db/prisma/migrations/20260706120000_add_trust_security_questionnaire_enabled/migration.sql
@@ -1,0 +1,5 @@
+-- Add a per-org toggle for the public trust portal's AI-assisted Security
+-- Questionnaire. Defaults to true so existing portals keep showing it; org
+-- owners can hide it when they'd rather review answers before customers run it.
+ALTER TABLE "Trust"
+  ADD COLUMN "securityQuestionnaireEnabled" BOOLEAN NOT NULL DEFAULT true;

--- a/packages/db/prisma/schema/trust.prisma
+++ b/packages/db/prisma/schema/trust.prisma
@@ -53,6 +53,11 @@ model Trust {
   // Favicon for trust portal (stored in S3)
   favicon String?
 
+  // Whether the AI-assisted Security Questionnaire is offered on the public
+  // trust portal. Defaults to true so existing portals keep their current
+  // behavior; org owners can hide it when they'd rather review answers first.
+  securityQuestionnaireEnabled Boolean @default(true)
+
   @@id([status, organizationId])
   @@unique([organizationId])
   @@index([organizationId])


### PR DESCRIPTION
## What

Adds a per-org setting to show or hide the AI-assisted **Security Questionnaire** on the public Trust Center. Org owners get a new **Questionnaire** tab in Trust Portal settings with a Visible / Hidden toggle.

Motivation: some companies want control over whether customers can self-serve the questionnaire before they've reviewed how it responds. The toggle gives them that control. **Defaults to on**, so existing portals are unchanged.

## Changes

- **DB**: `Trust.securityQuestionnaireEnabled` (`Boolean @default(true)`) + additive migration (backfills existing rows to `true`).
- **API (admin)**: `PUT /v1/trust-portal/settings/security-questionnaire` (`trust:update`); the flag is surfaced in `GET /v1/trust-portal/settings`.
- **API (public read)**: `GET /v1/trust-access/:friendlyUrl/security-questionnaire` returning `{ enabled }` (mirrors `getPublicOverview`, defaults to enabled when the portal can't be resolved), and the flag added to the access-grant response so the token-gated access area can read it.
- **Admin UI**: `TrustPortalQuestionnaire` toggle (mirrors the existing overview Visible/Hidden pattern) in a new "Questionnaire" tab.

The public trust portal (comp-private) consumes the flag over these HTTP endpoints, so it needs no `@trycompai/db` bump — see the companion PR in comp-private.

## Tests

- `trust-portal.security-questionnaire.service.spec.ts` — update method (persist + NotFound guard).
- `trust-access.security-questionnaire.service.spec.ts` — public getter (resolves by friendlyUrl/orgId, defaults to enabled on miss).
- `TrustPortalQuestionnaire.test.tsx` — permission gating (admin can toggle, read-only can't) + save behavior.
- Full `trust-portal` API suite green (181 tests).

## Notes

- Typecheck clean for all changed files.
- Merging carries a Prisma migration and, via semantic-release, publishes a new `@trycompai/db`. The comp-private portal reads the flag over HTTP and does not require that bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013rNndGzad97VwwQvQGT4pg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-organization setting to show or hide the Security Questionnaire on the public trust portal. Defaults to on and is managed from a new Questionnaire tab in Trust Portal settings.

- **New Features**
  - DB: added `Trust.securityQuestionnaireEnabled` (boolean, default true).
  - Admin API: `PUT /v1/trust-portal/settings/security-questionnaire`; flag returned by `GET /v1/trust-portal/settings`.
  - Public API: `GET /v1/trust-access/:friendlyUrl/security-questionnaire` returns `{ enabled }`; flag also included on the access-grant response. Resolves by friendlyUrl, then organizationId (deterministic). Shared resolver used by favicon and questionnaire endpoints.
  - Admin UI: new Questionnaire tab with a Visible/Hidden toggle, permission gated. The toggle resyncs when server state changes and sets `aria-pressed` for accessibility.

- **Migration**
  - Run the new Prisma migration to add `securityQuestionnaireEnabled` (backfilled to true).

<sup>Written for commit f5551854fd2b4e329b40c29efa3cd505cd50f2c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

