### PR TITLE
fix(trust-portal): derive public vendor badges from cert data (CS-688)

### DIFF
--- a/apps/api/src/trust-portal/cert-badge-mapper.spec.ts
+++ b/apps/api/src/trust-portal/cert-badge-mapper.spec.ts
@@ -20,6 +20,14 @@ describe('mapCertificationToBadgeType', () => {
     expect(mapCertificationToBadgeType('NEN 7510')).toBe('nen7510');
   });
 
+  // The fully spelled-out PCI name must map too — the scan-time mappers already
+  // recognize it, so the shared display mapper must not drop it.
+  it('maps the spelled-out "Payment Card Industry Data Security Standard"', () => {
+    expect(
+      mapCertificationToBadgeType('Payment Card Industry Data Security Standard'),
+    ).toBe('pci_dss');
+  });
+
   // The digits alone must not classify an unrelated identifier.
   it('does not misclassify ids that merely contain the standard digits', () => {
     expect(mapCertificationToBadgeType('Catalog 19001')).toBeNull();

--- a/apps/api/src/trust-portal/cert-badge-mapper.spec.ts
+++ b/apps/api/src/trust-portal/cert-badge-mapper.spec.ts
@@ -1,0 +1,85 @@
+import {
+  extractComplianceBadges,
+  mapCertificationToBadgeType,
+} from './cert-badge-mapper';
+
+describe('mapCertificationToBadgeType', () => {
+  // CS-688: the "IEC" infix and ":2022" suffix must not stop ISO 27001 from
+  // being recognized.
+  it('maps "ISO/IEC 27001:2022" to iso27001', () => {
+    expect(mapCertificationToBadgeType('ISO/IEC 27001:2022')).toBe('iso27001');
+  });
+
+  it('maps common certifications to their canonical badge types', () => {
+    expect(mapCertificationToBadgeType('SOC 2 Type II')).toBe('soc2');
+    expect(mapCertificationToBadgeType('ISO 9001:2015')).toBe('iso9001');
+    expect(mapCertificationToBadgeType('ISO/IEC 42001:2023')).toBe('iso42001');
+    expect(mapCertificationToBadgeType('GDPR Compliance')).toBe('gdpr');
+    expect(mapCertificationToBadgeType('HIPAA')).toBe('hipaa');
+    expect(mapCertificationToBadgeType('PCI DSS')).toBe('pci_dss');
+    expect(mapCertificationToBadgeType('NEN 7510')).toBe('nen7510');
+  });
+
+  // The digits alone must not classify an unrelated identifier.
+  it('does not misclassify ids that merely contain the standard digits', () => {
+    expect(mapCertificationToBadgeType('Catalog 19001')).toBeNull();
+    expect(mapCertificationToBadgeType('ISO 90010')).toBeNull();
+  });
+
+  // Distinct 2701x standards must not earn the 27001 badge.
+  it('does not read ISO/IEC 27017 or 27018 as iso27001', () => {
+    expect(mapCertificationToBadgeType('ISO/IEC 27017:2015')).toBeNull();
+    expect(mapCertificationToBadgeType('ISO/IEC 27018:2019')).toBeNull();
+  });
+
+  it('returns null for certifications with no badge', () => {
+    expect(mapCertificationToBadgeType('HDS')).toBeNull();
+    expect(mapCertificationToBadgeType('')).toBeNull();
+  });
+});
+
+describe('extractComplianceBadges', () => {
+  // CS-688 regression: Scaleway's verified certs must yield iso27001 + gdpr.
+  it('extracts verified badges and skips unrecognized certs', () => {
+    const badges = extractComplianceBadges({
+      certifications: [
+        { type: 'ISO/IEC 27001:2022', status: 'verified' },
+        { type: 'HDS', status: 'verified' },
+        { type: 'GDPR Compliance', status: 'verified' },
+      ],
+    });
+
+    const types = badges.map((b) => b.type);
+    expect(types).toContain('iso27001');
+    expect(types).toContain('gdpr');
+    expect(types).not.toContain('HDS');
+  });
+
+  it('ignores certifications that are not verified', () => {
+    const badges = extractComplianceBadges({
+      certifications: [
+        { type: 'ISO/IEC 27001:2022', status: 'expired' },
+        { type: 'GDPR Compliance', status: 'verified' },
+      ],
+    });
+
+    expect(badges.map((b) => b.type)).toEqual(['gdpr']);
+  });
+
+  it('de-duplicates repeated badge types', () => {
+    const badges = extractComplianceBadges({
+      certifications: [
+        { type: 'ISO/IEC 27001:2022', status: 'verified' },
+        { type: 'ISO 27001:2013', status: 'verified' },
+      ],
+    });
+
+    expect(badges).toEqual([{ type: 'iso27001', verified: true }]);
+  });
+
+  it('returns an empty array for missing or malformed data', () => {
+    expect(extractComplianceBadges(null)).toEqual([]);
+    expect(extractComplianceBadges({})).toEqual([]);
+    expect(extractComplianceBadges({ certifications: 'nope' })).toEqual([]);
+  });
+});

--- a/apps/api/src/trust-portal/cert-badge-mapper.ts
+++ b/apps/api/src/trust-portal/cert-badge-mapper.ts
@@ -1,0 +1,92 @@
+/**
+ * Single source of truth for turning AI-extracted certification names
+ * (`GlobalVendors.riskAssessmentData.certifications[].type`) into Trust Portal
+ * compliance badge types.
+ *
+ * Both the admin vendor sync (`trust-portal.service.ts`) and the public,
+ * visitor-facing portal (`trust-access.service.ts`) derive badges through this
+ * module so the two surfaces can never disagree — the mismatch that caused
+ * CS-688 (Scaleway showed ISO 27001 in the admin Vendors tab but only GDPR on
+ * the public Trust Centre).
+ */
+
+export type ComplianceBadge = {
+  type: string;
+  verified: boolean;
+};
+
+/**
+ * Whether a normalized cert string (lowercased, alphanumerics only) names the
+ * given ISO standard number.
+ *
+ * - Requires an "iso" / "iso iec" prefix, so unrelated ids that merely contain
+ *   the digits ("19001", "127001") are not misclassified.
+ * - The optional "iec" handles joint ISO/IEC standards whose "IEC" infix would
+ *   otherwise break the match ("ISO/IEC 27001:2022" -> "isoiec270012022").
+ * - Allows an optional trailing 4-digit year ("ISO 9001:2015" -> "iso90012015")
+ *   but forbids any other trailing digit, so a longer number is not read as a
+ *   shorter standard ("ISO 90010" is not "ISO 9001", "ISO 27017" is not 27001).
+ *
+ * `standardNumber` is always a hard-coded digit literal — never user input —
+ * so building the RegExp from it carries no injection risk.
+ */
+function matchesIsoStandard(normalized: string, standardNumber: string): boolean {
+  return new RegExp(`iso(?:iec)?${standardNumber}(?:\\d{4})?(?!\\d)`).test(
+    normalized,
+  );
+}
+
+/**
+ * Map a single certification name to its canonical badge type, or `null` when
+ * the certification is not one we render a badge for.
+ */
+export function mapCertificationToBadgeType(certType: string): string | null {
+  const normalized = certType.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+  if (normalized.includes('soc2') || normalized.includes('soc 2')) return 'soc2';
+  if (matchesIsoStandard(normalized, '27001')) return 'iso27001';
+  if (matchesIsoStandard(normalized, '42001')) return 'iso42001';
+  if (normalized.includes('gdpr')) return 'gdpr';
+  if (normalized.includes('hipaa')) return 'hipaa';
+  if (
+    normalized.includes('pcidss') ||
+    normalized.includes('pci dss') ||
+    normalized.includes('pci_dss')
+  )
+    return 'pci_dss';
+  if (normalized.includes('nen7510') || normalized.includes('nen 7510'))
+    return 'nen7510';
+  if (matchesIsoStandard(normalized, '9001')) return 'iso9001';
+
+  return null;
+}
+
+/**
+ * Extract the deduplicated set of verified compliance badges from a
+ * `GlobalVendors.riskAssessmentData` object. Unrecognized certifications are
+ * skipped. Returns an empty array when there is nothing to map.
+ */
+export function extractComplianceBadges(data: unknown): ComplianceBadge[] {
+  if (!data || typeof data !== 'object') return [];
+
+  const certifications = (data as { certifications?: unknown }).certifications;
+  if (!Array.isArray(certifications)) return [];
+
+  const badges: ComplianceBadge[] = [];
+  const seenTypes = new Set<string>();
+
+  for (const cert of certifications) {
+    if (!cert || typeof cert !== 'object') continue;
+
+    const { type, status } = cert as { type?: unknown; status?: unknown };
+    if (status !== 'verified' || typeof type !== 'string') continue;
+
+    const badgeType = mapCertificationToBadgeType(type);
+    if (badgeType && !seenTypes.has(badgeType)) {
+      seenTypes.add(badgeType);
+      badges.push({ type: badgeType, verified: true });
+    }
+  }
+
+  return badges;
+}

--- a/apps/api/src/trust-portal/cert-badge-mapper.ts
+++ b/apps/api/src/trust-portal/cert-badge-mapper.ts
@@ -41,21 +41,23 @@ function matchesIsoStandard(normalized: string, standardNumber: string): boolean
  * the certification is not one we render a badge for.
  */
 export function mapCertificationToBadgeType(certType: string): string | null {
+  // Strip every non-alphanumeric char (spaces, slashes, colons, underscores)
+  // so separator variants collapse to one form — "PCI DSS", "PCI-DSS" and
+  // "pci_dss" all become "pcidss". Matches below therefore never need to spell
+  // out separator variants.
   const normalized = certType.toLowerCase().replace(/[^a-z0-9]/g, '');
 
-  if (normalized.includes('soc2') || normalized.includes('soc 2')) return 'soc2';
+  if (normalized.includes('soc2')) return 'soc2';
   if (matchesIsoStandard(normalized, '27001')) return 'iso27001';
   if (matchesIsoStandard(normalized, '42001')) return 'iso42001';
   if (normalized.includes('gdpr')) return 'gdpr';
   if (normalized.includes('hipaa')) return 'hipaa';
-  if (
-    normalized.includes('pcidss') ||
-    normalized.includes('pci dss') ||
-    normalized.includes('pci_dss')
-  )
+  // "pcidss" covers "PCI DSS"; "paymentcard" covers the fully spelled-out
+  // "Payment Card Industry Data Security Standard" (kept in sync with the
+  // scan-time mappers in trigger/vendor/vendor-risk-assessment*).
+  if (normalized.includes('pcidss') || normalized.includes('paymentcard'))
     return 'pci_dss';
-  if (normalized.includes('nen7510') || normalized.includes('nen 7510'))
-    return 'nen7510';
+  if (normalized.includes('nen7510')) return 'nen7510';
   if (matchesIsoStandard(normalized, '9001')) return 'iso9001';
 
   return null;

--- a/apps/api/src/trust-portal/trust-access.service.spec.ts
+++ b/apps/api/src/trust-portal/trust-access.service.spec.ts
@@ -24,6 +24,12 @@ jest.mock('@db', () => ({
     member: {
       findFirst: jest.fn(),
     },
+    vendor: {
+      findMany: jest.fn(),
+    },
+    globalVendors: {
+      findMany: jest.fn(),
+    },
     $transaction: jest.fn(),
   },
   Prisma: {
@@ -74,12 +80,89 @@ const mockDb = db as unknown as {
   member: {
     findFirst: jest.Mock;
   };
+  vendor: {
+    findMany: jest.Mock;
+  };
+  globalVendors: {
+    findMany: jest.Mock;
+  };
   $transaction: jest.Mock;
 };
 
 const mockGetSignedUrl = getSignedUrl as jest.MockedFunction<
   typeof getSignedUrl
 >;
+
+describe('TrustAccessService getPublicVendors compliance badges (CS-688)', () => {
+  const service = new TrustAccessService(
+    {
+      getSignedUrl: jest.fn(),
+    } as any,
+    {} as any,
+    {} as any,
+    {} as any,
+    {} as any,
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDb.trust.findUnique.mockResolvedValue({ organizationId: 'org_1' });
+  });
+
+  // Regression: the public Trust Centre served a stale stored badge set
+  // (GDPR only) for Scaleway while the vendor's verified certifications include
+  // ISO 27001. The public path must derive badges from the certification data,
+  // not trust the stale stored value.
+  it('derives ISO 27001 from cert data even when stored badges are stale (GDPR only)', async () => {
+    mockDb.vendor.findMany.mockResolvedValue([
+      {
+        id: 'vnd_scaleway',
+        name: 'Scaleway',
+        description: null,
+        website: 'scaleway.com',
+        logoUrl: null,
+        complianceBadges: [{ type: 'gdpr', verified: true }],
+      },
+    ]);
+    mockDb.globalVendors.findMany.mockResolvedValue([
+      {
+        website: 'scaleway.com',
+        riskAssessmentData: {
+          certifications: [
+            { type: 'ISO/IEC 27001:2022', status: 'verified' },
+            { type: 'HDS', status: 'verified' },
+            { type: 'GDPR Compliance', status: 'verified' },
+          ],
+        },
+      },
+    ]);
+
+    const result = await service.getPublicVendors('capawesome');
+    const types = result[0].complianceBadges.map((b) => b.type);
+
+    expect(types).toContain('iso27001');
+    expect(types).toContain('gdpr');
+  });
+
+  it('keeps the stored badges when there is no derivable cert data', async () => {
+    mockDb.vendor.findMany.mockResolvedValue([
+      {
+        id: 'vnd_x',
+        name: 'X',
+        description: null,
+        website: 'x.com',
+        logoUrl: null,
+        complianceBadges: [{ type: 'soc2', verified: true }],
+      },
+    ]);
+    mockDb.globalVendors.findMany.mockResolvedValue([]);
+
+    const result = await service.getPublicVendors('capawesome');
+    const types = result[0].complianceBadges.map((b) => b.type);
+
+    expect(types).toEqual(['soc2']);
+  });
+});
 
 describe('TrustAccessService favicon branding', () => {
   const service = new TrustAccessService(

--- a/apps/api/src/trust-portal/trust-access.service.ts
+++ b/apps/api/src/trust-portal/trust-access.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { db } from '@db';
 import { randomBytes } from 'crypto';
+import { extractComplianceBadges } from './cert-badge-mapper';
 import {
   ApproveAccessRequestDto,
   CreateAccessRequestDto,
@@ -2876,9 +2877,14 @@ export class TrustAccessService {
             }
           }
 
-          // Extract compliance badges from riskAssessmentData when vendor record has none
-          if (!badges || !Array.isArray(badges) || badges.length === 0) {
-            badges = this.extractBadgesFromRiskData(parsed);
+          // Prefer badges freshly derived from the vendor's verified
+          // certifications so the public Trust Centre always matches the admin
+          // Vendors tab, rather than trusting a possibly-stale stored
+          // complianceBadges value (CS-688). Fall back to the stored value only
+          // when there is nothing to derive.
+          const derivedBadges = extractComplianceBadges(parsed);
+          if (derivedBadges.length > 0) {
+            badges = derivedBadges;
           }
         }
       }
@@ -2888,63 +2894,6 @@ export class TrustAccessService {
         trustPortalUrl,
       };
     });
-  }
-
-  /**
-   * Extract compliance badges from GlobalVendors riskAssessmentData certifications.
-   * Used as fallback when the vendor record has no complianceBadges synced yet.
-   */
-  private extractBadgesFromRiskData(
-    data: Record<string, unknown>,
-  ): Array<{ type: string; verified: boolean }> | null {
-    const certs = data.certifications;
-    if (!Array.isArray(certs)) return null;
-
-    const CERT_MAP: Record<string, string> = {
-      soc2: 'soc2',
-      'soc 2': 'soc2',
-      soc3: 'soc3',
-      'soc 3': 'soc3',
-      iso27001: 'iso27001',
-      'iso 27001': 'iso27001',
-      iso42001: 'iso42001',
-      'iso 42001': 'iso42001',
-      gdpr: 'gdpr',
-      hipaa: 'hipaa',
-      pcidss: 'pci_dss',
-      'pci dss': 'pci_dss',
-      pci_dss: 'pci_dss',
-      nen7510: 'nen7510',
-      'nen 7510': 'nen7510',
-      iso9001: 'iso9001',
-      'iso 9001': 'iso9001',
-      pipeda: 'pipeda',
-      ccpa: 'ccpa',
-    };
-
-    const badges: Array<{ type: string; verified: boolean }> = [];
-    const seen = new Set<string>();
-
-    for (const cert of certs) {
-      if (
-        !cert ||
-        typeof cert !== 'object' ||
-        cert.status !== 'verified' ||
-        typeof cert.type !== 'string'
-      )
-        continue;
-
-      const normalized = cert.type.toLowerCase().replace(/[^a-z0-9 _]/g, '');
-      // Use canonical slug for known certs, keep original type for unknown ones
-      const badgeType = CERT_MAP[normalized] ?? cert.type.trim();
-      const key = badgeType.toLowerCase();
-      if (badgeType && !seen.has(key)) {
-        seen.add(key);
-        badges.push({ type: badgeType, verified: true });
-      }
-    }
-
-    return badges.length > 0 ? badges : null;
   }
 
   /**

--- a/apps/api/src/trust-portal/trust-portal.service.ts
+++ b/apps/api/src/trust-portal/trust-portal.service.ts
@@ -12,6 +12,7 @@ import {
   PutObjectCommand,
 } from '@aws-sdk/client-s3';
 import { db } from '@db';
+import { extractComplianceBadges } from './cert-badge-mapper';
 import {
   DomainStatusResponseDto,
   DomainVerificationDto,
@@ -1875,10 +1876,10 @@ export class TrustPortalService {
           });
 
           if (globalVendor?.riskAssessmentData) {
-            const extractedBadges = this.extractComplianceBadges(
+            const extractedBadges = extractComplianceBadges(
               globalVendor.riskAssessmentData,
             );
-            if (extractedBadges && extractedBadges.length > 0) {
+            if (extractedBadges.length > 0) {
               const currentBadges = vendor.complianceBadges as Array<{
                 type: string;
               }> | null;
@@ -1932,83 +1933,6 @@ export class TrustPortalService {
       logoUrl: v.logoUrl,
       complianceBadges: v.complianceBadges,
     }));
-  }
-
-  private extractComplianceBadges(
-    data: Prisma.JsonValue,
-  ): Array<{ type: string; verified: boolean }> | null {
-    try {
-      const parsed = data as {
-        certifications?: Array<{ type: string; status: string }>;
-      };
-
-      if (!parsed?.certifications || !Array.isArray(parsed.certifications)) {
-        return null;
-      }
-
-      const badges: Array<{ type: string; verified: boolean }> = [];
-      const seenTypes = new Set<string>();
-
-      for (const cert of parsed.certifications) {
-        if (cert.status !== 'verified') continue;
-
-        const badgeType = this.mapCertificationToBadgeType(cert.type);
-        if (badgeType && !seenTypes.has(badgeType)) {
-          seenTypes.add(badgeType);
-          badges.push({ type: badgeType, verified: true });
-        }
-      }
-
-      return badges.length > 0 ? badges : null;
-    } catch {
-      return null;
-    }
-  }
-
-  private mapCertificationToBadgeType(certType: string): string | null {
-    const normalized = certType.toLowerCase().replace(/[^a-z0-9]/g, '');
-
-    if (normalized.includes('soc2') || normalized.includes('soc 2'))
-      return 'soc2';
-    if (this.matchesIsoStandard(normalized, '27001')) return 'iso27001';
-    if (this.matchesIsoStandard(normalized, '42001')) return 'iso42001';
-    if (normalized.includes('gdpr')) return 'gdpr';
-    if (normalized.includes('hipaa')) return 'hipaa';
-    if (
-      normalized.includes('pcidss') ||
-      normalized.includes('pci dss') ||
-      normalized.includes('pci_dss')
-    )
-      return 'pci_dss';
-    if (normalized.includes('nen7510') || normalized.includes('nen 7510'))
-      return 'nen7510';
-    if (this.matchesIsoStandard(normalized, '9001')) return 'iso9001';
-
-    return null;
-  }
-
-  /**
-   * Whether a normalized cert string (lowercased, alphanumerics only) names the
-   * given ISO standard number.
-   *
-   * - Requires an "iso" / "iso iec" prefix, so unrelated ids that merely contain
-   *   the digits ("19001", "127001") are not misclassified.
-   * - The optional "iec" handles joint ISO/IEC standards whose "IEC" infix would
-   *   otherwise break the match ("ISO/IEC 27001:2022" -> "isoiec270012022").
-   * - Allows an optional trailing 4-digit year ("ISO 9001:2015" -> "iso90012015")
-   *   but forbids any other trailing digit, so a longer number is not read as a
-   *   shorter standard ("ISO 90010" is not "ISO 9001", "ISO 27017" is not 27001).
-   *
-   * `standardNumber` is always a hard-coded digit literal — never user input —
-   * so building the RegExp from it carries no injection risk.
-   */
-  private matchesIsoStandard(
-    normalized: string,
-    standardNumber: string,
-  ): boolean {
-    return new RegExp(`iso(?:iec)?${standardNumber}(?:\\d{4})?(?!\\d)`).test(
-      normalized,
-    );
   }
 
   private generateLogoUrl(website: string | null): string | null {


### PR DESCRIPTION
## Problem
CS-688 was marked Done via #3315/#3318 but the customer reopened it: Scaleway on the public Trust Centre (`trust.inc/capawesome`) still shows **only GDPR**, while the admin Vendors tab lists ISO/IEC 27001:2022, HDS and GDPR as verified.

## Root cause — the fix landed on the wrong code path
There are two separate paths, and #3315/#3318 only fixed the admin one:

- **Admin** (`trust-portal.service.ts::getAllVendorsWithSync`) — its mapper was corrected and it *self-heals* the stored `Vendor.complianceBadges` on read. But that only runs when an admin opens the Vendors page.
- **Public / visitor** (`trust-access.service.ts::getPublicVendors`) — serves the **stored** `complianceBadges` verbatim and only re-derives when it's *empty*. Scaleway's stored value is a stale `[gdpr]`, so it's served as-is. Its fallback mapper (`extractBadgesFromRiskData`) was also the old brittle exact-match that never recognized `"ISO/IEC 27001:2022"`.

Net: the public portal reads different code than the admin, depends on an admin action that never happened, and can't self-correct. (Also confirmed the visitor fetch is `cache: 'no-store'`, so no caching was hiding a fix, and the admin "Vendors tab" reads the *same* `riskAssessmentData.certifications`, so the corrected mapper will map it.)

## Fix — one mapper, public path derives live
- New **`cert-badge-mapper.ts`** — single source of truth for cert-name → badge-type, moved verbatim from the tested admin mapper (incl. the bounded `matchesIsoStandard` that handles the `IEC` infix and `:2022` suffix while rejecting 2701x/unrelated digits).
- **`getPublicVendors`** now derives badges from `riskAssessmentData` with that shared mapper and treats them as **authoritative when present** — mirroring the admin sync — falling back to stored badges only when there's nothing to derive. So the two surfaces can no longer disagree.
- **`trust-portal.service.ts`** (admin) now imports the shared mapper instead of its own private copies.

**No data backfill required:** the public path corrects stale stored badges on the fly, so Scaleway shows ISO 27001 as soon as this deploys — no script, no admin action.

## Safety / scope
- Behavior mirrors the already-in-production admin logic, just applied to the read path; all 7 existing admin regression tests stay green through the shared mapper.
- Unrecognized certs (e.g. HDS) are dropped consistently with the admin tab — HDS badge support was explicitly out of scope in #3315 and stays out here.
- The scan-time writers (`vendor-risk-assessment-task.ts`, `trust-portal-deep-scrape-merge.ts`) still have their own mappers, but the public path no longer depends on what they persist. Consolidating those is a sensible follow-up, not needed for this fix.

## Testing
- `cert-badge-mapper.spec.ts` — unit tests: ISO/IEC 27001:2022 → iso27001, 27017/27018 and unrelated-digit guards, verified-only, dedupe, malformed input.
- `trust-access.service.spec.ts` — new `getPublicVendors` regression: a stale `[gdpr]` stored set + cert data with ISO/IEC 27001:2022 now yields **iso27001 + gdpr**; plus a no-cert-data case that keeps stored badges.
- `npx jest src/trust-portal` → 31 passing. Typecheck clean for changed files (repo `main` has unrelated pre-existing typecheck errors).

Fixes CS-688

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CS-688 by making the public Trust Centre derive vendor badges from verified certification data, aligning with the admin view and correcting stale displays (e.g., Scaleway). Adds shared mapping with ISO 27001 and spelled‑out PCI DSS support.

- **Bug Fixes**
  - Added `cert-badge-mapper.ts` as a shared source for cert-name → badge-type (handles ISO/IEC 27001:2022 and maps spelled‑out “Payment Card Industry Data Security Standard” to `pci_dss`); removed duplicate mappers and dead, separator-specific branches after normalization.
  - `getPublicVendors` now prefers badges derived from `riskAssessmentData` and falls back to stored badges only when none are derivable, preventing admin/public mismatches.
  - Admin sync now imports the shared mapper; tests cover the mapper (ISO boundaries, PCI spelled‑out) and a `getPublicVendors` regression; no data backfill required.

<sup>Written for commit 839d4abe0af13837bcd7be930e78f0ff83b2a633. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

