### PR TITLE
fix(trust-portal): restore soc3/pipeda/ccpa badge mappings (CS-688 follow-up)

### DIFF
--- a/apps/api/src/trust-portal/cert-badge-mapper.spec.ts
+++ b/apps/api/src/trust-portal/cert-badge-mapper.spec.ts
@@ -28,6 +28,15 @@ describe('mapCertificationToBadgeType', () => {
     ).toBe('pci_dss');
   });
 
+  // Regression: soc3 / pipeda / ccpa were supported by the public portal's
+  // original mapper. Consolidation must not drop them or affected vendors lose
+  // their public Trust Centre badges.
+  it('maps soc3 / pipeda / ccpa (restored after consolidation)', () => {
+    expect(mapCertificationToBadgeType('SOC 3')).toBe('soc3');
+    expect(mapCertificationToBadgeType('PIPEDA')).toBe('pipeda');
+    expect(mapCertificationToBadgeType('CCPA')).toBe('ccpa');
+  });
+
   // The digits alone must not classify an unrelated identifier.
   it('does not misclassify ids that merely contain the standard digits', () => {
     expect(mapCertificationToBadgeType('Catalog 19001')).toBeNull();

--- a/apps/api/src/trust-portal/cert-badge-mapper.ts
+++ b/apps/api/src/trust-portal/cert-badge-mapper.ts
@@ -48,6 +48,7 @@ export function mapCertificationToBadgeType(certType: string): string | null {
   const normalized = certType.toLowerCase().replace(/[^a-z0-9]/g, '');
 
   if (normalized.includes('soc2')) return 'soc2';
+  if (normalized.includes('soc3')) return 'soc3';
   if (matchesIsoStandard(normalized, '27001')) return 'iso27001';
   if (matchesIsoStandard(normalized, '42001')) return 'iso42001';
   if (normalized.includes('gdpr')) return 'gdpr';
@@ -59,6 +60,12 @@ export function mapCertificationToBadgeType(certType: string): string | null {
     return 'pci_dss';
   if (normalized.includes('nen7510')) return 'nen7510';
   if (matchesIsoStandard(normalized, '9001')) return 'iso9001';
+  // soc3 / pipeda / ccpa were supported by the public portal's original mapper
+  // before consolidation; keep them so those vendors don't lose their public
+  // Trust Centre badges. The public portal renders them via label text and the
+  // admin UI safely skips badge types it has no icon for.
+  if (normalized.includes('pipeda')) return 'pipeda';
+  if (normalized.includes('ccpa')) return 'ccpa';
 
   return null;
 }


### PR DESCRIPTION
## Problem
The cubic review on the production-deploy PR (#3356) flagged a **P1**: consolidating the public + admin badge logic into the shared `cert-badge-mapper` (in #3355 / CS-688) dropped **soc3**, **pipeda** and **ccpa**.

Verified — real regression. The public portal's original `extractBadgesFromRiskData` mapped those three; the admin mapper (which the shared version was based on) never did. Since the shared mapper now governs both surfaces, vendors with a SOC 3 / PIPEDA / CCPA certification would lose that badge on the public Trust Centre.

## Fix
Restore all three to the shared `mapCertificationToBadgeType`. Safe on both surfaces:
- **Public portal** renders them as text chips — `formatComplianceBadgeLabels` already has the `SOC 3` / `PIPEDA` / `CCPA` labels.
- **Admin UI** (`TrustPortalVendors.tsx`) guards unknown types (`if (!IconComponent) return null`), so introducing these types shows no icon there but does not break — same as its current behavior.

`pci_dss` etc. use substring `includes`, so the three restored checks follow the same style (`soc3`, `pipeda`, `ccpa`), which is broader than the old exact-match `CERT_MAP` and therefore strictly no worse.

## Testing
- `cert-badge-mapper.spec.ts`: added a regression test asserting `SOC 3 → soc3`, `PIPEDA → pipeda`, `CCPA → ccpa`.
- `npx jest src/trust-portal` → 33 passing. Typecheck clean for the changed file.

## Note on the other cubic finding
The second cubic finding on #3356 (chunk the `updateMany({ id: { in: deletedSourceIds }})` in `run-linkage.ts`) is **stale** — that code was introduced in an intermediate commit (`70c393c8`) and already removed in `eb3c097a` ("harden orphan task-vector prune"). `deletedSourceIds` / that `updateMany` exist nowhere on `main`; hash writes are now per-row `db.task.update`. No action needed.

Relates to CS-688.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores SOC 3, PIPEDA, and CCPA badge mappings in the shared `cert-badge-mapper` so these badges appear on the public Trust Centre again. Follow-up to CS-688 to keep public/admin mappings aligned; admin UI remains safe.

- **Bug Fixes**
  - Added `soc3`, `pipeda`, and `ccpa` detections to `mapCertificationToBadgeType` in `apps/api/src/trust-portal/cert-badge-mapper.ts`.
  - Added regression tests in `cert-badge-mapper.spec.ts` to cover these mappings.

<sup>Written for commit 7b302a7d1547737322c9388b334a3ed6caef18e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

