### PR TITLE
fix(policies): keep PDF headings with their section (CS-704)

### DIFF
--- a/apps/api/src/trust-portal/policy-pdf-renderer.service.spec.ts
+++ b/apps/api/src/trust-portal/policy-pdf-renderer.service.spec.ts
@@ -937,6 +937,117 @@ describe('PolicyPdfRendererService', () => {
       expect(result.length).toBeGreaterThan(0);
     });
 
+    // --- CS-704: heading keep-together (no orphaned headings) ---------------
+
+    // Split an (uncompressed) jsPDF buffer into per-page visible text. jsPDF
+    // writes one content stream per page, so the concatenated (text)Tj tokens
+    // between two `endstream` markers are exactly one page's text. This lets
+    // us assert which page a given string lands on.
+    const pageTextsFrom = (buf: Buffer): string[] =>
+      buf
+        .toString('latin1')
+        .split('endstream')
+        .map((segment) => {
+          const start = segment.lastIndexOf('stream');
+          if (start === -1) return '';
+          const body = segment.slice(start + 'stream'.length);
+          const re = /\((.*?)\)\s*Tj/g;
+          let text = '';
+          let m: RegExpExecArray | null;
+          while ((m = re.exec(body)) !== null) text += m[1];
+          return text;
+        })
+        .filter((t) => t.length > 0);
+
+    const pageIndexContaining = (pages: string[], needle: string): number =>
+      pages.findIndex((t) => t.includes(needle));
+
+    it('does not orphan a heading at the bottom of a page (CS-704)', () => {
+      // Sweep headings across many vertical offsets by growing the amount of
+      // filler before each one. Without keep-together logic at least one
+      // heading lands at a page bottom with its body flowing to the next page.
+      // With the fix, every heading must share a page with the first line of
+      // its section.
+      const SECTIONS = 30;
+      const nodes: Array<Record<string, unknown>> = [];
+      for (let i = 0; i < SECTIONS; i++) {
+        for (let f = 0; f < i; f++) {
+          nodes.push({
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: `filler ${i}-${f} advancing the cursor down the page`,
+              },
+            ],
+          });
+        }
+        nodes.push({
+          type: 'heading',
+          attrs: { level: 2 },
+          content: [{ type: 'text', text: `HEADINGMARKER${i} Section ${i}` }],
+        });
+        nodes.push({
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              text: `BODYMARKER${i} first line of the section body content`,
+            },
+          ],
+        });
+      }
+
+      const result = service.renderPoliciesPdfBuffer([
+        { name: 'Keep Together Policy', content: { type: 'doc', content: nodes } },
+      ]);
+
+      const pages = pageTextsFrom(result);
+      expect(pages.length).toBeGreaterThan(1); // multi-page, or the test is moot
+
+      const orphaned: number[] = [];
+      for (let i = 0; i < SECTIONS; i++) {
+        const headingPage = pageIndexContaining(pages, `HEADINGMARKER${i}`);
+        const bodyPage = pageIndexContaining(pages, `BODYMARKER${i}`);
+        expect(headingPage).toBeGreaterThanOrEqual(0);
+        expect(bodyPage).toBeGreaterThanOrEqual(0);
+        if (headingPage !== bodyPage) orphaned.push(i);
+      }
+
+      expect(orphaned).toEqual([]);
+    });
+
+    it('does not push a trailing heading (no following content) to its own page', () => {
+      // The keep-together reserve must only apply when a section actually
+      // follows the heading — a heading that is the last node stays on the
+      // current page rather than being bumped to a fresh one.
+      const result = service.renderPoliciesPdfBuffer([
+        {
+          name: 'Trailing Heading Policy',
+          content: {
+            type: 'doc',
+            content: [
+              {
+                type: 'paragraph',
+                content: [{ type: 'text', text: 'INTROBODY opening paragraph' }],
+              },
+              {
+                type: 'heading',
+                attrs: { level: 2 },
+                content: [{ type: 'text', text: 'TRAILINGHEADING appendix' }],
+              },
+            ],
+          },
+        },
+      ]);
+
+      const pages = pageTextsFrom(result);
+      const introPage = pageIndexContaining(pages, 'INTROBODY');
+      const headingPage = pageIndexContaining(pages, 'TRAILINGHEADING');
+      expect(introPage).toBe(0);
+      expect(headingPage).toBe(0);
+    });
+
     it('applies custom primary color', () => {
       const result = service.renderPoliciesPdfBuffer(
         [

--- a/apps/api/src/trust-portal/policy-pdf-renderer.service.spec.ts
+++ b/apps/api/src/trust-portal/policy-pdf-renderer.service.spec.ts
@@ -962,6 +962,23 @@ describe('PolicyPdfRendererService', () => {
     const pageIndexContaining = (pages: string[], needle: string): number =>
       pages.findIndex((t) => t.includes(needle));
 
+    // Like pageTextsFrom but keeps blank pages (in order), so a blank leading
+    // page shifts the index of later content. Drops the trailing xref/trailer
+    // segment that follows the final content stream.
+    const orderedPageTexts = (buf: Buffer): string[] => {
+      const segments = buf.toString('latin1').split('endstream');
+      return segments.slice(0, -1).map((segment) => {
+        const start = segment.lastIndexOf('stream');
+        if (start === -1) return '';
+        const body = segment.slice(start + 'stream'.length);
+        const re = /\((.*?)\)\s*Tj/g;
+        let text = '';
+        let m: RegExpExecArray | null;
+        while ((m = re.exec(body)) !== null) text += m[1];
+        return text;
+      });
+    };
+
     it('does not orphan a heading at the bottom of a page (CS-704)', () => {
       // Sweep headings across many vertical offsets by growing the amount of
       // filler before each one. Without keep-together logic at least one
@@ -1080,6 +1097,100 @@ describe('PolicyPdfRendererService', () => {
       // pushed onto a page of its own.
       expect(pageIndexContaining(pages, 'filler line 22')).toBe(0);
       expect(pageIndexContaining(pages, 'EMPTYTRAILHEADING')).toBe(0);
+    });
+
+    it('keeps a heading with a following table that has a tall first row', () => {
+      // A heading immediately followed by a table with a tall first row must
+      // not be orphaned: the reserve has to account for the table's first-row
+      // height, not just a few plain text lines. Sweep offsets so at least one
+      // heading lands where the fixed text-only reserve would have orphaned it.
+      const tallCell = (label: string) => ({
+        type: 'tableCell',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: `${label} line one line two line three line four line five line six`,
+              },
+            ],
+          },
+        ],
+      });
+
+      const SECTIONS = 24;
+      const nodes: Array<Record<string, unknown>> = [];
+      for (let i = 0; i < SECTIONS; i++) {
+        for (let f = 0; f < i; f++) {
+          nodes.push({
+            type: 'paragraph',
+            content: [
+              { type: 'text', text: `filler ${i}-${f} advancing the cursor` },
+            ],
+          });
+        }
+        nodes.push({
+          type: 'heading',
+          attrs: { level: 2 },
+          content: [{ type: 'text', text: `TABLEHEADING${i} Section ${i}` }],
+        });
+        nodes.push({
+          type: 'table',
+          content: [
+            {
+              type: 'tableRow',
+              content: [tallCell(`TABLECELL${i}`), tallCell(`meta${i}`)],
+            },
+          ],
+        });
+      }
+
+      const result = service.renderPoliciesPdfBuffer([
+        { name: 'Heading Table Policy', content: { type: 'doc', content: nodes } },
+      ]);
+
+      const pages = pageTextsFrom(result);
+      const orphaned: number[] = [];
+      for (let i = 0; i < SECTIONS; i++) {
+        const headingPage = pageIndexContaining(pages, `TABLEHEADING${i}`);
+        const tablePage = pageIndexContaining(pages, `TABLECELL${i}`);
+        expect(headingPage).toBeGreaterThanOrEqual(0);
+        expect(tablePage).toBeGreaterThanOrEqual(0);
+        if (headingPage !== tablePage) orphaned.push(i);
+      }
+      expect(orphaned).toEqual([]);
+    });
+
+    it('does not emit a blank leading page for an oversized heading', () => {
+      // A nameless policy whose first (and only) node is a heading taller than
+      // the page must start rendering on page 1, not after an empty page. The
+      // reserve is capped at the usable page height so the up-front check can't
+      // add a page while the current one is still empty.
+      const longHeadingText = Array.from(
+        { length: 200 },
+        () => 'BLANKGUARDWORD',
+      ).join(' ');
+
+      const result = service.renderPoliciesPdfBuffer([
+        {
+          name: '',
+          content: {
+            type: 'doc',
+            content: [
+              {
+                type: 'heading',
+                attrs: { level: 1 },
+                content: [{ type: 'text', text: longHeadingText }],
+              },
+            ],
+          },
+        },
+      ]);
+
+      const orderedPages = orderedPageTexts(result);
+      // The very first page carries heading text — no blank page precedes it.
+      expect(orderedPages[0]).toContain('BLANKGUARDWORD');
     });
 
     it('paginates a heading longer than a page instead of overflowing', () => {

--- a/apps/api/src/trust-portal/policy-pdf-renderer.service.spec.ts
+++ b/apps/api/src/trust-portal/policy-pdf-renderer.service.spec.ts
@@ -1048,6 +1048,71 @@ describe('PolicyPdfRendererService', () => {
       expect(headingPage).toBe(0);
     });
 
+    it('does not bump a heading when only empty nodes follow it', () => {
+      // A heading near the page bottom followed ONLY by empty paragraphs / hard
+      // breaks (common trailing nodes in TipTap docs) must be treated as a
+      // trailing heading — reserving keep-together space for a non-existent
+      // section would bump it to a lonely page.
+      const nodes: Array<Record<string, unknown>> = [];
+      for (let f = 0; f < 23; f++) {
+        nodes.push({
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: `filler line ${f} to consume vertical space` },
+          ],
+        });
+      }
+      nodes.push({
+        type: 'heading',
+        attrs: { level: 2 },
+        content: [{ type: 'text', text: 'EMPTYTRAILHEADING near the bottom' }],
+      });
+      // Empty trailing content that renders nothing visible.
+      nodes.push({ type: 'paragraph' });
+      nodes.push({ type: 'paragraph', content: [{ type: 'hardBreak' }] });
+
+      const result = service.renderPoliciesPdfBuffer([
+        { name: 'Empty Trailing Policy', content: { type: 'doc', content: nodes } },
+      ]);
+
+      const pages = pageTextsFrom(result);
+      // The heading shares the page with the filler above it, rather than being
+      // pushed onto a page of its own.
+      expect(pageIndexContaining(pages, 'filler line 22')).toBe(0);
+      expect(pageIndexContaining(pages, 'EMPTYTRAILHEADING')).toBe(0);
+    });
+
+    it('paginates a heading longer than a page instead of overflowing', () => {
+      // Pathological guard: a heading that wraps to more lines than fit on one
+      // page must span multiple pages rather than run off the bottom margin.
+      const longHeadingText = Array.from(
+        { length: 200 },
+        () => 'OVERFLOWWORD',
+      ).join(' ');
+
+      const result = service.renderPoliciesPdfBuffer([
+        {
+          name: 'Giant Heading Policy',
+          content: {
+            type: 'doc',
+            content: [
+              {
+                type: 'heading',
+                attrs: { level: 1 },
+                content: [{ type: 'text', text: longHeadingText }],
+              },
+            ],
+          },
+        },
+      ]);
+
+      const pages = pageTextsFrom(result);
+      const pagesWithHeading = pages.filter((t) =>
+        t.includes('OVERFLOWWORD'),
+      ).length;
+      expect(pagesWithHeading).toBeGreaterThan(1);
+    });
+
     it('applies custom primary color', () => {
       const result = service.renderPoliciesPdfBuffer(
         [

--- a/apps/api/src/trust-portal/policy-pdf-renderer.service.ts
+++ b/apps/api/src/trust-portal/policy-pdf-renderer.service.ts
@@ -235,20 +235,74 @@ export class PolicyPdfRendererService {
     return text;
   }
 
-  // Whether any sibling after `index` renders visible text. Used so the heading
-  // keep-together reserve treats a heading followed only by empty paragraphs or
-  // hard breaks as a trailing heading (all renderable node types here carry
-  // text, so an empty result means nothing visible follows).
-  private hasRenderableTextAfter(
+  // First-row height of a table, mirroring the row-height math in renderTable
+  // so the heading keep-together reserve can size itself against a table that
+  // follows a heading (not just plain paragraphs).
+  // NOTE: keep in sync with renderTable's rowHeight calculation.
+  private measureTableFirstRowHeight(
+    tableNode: JSONContent,
+    config: PDFConfig,
+  ): number {
+    const firstRow = tableNode.content?.[0];
+    if (!firstRow?.content?.length) return 0;
+
+    let columnCount = 0;
+    for (const cell of firstRow.content) {
+      columnCount += cell.attrs?.colspan ?? 1;
+    }
+    if (columnCount === 0) return 0;
+
+    const colWidth = config.contentWidth / columnCount;
+    const cellPadding = 2;
+    let rowHeight = config.lineHeight + cellPadding * 2;
+    for (const cell of firstRow.content) {
+      if (cell.type !== 'tableCell' && cell.type !== 'tableHeader') continue;
+      const width = colWidth * (cell.attrs?.colspan ?? 1);
+      const text = this.cleanTextForPDF(this.extractCellText(cell.content ?? []));
+      const lines = config.doc.splitTextToSize(
+        text || ' ',
+        width - cellPadding * 2,
+      ) as string[];
+      rowHeight = Math.max(
+        rowHeight,
+        lines.length * config.lineHeight + cellPadding * 2,
+      );
+    }
+    return rowHeight;
+  }
+
+  // Extra height (beyond the heading's own height) needed to keep a heading
+  // with the start of the section that follows it. Returns 0 when nothing
+  // visible follows (a trailing heading). Handles tables (first-row height) and
+  // leading hard breaks, so keep-together isn't limited to plain paragraphs.
+  private sectionLeadHeight(
     content: JSONContent[],
     index: number,
-  ): boolean {
+    config: PDFConfig,
+  ): number {
+    let lead = 0;
     for (let i = index + 1; i < content.length; i++) {
-      if (this.extractTextFromContent([content[i]]).trim().length > 0) {
-        return true;
+      const node = content[i];
+      if (node.type === 'hardBreak') {
+        lead += config.lineHeight;
+        continue;
       }
+      if (node.type === 'table' && node.content?.length) {
+        // Heading trailing gap + the table's first row must fit together.
+        return (
+          lead + config.lineHeight + this.measureTableFirstRowHeight(node, config)
+        );
+      }
+      if (this.extractTextFromContent([node]).trim().length === 0) {
+        // Empty paragraph or similar: advances the cursor slightly, keep scanning.
+        if (node.type === 'paragraph') lead += config.lineHeight * 0.5;
+        continue;
+      }
+      // First text-bearing block: reserve the heading's first few section lines
+      // (HEADING_KEEP_WITH_LINES advances, the last still needs the look-ahead).
+      return lead + HEADING_KEEP_WITH_LINES * config.lineHeight + DEFAULT_BREAK_SPACE;
     }
-    return false;
+    return 0;
   }
 
   private checkPageBreak(
@@ -319,26 +373,19 @@ export class PolicyPdfRendererService {
           // Keep-together: require room for the heading itself PLUS the first
           // few lines of the section that follows it; otherwise push the whole
           // heading to the next page so it isn't stranded at the page bottom.
-          // Only reserve the following-section space when content actually
-          // follows this heading (a trailing heading shouldn't be pushed to a
-          // page of its own).
-          //
-          // The heading advances the cursor by its own height plus a trailing
-          // gap (config.lineHeight), then each following body line advances
-          // config.lineHeight and the last one still needs DEFAULT_BREAK_SPACE
-          // of look-ahead — hence: headingHeight + keepWithLines * lineHeight
-          // (trailing gap + first keepWithLines-1 advances) + one look-ahead.
-          const hasFollowingContent = this.hasRenderableTextAfter(
-            content,
-            nodeIndex,
-          );
+          // sectionLeadHeight measures what the following section needs (a few
+          // text lines, or a table's first row, or 0 for a trailing heading),
+          // and is added to the heading's own height. The reserve is capped at
+          // the usable page height so an oversized heading can't force an empty
+          // leading page — the per-line loop below paginates it instead.
+          const leadHeight = this.sectionLeadHeight(content, nodeIndex, config);
           const headingHeight =
             Math.max(headingLines.length, 1) * config.lineHeight * 1.2;
-          const requiredHeight = hasFollowingContent
-            ? headingHeight +
-              HEADING_KEEP_WITH_LINES * config.lineHeight +
-              DEFAULT_BREAK_SPACE
-            : headingHeight;
+          const usableHeight = config.pageHeight - config.margin * 2;
+          const requiredHeight = Math.min(
+            leadHeight > 0 ? headingHeight + leadHeight : headingHeight,
+            usableHeight,
+          );
           this.checkPageBreak(config, requiredHeight);
 
           // For a normal heading the up-front check already reserved room, so

--- a/apps/api/src/trust-portal/policy-pdf-renderer.service.ts
+++ b/apps/api/src/trust-portal/policy-pdf-renderer.service.ts
@@ -235,6 +235,22 @@ export class PolicyPdfRendererService {
     return text;
   }
 
+  // Whether any sibling after `index` renders visible text. Used so the heading
+  // keep-together reserve treats a heading followed only by empty paragraphs or
+  // hard breaks as a trailing heading (all renderable node types here carry
+  // text, so an empty result means nothing visible follows).
+  private hasRenderableTextAfter(
+    content: JSONContent[],
+    index: number,
+  ): boolean {
+    for (let i = index + 1; i < content.length; i++) {
+      if (this.extractTextFromContent([content[i]]).trim().length > 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   private checkPageBreak(
     config: PDFConfig,
     requiredSpace: number = DEFAULT_BREAK_SPACE,
@@ -312,7 +328,10 @@ export class PolicyPdfRendererService {
           // config.lineHeight and the last one still needs DEFAULT_BREAK_SPACE
           // of look-ahead — hence: headingHeight + keepWithLines * lineHeight
           // (trailing gap + first keepWithLines-1 advances) + one look-ahead.
-          const hasFollowingContent = nodeIndex < content.length - 1;
+          const hasFollowingContent = this.hasRenderableTextAfter(
+            content,
+            nodeIndex,
+          );
           const headingHeight =
             Math.max(headingLines.length, 1) * config.lineHeight * 1.2;
           const requiredHeight = hasFollowingContent
@@ -322,10 +341,13 @@ export class PolicyPdfRendererService {
             : headingHeight;
           this.checkPageBreak(config, requiredHeight);
 
-          // The up-front check guarantees the whole heading fits, so render its
-          // lines without further page-break checks (which could split the
-          // heading across pages).
+          // For a normal heading the up-front check already reserved room, so
+          // these per-line checks never fire (the heading stays intact). They
+          // only act as a safety net for a pathological heading that wraps to
+          // more lines than fit on a page, paginating it instead of letting it
+          // overflow past the bottom margin.
           for (const line of headingLines) {
+            this.checkPageBreak(config, config.lineHeight * 1.2);
             config.doc.text(line, config.margin, config.yPosition);
             config.yPosition += config.lineHeight * 1.2;
           }

--- a/apps/api/src/trust-portal/policy-pdf-renderer.service.ts
+++ b/apps/api/src/trust-portal/policy-pdf-renderer.service.ts
@@ -25,6 +25,19 @@ interface PolicyForPDF {
   content: any;
 }
 
+// Keep-together: minimum number of body lines that must fit on the same page
+// as a heading. If the heading plus this many lines of the following section
+// don't fit, the heading is pushed to the next page so it isn't orphaned at
+// the bottom of a page (CS-704).
+// NOTE: Keep in sync with apps/app/src/lib/pdf-generator.ts HEADING_KEEP_WITH_LINES
+const HEADING_KEEP_WITH_LINES = 3;
+
+// Default vertical room (mm) checkPageBreak requires below the cursor before
+// committing content to the current page. Body lines are laid out one at a
+// time and each one demands this much space, so the heading keep-together
+// reserve must include one such look-ahead for the following section.
+const DEFAULT_BREAK_SPACE = 20;
+
 @Injectable()
 export class PolicyPdfRendererService {
   /**
@@ -222,7 +235,10 @@ export class PolicyPdfRendererService {
     return text;
   }
 
-  private checkPageBreak(config: PDFConfig, requiredSpace: number = 20): void {
+  private checkPageBreak(
+    config: PDFConfig,
+    requiredSpace: number = DEFAULT_BREAK_SPACE,
+  ): void {
     if (config.yPosition + requiredSpace > config.pageHeight - config.margin) {
       config.doc.addPage();
       config.yPosition = config.margin;
@@ -256,10 +272,9 @@ export class PolicyPdfRendererService {
   }
 
   private processContent(config: PDFConfig, content: JSONContent[]): void {
-    for (const node of content) {
+    for (const [nodeIndex, node] of content.entries()) {
       switch (node.type) {
-        case 'heading':
-          this.checkPageBreak(config, 30);
+        case 'heading': {
           const level = node.attrs?.level || 1;
           const headingSizes: { [key: number]: number } = {
             1: 16,
@@ -273,25 +288,53 @@ export class PolicyPdfRendererService {
           config.doc.setFont('helvetica', 'bold');
           config.doc.setTextColor(0, 0, 0);
 
-          if (node.content) {
-            const headingText = this.cleanTextForPDF(
-              this.extractTextFromContent(node.content),
-            );
-            const lines = config.doc.splitTextToSize(
-              headingText,
-              config.contentWidth,
-            );
-            for (const line of lines) {
-              this.checkPageBreak(config);
-              config.doc.text(line, config.margin, config.yPosition);
-              config.yPosition += config.lineHeight * 1.2;
-            }
+          // Measure the heading against the heading font BEFORE deciding
+          // whether it fits, so multi-line headings are counted correctly.
+          const headingText = node.content
+            ? this.cleanTextForPDF(this.extractTextFromContent(node.content))
+            : '';
+          const headingLines = headingText
+            ? (config.doc.splitTextToSize(
+                headingText,
+                config.contentWidth,
+              ) as string[])
+            : [];
+
+          // Keep-together: require room for the heading itself PLUS the first
+          // few lines of the section that follows it; otherwise push the whole
+          // heading to the next page so it isn't stranded at the page bottom.
+          // Only reserve the following-section space when content actually
+          // follows this heading (a trailing heading shouldn't be pushed to a
+          // page of its own).
+          //
+          // The heading advances the cursor by its own height plus a trailing
+          // gap (config.lineHeight), then each following body line advances
+          // config.lineHeight and the last one still needs DEFAULT_BREAK_SPACE
+          // of look-ahead — hence: headingHeight + keepWithLines * lineHeight
+          // (trailing gap + first keepWithLines-1 advances) + one look-ahead.
+          const hasFollowingContent = nodeIndex < content.length - 1;
+          const headingHeight =
+            Math.max(headingLines.length, 1) * config.lineHeight * 1.2;
+          const requiredHeight = hasFollowingContent
+            ? headingHeight +
+              HEADING_KEEP_WITH_LINES * config.lineHeight +
+              DEFAULT_BREAK_SPACE
+            : headingHeight;
+          this.checkPageBreak(config, requiredHeight);
+
+          // The up-front check guarantees the whole heading fits, so render its
+          // lines without further page-break checks (which could split the
+          // heading across pages).
+          for (const line of headingLines) {
+            config.doc.text(line, config.margin, config.yPosition);
+            config.yPosition += config.lineHeight * 1.2;
           }
 
           config.doc.setFontSize(config.defaultFontSize);
           config.doc.setFont('helvetica', 'normal');
           config.yPosition += config.lineHeight;
           break;
+        }
 
         case 'paragraph':
           this.checkPageBreak(config);

--- a/apps/app/src/lib/pdf-generator.ts
+++ b/apps/app/src/lib/pdf-generator.ts
@@ -101,6 +101,13 @@ const convertToInternalFormat = (content: TipTapJSONContent[]): JSONContent[] =>
   }));
 };
 
+// Keep-together: minimum number of body lines that must fit on the same page
+// as a heading. If the heading plus this many lines of the following section
+// don't fit, the heading is pushed to the next page so it isn't orphaned at
+// the bottom of a page (CS-704).
+// NOTE: Keep in sync with apps/api/src/trust-portal/policy-pdf-renderer.service.ts HEADING_KEEP_WITH_LINES
+const HEADING_KEEP_WITH_LINES = 3;
+
 // Helper function to check for page breaks
 const checkPageBreak = (config: PDFConfig, requiredHeight: number = config.lineHeight) => {
   if (config.yPosition + requiredHeight > config.pageHeight - config.margin) {
@@ -178,14 +185,14 @@ const renderFormattedContent = (
 
 // Process JSON content recursively
 const processContent = (config: PDFConfig, content: JSONContent[], level: number = 0) => {
-  for (const item of content) {
+  for (const [nodeIndex, item] of content.entries()) {
     switch (item.type) {
-      case 'heading':
+      case 'heading': {
         const headingLevel = item.attrs?.level || 1;
         let fontSize: number;
         let spacingBefore: number;
         let spacingAfter: number;
-        
+
         switch (headingLevel) {
           case 1:
             fontSize = 14;
@@ -207,18 +214,43 @@ const processContent = (config: PDFConfig, content: JSONContent[], level: number
             spacingBefore = config.lineHeight;
             spacingAfter = config.lineHeight * 0.5;
         }
-        
+
         config.yPosition += spacingBefore;
-        checkPageBreak(config);
-        
-        if (item.content) {
-          const headingText = extractTextFromContent(item.content);
+
+        // Keep-together: require room for the heading itself PLUS the first
+        // few lines of the section that follows it; otherwise push the whole
+        // heading to the next page so it isn't stranded at the page bottom
+        // (CS-704). Only reserve the following-section space when content
+        // actually follows this heading.
+        const headingText = item.content
+          ? extractTextFromContent(item.content)
+          : '';
+        config.doc.setFontSize(fontSize);
+        config.doc.setFont('helvetica', 'bold');
+        const headingLineCount = headingText
+          ? config.doc.splitTextToSize(
+              cleanTextForPDF(headingText),
+              config.contentWidth,
+            ).length
+          : 0;
+        // The heading advances the cursor by its own lines plus spacingAfter,
+        // then each following body line advances (and requires) config.lineHeight
+        // — so reserve headingHeight + spacingAfter + keepWithLines * lineHeight.
+        const headingHeight = Math.max(headingLineCount, 1) * config.lineHeight;
+        const hasFollowingContent = nodeIndex < content.length - 1;
+        const requiredHeight = hasFollowingContent
+          ? headingHeight + spacingAfter + HEADING_KEEP_WITH_LINES * config.lineHeight
+          : headingHeight;
+        checkPageBreak(config, requiredHeight);
+
+        if (headingText) {
           addTextWithWrapping(config, headingText, fontSize, true);
         }
-        
+
         config.yPosition += spacingAfter;
         break;
-        
+      }
+
       case 'paragraph':
         if (item.content) {
           const paragraphText = extractTextFromContent(item.content);

--- a/apps/app/src/lib/pdf-generator.ts
+++ b/apps/app/src/lib/pdf-generator.ts
@@ -155,17 +155,58 @@ const extractTextFromContent = (content: JSONContent[]): string => {
   }).join('');
 };
 
-// Whether any sibling after `index` renders visible text. Used so the heading
-// keep-together reserve treats a heading followed only by empty paragraphs or
-// hard breaks as a trailing heading (all renderable node types here carry
-// text, so an empty result means nothing visible follows).
-const hasRenderableTextAfter = (content: JSONContent[], index: number): boolean => {
-  for (let i = index + 1; i < content.length; i++) {
-    if (extractTextFromContent([content[i]]).trim().length > 0) {
-      return true;
-    }
+// First-row height of a table, mirroring renderTable's row-height math so the
+// heading keep-together reserve can size itself against a table that follows a
+// heading (not just plain paragraphs). Keep in sync with renderTable below.
+const measureTableFirstRowHeight = (
+  tableNode: JSONContent,
+  config: PDFConfig,
+): number => {
+  const firstRow = tableNode.content?.[0];
+  if (!firstRow?.content?.length) return 0;
+
+  let columnCount = 0;
+  for (const cell of firstRow.content) {
+    columnCount += cell.attrs?.colspan ?? 1;
   }
-  return false;
+  if (columnCount === 0) return 0;
+
+  const colWidth = config.contentWidth / columnCount;
+  const cellPadding = 2;
+  let rowHeight = config.lineHeight + cellPadding * 2;
+  for (const cell of firstRow.content) {
+    if (cell.type !== 'tableCell' && cell.type !== 'tableHeader') continue;
+    const width = colWidth * (cell.attrs?.colspan ?? 1);
+    const text = cleanTextForPDF(extractCellText(cell.content ?? []));
+    const lines = config.doc.splitTextToSize(text || ' ', width - cellPadding * 2);
+    rowHeight = Math.max(
+      rowHeight,
+      lines.length * config.lineHeight + cellPadding * 2,
+    );
+  }
+  return rowHeight;
+};
+
+// Content height (beyond the heading's own height plus spacingAfter) needed to
+// keep a heading with the start of the section that follows it. Returns 0 when
+// nothing visible follows (a trailing heading). Handles tables (first-row
+// height) so keep-together isn't limited to plain paragraphs. Empty paragraphs
+// and hard breaks render nothing here, so they're skipped.
+const sectionLeadHeight = (
+  content: JSONContent[],
+  index: number,
+  config: PDFConfig,
+  spacingAfter: number,
+): number => {
+  for (let i = index + 1; i < content.length; i++) {
+    const node = content[i];
+    if (node.type === 'table' && node.content?.length) {
+      return spacingAfter + measureTableFirstRowHeight(node, config);
+    }
+    if (extractTextFromContent([node]).trim().length === 0) continue;
+    return spacingAfter + HEADING_KEEP_WITH_LINES * config.lineHeight;
+  }
+  return 0;
 };
 
 // Enhanced helper function that renders text with proper formatting
@@ -246,14 +287,23 @@ const processContent = (config: PDFConfig, content: JSONContent[], level: number
               config.contentWidth,
             ).length
           : 0;
-        // The heading advances the cursor by its own lines plus spacingAfter,
-        // then each following body line advances (and requires) config.lineHeight
-        // — so reserve headingHeight + spacingAfter + keepWithLines * lineHeight.
+        // sectionLeadHeight measures what the following section needs (a few
+        // text lines, or a table's first row, or 0 for a trailing heading),
+        // added to the heading's own height. The reserve is capped at the
+        // usable page height so an oversized heading can't force an empty
+        // leading page — addTextWithWrapping's per-line checks paginate it.
         const headingHeight = Math.max(headingLineCount, 1) * config.lineHeight;
-        const hasFollowingContent = hasRenderableTextAfter(content, nodeIndex);
-        const requiredHeight = hasFollowingContent
-          ? headingHeight + spacingAfter + HEADING_KEEP_WITH_LINES * config.lineHeight
-          : headingHeight;
+        const leadHeight = sectionLeadHeight(
+          content,
+          nodeIndex,
+          config,
+          spacingAfter,
+        );
+        const usableHeight = config.pageHeight - config.margin * 2;
+        const requiredHeight = Math.min(
+          leadHeight > 0 ? headingHeight + leadHeight : headingHeight,
+          usableHeight,
+        );
         checkPageBreak(config, requiredHeight);
 
         if (headingText) {

--- a/apps/app/src/lib/pdf-generator.ts
+++ b/apps/app/src/lib/pdf-generator.ts
@@ -155,6 +155,19 @@ const extractTextFromContent = (content: JSONContent[]): string => {
   }).join('');
 };
 
+// Whether any sibling after `index` renders visible text. Used so the heading
+// keep-together reserve treats a heading followed only by empty paragraphs or
+// hard breaks as a trailing heading (all renderable node types here carry
+// text, so an empty result means nothing visible follows).
+const hasRenderableTextAfter = (content: JSONContent[], index: number): boolean => {
+  for (let i = index + 1; i < content.length; i++) {
+    if (extractTextFromContent([content[i]]).trim().length > 0) {
+      return true;
+    }
+  }
+  return false;
+};
+
 // Enhanced helper function that renders text with proper formatting
 const renderFormattedContent = (
   config: PDFConfig,
@@ -237,7 +250,7 @@ const processContent = (config: PDFConfig, content: JSONContent[], level: number
         // then each following body line advances (and requires) config.lineHeight
         // — so reserve headingHeight + spacingAfter + keepWithLines * lineHeight.
         const headingHeight = Math.max(headingLineCount, 1) * config.lineHeight;
-        const hasFollowingContent = nodeIndex < content.length - 1;
+        const hasFollowingContent = hasRenderableTextAfter(content, nodeIndex);
         const requiredHeight = hasFollowingContent
           ? headingHeight + spacingAfter + HEADING_KEEP_WITH_LINES * config.lineHeight
           : headingHeight;


### PR DESCRIPTION
## What & why

Fixes **CS-704** — policy PDF exports split sections across pages: a section heading landed at the bottom of a page while its body flowed to the next page (orphaned heading). Reported for both single-policy and full-pack exports.

**Root cause:** both PDF generators computed the heading page-break wrong. They only guaranteed the heading (or a fixed slab) fit before rendering it — never the heading **plus the first lines of its section** — so a heading could render on the last usable line of a page and its body would break to the next page.

## Fix

Before rendering a heading, reserve room for the heading **plus the first few lines of the following section** (`HEADING_KEEP_WITH_LINES = 3`). If it doesn't fit, the whole heading is pushed to the next page. The reserve is tuned to each generator's real cursor advancement:

- **App** (`apps/app/src/lib/pdf-generator.ts`) — powers the **single-policy in-app export** (the fallback used whenever a policy has no manually-uploaded PDF). Per-line body checks use `lineHeight`, so the reserve is `headingHeight + spacingAfter + keepWithLines·lineHeight`.
- **API** (`apps/api/src/trust-portal/policy-pdf-renderer.service.ts`) — powers the **full policy-pack export** (in-app **and** the Trust Portal) via `renderPoliciesPdfBuffer`. Its `checkPageBreak` uses a 20mm (`DEFAULT_BREAK_SPACE`) look-ahead per body line, so the reserve adds one such look-ahead.

These two files carry explicit "keep in sync" markers, so both were updated together.

Additional correctness improvements:
- The reserve only applies when content actually follows the heading, so a **trailing heading** (last node) isn't bumped to a lonely page.
- Heading lines now render **without** per-line page-break checks (the up-front check already guarantees they fit), so a multi-line heading can no longer be **split** across pages.

Out of scope: the ticket's soft "Consider basic orphan/widow control" bullet. The reported, reproducible defect is stranded headings; aggressive block-level widow control would repaginate every existing policy and risks new layout regressions, so it's intentionally deferred.

## Tests

`apps/api/src/trust-portal/policy-pdf-renderer.service.spec.ts`:
- **Sweep test** — renders 30 sections at growing vertical offsets and asserts no heading is separated from the first line of its section. Verified it **fails without the fix** (headings orphaned) and passes with it.
- **Trailing-heading guard** — a heading as the last node stays on the current page.

`cd apps/api && npx jest src/trust-portal/policy-pdf-renderer.service.spec.ts` → **22 passed**. Typecheck of both touched files is clean (repo has an unrelated pre-existing RED baseline).

The app generator applies the identical algorithm (proven by the API spec); it isn't separately unit-tested because it's a browser module that triggers a `doc.save()` download and doesn't expose the buffer — testing it would need a refactor out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps section headings with the start of their section in policy PDF exports (CS-704), including cases with tables and oversized headings. Works for both single‑policy and full‑pack PDFs.

- **Bug Fixes**
  - Add keep‑together rule (`HEADING_KEEP_WITH_LINES = 3`): only render a heading if it and the next 3 body lines fit; otherwise move it to the next page (matches the Linear ask).
  - Measure what follows via `sectionLeadHeight`: skips empty paragraphs/hard breaks, handles tables by using the first row’s height, and only reserves space when visible content follows (trailing headings stay on the current page).
  - Reserve space per generator: app uses `headingHeight + spacingAfter + keepWithLines·lineHeight`; API adds a `DEFAULT_BREAK_SPACE` look‑ahead. The reserve is capped to the usable page height to avoid blank leading pages for oversized headings. Applied to both generators.
  - API safety net: per‑line checks paginate pathological multi‑page headings; normal headings remain intact.
  - Tests cover boundary sweeps (no orphaned headings), heading‑before‑tall‑table, trailing/empty‑node cases, blank‑leading‑page guard, and long‑heading pagination.

<sup>Written for commit 439a4536487b81e71e57572bf9136fa0132cf5e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

