### PR TITLE
fix(risk-treatment): rank tasks by exact in-process cosine, not filtered ANN (CS-681)

### DIFF
--- a/apps/app/src/lib/embedding/embedding.spec.ts
+++ b/apps/app/src/lib/embedding/embedding.spec.ts
@@ -29,9 +29,11 @@ vi.mock('ai', () => ({
   })),
 }));
 
+import { embedMany } from 'ai';
 import {
   upsertEntityEmbeddings,
   findSimilarTasks,
+  cosineToUnitScore,
   waitForIndexed,
   pruneOrphanTaskVectors,
 } from './index';
@@ -168,11 +170,42 @@ describe('upsertEntityEmbeddings', () => {
   });
 });
 
+describe('cosineToUnitScore', () => {
+  it('maps identical vectors to 1, opposite to 0, orthogonal to 0.5', () => {
+    expect(cosineToUnitScore([1, 0], [1, 0])).toBeCloseTo(1, 10);
+    expect(cosineToUnitScore([1, 0], [-1, 0])).toBeCloseTo(0, 10);
+    expect(cosineToUnitScore([1, 0], [0, 1])).toBeCloseTo(0.5, 10);
+  });
+
+  it('is magnitude-invariant (pure cosine) and matches Upstash (1+cos)/2', () => {
+    // Same direction, different magnitudes → still 1.
+    expect(cosineToUnitScore([2, 0], [5, 0])).toBeCloseTo(1, 10);
+    // cos = 0.6 → (1 + 0.6) / 2 = 0.8
+    expect(cosineToUnitScore([3, 4], [3, 0])).toBeCloseTo(0.8, 10);
+  });
+
+  it('returns 0 for a zero vector instead of NaN', () => {
+    expect(cosineToUnitScore([0, 0], [1, 1])).toBe(0);
+    expect(cosineToUnitScore([1, 1], [0, 0])).toBe(0);
+  });
+});
+
 describe('findSimilarTasks', () => {
-  it('queries with org + sourceType filter and returns id+score+department', async () => {
-    queryMock.mockResolvedValueOnce([
-      { id: 'task_org_1_tsk_a', score: 0.82, metadata: { sourceId: 'tsk_a', department: 'hr' } },
-      { id: 'task_org_1_tsk_b', score: 0.71, metadata: { sourceId: 'tsk_b', department: 'none' } },
+  // Range page helper — `nextCursor: ''` signals the enumeration is drained.
+  function taskPage(
+    vectors: Array<{ id: string; vector: number[]; metadata?: Record<string, unknown> }>,
+  ) {
+    rangeMock.mockResolvedValueOnce({ nextCursor: '', vectors });
+  }
+
+  it('enumerates the org task vectors by prefix and ranks them in-process by cosine', async () => {
+    // Query points along [1,0]; task vectors are chosen so the cosine ordering
+    // is deterministic: tsk_a (identical) > tsk_b (orthogonal) > tsk_c (opposite).
+    vi.mocked(embedMany).mockResolvedValueOnce({ embeddings: [[1, 0]] } as never);
+    taskPage([
+      { id: 'task_org_1_tsk_b', vector: [0, 1], metadata: { sourceId: 'tsk_b', department: 'none' } },
+      { id: 'task_org_1_tsk_a', vector: [1, 0], metadata: { sourceId: 'tsk_a', department: 'hr' } },
+      { id: 'task_org_1_tsk_c', vector: [-1, 0], metadata: { sourceId: 'tsk_c' } },
     ]);
 
     const results = await findSimilarTasks({
@@ -181,42 +214,88 @@ describe('findSimilarTasks', () => {
       topK: 10,
     });
 
-    expect(queryMock).toHaveBeenCalledWith(
+    // Enumerates via prefix range WITH the stored vectors — never an ANN query.
+    expect(rangeMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        topK: 10,
+        cursor: '0',
+        prefix: 'task_org_1_',
+        includeVectors: true,
         includeMetadata: true,
-        filter: 'organizationId = "org_1" AND sourceType = "task"',
       }),
     );
+    expect(queryMock).not.toHaveBeenCalled();
+    // Sorted by score desc, scores on Upstash's (1+cos)/2 scale.
     expect(results).toEqual([
-      { id: 'tsk_a', score: 0.82, department: 'hr' },
-      { id: 'tsk_b', score: 0.71, department: 'none' },
+      { id: 'tsk_a', score: 1, department: 'hr' },
+      { id: 'tsk_b', score: 0.5, department: 'none' },
+      { id: 'tsk_c', score: 0, department: undefined },
     ]);
   });
 
-  it('returns empty when query text is empty', async () => {
+  it('applies the topK cap after ranking', async () => {
+    vi.mocked(embedMany).mockResolvedValueOnce({ embeddings: [[1, 0]] } as never);
+    taskPage([
+      { id: 'task_org_1_tsk_a', vector: [1, 0], metadata: { sourceId: 'tsk_a' } },
+      { id: 'task_org_1_tsk_b', vector: [0.9, 0.1], metadata: { sourceId: 'tsk_b' } },
+      { id: 'task_org_1_tsk_c', vector: [-1, 0], metadata: { sourceId: 'tsk_c' } },
+    ]);
+
     const results = await findSimilarTasks({
       organizationId: 'org_1',
-      queryText: '   ',
+      queryText: 'phishing risk',
+      topK: 2,
     });
+
+    expect(results).toHaveLength(2);
+    expect(results.map((r) => r.id)).toEqual(['tsk_a', 'tsk_b']);
+  });
+
+  it('paginates the enumeration across cursor pages', async () => {
+    vi.mocked(embedMany).mockResolvedValueOnce({ embeddings: [[1, 0]] } as never);
+    rangeMock
+      .mockResolvedValueOnce({
+        nextCursor: 'cursor_2',
+        vectors: [{ id: 'task_org_1_tsk_p1', vector: [1, 0], metadata: { sourceId: 'tsk_p1' } }],
+      })
+      .mockResolvedValueOnce({
+        nextCursor: '',
+        vectors: [{ id: 'task_org_1_tsk_p2', vector: [0, 1], metadata: { sourceId: 'tsk_p2' } }],
+      });
+
+    const results = await findSimilarTasks({ organizationId: 'org_1', queryText: 'x' });
+
+    expect(rangeMock).toHaveBeenCalledTimes(2);
+    expect(rangeMock.mock.calls[1][0]).toEqual(
+      expect.objectContaining({ cursor: 'cursor_2', prefix: 'task_org_1_' }),
+    );
+    // A task from page 2 is included in the ranking.
+    expect(results.map((r) => r.id).sort()).toEqual(['tsk_p1', 'tsk_p2']);
+  });
+
+  it('returns empty when query text is empty (no embed, no range)', async () => {
+    const results = await findSimilarTasks({ organizationId: 'org_1', queryText: '   ' });
     expect(results).toEqual([]);
+    expect(rangeMock).not.toHaveBeenCalled();
     expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('returns empty when the org has no task vectors', async () => {
+    vi.mocked(embedMany).mockResolvedValueOnce({ embeddings: [[1, 0]] } as never);
+    taskPage([]);
+    const results = await findSimilarTasks({ organizationId: 'org_1', queryText: 'x' });
+    expect(results).toEqual([]);
   });
 
   it('recovers the raw task id from the prefix when metadata.sourceId is missing', async () => {
     // Legacy vector with no sourceId metadata. Returning the prefixed embedding
     // id would make runLinkage drop it as "not in live scope" (taskById is keyed
     // by raw ids), silently starving suggestions. (cubic P1)
-    queryMock.mockResolvedValueOnce([
-      { id: 'task_org_1_tsk_legacy', score: 0.8, metadata: {} },
-    ]);
+    vi.mocked(embedMany).mockResolvedValueOnce({ embeddings: [[1, 0]] } as never);
+    taskPage([{ id: 'task_org_1_tsk_legacy', vector: [1, 0], metadata: {} }]);
 
-    const results = await findSimilarTasks({
-      organizationId: 'org_1',
-      queryText: 'phishing risk',
-    });
+    const results = await findSimilarTasks({ organizationId: 'org_1', queryText: 'phishing risk' });
 
-    expect(results).toEqual([{ id: 'tsk_legacy', score: 0.8, department: undefined }]);
+    expect(results).toEqual([{ id: 'tsk_legacy', score: 1, department: undefined }]);
   });
 });
 

--- a/apps/app/src/lib/embedding/index.ts
+++ b/apps/app/src/lib/embedding/index.ts
@@ -57,13 +57,14 @@ export interface SimilarTaskResult {
 const EMBEDDING_MODEL = 'text-embedding-3-large';
 const EMBEDDING_DIMENSIONS = 1536;
 const DEFAULT_TOP_K = 25;
-// Page size for the orphan-vector sweep. `pruneOrphanTaskVectors` paginates an
-// org's task vectors via `range` over their shared id prefix, so there is no
-// top-K ceiling — this only controls how many vectors come back per round trip.
-const ORPHAN_SCAN_PAGE_SIZE = 1000;
+// Pagination for enumerating an org's task vectors by their shared id prefix —
+// used by both `findSimilarTasks` (exact in-process ranking) and
+// `pruneOrphanTaskVectors` (orphan sweep). Prefix enumeration has no top-K
+// ceiling; page size only controls how many vectors come back per round trip.
+const TASK_VECTOR_PAGE_SIZE = 1000;
 // Backstop so a misbehaving cursor can't loop forever. 500 pages × 1000 = 500k
 // task vectors, far beyond any real org — hitting it signals a bug, not scale.
-const ORPHAN_SCAN_MAX_PAGES = 500;
+const TASK_VECTOR_MAX_PAGES = 500;
 
 let cachedIndex: Index | null = null;
 
@@ -187,9 +188,90 @@ export async function upsertEntityEmbeddings({
   };
 }
 
+interface OrgTaskVector {
+  /** raw task id (sourceId), not the prefixed embedding id */
+  sourceId: string;
+  vector: number[];
+  department?: string;
+}
+
+/**
+ * Enumerate an org's task vectors (with their embeddings) by their shared id
+ * prefix. Every task vector is keyed `task_${organizationId}_${sourceId}` (see
+ * `embeddingId`), so a cursor-paginated `range` returns exactly this org's task
+ * vectors — no metadata filter, no top-K ceiling.
+ */
+async function fetchOrgTaskVectors(organizationId: string): Promise<OrgTaskVector[]> {
+  const index = getIndex();
+  const prefix = embeddingIdPrefix('task', organizationId);
+
+  const out: OrgTaskVector[] = [];
+  let cursor: string | number = '0';
+  let enumeratedFully = false;
+  for (let page = 0; page < TASK_VECTOR_MAX_PAGES; page++) {
+    const { vectors, nextCursor }: RangeResult = await index.range({
+      cursor,
+      limit: TASK_VECTOR_PAGE_SIZE,
+      prefix,
+      includeVectors: true,
+      includeMetadata: true,
+    });
+    for (const r of vectors) {
+      if (!r.vector) continue; // defensive: skip any vector row missing embeddings
+      const meta = (r.metadata ?? {}) as { sourceId?: string; department?: string };
+      out.push({
+        sourceId: meta.sourceId ?? sourceIdFromEmbeddingId('task', organizationId, String(r.id)),
+        vector: r.vector as number[],
+        department: meta.department ?? undefined,
+      });
+    }
+    if (!nextCursor) {
+      enumeratedFully = true;
+      break;
+    }
+    cursor = nextCursor;
+  }
+  if (!enumeratedFully) {
+    console.warn(
+      `[embedding] task-vector enumeration hit the ${TASK_VECTOR_MAX_PAGES}-page cap for org ${organizationId} after ${out.length} vector(s); ranking may be incomplete`,
+    );
+  }
+  return out;
+}
+
+/**
+ * Cosine similarity mapped to Upstash's COSINE score scale, `(1 + cos) / 2`, so
+ * scores stay in [0, 1] and are drop-in compatible with the department boost /
+ * threshold in `linkSuggestions` and the reranker's `cosineScore` hint.
+ */
+export function cosineToUnitScore(a: number[], b: number[]): number {
+  const len = Math.min(a.length, b.length);
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < len; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  if (normA === 0 || normB === 0) return 0;
+  const cos = dot / (Math.sqrt(normA) * Math.sqrt(normB));
+  return (1 + cos) / 2;
+}
+
 /**
  * Find the top-K most similar Tasks in an org for a given query string.
  * Returns raw task ids (not prefixed embedding ids) along with score + department.
+ *
+ * Retrieval enumerates the org's task vectors by id prefix and scores them
+ * exactly in-process, rather than issuing a metadata-filtered ANN query. A
+ * filtered `query` (`organizationId AND sourceType`) collapses to near-zero
+ * recall here: one org is a tiny slice of a 180k+ vector shared-namespace index,
+ * so Upstash's approximate traversal exhausts its candidate budget on nearer,
+ * non-matching vectors before reaching this org's tasks — returning 0 candidates
+ * even when relevant tasks exist, which starved treatment plans of every
+ * suggestion (CS-681). An org holds at most low-hundreds of tasks, so exact
+ * scoring over the full set is both correct (no recall loss) and cheap.
  */
 export async function findSimilarTasks({
   organizationId,
@@ -203,23 +285,19 @@ export async function findSimilarTasks({
     values: [queryText],
     providerOptions: { openai: { dimensions: EMBEDDING_DIMENSIONS } },
   });
+  const queryVector = embeddings[0];
 
-  const index = getIndex();
-  const results = await index.query({
-    vector: embeddings[0],
-    topK,
-    includeMetadata: true,
-    filter: `organizationId = "${organizationId}" AND sourceType = "task"`,
-  });
+  const taskVectors = await fetchOrgTaskVectors(organizationId);
+  if (taskVectors.length === 0) return [];
 
-  return results.map((r) => {
-    const meta = (r.metadata ?? {}) as { sourceId?: string; department?: string };
-    return {
-      id: meta.sourceId ?? sourceIdFromEmbeddingId('task', organizationId, String(r.id)),
-      score: r.score,
-      department: meta.department ?? undefined,
-    };
-  });
+  return taskVectors
+    .map((t) => ({
+      id: t.sourceId,
+      score: cosineToUnitScore(queryVector, t.vector),
+      department: t.department,
+    }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, topK);
 }
 
 export interface PruneOrphanTaskVectorsResult {
@@ -267,12 +345,12 @@ export async function pruneOrphanTaskVectors({
   let scanned = 0;
   let cursor: string | number = '0';
   let enumeratedFully = false;
-  for (let page = 0; page < ORPHAN_SCAN_MAX_PAGES; page++) {
+  for (let page = 0; page < TASK_VECTOR_MAX_PAGES; page++) {
     // Annotate the result explicitly: `cursor = nextCursor` would otherwise make
     // TS infer `nextCursor`'s type from a binding that depends on it (TS7022).
     const { vectors, nextCursor }: RangeResult = await index.range({
       cursor,
-      limit: ORPHAN_SCAN_PAGE_SIZE,
+      limit: TASK_VECTOR_PAGE_SIZE,
       prefix,
       includeMetadata: true,
     });
@@ -292,7 +370,7 @@ export async function pruneOrphanTaskVectors({
   }
   if (!enumeratedFully) {
     console.warn(
-      `[embedding] orphan sweep hit the ${ORPHAN_SCAN_MAX_PAGES}-page cap for org ${organizationId} after scanning ${scanned} vector(s); enumeration may be incomplete`,
+      `[embedding] orphan sweep hit the ${TASK_VECTOR_MAX_PAGES}-page cap for org ${organizationId} after scanning ${scanned} vector(s); enumeration may be incomplete`,
     );
   }
 


### PR DESCRIPTION
## Problem

"Draft plan & suggest links" on a risk's Treatment Plan returns **"0 tasks and 0 controls"** for most risks in affected orgs. My earlier fix (#3340) targeted orphan-vector pruning — a real but *different* problem that isn't present in the affected orgs, so it shipped and the symptom remained.

## Root cause (verified against prod)

`findSimilarTasks` retrieved candidates with a metadata-filtered ANN query:

```
filter: organizationId = "<org>" AND sourceType = "task"
```

against a **single ~180k-vector shared-namespace index**. Upstash applies metadata filters *during* approximate (HNSW) traversal, so a highly selective per-org filter (one org ≈ 0.04% of the index) makes the traversal exhaust its candidate budget on nearer, non-matching vectors before reaching the org's tasks — returning **0 results even at topK=1000**, even though the vectors exist. It degrades as the shared index grows.

Because controls are derived from the suggested tasks, 0 tasks ⟹ 0 controls.

## Fix

An org has at most low-hundreds of tasks (max in prod today: 96). So instead of an approximate filtered query, enumerate the org's task vectors by their `task_${org}_` id prefix and score them **exactly, in-process**. At this scale exact scoring is the right-sized tool: no recall loss, no data migration, no second system.

- New `fetchOrgTaskVectors` (paginated `range` by id prefix, reuses the existing enumeration constants + `sourceIdFromEmbeddingId` fallback).
- New `cosineToUnitScore` — maps cosine to Upstash's `(1 + cos) / 2` scale so the downstream department boost / threshold in `linkSuggestions` and the reranker's `cosineScore` hint are **unchanged**.
- `findSimilarTasks` rewired to rank in-process. Same signature, same return shape.

## Explicitly NOT touched

- `pruneOrphanTaskVectors` (only a constant rename it shares) and the in-scope filtering in `runLinkage` — they still compose correctly: enumeration returns all of an org's task vectors, and the in-scope filter still drops any not in the live DB scope.
- No changes to embedding/upsert, the reranker, or the trigger wrapper.

## Verification (real production data)

- **Example risk from the ticket:** old filtered ANN = **0 tasks** → new = **full task list** (confirmed via the live OpenAI embedding path, not just stored vectors); top suggestions are relevant (policies, secure storage, incident response, retention…).
- **Reported org:** old returned 0 tasks for **19/20** risks → new returns tasks for **20/20**, zero regressions.
- **Largest org (96 tasks):** old 0 for 4/5 → new **5/5**.
- New unit tests for `cosineToUnitScore` (scale + zero-vector guard) and `findSimilarTasks` (prefix enumeration, in-process ranking, topK cap, pagination, empty cases, legacy-id fallback). Typecheck adds zero new errors.

## Note / follow-ups

- Per-call enumeration (one cheap `range` page for ≤~100 tasks) replaces one ANN query per call — no meaningful latency change; could batch to one fetch per run later if ever needed.
- The same shared-index query pattern is duplicated in `apps/api/src/vector-store` and likely has the same latent issue — separate follow-up.

Fixes CS-681

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CS-681 by ranking each org’s tasks with exact in-process cosine over prefix-enumerated vectors instead of a metadata-filtered ANN query on the shared index. Restores task and control suggestions in Treatment Plans that were returning 0/0.

- **Bug Fixes**
  - Rewired `findSimilarTasks` to enumerate `task_${org}_*` via `range` (include vectors), score locally by cosine, then sort and apply `topK`.
  - Added `cosineToUnitScore` to match Upstash’s `(1 + cos)/2` scale so downstream thresholds/boosts remain unchanged; guards zero vectors.
  - Tests cover ranking order, `topK` cap, pagination, empty input/org, and legacy id fallback; kept `pruneOrphanTaskVectors` behavior (pagination constant rename only).

<sup>Written for commit f3a0d54eb013c33f60910dbf2ad96090652baf23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

