### PR TITLE
fix(isms): production-deploy review follow-ups (CS-701)

### DIFF
--- a/apps/api/src/isms/dto/export-isms-document.dto.ts
+++ b/apps/api/src/isms/dto/export-isms-document.dto.ts
@@ -12,7 +12,8 @@ export class ExportIsmsDocumentDto {
 
   @ApiPropertyOptional({
     description:
-      'Published version to export. Omit to export the current working draft; ' +
+      "Published version to export. Omit to export the document's current " +
+      'published version (or the working draft if it has never been published); ' +
       'provide a version id to download exactly what was approved at that version.',
   })
   @IsOptional()

--- a/apps/api/src/isms/isms.service.spec.ts
+++ b/apps/api/src/isms/isms.service.spec.ts
@@ -89,6 +89,29 @@ describe('IsmsService ensureSetup', () => {
         expect(mockDb.ismsDocument.findMany).toHaveBeenCalledTimes(1);
         expect(result.documents).toHaveLength(1);
       });
+
+      it('reports hasApprovedVersion from a published version OR an approved status', async () => {
+        (mockDb.frameworkEditorFramework.findUnique as jest.Mock).mockResolvedValue({
+          id: 'fw_1',
+          requirements: [],
+        });
+        (mockDb.ismsDocument.findMany as jest.Mock).mockResolvedValueOnce([
+          // Published version exists.
+          { id: 'd1', type: 'isms_scope', status: 'draft', requirementId: null, currentVersionId: 'isms_ver_1' },
+          // Approved before versioning existed: no version row, but still approved.
+          { id: 'd2', type: 'leadership_commitment', status: 'approved', requirementId: null, currentVersionId: null },
+          // Never approved.
+          { id: 'd3', type: 'objectives_plan', status: 'draft', requirementId: null, currentVersionId: null },
+        ]);
+
+        const result = await service.ensureSetup({ ...dto, canWrite: false });
+
+        expect(result.documents.map((d) => d.hasApprovedVersion)).toEqual([
+          true,
+          true,
+          false,
+        ]);
+      });
     });
 
     describe('template-driven (templates seeded)', () => {

--- a/apps/api/src/isms/isms.service.ts
+++ b/apps/api/src/isms/isms.service.ts
@@ -65,9 +65,13 @@ export class IsmsService {
         type: doc.type,
         status: doc.status,
         requirementId: doc.requirementId,
-        // A published version exists (the document has been approved at least
-        // once) — independent of whether the draft has since been edited.
-        hasApprovedVersion: doc.currentVersionId != null,
+        // The document has an approved artifact: either a published version row
+        // (approved under the versioning model) or `status === 'approved'` — the
+        // latter covers documents approved before versioning existed, whose legacy
+        // version rows were dropped by the migration and which capture a real
+        // versioned artifact on their next approval.
+        hasApprovedVersion:
+          doc.currentVersionId != null || doc.status === 'approved',
       })),
     };
   }

--- a/apps/app/src/app/(app)/[orgId]/documents/isms/components/IsmsApprovalSection.tsx
+++ b/apps/app/src/app/(app)/[orgId]/documents/isms/components/IsmsApprovalSection.tsx
@@ -128,8 +128,8 @@ export function IsmsApprovalSection({
             <Text as="span" size="sm" weight="medium">
               v{publishedVersion}
             </Text>{' '}
-            stays live and exportable. Your changes are an in-progress draft (v
-            {nextDraftVersion}) — submit it for approval to publish.
+            stays live and exportable. Your changes are an in-progress draft{' '}
+            {`(v${nextDraftVersion})`} — submit it for approval to publish.
           </AlertDescription>
         </Alert>
       )}

--- a/apps/app/src/app/(app)/[orgId]/documents/isms/components/ScopeClient.tsx
+++ b/apps/app/src/app/(app)/[orgId]/documents/isms/components/ScopeClient.tsx
@@ -64,10 +64,17 @@ export function ScopeClient(props: ScopeClientProps) {
         };
 
         const narrative = toScopeNarrative(document.draftNarrative);
+        // Re-seed the form (via remount) whenever the persisted draft content
+        // changes — e.g. after "Generate from platform data" or a reload — not
+        // just when the published version changes. ScopeForm reads its defaults
+        // at mount, so the key must reflect the draft, not currentVersionId alone.
+        const formKey = `${document.currentVersionId ?? 'draft'}:${JSON.stringify(
+          document.draftNarrative ?? {},
+        )}`;
 
         return (
           <ScopeForm
-            key={document.currentVersionId ?? 'draft'}
+            key={formKey}
             narrative={narrative}
             canEdit={canManage}
             onSave={handleSaveNarrative}


### PR DESCRIPTION
## Why

The main→release production-deploy PR (#3364) got an automated review that flagged 4 ISMS issues in the CS-701 versioning work (already merged to `main`). This PR fixes the real ones. Base is `main` (stage); it flows to `release` (production) on the next deploy.

## What (each maps to a flagged issue)

- **P2 — `hasApprovedVersion` could report `false` for an approved doc.** The migration intentionally drops legacy (pre-CS-701, snapshot-less) version rows but preserves the `approved` status, leaving `currentVersionId` null. `hasApprovedVersion` now checks `currentVersionId != null || status === 'approved'`, so those docs stay consistent (they capture a real versioned artifact on their next approval). Locked with a unit test.
- **P3 — Scope form showed stale text after "Generate from platform data" / reload.** `ScopeForm` reads its defaults at mount; its remount key tracked the published `currentVersionId`, which doesn't change when the *draft* does. The key now reflects `draftNarrative`, so the form re-seeds on draft changes. (LeadershipForm already handled this via a reset effect; ScopeForm's narrative is a fresh object each render, so keying is the clean equivalent.)
- **P3 — export DTO description was misleading.** It said omitting `versionId` exports the working draft, but runtime serves the current *published* version when one exists. Description updated to match.
- **P3 — approval banner rendered `v 2` instead of `v2`** (JSX split the `v` and the number). Now a single expression.

## Not changed (by design)

The migration stays **non-destructive** (approvals preserved rather than reset to draft). The `hasApprovedVersion` fix makes that state self-consistent, so no destructive reset or heavy backfill is needed for pre-GA (flag-gated) data.

## Testing

- **319 API + 123 app ISMS tests passing**, typecheck clean on both.

Follows up on #3361 (CS-701). Flagged in #3364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CweXoSSEP89mX93u3Bdcp


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ISMS follow-ups from CS-701 versioning to keep approval state accurate and refresh scope text, plus minor UI/DTO copy corrections for a cleaner publish/export experience.

- **Bug Fixes**
  - `hasApprovedVersion` now true when `currentVersionId` exists or `status === 'approved'` (covers pre-versioning approvals); adds unit test.
  - Scope form remounts when `draftNarrative` changes so generated/reloaded text appears immediately.
  - Export DTO description corrected: omitting `versionId` exports the current published version, or the draft if never published.
  - Approval banner now renders `(v2)` instead of `v 2`.

<sup>Written for commit c815b4844560a43a398c363c1b783329c2732ff2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

