### PR TITLE
fix(isms): centrally serialize all content edits against approve (CS-701)

### DIFF
--- a/apps/api/src/isms/isms-document-control.service.spec.ts
+++ b/apps/api/src/isms/isms-document-control.service.spec.ts
@@ -14,6 +14,8 @@ jest.mock('@db', () => {
       createMany: jest.fn(),
       deleteMany: jest.fn(),
     },
+    // Advisory lock taken by invalidateApprovalIfNeeded (serializes vs approve).
+    $executeRaw: jest.fn(),
     // Run the callback with the same mock as the transaction client.
     $transaction: jest.fn((cb: (tx: unknown) => unknown) => cb(db)),
   };

--- a/apps/api/src/isms/isms-narrative.service.spec.ts
+++ b/apps/api/src/isms/isms-narrative.service.spec.ts
@@ -9,6 +9,8 @@ jest.mock('@db', () => {
       findUnique: jest.fn(),
       update: jest.fn(),
     },
+    // Advisory lock taken by invalidateApprovalIfNeeded (serializes vs approve).
+    $executeRaw: jest.fn(),
     // Run the callback with the same mock as the transaction client.
     $transaction: jest.fn((cb: (tx: unknown) => unknown) => cb(db)),
   };

--- a/apps/api/src/isms/utils/approval.spec.ts
+++ b/apps/api/src/isms/utils/approval.spec.ts
@@ -1,0 +1,62 @@
+import { invalidateApprovalIfNeeded } from './approval';
+
+/**
+ * invalidateApprovalIfNeeded is the central serialization point: every ISMS
+ * content-mutation path calls it, and it must take the per-document advisory lock
+ * (so edits serialize against approve()) BEFORE reading/altering status.
+ */
+function makeTx() {
+  return {
+    $executeRaw: jest.fn().mockResolvedValue(0),
+    ismsDocument: {
+      findUnique: jest.fn(),
+      update: jest.fn().mockResolvedValue({}),
+    },
+  };
+}
+
+describe('invalidateApprovalIfNeeded', () => {
+  it('acquires the per-document advisory lock before reading status', async () => {
+    const tx = makeTx();
+    tx.ismsDocument.findUnique.mockResolvedValue({ status: 'draft' });
+
+    await invalidateApprovalIfNeeded({
+      tx: tx as never,
+      documentId: 'doc_1',
+    });
+
+    expect(tx.$executeRaw).toHaveBeenCalledTimes(1);
+    // Lock is taken before the status read (serializes vs approve()).
+    expect(tx.$executeRaw.mock.invocationCallOrder[0]).toBeLessThan(
+      tx.ismsDocument.findUnique.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('reverts an approved document to draft (clearing approver + approvedAt)', async () => {
+    const tx = makeTx();
+    tx.ismsDocument.findUnique.mockResolvedValue({ status: 'approved' });
+
+    await invalidateApprovalIfNeeded({
+      tx: tx as never,
+      documentId: 'doc_1',
+    });
+
+    expect(tx.ismsDocument.update).toHaveBeenCalledWith({
+      where: { id: 'doc_1' },
+      data: { status: 'draft', approvedAt: null, approverId: null },
+    });
+  });
+
+  it('is a no-op for a non-approved document (but still locked)', async () => {
+    const tx = makeTx();
+    tx.ismsDocument.findUnique.mockResolvedValue({ status: 'needs_review' });
+
+    await invalidateApprovalIfNeeded({
+      tx: tx as never,
+      documentId: 'doc_1',
+    });
+
+    expect(tx.$executeRaw).toHaveBeenCalledTimes(1);
+    expect(tx.ismsDocument.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/isms/utils/approval.ts
+++ b/apps/api/src/isms/utils/approval.ts
@@ -1,4 +1,5 @@
 import type { Prisma } from '@db';
+import { lockDocument } from './document-lock';
 
 /**
  * Editing an approved ISMS document invalidates its sign-off: revert it to draft
@@ -6,6 +7,15 @@ import type { Prisma } from '@db';
  * touches the document when it is currently `approved`; a no-op otherwise. Must
  * run inside the same transaction as the content write so a failed write does not
  * leave the document reverted to draft without the new content.
+ *
+ * Every content-mutation path (register create/update/delete, narrative save,
+ * control link add/remove, regenerate) calls this, so acquiring the per-document
+ * advisory lock here centrally serializes ALL edits against approve() — which
+ * takes the same lock. Without it, an edit could interleave while approve() is
+ * loading + freezing the version under READ COMMITTED, leaving an approved version
+ * that omits the edit (or an edit that never invalidated the approval). The lock
+ * is transaction-scoped and re-entrant, so create paths that already take it for
+ * position allocation are unaffected.
  */
 export async function invalidateApprovalIfNeeded({
   tx,
@@ -14,6 +24,8 @@ export async function invalidateApprovalIfNeeded({
   tx: Prisma.TransactionClient;
   documentId: string;
 }): Promise<void> {
+  await lockDocument(tx, documentId);
+
   const document = await tx.ismsDocument.findUnique({
     where: { id: documentId },
     select: { status: true },


### PR DESCRIPTION
## Why

Follow-up to #3366. On the production-deploy review (#3364), cubic correctly flagged (P1) that #3366's approve-race fix was **incomplete**: the advisory lock only protected paths that also take it, so a register **update/delete** (or narrative save / control link / regenerate) could still interleave while `approve()` loads `EXPORT_DOCUMENT_INCLUDE` and freezes the version — leaving an approved version that omits the edit, or an edit that never invalidated the approval.

## Fix — enforced centrally (as cubic suggested)

Rather than add the lock to ~12 scattered transactions, `invalidateApprovalIfNeeded` now takes the per-document advisory lock as its **first action**. Every content-mutation path already calls it — register create/update/delete, narrative save, control add/remove, and regenerate — so **all** edits now serialize against `approve()` (which takes the same lock). Either the edit is frozen into the version, or it correctly reverts the document to draft; no interleaving can do neither.

The lock is transaction-scoped and re-entrant, so the register create paths that already acquire it for `max(position)` allocation are unaffected.

## Tests

- Adds `utils/approval.spec.ts` (lock-taken-before-status-read ordering + revert / no-op behavior).
- `$executeRaw` added to the two tx mocks that exercise the real `invalidateApprovalIfNeeded`.
- **324 API ISMS tests passing**, typecheck clean, on top of current `main` (incl. #3366).

Closes the residual flagged on #3364; completes #3366.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CweXoSSEP89mX93u3Bdcp


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes the per-document advisory lock so all ISMS content edits serialize against approval, fixing a race that could freeze an incomplete version or let edits bypass invalidation. Supports CS-701 by ensuring published version snapshots are always accurate.

- **Bug Fixes**
  - `invalidateApprovalIfNeeded` now acquires the per-document advisory lock first, so every edit path (register update/delete, narrative save, control link, regenerate) serializes against `approve()`.
  - Prevents interleaving under READ COMMITTED: either the edit is included in the approved version or the document cleanly reverts to draft.
  - Lock is transaction-scoped and re-entrant, so existing create paths using the lock for position allocation are unaffected.

- **Tests**
  - Added `utils/approval.spec.ts` to assert lock-before-status ordering and revert/no-op behavior.
  - Updated test transaction mocks to include `$executeRaw` in `@db`-backed specs.

<sup>Written for commit 96dfb64ae17ec33b3d375ea007f58291c6979a0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

