### PR TITLE
fix(isms): lock control-link edits before write (CS-701)

### DIFF
--- a/apps/api/src/isms/isms-document-control.service.spec.ts
+++ b/apps/api/src/isms/isms-document-control.service.spec.ts
@@ -90,6 +90,20 @@ describe('IsmsDocumentControlService', () => {
         skipDuplicates: true,
       });
     });
+
+    it('takes the per-document lock BEFORE writing links (serializes vs approve)', async () => {
+      await service.addControls({
+        documentId: 'doc_1',
+        organizationId: 'org_1',
+        controlIds: ['ctl_1', 'ctl_2'],
+      });
+
+      const lockOrder = (mockDb.$executeRaw as jest.Mock).mock
+        .invocationCallOrder[0];
+      const writeOrder = (mockDb.ismsDocumentControlLink.createMany as jest.Mock)
+        .mock.invocationCallOrder[0];
+      expect(lockOrder).toBeLessThan(writeOrder);
+    });
   });
 
   describe('removeControl', () => {

--- a/apps/api/src/isms/isms-document-control.service.ts
+++ b/apps/api/src/isms/isms-document-control.service.ts
@@ -5,6 +5,7 @@ import {
 } from '@nestjs/common';
 import { db } from '@db';
 import { invalidateApprovalIfNeeded } from './utils/approval';
+import { lockDocument } from './utils/document-lock';
 
 /**
  * Org-level mapping between an ISMS document and the organization's Controls
@@ -41,6 +42,11 @@ export class IsmsDocumentControlService {
     // register/narrative edits). Only a REAL change invalidates — an idempotent
     // re-link that inserts nothing must not downgrade an approved document.
     await db.$transaction(async (tx) => {
+      // Take the per-document lock BEFORE writing links so the mutation is fully
+      // serialized against approve() (which holds the same lock). invalidate is
+      // only called on a real change, and the lock is re-entrant, so re-taking it
+      // there is a no-op.
+      await lockDocument(tx, documentId);
       const { count } = await tx.ismsDocumentControlLink.createMany({
         data: uniqueControlIds.map((controlId) => ({
           ismsDocumentId: documentId,
@@ -68,6 +74,9 @@ export class IsmsDocumentControlService {
     // Only a real unlink (a row actually deleted) invalidates sign-off; removing
     // a control that wasn't linked must not downgrade an approved document.
     await db.$transaction(async (tx) => {
+      // Lock before the delete so the mutation serializes against approve()
+      // (same lock); invalidate only on a real unlink, re-taking the lock no-ops.
+      await lockDocument(tx, documentId);
       const { count } = await tx.ismsDocumentControlLink.deleteMany({
         where: { ismsDocumentId: documentId, controlId },
       });


### PR DESCRIPTION
## Why

Flagged on the production-deploy PR #3364 (P2): `addControls`/`removeControl` wrote the control-link rows **first** and only then called `invalidateApprovalIfNeeded` (which holds the per-document lock). So the link write ran *outside* the lock and could interleave with `approve()` before serialization kicked in.

Impact was limited — control links are **not** part of the frozen version snapshot, so no published version could be corrupted — but the mutation should still be serialized like every other content edit, and the lock-before-write pattern is the correct one.

## Fix

Both control transactions now take `lockDocument()` as their **first** statement, before `createMany`/`deleteMany`. The conditional `invalidateApprovalIfNeeded` (real-change-only) is unchanged, and the advisory lock is transaction-scoped + re-entrant, so re-taking it there is a no-op. Added an ordering test asserting the lock precedes the write.

## Tests

- **325 API ISMS tests passing**, typecheck clean, on top of current `main`.

Completes the ISMS concurrency hardening (#3366, #3367). Flagged in #3364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012CweXoSSEP89mX93u3Bdcp


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lock control-link edits before writes so `addControls`/`removeControl` run inside the per-document lock and serialize with `approve()`. Implements CS-701.

- **Bug Fixes**
  - Call `lockDocument` first in both transactions, before `createMany`/`deleteMany`, to prevent interleaving with `approve()`.
  - Keep `invalidateApprovalIfNeeded` conditional; the lock is re-entrant so re-taking it is a no-op. Added a test asserting the lock precedes the write.

<sup>Written for commit b075f7cd2bc539e4f3a768a5a3d4e2482e64cfb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

