### PR TITLE
fix(integrations): redirect GitHub App users to install when not installed (CS-710)

### DIFF
--- a/apps/api/src/integration-platform/controllers/oauth.controller.spec.ts
+++ b/apps/api/src/integration-platform/controllers/oauth.controller.spec.ts
@@ -614,13 +614,74 @@ describe('OAuthController', () => {
         config: {
           authorizeUrl: 'https://github.com/login/oauth/authorize',
           tokenUrl: 'https://github.com/login/oauth/access_token',
+          installUrl:
+            'https://github.com/apps/comp-ai-compliance/installations/new',
         },
       },
       capabilities: [],
       isActive: true,
     };
 
-    it('blocks the GitHub App connect when the App is not installed', async () => {
+    const notInstalledFetch = () =>
+      jest
+        .spyOn(global, 'fetch')
+        // 1) token exchange
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ access_token: 'gh_token' }),
+          text: () => Promise.resolve(''),
+        } as unknown as Response)
+        // 2) GET /user/installations -> none
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ total_count: 0, installations: [] }),
+          text: () => Promise.resolve(''),
+        } as unknown as Response);
+
+    it('redirects to the install URL when the App is not installed (first pass)', async () => {
+      const futureDate = new Date(Date.now() + 600000);
+      mockOAuthStateRepository.findByState.mockResolvedValue({
+        state: 'gh_state',
+        providerSlug: 'github-app',
+        organizationId: 'org_1',
+        userId: 'user_1',
+        codeVerifier: null,
+        redirectUrl: null,
+        expiresAt: futureDate,
+      });
+      mockedGetManifest.mockReturnValue(githubAppManifest as never);
+      mockOAuthCredentialsService.getCredentials.mockResolvedValue({
+        clientId: 'c',
+        clientSecret: 's',
+        scopes: [],
+        source: 'platform',
+      });
+      mockOAuthStateRepository.create.mockResolvedValue({
+        state: 'install_state',
+      });
+
+      const fetchSpy = notInstalledFetch();
+
+      await controller.oauthCallback(
+        { code: 'auth_code', state: 'gh_state' },
+        mockRequest,
+        mockResponse,
+      );
+
+      // No installation yet → send them to install, don't finalize.
+      expect(mockConnectionService.activateConnection).not.toHaveBeenCalled();
+      const redirectUrl = (mockResponse.redirect as jest.Mock).mock.calls[0][0];
+      expect(redirectUrl).toContain(
+        'https://github.com/apps/comp-ai-compliance/installations/new',
+      );
+      expect(redirectUrl).toContain('state=install_state');
+
+      fetchSpy.mockRestore();
+    });
+
+    it('errors (no loop) when still not installed after an install attempt', async () => {
       const futureDate = new Date(Date.now() + 600000);
       mockOAuthStateRepository.findByState.mockResolvedValue({
         state: 'gh_state',
@@ -639,30 +700,15 @@ describe('OAuthController', () => {
         source: 'platform',
       });
 
-      const fetchSpy = jest
-        .spyOn(global, 'fetch')
-        // 1) token exchange
-        .mockResolvedValueOnce({
-          ok: true,
-          status: 200,
-          json: () => Promise.resolve({ access_token: 'gh_token' }),
-          text: () => Promise.resolve(''),
-        } as unknown as Response)
-        // 2) GET /user/installations -> none
-        .mockResolvedValueOnce({
-          ok: true,
-          status: 200,
-          json: () => Promise.resolve({ total_count: 0, installations: [] }),
-          text: () => Promise.resolve(''),
-        } as unknown as Response);
+      const fetchSpy = notInstalledFetch();
 
+      // installation_id present → we already came back from an install attempt.
       await controller.oauthCallback(
-        { code: 'auth_code', state: 'gh_state' },
+        { code: 'auth_code', state: 'gh_state', installation_id: '999' },
         mockRequest,
         mockResponse,
       );
 
-      // The connection must NOT be activated when the App isn't installed.
       expect(mockConnectionService.activateConnection).not.toHaveBeenCalled();
       const redirectUrl = (mockResponse.redirect as jest.Mock).mock.calls[0][0];
       expect(redirectUrl).toContain('error=github_app_not_installed');

--- a/apps/api/src/integration-platform/controllers/oauth.controller.ts
+++ b/apps/api/src/integration-platform/controllers/oauth.controller.ts
@@ -39,6 +39,9 @@ interface OAuthCallbackQuery {
   state: string;
   error?: string;
   error_description?: string;
+  // Present when GitHub returns from an App installation (install-time OAuth).
+  // Used only as a loop guard for the install redirect — never persisted.
+  installation_id?: string;
 }
 
 @Controller({ path: 'integrations/oauth', version: '1' })
@@ -335,26 +338,49 @@ export class OAuthController {
         oauthState.codeVerifier,
       );
 
-      // GitHub App: a user can complete OAuth *without* installing the App,
-      // which yields a token that cannot read any repositories. If GitHub
-      // definitively reports no installation for this user, stop here and tell
-      // them to install the App instead of creating a "connected" but unusable
-      // integration. Fails open on any uncertainty so a valid connection is
-      // never blocked by a transient error.
+      // GitHub App: user *authorization* and app *installation* are separate on
+      // GitHub. A user can complete OAuth without installing the App, producing a
+      // token that can read no repositories. If GitHub definitively reports no
+      // installation, don't finalize a useless connection — send the user to
+      // install the App (choose org + repositories). They return through
+      // install-time OAuth (with an installation_id) and this check then passes.
+      // Fails open on any uncertainty so a valid connection is never blocked by a
+      // transient error.
       if (
         oauthState.providerSlug === 'github-app' &&
         (await this.githubAppInstallationMissing(tokens.access_token))
       ) {
         await this.oauthStateRepository.delete(state);
+
+        // First pass (came from plain authorize, no installation_id): send the
+        // user to install the App, then they return here via install-time OAuth.
+        if (!query.installation_id && oauthConfig.installUrl) {
+          const installState = await this.oauthStateRepository.create({
+            providerSlug: oauthState.providerSlug,
+            organizationId: oauthState.organizationId,
+            userId: oauthState.userId,
+            redirectUrl: oauthState.redirectUrl ?? undefined,
+          });
+          const installRedirect = new URL(oauthConfig.installUrl);
+          installRedirect.searchParams.set('state', installState.state);
+          this.logger.log(
+            `GitHub App authorized but not installed; redirecting org ${oauthState.organizationId} to install`,
+          );
+          res.redirect(installRedirect.toString());
+          return;
+        }
+
+        // We already came back from an install attempt but still see no
+        // installation — stop rather than loop.
         this.logger.warn(
-          `GitHub App authorized but not installed for org ${oauthState.organizationId}`,
+          `GitHub App still not installed after install attempt for org ${oauthState.organizationId}`,
         );
         const errorUrl = this.buildRedirectUrl(
           oauthState.redirectUrl,
           {
             error: 'github_app_not_installed',
             error_description:
-              'You authorized Comp AI, but the GitHub App is not installed on your organization yet. Install the App on GitHub, then reconnect.',
+              'The GitHub App was not installed on your organization. Please install it (selecting at least one repository) and try again.',
           },
           oauthState.organizationId,
         );

--- a/packages/integration-platform/src/manifests/github-app/index.ts
+++ b/packages/integration-platform/src/manifests/github-app/index.ts
@@ -15,19 +15,21 @@
  * is left completely untouched so current connections keep working. New/concerned
  * customers opt into this one.
  *
- * Connect flow (user-to-server token via the standard OAuth authorize URL):
+ * Connect flow (user-to-server token — GitHub separates user *authorization*
+ * from app *installation*, so the callback bridges the two):
  *   1. The customer is sent to `https://github.com/login/oauth/authorize` with
- *      the App's client id. First-time users get an "Install & Authorize" screen
- *      (install the App + pick repositories); already-installed users just
- *      authorize. Either way GitHub returns to our callback with a `code`.
- *   2. The shared OAuth callback exchanges the `code` for a user-to-server access
- *      token (read-only, capped by the App's permissions) and stores it like any
- *      other OAuth token.
- *
- * We deliberately use the authorize URL rather than the App's install URL: the
- * install URL dead-ends on a "manage" page (no `code`) for orgs that already have
- * the App installed, whereas the authorize URL works in both cases and honors
- * `redirect_uri` for per-environment callback routing.
+ *      the App's client id. This returns a `code` to our callback whether or not
+ *      the App is installed (unlike the install URL, which dead-ends on a
+ *      "manage" page for already-installed orgs), and it honors `redirect_uri`
+ *      for per-environment callback routing.
+ *   2. The callback exchanges the `code` for a user-to-server token, then checks
+ *      whether the user actually has an installation (GET /user/installations):
+ *        - Installed  → finalize the connection.
+ *        - NOT installed → redirect to `installUrl` so the user installs the App
+ *          on their org and picks repositories. GitHub then returns through
+ *          install-time OAuth (with an `installation_id`), the check passes, and
+ *          the connection is finalized. The `installation_id` on the return trip
+ *          is used only as a loop guard, never persisted.
  *
  * The five checks are reused verbatim from the `github` manifest — only the way
  * the token is obtained differs (read-only App vs read/write OAuth App), so there
@@ -69,11 +71,14 @@ export const githubAppManifest: IntegrationManifest = {
       // We use login/oauth/authorize rather than the App's install URL on
       // purpose: the authorize URL returns a `code` whether or not the App is
       // already installed (the install URL dead-ends on the "manage" page for
-      // already-installed orgs), shows an "Install & Authorize" screen for
-      // first-time users, and honors redirect_uri so each environment routes to
-      // its own callback.
+      // already-installed orgs) and honors redirect_uri so each environment
+      // routes to its own callback.
       authorizeUrl: 'https://github.com/login/oauth/authorize',
       tokenUrl: 'https://github.com/login/oauth/access_token',
+      // Where to send a user who authorized but has NOT installed the App yet, so
+      // they can install it on their org and choose repositories. The public app
+      // slug is the same across environments (one App, multiple callback URLs).
+      installUrl: 'https://github.com/apps/comp-ai-compliance/installations/new',
       scopes: [],
       pkce: false,
       clientAuthMethod: 'body',

--- a/packages/integration-platform/src/types.ts
+++ b/packages/integration-platform/src/types.ts
@@ -33,6 +33,14 @@ export const OAuthConfigSchema = z.object({
    */
   supportsRefreshToken: z.boolean().default(true),
   /**
+   * App-installation URL for providers (e.g. GitHub Apps) where user
+   * authorization and app installation are separate steps. When set, the OAuth
+   * callback can redirect a user who authorized but has NOT installed the app to
+   * this URL to complete installation (choosing account/repositories) before the
+   * connection is finalized.
+   */
+  installUrl: z.string().url().optional(),
+  /**
    * Separate URL for token refresh (if different from tokenUrl).
    * Most providers use the same tokenUrl for both.
    */


### PR DESCRIPTION
## Customer report

A first-time customer connecting the GitHub App was only asked to authorize their **personal** account — never got to **install the App on their org** or pick repositories — and the integration never showed as connected.

## Root cause

GitHub separates user **authorization** from app **installation**. The authorize URL (`login/oauth/authorize`) only authenticates the user; it does **not** install the App. So a first-time user authorized → the post-OAuth install check (added in #3371) correctly found no installation → the connection was (correctly) not finalized — but the user was never given a path to install. My previous change fixed *reconnect* but left *first-time install* with no way forward.

## Fix

When the install check finds **no installation**, redirect the user to the App's **install URL** (new `installUrl` manifest field) so they install on their org and choose repositories. They return through install-time OAuth (which carries an `installation_id`), the check passes, and the connection finalizes.

- **First-time user:** authorize → (not installed) → **install screen (org + repos)** → back via install-time OAuth → connected. ✅
- **Already-installed / reconnect:** check passes on the first callback → connected, no extra hop. ✅
- **Loop guard:** the `installation_id` GitHub sends after install is read only to detect "already tried installing" — if still not installed, we error instead of looping. It is **not persisted** (avoids the earlier IDOR concern).

No admin change: the install URL is hard-coded to the public app slug (`comp-ai-compliance`), same across environments (one App, multiple callback URLs).

## Tests

- redirect-to-install on first pass
- error (no loop) after an install attempt
- success when an installation already exists

22 API tests + 4 manifest tests pass; typecheck + prettier + build clean.

## Known limitation (prod is fine)

GitHub ignores `redirect_uri` on the **install** URL and returns to the App's **first** registered callback (production). So the *install hop* always lands on prod. First-time-install testing on **staging** won't round-trip; test first-time install on **prod**, or pre-install the App then test the (redirect_uri-honoring) authorize path on staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirect first‑time GitHub App users to the install screen when no installation is found after OAuth, so they can pick an org/repos and complete the connection. Addresses CS-710 and prevents dead-end authorizations.

- **Bug Fixes**
  - In `OAuthController`, if provider is `github-app` and no installations are found, redirect to the manifest `installUrl`; on return with `installation_id`, re-check and surface `github_app_not_installed` if still missing (no loops).
  - Added optional `installUrl` to `OAuthConfigSchema` and set it in the `github-app` manifest; already-installed/reconnect paths are unchanged.
  - Tests added for redirect-to-install, no-loop after install attempt, and success when an installation exists.

<sup>Written for commit 32df09a4866f3c30d3b9e1f94d3b3ab3464d408c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

