### PR TITLE
fix(integrations): create install-handoff state before deleting original (CS-710)

### DIFF
--- a/apps/api/src/integration-platform/controllers/oauth.controller.spec.ts
+++ b/apps/api/src/integration-platform/controllers/oauth.controller.spec.ts
@@ -678,6 +678,54 @@ describe('OAuthController', () => {
       );
       expect(redirectUrl).toContain('state=install_state');
 
+      // The install-handoff state must be created BEFORE the original state is
+      // deleted, so a create failure can't leave the outer catch double-deleting
+      // an already-removed record (which would hang the request).
+      const createOrder =
+        mockOAuthStateRepository.create.mock.invocationCallOrder[0];
+      const deleteOrder =
+        mockOAuthStateRepository.delete.mock.invocationCallOrder[0];
+      expect(createOrder).toBeLessThan(deleteOrder);
+
+      fetchSpy.mockRestore();
+    });
+
+    it('still emits an error redirect if creating the install-handoff state fails', async () => {
+      const futureDate = new Date(Date.now() + 600000);
+      mockOAuthStateRepository.findByState.mockResolvedValue({
+        state: 'gh_state',
+        providerSlug: 'github-app',
+        organizationId: 'org_1',
+        userId: 'user_1',
+        codeVerifier: null,
+        redirectUrl: null,
+        expiresAt: futureDate,
+      });
+      mockedGetManifest.mockReturnValue(githubAppManifest as never);
+      mockOAuthCredentialsService.getCredentials.mockResolvedValue({
+        clientId: 'c',
+        clientSecret: 's',
+        scopes: [],
+        source: 'platform',
+      });
+      // Creating the install-handoff state fails (e.g. DB error).
+      mockOAuthStateRepository.create.mockRejectedValue(new Error('db down'));
+
+      const fetchSpy = notInstalledFetch();
+
+      await controller.oauthCallback(
+        { code: 'auth_code', state: 'gh_state' },
+        mockRequest,
+        mockResponse,
+      );
+
+      // The original state was NOT deleted before the failed create, so the
+      // outer catch can still clean it up and emit an error redirect (no hang).
+      expect(mockOAuthStateRepository.delete).toHaveBeenCalledWith('gh_state');
+      const errRedirect = (mockResponse.redirect as jest.Mock).mock.calls[0][0];
+      expect(errRedirect).toContain('error=');
+      expect(mockConnectionService.activateConnection).not.toHaveBeenCalled();
+
       fetchSpy.mockRestore();
     });
 

--- a/apps/api/src/integration-platform/controllers/oauth.controller.ts
+++ b/apps/api/src/integration-platform/controllers/oauth.controller.ts
@@ -350,17 +350,20 @@ export class OAuthController {
         oauthState.providerSlug === 'github-app' &&
         (await this.githubAppInstallationMissing(tokens.access_token))
       ) {
-        await this.oauthStateRepository.delete(state);
-
         // First pass (came from plain authorize, no installation_id): send the
         // user to install the App, then they return here via install-time OAuth.
         if (!query.installation_id && oauthConfig.installUrl) {
+          // Create the install-handoff state BEFORE deleting the original one.
+          // If creation fails, the original state survives so the outer catch can
+          // clean it up and still emit an error redirect — deleting first would
+          // make the catch's delete throw (record gone) and hang the request.
           const installState = await this.oauthStateRepository.create({
             providerSlug: oauthState.providerSlug,
             organizationId: oauthState.organizationId,
             userId: oauthState.userId,
             redirectUrl: oauthState.redirectUrl ?? undefined,
           });
+          await this.oauthStateRepository.delete(state);
           const installRedirect = new URL(oauthConfig.installUrl);
           installRedirect.searchParams.set('state', installState.state);
           this.logger.log(
@@ -372,6 +375,7 @@ export class OAuthController {
 
         // We already came back from an install attempt but still see no
         // installation — stop rather than loop.
+        await this.oauthStateRepository.delete(state);
         this.logger.warn(
           `GitHub App still not installed after install attempt for org ${oauthState.organizationId}`,
         );


### PR DESCRIPTION
## What

Fixes an error-path ordering bug in the GitHub App install redirect (flagged by cubic on #3373).

## The bug

The install redirect deleted the original OAuth `state` **before** creating the install-handoff `state`. If that create failed (e.g. a DB hiccup), the outer `catch` block calls `delete(state)` again — but Prisma's `delete` throws `P2025` on an already-removed record, so the error redirect never ran and the request **hung** with no response.

## The fix

Create the install-handoff state **first**, then delete the original. On a create failure the original state still exists, so the outer catch cleans it up and emits a normal error redirect (no hang).

## Tests

- **Ordering invariant:** in the redirect-to-install path, `create` is invoked before `delete`.
- **Failure path:** when the handoff `create` throws, the callback still emits an error redirect and doesn't finalize the connection.

23 API tests pass; prettier + typecheck clean. Isolated to the github-app callback branch — no other flow affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an ordering bug in the GitHub App install redirect by creating the install-handoff OAuth state before deleting the original, preventing hung requests on DB errors. Stabilizes the new GitHub App flow for CS-710 by ensuring proper cleanup and consistent error redirects.

- **Bug Fixes**
  - Create install-handoff state first, then delete the original to avoid double-delete errors and hanging requests.
  - Add regression tests: verify create-before-delete ordering and ensure create failures produce an error redirect and do not activate a connection.
  - Limit impact to the `github-app` callback path; adds explicit cleanup after a failed install attempt.

<sup>Written for commit 04d82068a70784a6e35cc369d0cc9ca2399bcf82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

