### PR TITLE
Support Azure OpenAI for self-hosted onboarding

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -4,6 +4,7 @@
     "type": "module",
     "dependencies": {
         "@ai-sdk/anthropic": "^3.0.75",
+        "@ai-sdk/azure": "^3.0.86",
         "@ai-sdk/gateway": "^3.0.110",
         "@ai-sdk/google": "^3.0.68",
         "@ai-sdk/groq": "^3.0.38",

--- a/apps/app/src/app/(app)/onboarding/actions/complete-onboarding.ts
+++ b/apps/app/src/app/(app)/onboarding/actions/complete-onboarding.ts
@@ -194,26 +194,38 @@ export const completeOnboarding = authActionClientWithoutOrg
         update: {},
       });
 
-      // Now trigger the jobs that were skipped during minimal creation
-      const handle = await tasks.trigger<typeof onboardOrganizationTask>('onboard-organization', {
-        organizationId: parsedInput.organizationId,
-      });
+      // Trigger background jobs on a best-effort basis. In self-hosted POCs the
+      // Trigger.dev worker may not be deployed/reachable, but onboarding data is
+      // already saved above and should still complete for the user.
+      let handle: { id: string; publicAccessToken: string } | undefined;
 
-      // Update onboarding record with job ID
-      await db.onboarding.update({
-        where: {
+      try {
+        handle = await tasks.trigger<typeof onboardOrganizationTask>('onboard-organization', {
           organizationId: parsedInput.organizationId,
-        },
-        data: { triggerJobId: handle.id },
-      });
+        });
 
-      // Set cookie for job tracking
-      (await cookies()).set('publicAccessToken', handle.publicAccessToken);
+        // Update onboarding record with job ID
+        await db.onboarding.update({
+          where: {
+            organizationId: parsedInput.organizationId,
+          },
+          data: { triggerJobId: handle.id },
+        });
 
-      // Create Fleet Label
-      await tasks.trigger<typeof createFleetLabelForOrg>('create-fleet-label-for-org', {
-        organizationId: parsedInput.organizationId,
-      });
+        // Set cookie for job tracking
+        (await cookies()).set('publicAccessToken', handle.publicAccessToken);
+      } catch (error) {
+        console.warn('[complete-onboarding] Background onboarding trigger failed', error);
+      }
+
+      try {
+        // Create Fleet Label
+        await tasks.trigger<typeof createFleetLabelForOrg>('create-fleet-label-for-org', {
+          organizationId: parsedInput.organizationId,
+        });
+      } catch (error) {
+        console.warn('[complete-onboarding] Fleet label trigger failed', error);
+      }
 
       // Revalidate paths
       const headersList = await headers();
@@ -226,8 +238,8 @@ export const completeOnboarding = authActionClientWithoutOrg
 
       return {
         success: true,
-        handle: handle.id,
-        publicAccessToken: handle.publicAccessToken,
+        handle: handle?.id,
+        publicAccessToken: handle?.publicAccessToken,
         organizationId: parsedInput.organizationId,
         redirectUrl: `/${parsedInput.organizationId}/`,
       };
@@ -247,4 +259,3 @@ export const completeOnboarding = authActionClientWithoutOrg
       };
     }
   });
-

--- a/apps/app/src/lib/ai/provider.ts
+++ b/apps/app/src/lib/ai/provider.ts
@@ -1,0 +1,58 @@
+import 'server-only';
+
+import { createAzure } from '@ai-sdk/azure';
+import { createGatewayProvider } from '@ai-sdk/gateway';
+import { openai } from '@ai-sdk/openai';
+
+const azureEndpoint = process.env.AZURE_OPENAI_ENDPOINT?.trim();
+const azureApiKey = process.env.AZURE_OPENAI_API_KEY?.trim() ?? process.env.AZURE_API_KEY?.trim();
+const azureApiVersion = process.env.AZURE_OPENAI_API_VERSION?.trim() ?? '2024-10-21';
+const azureChatDeployment = process.env.AZURE_OPENAI_CHAT_DEPLOYMENT?.trim();
+const azureEmbeddingDeployment = process.env.AZURE_OPENAI_EMBEDDING_DEPLOYMENT?.trim();
+
+const gateway = createGatewayProvider({
+  baseURL: process.env.AI_GATEWAY_BASE_URL,
+});
+
+function azureBaseURL(endpoint: string): string {
+  const normalized = endpoint.replace(/\/+$/, '');
+  return normalized.endsWith('/openai') ? normalized : `${normalized}/openai`;
+}
+
+const azureProvider =
+  azureEndpoint && azureApiKey
+    ? createAzure({
+        baseURL: azureBaseURL(azureEndpoint),
+        apiKey: azureApiKey,
+        apiVersion: azureApiVersion,
+        useDeploymentBasedUrls: true,
+      })
+    : null;
+
+function isGatewayModel(model: string): boolean {
+  return model.includes('/');
+}
+
+export function isAiConfigured(): boolean {
+  return Boolean(azureProvider || process.env.AI_GATEWAY_API_KEY || process.env.OPENAI_API_KEY);
+}
+
+export function aiLanguageModel(requestedModel: string) {
+  if (azureProvider) {
+    return azureProvider.chat(azureChatDeployment ?? requestedModel);
+  }
+
+  if (isGatewayModel(requestedModel)) {
+    return gateway(requestedModel);
+  }
+
+  return openai(requestedModel);
+}
+
+export function aiEmbeddingModel(requestedModel: string) {
+  if (azureProvider) {
+    return azureProvider.embedding(azureEmbeddingDeployment ?? requestedModel);
+  }
+
+  return openai.embedding(requestedModel);
+}

--- a/apps/app/src/lib/embedding/index.ts
+++ b/apps/app/src/lib/embedding/index.ts
@@ -1,7 +1,7 @@
 import 'server-only';
 
 import { Index, type RangeResult } from '@upstash/vector';
-import { openai } from '@ai-sdk/openai';
+import { aiEmbeddingModel } from '@/lib/ai/provider';
 import { embedMany } from 'ai';
 import { createHash } from 'node:crypto';
 
@@ -54,8 +54,12 @@ export interface SimilarTaskResult {
 // while keeping the existing Upstash Vector index (which is provisioned at
 // 1536 dims) usable as-is. Bumping to the full 3072 dims would require a
 // new index + a one-time re-embed of every org.
-const EMBEDDING_MODEL = 'text-embedding-3-large';
+const EMBEDDING_MODEL = process.env.AZURE_OPENAI_EMBEDDING_DEPLOYMENT ?? 'text-embedding-3-large';
 const EMBEDDING_DIMENSIONS = 1536;
+const EMBEDDING_RATE_LIMIT_RETRY_MS = Number(process.env.EMBEDDING_RATE_LIMIT_RETRY_MS ?? '65000');
+const EMBEDDING_MAX_ATTEMPTS = Number(process.env.EMBEDDING_MAX_ATTEMPTS ?? '4');
+const EMBEDDING_BATCH_SIZE = Number(process.env.EMBEDDING_BATCH_SIZE ?? '5');
+const EMBEDDING_INTER_BATCH_DELAY_MS = Number(process.env.EMBEDDING_INTER_BATCH_DELAY_MS ?? '5000');
 const DEFAULT_TOP_K = 25;
 // Pagination for enumerating an org's task vectors by their shared id prefix —
 // used by both `findSimilarTasks` (exact in-process ranking) and
@@ -67,6 +71,15 @@ const TASK_VECTOR_PAGE_SIZE = 1000;
 const TASK_VECTOR_MAX_PAGES = 500;
 
 let cachedIndex: Index | null = null;
+
+function isRateLimitError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /rate limit|retry after|429|exceeded the call rate limit/i.test(message);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 function getIndex(): Index {
   if (cachedIndex) return cachedIndex;
@@ -159,11 +172,34 @@ export async function upsertEntityEmbeddings({
     return { appliedHashes: [], skippedCount };
   }
 
-  const { embeddings } = await embedMany({
-    model: openai.embedding(EMBEDDING_MODEL),
-    values: toEmbed.map(({ entity }) => entity.text),
-    providerOptions: { openai: { dimensions: EMBEDDING_DIMENSIONS } },
-  });
+  const embeddings: number[][] = [];
+  const values = toEmbed.map(({ entity }) => entity.text);
+  const batchSize = Math.max(1, EMBEDDING_BATCH_SIZE);
+
+  for (let start = 0; start < values.length; start += batchSize) {
+    const batch = values.slice(start, start + batchSize);
+
+    for (let attempt = 1; attempt <= EMBEDDING_MAX_ATTEMPTS; attempt += 1) {
+      try {
+        const result = await embedMany({
+          model: aiEmbeddingModel(EMBEDDING_MODEL),
+          values: batch,
+          providerOptions: { openai: { dimensions: EMBEDDING_DIMENSIONS } },
+        });
+        embeddings.push(...result.embeddings);
+        break;
+      } catch (error) {
+        if (!isRateLimitError(error) || attempt === EMBEDDING_MAX_ATTEMPTS) {
+          throw error;
+        }
+        await sleep(EMBEDDING_RATE_LIMIT_RETRY_MS * attempt);
+      }
+    }
+
+    if (start + batchSize < values.length) {
+      await sleep(EMBEDDING_INTER_BATCH_DELAY_MS);
+    }
+  }
 
   const index = getIndex();
   await Promise.all(
@@ -281,7 +317,7 @@ export async function findSimilarTasks({
   if (!queryText.trim()) return [];
 
   const { embeddings } = await embedMany({
-    model: openai.embedding(EMBEDDING_MODEL),
+    model: aiEmbeddingModel(EMBEDDING_MODEL),
     values: [queryText],
     providerOptions: { openai: { dimensions: EMBEDDING_DIMENSIONS } },
   });

--- a/apps/app/src/lib/embedding/run-linkage.ts
+++ b/apps/app/src/lib/embedding/run-linkage.ts
@@ -498,37 +498,37 @@ export async function runLinkage({
     if (v.embeddingHash !== null) vendorHashes.set(v.id, v.embeddingHash);
   }
 
-  const [taskUpsert, riskUpsert, vendorUpsert] = await Promise.all([
-    upsertEntityEmbeddings({
-      organizationId,
-      kind: 'task',
-      entities: tasks.map((t) => ({
-        id: t.id,
-        text: taskQueryText(t),
-        department: t.department ?? undefined,
-      })),
-      existingHashes: taskHashes,
-    }),
-    upsertEntityEmbeddings({
-      organizationId,
-      kind: 'risk',
-      entities: risks.map((r) => ({
-        id: r.id,
-        text: riskQueryText(r),
-        department: r.department ?? undefined,
-      })),
-      existingHashes: riskHashes,
-    }),
-    upsertEntityEmbeddings({
-      organizationId,
-      kind: 'vendor',
-      entities: vendors.map((v) => ({
-        id: v.id,
-        text: vendorQueryText(v),
-      })),
-      existingHashes: vendorHashes,
-    }),
-  ]);
+  const taskUpsert = await upsertEntityEmbeddings({
+    organizationId,
+    kind: 'task',
+    entities: tasks.map((t) => ({
+      id: t.id,
+      text: taskQueryText(t),
+      department: t.department ?? undefined,
+    })),
+    existingHashes: taskHashes,
+  });
+
+  const riskUpsert = await upsertEntityEmbeddings({
+    organizationId,
+    kind: 'risk',
+    entities: risks.map((r) => ({
+      id: r.id,
+      text: riskQueryText(r),
+      department: r.department ?? undefined,
+    })),
+    existingHashes: riskHashes,
+  });
+
+  const vendorUpsert = await upsertEntityEmbeddings({
+    organizationId,
+    kind: 'vendor',
+    entities: vendors.map((v) => ({
+      id: v.id,
+      text: vendorQueryText(v),
+    })),
+    existingHashes: vendorHashes,
+  });
 
   // Persist the freshly-computed hashes so the next linkage run can skip
   // these entities. Rows whose content was unchanged are not in the

--- a/apps/app/src/lib/rerank-suggestions.ts
+++ b/apps/app/src/lib/rerank-suggestions.ts
@@ -1,4 +1,4 @@
-import { createGatewayProvider } from '@ai-sdk/gateway';
+import { aiLanguageModel } from '@/lib/ai/provider';
 import { generateObject, jsonSchema } from 'ai';
 
 /**
@@ -38,10 +38,6 @@ export interface RerankedCandidate {
   /** 0-10, returned by the LLM. Higher is more relevant. */
   rerankScore: number;
 }
-
-const gateway = createGatewayProvider({
-  baseURL: process.env.AI_GATEWAY_BASE_URL,
-});
 
 const RERANK_MODEL = 'google/gemini-3.1-flash-lite-preview' as const;
 
@@ -109,7 +105,7 @@ export async function rerankSuggestions({
     .join('\n');
 
   const result = await generateObject({
-    model: gateway(RERANK_MODEL),
+    model: aiLanguageModel(RERANK_MODEL),
     system: SYSTEM_PROMPT,
     prompt: userPrompt,
     schema: rerankSchema,

--- a/apps/app/src/trigger/tasks/onboarding/link-risks-and-vendors-to-work.ts
+++ b/apps/app/src/trigger/tasks/onboarding/link-risks-and-vendors-to-work.ts
@@ -20,6 +20,7 @@ import {
 export const linkRisksAndVendorsToWork = task({
   id: 'link-risks-and-vendors-to-work',
   retry: { maxAttempts: 2 },
+  maxDuration: 60 * 20,
   run: async (payload: RunLinkageInput) => {
     const { organizationId, riskId, vendorId, replace, suggestionsOnly } = payload;
     const mode = suggestionsOnly

--- a/apps/app/src/trigger/tasks/onboarding/onboard-organization-helpers.ts
+++ b/apps/app/src/trigger/tasks/onboarding/onboard-organization-helpers.ts
@@ -1,4 +1,4 @@
-import { createGatewayProvider } from '@ai-sdk/gateway';
+import { aiLanguageModel } from '@/lib/ai/provider';
 import {
   Departments,
   FrameworkEditorFramework,
@@ -15,9 +15,6 @@ import { db } from '@db/server';
 import { logger, metadata, tasks } from '@trigger.dev/sdk';
 import { generateObject, jsonSchema } from 'ai';
 
-const gateway = createGatewayProvider({
-  baseURL: process.env.AI_GATEWAY_BASE_URL,
-});
 const ONBOARDING_MODEL = 'google/gemini-3-flash' as const;
 import axios from 'axios';
 import { z } from 'zod';
@@ -501,7 +498,7 @@ export async function extractVendorsFromContext(
   const customVendorNameSet = new Set(customVendors.map((v) => v.name.toLowerCase()));
 
   const { object } = await generateObject({
-    model: gateway(ONBOARDING_MODEL),
+    model: aiLanguageModel(ONBOARDING_MODEL),
     schema: jsonSchema({
       type: 'object',
       properties: {
@@ -669,7 +666,7 @@ Citations (write one sentence per item, in order):
 ${formatCitationsBlock(citations)}`;
 
   const result = await generateObject({
-    model: gateway(ONBOARDING_MODEL),
+    model: aiLanguageModel(ONBOARDING_MODEL),
     system: RISK_MITIGATION_PROMPT,
     prompt: userPrompt,
     schema: sentencesSchema,
@@ -1038,7 +1035,7 @@ Citations (write one sentence per item, in order):
 ${formatCitationsBlock(citations)}`;
 
   const result = await generateObject({
-    model: gateway(ONBOARDING_MODEL),
+    model: aiLanguageModel(ONBOARDING_MODEL),
     system: RISK_MITIGATION_PROMPT,
     prompt: userPrompt,
     schema: sentencesSchema,
@@ -1110,7 +1107,7 @@ export async function extractRisksFromContext(
   existingRisks: { title: string }[],
 ): Promise<RiskData[]> {
   const { object } = await generateObject({
-    model: gateway(ONBOARDING_MODEL),
+    model: aiLanguageModel(ONBOARDING_MODEL),
     schema: jsonSchema({
       type: 'object',
       properties: {

--- a/apps/app/src/trigger/tasks/onboarding/update-policies-helpers.ts
+++ b/apps/app/src/trigger/tasks/onboarding/update-policies-helpers.ts
@@ -1,14 +1,10 @@
-import { createGatewayProvider } from '@ai-sdk/gateway';
+import { aiLanguageModel } from '@/lib/ai/provider';
 import { db, FrameworkEditorFramework, FrameworkEditorPolicyTemplate, type Policy } from '@db/server';
 import type { JSONContent } from '@tiptap/react';
 import { logger } from '@trigger.dev/sdk';
 import { generateObject } from 'ai';
 import { z } from 'zod';
 import { processTemplate } from './process-policy-template';
-
-const gateway = createGatewayProvider({
-  baseURL: process.env.AI_GATEWAY_BASE_URL,
-});
 
 const CUE_LINE_PATTERN =
   /^(State that|Clarify that|Add a |Include a |Specify |List |Note that|Require that|Describe |Define )/;
@@ -61,7 +57,7 @@ async function refineCueLines(
 
   try {
     const { object } = await generateObject({
-      model: gateway('anthropic/claude-sonnet-4.6'),
+      model: aiLanguageModel('anthropic/claude-sonnet-4.6'),
       system: `You rewrite policy template instructions into direct, professional policy language. Each input is an instruction (e.g. "State that...", "Define..."). Return the equivalent text as it should appear in a published security policy — authoritative, concise, no instructional phrasing.`,
       prompt: `Policy: "${policyName}"\n\nRewrite each instruction:\n${cueLines.map((c, i) => `${i + 1}. ${c.text}`).join('\n')}`,
       schema: z.object({

--- a/bun.lock
+++ b/bun.lock
@@ -224,6 +224,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.75",
+        "@ai-sdk/azure": "^3.0.86",
         "@ai-sdk/gateway": "^3.0.110",
         "@ai-sdk/google": "^3.0.68",
         "@ai-sdk/groq": "^3.0.38",
@@ -823,7 +824,7 @@
 
     "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.75", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-5AV3CKwaOJFdGXhihVgvRLNrjwRn2Xmy71YygT8DYOA+5zTx93Seg2QSIS8b3tJxzZ7X4H84pEtrE8VZKBCZGA=="],
 
-    "@ai-sdk/azure": ["@ai-sdk/azure@2.0.108", "", { "dependencies": { "@ai-sdk/openai": "2.0.106", "@ai-sdk/provider": "2.0.3", "@ai-sdk/provider-utils": "3.0.25" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-/F+lx3glCDiqJfqkZP9IOCubYlWABX2Jg9Yzm/JIxZR5qHfo9rsLwS4zVtghbELVbEjxakaFlDT/c6uTBj0uug=="],
+    "@ai-sdk/azure": ["@ai-sdk/azure@3.0.86", "", { "dependencies": { "@ai-sdk/deepseek": "2.0.46", "@ai-sdk/openai": "3.0.82", "@ai-sdk/provider": "3.0.13", "@ai-sdk/provider-utils": "4.0.37" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-GYnP0+GG18pB9ZOdKVFG78BbmP6qlrv4j2WOyPsEvlTB3wpTZcaNDeRxukCvf5Gc8k2LhMJK472Gp9WEtySeuQ=="],
 
     "@ai-sdk/cerebras": ["@ai-sdk/cerebras@1.0.44", "", { "dependencies": { "@ai-sdk/openai-compatible": "1.0.39", "@ai-sdk/provider": "2.0.3", "@ai-sdk/provider-utils": "3.0.25" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-2w7+jq0bWEF6McgWPb2gjaEx1TpqdUq4eyX/gPLTp7HzfDZKEVmmVXRvnKvjzBP/VH7xW4OT5jhTpTPTfYNYYQ=="],
 
@@ -6647,9 +6648,13 @@
 
     "@ai-sdk/anthropic/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.26", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ=="],
 
-    "@ai-sdk/azure/@ai-sdk/openai": ["@ai-sdk/openai@2.0.106", "", { "dependencies": { "@ai-sdk/provider": "2.0.3", "@ai-sdk/provider-utils": "3.0.25" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-EFC0rpo1wfe4HIz5KZCE72edP2J7fOeR7wPXzjCDljaTRB1wectKDIKRLowpU4F0mbcJ+XScAsoYNPK/Z20aVQ=="],
+    "@ai-sdk/azure/@ai-sdk/deepseek": ["@ai-sdk/deepseek@2.0.46", "", { "dependencies": { "@ai-sdk/provider": "3.0.13", "@ai-sdk/provider-utils": "4.0.37" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-yuOuWdQQa+EIpM60KAjRcT8wqD9E5i68rXj/r3asZ733zMF7pYeDcyQejBjM62bQhL0quZViau1QWvrq31VPMg=="],
 
-    "@ai-sdk/azure/@ai-sdk/provider": ["@ai-sdk/provider@2.0.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww=="],
+    "@ai-sdk/azure/@ai-sdk/openai": ["@ai-sdk/openai@3.0.82", "", { "dependencies": { "@ai-sdk/provider": "3.0.13", "@ai-sdk/provider-utils": "4.0.37" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Gn1YliuNMneXoBmuLX1kH/e5SR/VnU9FXLvJ8WyiV61Noo+wPdE4nuzxRGt3lfV6rla1wyCb1syV4jU0A310ew=="],
+
+    "@ai-sdk/azure/@ai-sdk/provider": ["@ai-sdk/provider@3.0.13", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-ZPtVYt5QIJzOta1kdUiDuCx4HhFkvNPv/rvmZ2b1iXwybYjJsCnNYR4PAw4kW7rgVfDARvHXcU64efWuqNp6bw=="],
+
+    "@ai-sdk/azure/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.37", "", { "dependencies": { "@ai-sdk/provider": "3.0.13", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-VG4tpVXCuzm21U9xjg05BCMZnjZOazC72+MxBkLAa7hCKsnqNt542GYWUUqwmHSczJwgbSXN8UvaNgSerUaKdw=="],
 
     "@ai-sdk/cerebras/@ai-sdk/provider": ["@ai-sdk/provider@2.0.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww=="],
 
@@ -6766,6 +6771,8 @@
     "@browserbasehq/sdk/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
     "@browserbasehq/stagehand/@ai-sdk/anthropic": ["@ai-sdk/anthropic@2.0.79", "", { "dependencies": { "@ai-sdk/provider": "2.0.3", "@ai-sdk/provider-utils": "3.0.25" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-K0U09FPDO1kmLPjRLXFcNSvmnKHJBMARCb8r3Ulw7wU6/+Zh9djWcFDiPPNsklg6yAezcdLTcYPszgWJJ6iOTA=="],
+
+    "@browserbasehq/stagehand/@ai-sdk/azure": ["@ai-sdk/azure@2.0.108", "", { "dependencies": { "@ai-sdk/openai": "2.0.106", "@ai-sdk/provider": "2.0.3", "@ai-sdk/provider-utils": "3.0.25" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-/F+lx3glCDiqJfqkZP9IOCubYlWABX2Jg9Yzm/JIxZR5qHfo9rsLwS4zVtghbELVbEjxakaFlDT/c6uTBj0uug=="],
 
     "@browserbasehq/stagehand/@ai-sdk/google": ["@ai-sdk/google@2.0.72", "", { "dependencies": { "@ai-sdk/provider": "2.0.3", "@ai-sdk/provider-utils": "3.0.25" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-BjDY6l+rV4CmHKjZe4H0uRXW3M2o+g7PaYM8oFpW+9PP1qKNEybnJ6//Si7BSf6DT+86dKARrtEl09lxSSaMaA=="],
 
@@ -8390,6 +8397,8 @@
     "zod-error/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@ai-sdk/anthropic/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@ai-sdk/azure/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@ai-sdk/gateway/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 


### PR DESCRIPTION
## Summary

- add a shared AI provider that uses Azure OpenAI when Azure env vars are configured, while preserving AI Gateway/OpenAI behavior for default installs
- make onboarding completion resilient when Trigger background jobs cannot be enqueued immediately
- throttle and retry embedding upserts so low-quota Azure OpenAI deployments can finish linkage work
- extend the risk/vendor linkage Trigger task max duration for slower self-hosted runs

## Why

Self-hosted deployments that do not have AI Gateway configured currently fail during onboarding/vendor/risk generation. On Azure OpenAI, linkage can also fail on embedding rate limits because task/risk/vendor embedding batches run concurrently and the task hits the default 5 minute duration.

## Validation

- Verified equivalent patch on a self-hosted Azure VM with Azure OpenAI, Trigger dev runner, Postgres, Redis/Vector, and MinIO.
- On the VM, onboarding generated 18 policies, 6 vendors, 5 risks, 35 task embeddings, 5 risk embeddings, 6 vendor embeddings, 40 risk-task links, and 48 vendor-task links.
- Ran targeted ESLint on changed app files: no errors, existing warnings only.
- Ran app typecheck; it currently fails on unrelated existing repo issues such as missing `@trycompai/company` / `@trycompai/billing` modules and pre-existing test fixture type errors.
- Ran secret scan over this diff: no env secrets/tokens detected.

## Notes

This is opened as a draft because it was derived from a self-hosted POC patch. It intentionally excludes deployment-only VM files such as Caddy config, Docker overrides, `.env` backups, and generated Prisma artifacts.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Azure OpenAI support for self-hosted installs and hardens onboarding/linkage under low quotas and missing workers. Default installs keep using AI Gateway/OpenAI without changes.

- **New Features**
  - Introduced a shared AI provider that prefers Azure when `AZURE_*` env vars are set, falling back to AI Gateway or OpenAI.
  - Updated chat and embedding calls to use the provider; supports Azure deployment-based models.
  - Added `@ai-sdk/azure`.

- **Bug Fixes**
  - Onboarding completes even if Trigger jobs can’t be enqueued; background tasks are best-effort.
  - Embedding upserts now batch and retry with backoff; configurable via env. Also serialized task/risk/vendor upserts to reduce spikes.
  - Increased linkage task max duration to 20 minutes for slower self-hosted runs.

<sup>Written for commit 43f07b4418e6db9ac6498a73022a5acf919db4cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

