### PR TITLE
feat(devices): universal source-reported compliance + last-seen for device sync

### DIFF
--- a/apps/api/src/integration-platform/services/generic-device-sync.service.spec.ts
+++ b/apps/api/src/integration-platform/services/generic-device-sync.service.spec.ts
@@ -552,6 +552,22 @@ describe('GenericDeviceSyncService', () => {
       expect(data.sourceCompliance).toEqual({ isCompliant: false });
     });
 
+    it('clamps a future lastSeenAt to now (provider clock skew must not pin the device Online)', async () => {
+      const future = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString();
+      const before = Date.now();
+      await service.processDevices({
+        organizationId: ORG_ID,
+        connectionId: CONN_ID,
+        devices: [baseDevice({ lastSeenAt: future })],
+      });
+      const after = Date.now();
+
+      const data = mockDeviceCreate.mock.calls[0][0].data;
+      const ts = (data.lastCheckIn as Date).getTime();
+      expect(ts).toBeGreaterThanOrEqual(before);
+      expect(ts).toBeLessThanOrEqual(after);
+    });
+
     it('falls back to sync time for lastCheckIn when lastSeenAt is absent', async () => {
       const before = Date.now();
       await service.processDevices({

--- a/apps/api/src/integration-platform/services/generic-device-sync.service.spec.ts
+++ b/apps/api/src/integration-platform/services/generic-device-sync.service.spec.ts
@@ -466,4 +466,105 @@ describe('GenericDeviceSyncService', () => {
       expect(result.removed).toBe(0);
     });
   });
+  // ========================================================================
+  // Source-reported compliance (sourceCompliance) + provider last-seen
+  // ========================================================================
+
+  describe('Source-reported compliance', () => {
+    it('persists the provider verdict, checks, and lastSeenAt on create', async () => {
+      const lastSeenAt = '2026-07-09T18:00:00.000Z';
+      await service.processDevices({
+        organizationId: ORG_ID,
+        connectionId: CONN_ID,
+        devices: [
+          baseDevice({
+            isCompliant: true,
+            checks: [
+              { id: 'disk_encryption', label: 'Disk Encryption', passed: true },
+              { id: 'firewall', label: 'Firewall', passed: false },
+            ],
+            lastSeenAt,
+          }),
+        ],
+      });
+
+      expect(mockDeviceCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            sourceCompliance: {
+              isCompliant: true,
+              checks: [
+                { id: 'disk_encryption', label: 'Disk Encryption', passed: true },
+                { id: 'firewall', label: 'Firewall', passed: false },
+              ],
+            },
+            lastCheckIn: new Date(lastSeenAt),
+          }),
+        }),
+      );
+    });
+
+    it('persists checks without a verdict (provider reports checks only)', async () => {
+      await service.processDevices({
+        organizationId: ORG_ID,
+        connectionId: CONN_ID,
+        devices: [
+          baseDevice({
+            checks: [{ id: 'os_up_to_date', label: 'OS up to date', passed: true }],
+          }),
+        ],
+      });
+
+      const data = mockDeviceCreate.mock.calls[0][0].data;
+      expect(data.sourceCompliance).toEqual({
+        checks: [{ id: 'os_up_to_date', label: 'OS up to date', passed: true }],
+      });
+      expect(data.sourceCompliance.isCompliant).toBeUndefined();
+    });
+
+    it('writes JsonNull when the provider reports no compliance (clears stale values on update)', async () => {
+      // Existing integration device — update path.
+      mockDeviceFindFirst.mockResolvedValue({ id: 'dev_1', source: 'integration' });
+
+      await service.processDevices({
+        organizationId: ORG_ID,
+        connectionId: CONN_ID,
+        devices: [baseDevice()],
+      });
+
+      expect(mockDeviceUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            sourceCompliance: Prisma.JsonNull,
+          }),
+        }),
+      );
+    });
+
+    it('treats an explicit false verdict as reported (not as absent)', async () => {
+      await service.processDevices({
+        organizationId: ORG_ID,
+        connectionId: CONN_ID,
+        devices: [baseDevice({ isCompliant: false })],
+      });
+
+      const data = mockDeviceCreate.mock.calls[0][0].data;
+      expect(data.sourceCompliance).toEqual({ isCompliant: false });
+    });
+
+    it('falls back to sync time for lastCheckIn when lastSeenAt is absent', async () => {
+      const before = Date.now();
+      await service.processDevices({
+        organizationId: ORG_ID,
+        connectionId: CONN_ID,
+        devices: [baseDevice()],
+      });
+      const after = Date.now();
+
+      const data = mockDeviceCreate.mock.calls[0][0].data;
+      const ts = (data.lastCheckIn as Date).getTime();
+      expect(ts).toBeGreaterThanOrEqual(before);
+      expect(ts).toBeLessThanOrEqual(after);
+    });
+  });
 });

--- a/apps/api/src/integration-platform/services/generic-device-sync.service.ts
+++ b/apps/api/src/integration-platform/services/generic-device-sync.service.ts
@@ -160,16 +160,39 @@ export class GenericDeviceSyncService {
           });
         }
 
+        // Compliance as reported by the source, if any. Written on EVERY sync
+        // (JsonNull when absent) so stale values are cleared if the provider
+        // stops reporting — never freeze an outdated verdict on the row.
+        const hasSourceCompliance =
+          device.isCompliant !== undefined ||
+          (device.checks !== undefined && device.checks.length > 0);
+        const sourceCompliance: Prisma.InputJsonValue | typeof Prisma.JsonNull =
+          hasSourceCompliance
+            ? {
+                ...(device.isCompliant !== undefined
+                  ? { isCompliant: device.isCompliant }
+                  : {}),
+                ...(device.checks !== undefined && device.checks.length > 0
+                  ? { checks: device.checks }
+                  : {}),
+              }
+            : Prisma.JsonNull;
+
         const updateData = {
           name: device.name,
           hostname: device.hostname ?? device.name,
           platform: device.platform,
           osVersion: device.osVersion ?? 'Unknown',
           hardwareModel: device.hardwareModel,
-          lastCheckIn: new Date(),
+          // Prefer the provider's own last-contact timestamp (validated ISO
+          // string) so "Last seen" reflects the device, not our sync cadence.
+          lastCheckIn: device.lastSeenAt
+            ? new Date(device.lastSeenAt)
+            : new Date(),
           source: 'integration' as const,
           integrationConnectionId: connectionId,
           externalDeviceId: device.externalId,
+          sourceCompliance,
           // Backfill the serial on updates too, so an externalId-matched row
           // becomes serial-linkable once the provider reports one. When the
           // device has no serial, Prisma omits `undefined` and leaves it as-is.

--- a/apps/api/src/integration-platform/services/generic-device-sync.service.ts
+++ b/apps/api/src/integration-platform/services/generic-device-sync.service.ts
@@ -186,8 +186,12 @@ export class GenericDeviceSyncService {
           hardwareModel: device.hardwareModel,
           // Prefer the provider's own last-contact timestamp (validated ISO
           // string) so "Last seen" reflects the device, not our sync cadence.
+          // Clamped to now: a future timestamp (provider clock skew / bad
+          // mapping) would otherwise pin the device "Online" for days.
           lastCheckIn: device.lastSeenAt
-            ? new Date(device.lastSeenAt)
+            ? new Date(
+                Math.min(new Date(device.lastSeenAt).getTime(), Date.now()),
+              )
             : new Date(),
           source: 'integration' as const,
           integrationConnectionId: connectionId,

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceAgentDevicesList.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceAgentDevicesList.test.tsx
@@ -227,11 +227,84 @@ describe('DeviceAgentDevicesList — integration-imported devices', () => {
     ).toBeInTheDocument();
   });
 
-  it('does not present an imported device as Online or Offline', () => {
-    render(<DeviceAgentDevicesList devices={[makeIntegrationDevice()]} />);
-    // Imported devices get no live-status dot at all (a spacer, no title).
-    expect(screen.queryByTitle('Online')).not.toBeInTheDocument();
-    expect(screen.queryByTitle('Offline')).not.toBeInTheDocument();
+  it('presents an imported device as Online when the provider saw it recently', () => {
+    // lastCheckIn carries the PROVIDER's last-contact timestamp for imported
+    // devices (device sync lastSeenAt), so the live dot applies honestly.
+    render(
+      <DeviceAgentDevicesList
+        devices={[makeIntegrationDevice({ lastCheckIn: new Date().toISOString() })]}
+      />,
+    );
+    expect(screen.getByTitle('Online')).toBeInTheDocument();
+  });
+
+  it('presents an imported device as Offline when the provider has not seen it recently', () => {
+    const threeDaysAgo = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+    render(
+      <DeviceAgentDevicesList
+        devices={[makeIntegrationDevice({ lastCheckIn: threeDaysAgo })]}
+      />,
+    );
+    expect(screen.getByTitle('Offline')).toBeInTheDocument();
+  });
+
+  it('shows the SOURCE-reported verdict and named checks when the provider reports them', () => {
+    render(
+      <DeviceAgentDevicesList
+        devices={[
+          makeIntegrationDevice({
+            integrationProvider: { slug: 'intune', name: 'Microsoft Intune' },
+            sourceCompliance: {
+              isCompliant: true,
+              checks: [
+                { id: 'disk_encryption', label: 'Disk Encryption', passed: true },
+                { id: 'firewall', label: 'Firewall', passed: false },
+              ],
+            },
+          }),
+        ]}
+      />,
+    );
+    // Verdict shown instead of "Not tracked", with provider attribution.
+    expect(screen.getByText('Yes')).toBeInTheDocument();
+    expect(screen.queryByText('Not tracked')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Where does this compliance status come from\?/i }),
+    ).toBeInTheDocument();
+    // Provider-named check badges, pass and fail.
+    expect(screen.getByText('Disk Encryption')).toBeInTheDocument();
+    expect(screen.getByText('Firewall')).toBeInTheDocument();
+  });
+
+  it('shows a red "No" when the source reports non-compliant', () => {
+    render(
+      <DeviceAgentDevicesList
+        devices={[
+          makeIntegrationDevice({
+            sourceCompliance: { isCompliant: false },
+          }),
+        ]}
+      />,
+    );
+    expect(screen.getByText('No')).toBeInTheDocument();
+    expect(screen.queryByText('Not tracked')).not.toBeInTheDocument();
+  });
+
+  it('keeps "Not tracked" when the source reports checks but no verdict', () => {
+    render(
+      <DeviceAgentDevicesList
+        devices={[
+          makeIntegrationDevice({
+            sourceCompliance: {
+              checks: [{ id: 'os_up_to_date', label: 'OS up to date', passed: true }],
+            },
+          }),
+        ]}
+      />,
+    );
+    // Checks render, but with no overall verdict the compliance column stays honest.
+    expect(screen.getByText('OS up to date')).toBeInTheDocument();
+    expect(screen.getByText('Not tracked')).toBeInTheDocument();
   });
 
   it('renders a source filter only when more than one source is present', () => {

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceAgentDevicesList.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceAgentDevicesList.test.tsx
@@ -276,7 +276,7 @@ describe('DeviceAgentDevicesList — integration-imported devices', () => {
     expect(screen.getByText('Firewall')).toBeInTheDocument();
   });
 
-  it('shows a red "No" when the source reports non-compliant', () => {
+  it('shows "No" when the source reports non-compliant', () => {
     render(
       <DeviceAgentDevicesList
         devices={[

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceDetails.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceDetails.tsx
@@ -34,18 +34,35 @@ import { RevokeAgentAccessDialog } from './RevokeAgentAccessDialog';
 function DeviceComplianceBadge({ device }: { device: DeviceWithChecks }) {
   if (device.source === 'integration') {
     // Show the SOURCE's own verdict when it reports one (attributed via the
-    // title tooltip); otherwise untracked, as before.
+    // same tooltip pattern as the stale/not-tracked badges, so the provenance
+    // is reachable by keyboard/touch); otherwise untracked, as before.
     const verdict = sourceVerdict(device);
     if (verdict === undefined) {
       return <NotTrackedBadge device={device} />;
     }
     return (
-      <Badge
-        variant={verdict ? 'default' : 'destructive'}
-        title={sourceReportedTooltipCopy(device)}
-      >
-        {verdict ? 'Compliant' : 'Non-Compliant'}
-      </Badge>
+      <div className="flex items-center gap-1">
+        <Badge variant={verdict ? 'default' : 'destructive'}>
+          {verdict ? 'Compliant' : 'Non-Compliant'}
+        </Badge>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="Where does this compliance status come from?"
+                className="inline-flex items-center text-muted-foreground hover:text-foreground"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <Information size={14} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs text-xs">
+              {sourceReportedTooltipCopy(device)}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
     );
   }
   if (device.complianceStatus === 'stale') {
@@ -98,8 +115,11 @@ export const DeviceDetails = ({ device, onClose }: DeviceDetailsProps) => {
           <div className="flex items-center justify-between">
             <div>
               <div className="flex items-center gap-2">
-                {/* Live online/offline status only applies to agent devices. */}
-                {device.source === 'device_agent' && (
+                {/* Live status: agent devices report directly; imported devices
+                    carry the provider's last-contact timestamp (lastSeenAt), so
+                    the same rule applies — and stays consistent with the list. */}
+                {(device.source === 'device_agent' ||
+                  device.source === 'integration') && (
                   <span
                     className={`inline-block h-2.5 w-2.5 shrink-0 rounded-full ${
                       isDeviceOnline(device.lastCheckIn)
@@ -111,7 +131,8 @@ export const DeviceDetails = ({ device, onClose }: DeviceDetailsProps) => {
                 <Text size="lg" weight="semibold">
                   {device.name}
                 </Text>
-                {device.source === 'device_agent' && (
+                {(device.source === 'device_agent' ||
+                  device.source === 'integration') && (
                   <Badge variant="outline">
                     {isDeviceOnline(device.lastCheckIn) ? 'Online' : 'Offline'}
                   </Badge>

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceDetails.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceDetails.tsx
@@ -22,6 +22,9 @@ import {
   CHECK_FIELDS,
   PLATFORM_LABELS,
   isDeviceOnline,
+  sourceChecks,
+  sourceReportedTooltipCopy,
+  sourceVerdict,
   staleLabel,
   staleTooltipCopy,
 } from '../lib/device-source';
@@ -30,7 +33,20 @@ import { RevokeAgentAccessDialog } from './RevokeAgentAccessDialog';
 
 function DeviceComplianceBadge({ device }: { device: DeviceWithChecks }) {
   if (device.source === 'integration') {
-    return <NotTrackedBadge device={device} />;
+    // Show the SOURCE's own verdict when it reports one (attributed via the
+    // title tooltip); otherwise untracked, as before.
+    const verdict = sourceVerdict(device);
+    if (verdict === undefined) {
+      return <NotTrackedBadge device={device} />;
+    }
+    return (
+      <Badge
+        variant={verdict ? 'default' : 'destructive'}
+        title={sourceReportedTooltipCopy(device)}
+      >
+        {verdict ? 'Compliant' : 'Non-Compliant'}
+      </Badge>
+    );
   }
   if (device.complianceStatus === 'stale') {
     return (
@@ -191,7 +207,35 @@ export const DeviceDetails = ({ device, onClose }: DeviceDetailsProps) => {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {CHECK_FIELDS.map(({ key, dbKey, label }) => {
+          {/* Imported device with SOURCE-reported checks: show those (provider
+              vocabulary) instead of CompAI's fixed agent checks. */}
+          {device.source === 'integration' && sourceChecks(device).length > 0 &&
+            sourceChecks(device).map((check) => (
+              <TableRow key={check.id}>
+                <TableCell>
+                  <Text size="sm" weight="medium">
+                    {check.label}
+                  </Text>
+                </TableCell>
+                <TableCell>
+                  <Text size="sm" variant="muted">
+                    Reported by {device.integrationProvider?.name ?? 'the integration'}
+                  </Text>
+                </TableCell>
+                <TableCell>
+                  <Badge variant={check.passed ? 'default' : 'destructive'}>
+                    {check.passed ? 'Pass' : 'Fail'}
+                  </Badge>
+                </TableCell>
+                <TableCell>
+                  <Text size="sm" variant="muted">
+                    —
+                  </Text>
+                </TableCell>
+              </TableRow>
+            ))}
+          {!(device.source === 'integration' && sourceChecks(device).length > 0) &&
+          CHECK_FIELDS.map(({ key, dbKey, label }) => {
             const isIntegration = device.source === 'integration';
             const isFleetUnsupported =
               device.source === 'fleet' && key !== 'diskEncryptionEnabled';

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceListCells.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceListCells.tsx
@@ -30,7 +30,10 @@ import {
   isComplianceTracked,
   isDeviceOnline,
   notTrackedTooltipCopy,
+  sourceChecks,
   sourceLabel,
+  sourceReportedTooltipCopy,
+  sourceVerdict,
   staleLabel,
   staleTooltipCopy,
 } from '../lib/device-source';
@@ -108,11 +111,26 @@ export function NotTrackedBadge({ device }: { device: DeviceWithChecks }) {
 }
 
 export function CompliantBadge({ device }: { device: DeviceWithChecks }) {
-  // Integration-imported devices are inventory records, not compliance records —
-  // CompAI never ran security checks on them, so showing "No" (red) would be a
-  // false negative. Present them as untracked instead.
+  // Integration-imported devices: CompAI never ran security checks on them, so
+  // a red "No" from OUR checks would be a false negative. But when the SOURCE
+  // reports its own verdict (e.g. Intune complianceState), show that — clearly
+  // attributed to the provider. No verdict → untracked, as before.
   if (!isComplianceTracked(device)) {
-    return <NotTrackedBadge device={device} />;
+    const verdict = sourceVerdict(device);
+    if (verdict === undefined) {
+      return <NotTrackedBadge device={device} />;
+    }
+    return (
+      <div className="flex items-center gap-1">
+        <Badge variant={verdict ? 'default' : 'destructive'}>
+          {verdict ? 'Yes' : 'No'}
+        </Badge>
+        <InfoTooltip
+          label="Where does this compliance status come from?"
+          copy={sourceReportedTooltipCopy(device)}
+        />
+      </div>
+    );
   }
 
   if (device.complianceStatus === 'stale') {
@@ -133,6 +151,26 @@ export function CompliantBadge({ device }: { device: DeviceWithChecks }) {
 }
 
 export function CheckBadges({ device }: { device: DeviceWithChecks }) {
+  // Imported devices: render whatever checks the SOURCE reported, in the
+  // provider's own naming. Nothing reported → placeholder dashes, as before.
+  if (!isComplianceTracked(device)) {
+    const checks = sourceChecks(device);
+    if (checks.length > 0) {
+      return (
+        <div className="flex flex-wrap gap-1">
+          {checks.map((check) => (
+            <Badge
+              key={check.id}
+              variant={check.passed ? 'default' : 'destructive'}
+              title={`${check.label} — ${sourceReportedTooltipCopy(device)}`}
+            >
+              {check.label}
+            </Badge>
+          ))}
+        </div>
+      );
+    }
+  }
   if (!isComplianceTracked(device) || device.complianceStatus === 'stale') {
     const reason = !isComplianceTracked(device)
       ? 'not collected for imported devices'
@@ -174,14 +212,16 @@ export function DeviceTableRow({
   onRequestRemove,
 }: DeviceTableRowProps) {
   const isAgent = device.source === 'device_agent';
-  const showOnline = isAgent && isDeviceOnline(device.lastCheckIn);
+  // Imported devices carry the PROVIDER's last-contact timestamp in
+  // lastCheckIn (see device sync lastSeenAt), so the same online rule applies
+  // honestly to them too. Fleet rows keep the spacer.
+  const showsLiveDot = isAgent || device.source === 'integration';
+  const showOnline = showsLiveDot && isDeviceOnline(device.lastCheckIn);
   return (
     <TableRow onClick={() => onSelect(device)} style={{ cursor: 'pointer' }}>
       <TableCell>
         <div className="flex items-center gap-2">
-          {/* Live status only applies to agent devices; imported/fleet rows get a
-              spacer so they aren't visually labeled as an offline agent. */}
-          {isAgent ? (
+          {showsLiveDot ? (
             <span
               className={`inline-block h-2 w-2 shrink-0 rounded-full ${
                 showOnline ? 'bg-green-500' : 'bg-gray-300'

--- a/apps/app/src/app/(app)/[orgId]/people/devices/lib/device-source.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/lib/device-source.ts
@@ -1,4 +1,4 @@
-import type { DeviceWithChecks } from '../types';
+import type { DeviceWithChecks, SourceComplianceCheck } from '../types';
 
 /**
  * Human label for where a device came from. Shared by the devices table, the
@@ -31,6 +31,30 @@ export function sourceKey(device: DeviceWithChecks): string {
  */
 export function isComplianceTracked(device: DeviceWithChecks): boolean {
   return device.source !== 'integration';
+}
+
+/**
+ * The SOURCE integration's own compliance verdict for an imported device, or
+ * undefined when the provider doesn't report one (renders "Not tracked").
+ */
+export function sourceVerdict(device: DeviceWithChecks): boolean | undefined {
+  if (device.source !== 'integration') return undefined;
+  return device.sourceCompliance?.isCompliant;
+}
+
+/**
+ * The SOURCE integration's own named checks for an imported device (empty when
+ * the provider reports none). Provider vocabulary — rendered as-is.
+ */
+export function sourceChecks(device: DeviceWithChecks): SourceComplianceCheck[] {
+  if (device.source !== 'integration') return [];
+  return device.sourceCompliance?.checks ?? [];
+}
+
+/** Tooltip copy for compliance values reported by the source integration. */
+export function sourceReportedTooltipCopy(device: DeviceWithChecks): string {
+  const provider = device.integrationProvider?.name ?? 'the integration';
+  return `Reported by ${provider}. CompAI didn't run these checks itself — install the CompAI agent for measured compliance.`;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/app/src/app/(app)/[orgId]/people/devices/lib/devices-csv.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/lib/devices-csv.ts
@@ -1,5 +1,5 @@
 import type { DeviceWithChecks } from '../types';
-import { isComplianceTracked, sourceLabel } from './device-source';
+import { isComplianceTracked, sourceLabel, sourceVerdict } from './device-source';
 
 export const DEVICES_CSV_HEADER = [
   'Device Name',
@@ -38,10 +38,18 @@ function yesNo(value: boolean): 'yes' | 'no' {
 
 export function buildDevicesCsv(devices: DeviceWithChecks[]): string {
   const rows = devices.map((d) => {
-    // Integration-imported devices are inventory-only; agent + Fleet carry real
-    // compliance. Use the shared helper so the CSV matches the rest of the UI.
+    // Integration-imported devices are inventory-only for OUR checks; agent +
+    // Fleet carry measured compliance. When the source integration reports its
+    // own verdict, export it with explicit attribution.
     const tracked = isComplianceTracked(d);
-    const status = tracked ? d.complianceStatus : 'not_tracked';
+    const verdict = sourceVerdict(d);
+    const status = tracked
+      ? d.complianceStatus
+      : verdict === undefined
+        ? 'not_tracked'
+        : verdict
+          ? 'compliant (source-reported)'
+          : 'non_compliant (source-reported)';
     const check = (value: boolean) => (tracked ? yesNo(value) : 'n/a');
     return [
       escapeCell(d.name),

--- a/apps/app/src/app/(app)/[orgId]/people/devices/types/index.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/types/index.ts
@@ -11,6 +11,23 @@ export type CheckDetailEntry = {
 
 export type CheckDetails = Record<string, CheckDetailEntry>;
 
+/** A compliance check as reported by the source integration (provider naming). */
+export type SourceComplianceCheck = {
+  id: string;
+  label: string;
+  passed: boolean;
+};
+
+/**
+ * Compliance reported by the SOURCE integration for imported devices. Both
+ * fields optional — providers report what they know. null/absent = the source
+ * reports no compliance (UI shows "Not tracked").
+ */
+export type SourceCompliance = {
+  isCompliant?: boolean;
+  checks?: SourceComplianceCheck[];
+};
+
 export interface DeviceWithChecks {
   id: string;
   name: string;
@@ -46,6 +63,11 @@ export interface DeviceWithChecks {
     name: string;
     logoUrl?: string;
   };
+  /**
+   * Set only when `source === 'integration'` and the provider reports
+   * compliance: the source's verdict and/or its own named checks.
+   */
+  sourceCompliance?: SourceCompliance | null;
   /** Derived on the server; 'stale' = no check-in for >= 7 days. */
   complianceStatus: DeviceComplianceStatus;
   /** Whole days since last check-in, or null when never synced. */

--- a/apps/app/src/app/api/people/agent-devices/route.ts
+++ b/apps/app/src/app/api/people/agent-devices/route.ts
@@ -5,7 +5,11 @@ import {
   daysSinceCheckIn,
   getDeviceComplianceStatus,
 } from '@trycompai/utils/devices';
-import type { CheckDetails, DeviceWithChecks } from '@/app/(app)/[orgId]/people/devices/types';
+import type {
+  CheckDetails,
+  DeviceWithChecks,
+  SourceCompliance,
+} from '@/app/(app)/[orgId]/people/devices/types';
 
 /** Maps the DB `DeviceSource` enum to the frontend source discriminant. */
 function mapSource(source: string): DeviceWithChecks['source'] {
@@ -126,6 +130,12 @@ export async function GET(req: Request) {
         },
         source,
         ...(provider ? { integrationProvider: provider } : {}),
+        // Source-reported compliance for imported devices (null when the
+        // provider reports none). The stored JSON was validated against
+        // SyncDeviceSchema at sync time.
+        ...(source === 'integration'
+          ? { sourceCompliance: (device.sourceCompliance as SourceCompliance) ?? null }
+          : {}),
         complianceStatus,
         daysSinceLastCheckIn: daysSinceCheckIn(device.lastCheckIn),
         hasActiveAgentSession:

--- a/packages/db/prisma/migrations/20260710015503_add_device_source_compliance/migration.sql
+++ b/packages/db/prisma/migrations/20260710015503_add_device_source_compliance/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Device" ADD COLUMN     "sourceCompliance" JSONB;
+
+-- AlterTable
+ALTER TABLE "FrameworkEditorFrameworkFamily" ALTER COLUMN "updatedAt" SET DEFAULT CURRENT_TIMESTAMP;

--- a/packages/db/prisma/schema/device.prisma
+++ b/packages/db/prisma/schema/device.prisma
@@ -33,6 +33,12 @@ model Device {
   integrationConnectionId   String?
   externalDeviceId          String?
 
+  // Compliance as reported by the SOURCE integration (device sync), kept
+  // separate from the agent's measured columns above so provenance never
+  // blurs. Shape: { isCompliant?: boolean, checks?: [{id,label,passed}] }.
+  // NULL = the source reports no compliance (renders "Not tracked").
+  sourceCompliance Json?
+
   @@unique([serialNumber, organizationId])
   // Prevents duplicate integration-sourced devices for the same connection and
   // also serves the device-sync fallback lookup (externalDeviceId + connection).

--- a/packages/integration-platform/src/dsl/__tests__/interpreter.test.ts
+++ b/packages/integration-platform/src/dsl/__tests__/interpreter.test.ts
@@ -1158,6 +1158,19 @@ describe('interpretDeclarativeDeviceSync', () => {
     });
   });
 
+  it('accepts a lastSeenAt with a timezone offset (providers do not always report UTC)', async () => {
+    const runner = interpretDeclarativeDeviceSync({
+      definition: deviceDef(`scope.devices = [
+        { name: 'PC', platform: 'windows', userEmail: 'a@x.com', status: 'active', externalId: 'e1', lastSeenAt: '2026-07-09T18:00:00+02:00' },
+      ];`),
+    });
+
+    const devices = await runner.run(createMockContext());
+
+    expect(devices).toHaveLength(1);
+    expect(devices[0]!.lastSeenAt).toBe('2026-07-09T18:00:00+02:00');
+  });
+
   it('drops a device with an invalid lastSeenAt or an oversized checks list, keeps valid ones', async () => {
     const runner = interpretDeclarativeDeviceSync({
       definition: deviceDef(`

--- a/packages/integration-platform/src/dsl/__tests__/interpreter.test.ts
+++ b/packages/integration-platform/src/dsl/__tests__/interpreter.test.ts
@@ -1129,6 +1129,52 @@ describe('interpretDeclarativeDeviceSync', () => {
     expect(devices[0]!.name).toBe('Good');
   });
 
+  it('keeps source-reported compliance fields (verdict, named checks, lastSeenAt)', async () => {
+    const runner = interpretDeclarativeDeviceSync({
+      definition: deviceDef(`scope.devices = [
+        {
+          name: 'PC', platform: 'windows', userEmail: 'a@x.com', status: 'active',
+          externalId: 'ext-1',
+          isCompliant: true,
+          checks: [
+            { id: 'disk_encryption', label: 'Disk Encryption', passed: true },
+            { id: 'firewall', label: 'Firewall', passed: false },
+          ],
+          lastSeenAt: '2026-07-09T18:00:00.000Z',
+        },
+      ];`),
+    });
+
+    const devices = await runner.run(createMockContext());
+
+    expect(devices).toHaveLength(1);
+    expect(devices[0]).toMatchObject({
+      isCompliant: true,
+      checks: [
+        { id: 'disk_encryption', label: 'Disk Encryption', passed: true },
+        { id: 'firewall', label: 'Firewall', passed: false },
+      ],
+      lastSeenAt: '2026-07-09T18:00:00.000Z',
+    });
+  });
+
+  it('drops a device with an invalid lastSeenAt or an oversized checks list, keeps valid ones', async () => {
+    const runner = interpretDeclarativeDeviceSync({
+      definition: deviceDef(`
+        const tooMany = Array.from({ length: 51 }, (_, i) => ({ id: 'c' + i, label: 'C' + i, passed: true }));
+        scope.devices = [
+          { name: 'Good', platform: 'macos', userEmail: 'a@x.com', status: 'active', externalId: 'e1' },
+          { name: 'Bad date', platform: 'macos', userEmail: 'b@x.com', status: 'active', externalId: 'e2', lastSeenAt: 'yesterday' },
+          { name: 'Too many checks', platform: 'macos', userEmail: 'c@x.com', status: 'active', externalId: 'e3', checks: tooMany },
+        ];`),
+    });
+
+    const devices = await runner.run(createMockContext());
+
+    expect(devices).toHaveLength(1);
+    expect(devices[0]!.name).toBe('Good');
+  });
+
   it('reads from a custom devicesPath', async () => {
     const runner = interpretDeclarativeDeviceSync({
       definition: deviceDef(

--- a/packages/integration-platform/src/dsl/types.ts
+++ b/packages/integration-platform/src/dsl/types.ts
@@ -354,8 +354,10 @@ export const SyncDeviceSchema = z.object({
   /**
    * When the device last contacted the PROVIDER (e.g. Intune lastSyncDateTime),
    * ISO 8601. Feeds the device list's "Last seen" column and online indicator.
+   * offset:true — providers commonly return timezone offsets (+02:00), and a
+   * rejected timestamp would drop the whole device from the sync.
    */
-  lastSeenAt: z.string().datetime().optional(),
+  lastSeenAt: z.string().datetime({ offset: true }).optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
 });
 

--- a/packages/integration-platform/src/dsl/types.ts
+++ b/packages/integration-platform/src/dsl/types.ts
@@ -318,6 +318,21 @@ export type SyncDefinition = z.infer<typeof SyncDefinitionSchema>;
 // Sync Device Schema (for dynamic device sync)
 // ============================================================================
 
+/**
+ * A single security/compliance check as reported by the SOURCE (the MDM /
+ * provider), in the provider's own vocabulary. Universal on purpose: every
+ * provider reports a different subset (or none), so nothing here is assumed.
+ */
+export const SyncDeviceCheckSchema = z.object({
+  /** Stable slug from the provider, e.g. 'disk_encryption', 'firewall'. */
+  id: z.string().min(1).max(64),
+  /** Display name in the provider's own wording, e.g. 'BitLocker'. */
+  label: z.string().min(1).max(120),
+  passed: z.boolean(),
+});
+
+export type SyncDeviceCheck = z.infer<typeof SyncDeviceCheckSchema>;
+
 export const SyncDeviceSchema = z.object({
   name: z.string(),
   platform: z.enum(['macos', 'windows', 'linux']),
@@ -328,6 +343,19 @@ export const SyncDeviceSchema = z.object({
   userEmail: z.string(),
   status: z.enum(['active', 'inactive']),
   externalId: z.string().optional(),
+  /**
+   * Provider-reported compliance — all optional because providers differ in
+   * what (if anything) they report. Omitted fields render as "Not tracked" in
+   * the UI; only what the source actually knows is shown.
+   */
+  isCompliant: z.boolean().optional(),
+  /** Capped so a buggy definition can't stuff megabytes into device rows. */
+  checks: z.array(SyncDeviceCheckSchema).max(50).optional(),
+  /**
+   * When the device last contacted the PROVIDER (e.g. Intune lastSyncDateTime),
+   * ISO 8601. Feeds the device list's "Last seen" column and online indicator.
+   */
+  lastSeenAt: z.string().datetime().optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
 });
 


### PR DESCRIPTION
## What

Device sync's universal device shape (`SyncDeviceSchema`) gains three **optional** provider-reported fields, so ANY dynamic integration can report what it knows — and only what it knows:

- `isCompliant` — the provider's overall compliance verdict (e.g. Intune `complianceState`)
- `checks[]` — `{id, label, passed}` in the **provider's own vocabulary** (one check or twenty — capped at 50); no forced mapping into our fixed agent-check categories
- `lastSeenAt` — when the device last contacted the provider, feeding the existing Last Seen column and online/offline dot honestly (previously imported devices' lastCheckIn was just our sync time)

Stored in a new **nullable** `Device.sourceCompliance` JSON column (migration included) — fully separate from the agent's measured compliance columns, so provenance never blurs.

## UI

| Provider reported | Compliant column | Checks column |
|---|---|---|
| Nothing | Not tracked *(unchanged)* | dashes *(unchanged)* |
| Verdict only | **Yes/No** + "Reported by {Provider}" tooltip | dashes |
| Named checks | verdict if reported, else Not tracked | provider-named badges (green/red) |

Applied consistently across the device list, the details panel (source checks table), and the CSV export (`compliant (source-reported)` status attribution). Imported devices now show the online/offline dot driven by the provider timestamp.

## Back-compat

- All new schema fields optional → existing Kandji/Intune/JumpCloud definitions validate unchanged
- Agent + Fleet rendering paths untouched; existing imported devices have `null` and render exactly as before
- Sync-time zod validation: malformed compliance data drops that device with a warning (existing behavior), never crashes a sync
- Stale-value safety: the column is rewritten every sync (JsonNull when absent), so a provider that stops reporting doesn't freeze an outdated verdict

## Tests

- integration-platform (bun): 25/25 — schema keeps new fields, drops bad lastSeenAt / >50 checks
- api (jest): 20/20 — persists verdict/checks/lastSeenAt, JsonNull clearing, false-verdict ≠ absent
- app (vitest): 83/83 — verdict + provider-named badges, checks-without-verdict stays Not tracked, online/offline dot for imported devices

## Rollout

After deploy, providers adopt via DB-row definition edits (no further deploys). First: Intune — verdict + disk encryption (`isEncrypted`) + `lastSyncDateTime`, staging first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TfDHFTwRgYxUoyyqGkHPDc

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds provider-reported compliance to device sync and uses the provider’s last-seen timestamp to drive status for imported devices. The UI shows the source’s verdict and named checks with attribution, plus an honest online/offline dot in list and details.

- **New Features**
  - `SyncDeviceSchema` now supports optional `isCompliant`, `checks[]`, and `lastSeenAt` (ISO 8601 with timezone offsets).
  - Persists provider data in `Device.sourceCompliance` (nullable JSON), rewritten every sync; absent data becomes `JsonNull` to prevent staleness.
  - `lastSeenAt` updates `lastCheckIn` for imported devices; future times are clamped to now, and missing values fall back to sync time. Online/offline and “Last seen” now reflect the provider in both list and details.
  - Device list, details, and CSV display the source’s Yes/No with an accessible tooltip and provider‑named badges; CSV marks statuses as “(source-reported)”. No verdict → “Not tracked”.
  - Validation caps `checks` at 50, accepts timezone offsets, and drops devices with invalid `lastSeenAt`; explicit `false` is treated as reported.

- **Migration**
  - Adds nullable `Device.sourceCompliance` JSONB. Run Prisma migration (`prisma migrate deploy`).

<sup>Written for commit c5c91275259b665fc704295514568e545a70966f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

