### PR TITLE
feat(devices): count imported devices in the compliance chart

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceComplianceChart.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceComplianceChart.test.tsx
@@ -219,4 +219,79 @@ describe('DeviceComplianceChart', () => {
     // Array.every on empty array returns true
     expect(screen.getByText('Compliant (1)')).toBeInTheDocument();
   });
+
+  it('does not show a Not Tracked legend entry when every device has a verdict', () => {
+    render(
+      <DeviceComplianceChart fleetDevices={[]} agentDevices={[makeAgentDevice()]} />,
+    );
+    expect(screen.queryByText(/Not Tracked/)).not.toBeInTheDocument();
+  });
+});
+
+function makeIntegrationDevice(
+  overrides: Partial<DeviceWithChecks> = {},
+): DeviceWithChecks {
+  return makeAgentDevice({
+    source: 'integration',
+    integrationProvider: { slug: 'intune', name: 'Microsoft Intune' },
+    // Server derives non_compliant for imported rows; the chart must use the
+    // source verdict (or Not Tracked), never this derived status.
+    isCompliant: false,
+    complianceStatus: 'non_compliant',
+    agentVersion: null,
+    ...overrides,
+  });
+}
+
+describe('DeviceComplianceChart — integration-imported devices', () => {
+  it('counts an imported device with a source verdict of compliant as Compliant', () => {
+    render(
+      <DeviceComplianceChart
+        fleetDevices={[]}
+        agentDevices={[
+          makeAgentDevice({ isCompliant: false, complianceStatus: 'non_compliant' }),
+          makeIntegrationDevice({ sourceCompliance: { isCompliant: true } }),
+        ]}
+      />,
+    );
+    expect(screen.getByText('Compliant (1)')).toBeInTheDocument();
+    expect(screen.getByText('Non-Compliant (1)')).toBeInTheDocument();
+    expect(screen.queryByText(/Not Tracked/)).not.toBeInTheDocument();
+  });
+
+  it('counts an imported device with a source verdict of non-compliant as Non-Compliant', () => {
+    render(
+      <DeviceComplianceChart
+        fleetDevices={[]}
+        agentDevices={[makeIntegrationDevice({ sourceCompliance: { isCompliant: false } })]}
+      />,
+    );
+    expect(screen.getByText('Non-Compliant (1)')).toBeInTheDocument();
+  });
+
+  it('puts an imported device with no source verdict into a Not Tracked segment', () => {
+    render(
+      <DeviceComplianceChart
+        fleetDevices={[]}
+        agentDevices={[
+          makeAgentDevice(),
+          makeIntegrationDevice({ sourceCompliance: null }),
+        ]}
+      />,
+    );
+    expect(screen.getByText('Compliant (1)')).toBeInTheDocument();
+    expect(screen.getByText('Non-Compliant (0)')).toBeInTheDocument();
+    expect(screen.getByText('Not Tracked (1)')).toBeInTheDocument();
+  });
+
+  it('renders the chart (not the empty state) for an org with ONLY imported devices', () => {
+    render(
+      <DeviceComplianceChart
+        fleetDevices={[]}
+        agentDevices={[makeIntegrationDevice({ sourceCompliance: { isCompliant: true } })]}
+      />,
+    );
+    expect(screen.queryByText(/No device data available/)).not.toBeInTheDocument();
+    expect(screen.getByText('Compliant (1)')).toBeInTheDocument();
+  });
 });

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceComplianceChart.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceComplianceChart.tsx
@@ -16,10 +16,14 @@ interface DeviceComplianceChartProps {
   agentDevices: DeviceWithChecks[];
 }
 
+// Design-system tokens (full oklch values — no hsl() wrapper). The previous
+// `hsl(var(--chart-positive))` tokens came from the legacy @trycompai/ui
+// stylesheet the app no longer loads, so every segment silently rendered as
+// SVG-default black.
 const CHART_COLORS = {
-  compliant: 'hsl(var(--chart-positive))',
-  nonCompliant: 'hsl(var(--chart-destructive))',
-  notTracked: 'hsl(var(--chart-warning))', // gray — no compliance data available
+  compliant: 'var(--primary)', // brand green
+  nonCompliant: 'var(--destructive)', // red
+  notTracked: 'var(--muted-foreground)', // gray — no compliance data available
 };
 
 export function DeviceComplianceChart({ fleetDevices, agentDevices }: DeviceComplianceChartProps) {

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceComplianceChart.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceComplianceChart.tsx
@@ -19,17 +19,15 @@ interface DeviceComplianceChartProps {
 const CHART_COLORS = {
   compliant: 'hsl(var(--chart-positive))',
   nonCompliant: 'hsl(var(--chart-destructive))',
+  notTracked: 'hsl(var(--chart-warning))', // gray — no compliance data available
 };
 
 export function DeviceComplianceChart({ fleetDevices, agentDevices }: DeviceComplianceChartProps) {
-  // Integration-imported devices carry no compliance data, so they must not be
-  // counted as non-compliant here — this chart reflects compliance-tracked
-  // devices only (agent + Fleet).
-  const trackedAgentDevices = React.useMemo(
-    () => (agentDevices ?? []).filter((d) => d.source === 'device_agent'),
-    [agentDevices],
-  );
-  const devices = [...trackedAgentDevices, ...(fleetDevices ?? [])];
+  // ALL devices count — the chart total must match the table so the page never
+  // looks self-contradictory. Imported devices use the SOURCE's verdict when
+  // it reports one; imported devices with no verdict land in a gray
+  // "Not tracked" segment rather than being fabricated into a verdict.
+  const devices = [...(agentDevices ?? []), ...(fleetDevices ?? [])];
 
   const { pieDisplayData, legendDisplayData } = React.useMemo(() => {
     if (devices.length === 0) {
@@ -37,10 +35,19 @@ export function DeviceComplianceChart({ fleetDevices, agentDevices }: DeviceComp
     }
     let compliantCount = 0;
     let nonCompliantCount = 0;
+    let notTrackedCount = 0;
 
-    // Count device-agent devices. Stale devices (no check-in for >= 7 days)
-    // count as non-compliant to match the table's three-state rendering.
-    for (const device of trackedAgentDevices) {
+    for (const device of agentDevices ?? []) {
+      if (device.source === 'integration') {
+        // Source-reported verdict (e.g. Intune complianceState), if any.
+        const verdict = device.sourceCompliance?.isCompliant;
+        if (verdict === true) compliantCount++;
+        else if (verdict === false) nonCompliantCount++;
+        else notTrackedCount++;
+        continue;
+      }
+      // Device-agent devices. Stale devices (no check-in for >= 7 days)
+      // count as non-compliant to match the table's three-state rendering.
       if (device.complianceStatus === 'compliant') {
         compliantCount++;
       } else {
@@ -69,12 +76,21 @@ export function DeviceComplianceChart({ fleetDevices, agentDevices }: DeviceComp
         value: nonCompliantCount,
         fill: CHART_COLORS.nonCompliant,
       },
+      {
+        name: 'Not Tracked',
+        value: notTrackedCount,
+        fill: CHART_COLORS.notTracked,
+      },
     ];
     return {
       pieDisplayData: allItems.filter((item) => item.value > 0),
-      legendDisplayData: allItems,
+      // "Not Tracked" only appears in the legend when it exists — orgs with no
+      // verdict-less imported devices keep the familiar two-entry legend.
+      legendDisplayData: allItems.filter(
+        (item) => item.name !== 'Not Tracked' || item.value > 0,
+      ),
     };
-  }, [trackedAgentDevices, fleetDevices]);
+  }, [agentDevices, fleetDevices]);
 
   const totalDevices = devices.length;
 


### PR DESCRIPTION
## Problem

The Device Compliance donut excluded integration-imported devices entirely — with an Intune-synced device in the table, the chart said "3 devices" while the table showed 4, and the Compliant counts didn't line up with the visible Yes badges. Reads as a bug (and was reported as one).

## Change

Every device in the table now counts in the chart:

- Imported device with a **source verdict** (`sourceCompliance.isCompliant`) → Compliant / Non-Compliant
- Imported device with **no verdict** (provider reports none) → gray **Not Tracked** segment — never fabricated into a verdict
- Agent + Fleet counting unchanged (stale still counts as non-compliant)
- "Not Tracked" appears in the legend only when non-zero, so orgs without imported devices see the exact same chart as before
- Orgs with ONLY imported devices now get a chart instead of the install-the-agent empty state

## Tests

5 new chart cases (verdict compliant/non-compliant, no-verdict → Not Tracked, imported-only org, no spurious legend entry) — 88/88 devices tests passing, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TfDHFTwRgYxUoyyqGkHPDc

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include integration-imported devices in the Device Compliance chart so totals match the table, and fix chart colors to use design‑system tokens. Imported devices without a source verdict now show as a gray Not Tracked segment.

- **Bug Fixes**
  - Imported devices use `sourceCompliance.isCompliant` for Compliant/Non-Compliant; no verdict → Not Tracked.
  - Legend shows Not Tracked only when non-zero; imported-only orgs now see the chart.
  - Agent and Fleet logic unchanged; stale agent devices still count as non-compliant.

<sup>Written for commit bb9102d01751466690ea955305cad79ffc14cbea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

