### PR TITLE
refactor(devices): drop inline synced-ago text, neutral re-sync button

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceSyncProviderSelector.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceSyncProviderSelector.test.tsx
@@ -146,18 +146,12 @@ describe('DeviceSyncProviderSelector — last synced text', () => {
     );
   });
 
-  it('shows "Synced Xh ago" next to the control when the selected provider has synced', () => {
+  it('shows no inline synced text — sync times live inside the dropdown info block', () => {
     const threeHoursAgo = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
     mockHook({
       availableProviders: [{ ...provider, lastSyncAt: threeHoursAgo }],
     });
 
-    render(<DeviceSyncProviderSelector />);
-
-    expect(screen.getByText('Synced 3h ago')).toBeInTheDocument();
-  });
-
-  it('shows no synced text when the provider has never synced', () => {
     render(<DeviceSyncProviderSelector />);
 
     expect(screen.queryByText(/^Synced /)).not.toBeInTheDocument();

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceSyncProviderSelector.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceSyncProviderSelector.tsx
@@ -14,7 +14,6 @@ import {
 } from '@trycompai/design-system';
 import { InProgress, Renew } from '@trycompai/design-system/icons';
 import { usePermissions } from '@/hooks/use-permissions';
-import { formatTimeAgo } from '../lib/device-source';
 import { useDeviceSync } from '../hooks/useDeviceSync';
 
 const NO_SYNC_VALUE = '__no_sync__';
@@ -100,15 +99,10 @@ export function DeviceSyncProviderSelector() {
   };
 
   return (
-    // Right-aligned inline row: "Synced Xh ago · [provider select] · [↻]".
-    // The provider name + refresh affordance say what this is; the last-synced
-    // text gives the freshness at a glance without opening the dropdown.
+    // Right-aligned inline row: [provider select] · [↻]. The provider name +
+    // refresh affordance say what this is; last/next sync times live inside
+    // the dropdown's info block.
     <div className="flex flex-wrap items-center justify-end gap-2">
-      {selected?.lastSyncAt && (
-        <span className="text-xs text-muted-foreground">
-          Synced {formatTimeAgo(selected.lastSyncAt)}
-        </span>
-      )}
       <div className="w-full max-w-[240px]">
         {/* Uncontrolled on purpose — mirrors the (working) people-sync select. */}
         <Select onValueChange={handleValueChange} disabled={isSyncing}>
@@ -222,9 +216,10 @@ export function DeviceSyncProviderSelector() {
       </div>
 
       {selected && (
-        // Icon-only re-sync in the brand primary: the select already says
-        // what's syncing — aria-label + title keep it accessible.
+        // Icon-only re-sync, neutral outline — a lone refresh icon doesn't
+        // warrant primary emphasis. aria-label + title keep it accessible.
         <Button
+          variant="outline"
           size="icon-lg"
           onClick={handleSyncNow}
           disabled={isSyncing}


### PR DESCRIPTION
Two small reverts on the device-sync control (per Tofik's review of the live version):

- **Removed the inline "Synced Xh ago" text** — the dropdown's info block already shows last/next sync times, so it was redundant.
- **Re-sync button back to the neutral outline variant** — a lone refresh icon doesn't warrant primary-color emphasis.

Layout stays as merged: right-aligned row, compact provider select, icon-only ↻ beside it (aria-label/tooltip "Sync now").

89/89 devices tests passing, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the inline “Synced Xh ago” text from the device sync control; last/next sync info now lives in the dropdown. Switched the re-sync button to a neutral `outline` variant while keeping the icon-only “Sync now” affordance and accessibility labels.

<sup>Written for commit bcdd3f36fcbaaf074cb945856a89579bfc7cdd3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

