### PR TITLE
fix(devices): judge imported devices by the canonical four-check standard

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceAgentDevicesList.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceAgentDevicesList.test.tsx
@@ -248,16 +248,19 @@ describe('DeviceAgentDevicesList — integration-imported devices', () => {
     expect(screen.getByTitle('Offline')).toBeInTheDocument();
   });
 
-  it('shows the SOURCE-reported verdict and named checks when the provider reports them', () => {
+  it('shows Yes only when all four canonical checks pass (extras are display-only)', () => {
     render(
       <DeviceAgentDevicesList
         devices={[
           makeIntegrationDevice({
             integrationProvider: { slug: 'intune', name: 'Microsoft Intune' },
             sourceCompliance: {
-              isCompliant: true,
               checks: [
                 { id: 'disk_encryption', label: 'Disk Encryption', passed: true },
+                { id: 'antivirus', label: 'Antivirus', passed: true },
+                { id: 'password_policy', label: 'Password Policy', passed: true },
+                { id: 'screen_lock', label: 'Screen Lock', passed: true },
+                // Non-canonical: shown as a badge but never affects the verdict.
                 { id: 'firewall', label: 'Firewall', passed: false },
               ],
             },
@@ -265,46 +268,75 @@ describe('DeviceAgentDevicesList — integration-imported devices', () => {
         ]}
       />,
     );
-    // Verdict shown instead of "Not tracked", with provider attribution.
     expect(screen.getByText('Yes')).toBeInTheDocument();
-    expect(screen.queryByText('Not tracked')).not.toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: /Where does this compliance status come from\?/i }),
-    ).toBeInTheDocument();
-    // Provider-named check badges, pass and fail.
+    expect(screen.queryByText(/Unverified/)).not.toBeInTheDocument();
+    // Provider-named check badges, incl. the informational extra.
     expect(screen.getByText('Disk Encryption')).toBeInTheDocument();
     expect(screen.getByText('Firewall')).toBeInTheDocument();
   });
 
-  it('shows "No" when the source reports non-compliant', () => {
-    render(
-      <DeviceAgentDevicesList
-        devices={[
-          makeIntegrationDevice({
-            sourceCompliance: { isCompliant: false },
-          }),
-        ]}
-      />,
-    );
-    expect(screen.getByText('No')).toBeInTheDocument();
-    expect(screen.queryByText('Not tracked')).not.toBeInTheDocument();
-  });
-
-  it('keeps "Not tracked" when the source reports checks but no verdict', () => {
+  it('shows "No" when a canonical check fails, even if the vendor claims compliant (showcase bug)', () => {
     render(
       <DeviceAgentDevicesList
         devices={[
           makeIntegrationDevice({
             sourceCompliance: {
+              // Intune with no policies configured calls everything compliant —
+              // CompAI's framework standard (the four checks) must overrule it.
+              isCompliant: true,
+              checks: [
+                { id: 'disk_encryption', label: 'Disk Encryption', passed: false },
+              ],
+            },
+          }),
+        ]}
+      />,
+    );
+    expect(screen.getByText('No')).toBeInTheDocument();
+    expect(screen.queryByText('Yes')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Unverified/)).not.toBeInTheDocument();
+  });
+
+  it('shows "Unverified (n/4)" when only some canonical checks are reported and none fail', () => {
+    render(
+      <DeviceAgentDevicesList
+        devices={[
+          makeIntegrationDevice({
+            sourceCompliance: {
+              checks: [
+                { id: 'disk_encryption', label: 'Disk Encryption', passed: true },
+                { id: 'antivirus', label: 'Antivirus', passed: true },
+              ],
+            },
+          }),
+        ]}
+      />,
+    );
+    expect(screen.getByText('Unverified (2/4)')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Why is compliance unverified\?/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Yes')).not.toBeInTheDocument();
+    expect(screen.queryByText('No')).not.toBeInTheDocument();
+  });
+
+  it('keeps "Not tracked" when the source reports no canonical checks at all', () => {
+    render(
+      <DeviceAgentDevicesList
+        devices={[
+          makeIntegrationDevice({
+            sourceCompliance: {
+              // A vendor verdict alone is NOT evidence against our standard.
+              isCompliant: true,
               checks: [{ id: 'os_up_to_date', label: 'OS up to date', passed: true }],
             },
           }),
         ]}
       />,
     );
-    // Checks render, but with no overall verdict the compliance column stays honest.
     expect(screen.getByText('OS up to date')).toBeInTheDocument();
     expect(screen.getByText('Not tracked')).toBeInTheDocument();
+    expect(screen.queryByText('Yes')).not.toBeInTheDocument();
   });
 
   it('renders a source filter only when more than one source is present', () => {

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceComplianceChart.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceComplianceChart.test.tsx
@@ -220,11 +220,11 @@ describe('DeviceComplianceChart', () => {
     expect(screen.getByText('Compliant (1)')).toBeInTheDocument();
   });
 
-  it('does not show a Not Tracked legend entry when every device has a verdict', () => {
+  it('does not show an Unverified legend entry when every device has a verdict', () => {
     render(
       <DeviceComplianceChart fleetDevices={[]} agentDevices={[makeAgentDevice()]} />,
     );
-    expect(screen.queryByText(/Not Tracked/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Unverified/)).not.toBeInTheDocument();
   });
 });
 
@@ -244,32 +244,49 @@ function makeIntegrationDevice(
 }
 
 describe('DeviceComplianceChart — integration-imported devices', () => {
-  it('counts an imported device with a source verdict of compliant as Compliant', () => {
+  it('counts an imported device with all four canonical checks passing as Compliant', () => {
     render(
       <DeviceComplianceChart
         fleetDevices={[]}
         agentDevices={[
           makeAgentDevice({ isCompliant: false, complianceStatus: 'non_compliant' }),
-          makeIntegrationDevice({ sourceCompliance: { isCompliant: true } }),
+          makeIntegrationDevice({
+            sourceCompliance: {
+              checks: [
+                { id: 'disk_encryption', label: 'Disk Encryption', passed: true },
+                { id: 'antivirus', label: 'Antivirus', passed: true },
+                { id: 'password_policy', label: 'Password Policy', passed: true },
+                { id: 'screen_lock', label: 'Screen Lock', passed: true },
+              ],
+            },
+          }),
         ]}
       />,
     );
     expect(screen.getByText('Compliant (1)')).toBeInTheDocument();
     expect(screen.getByText('Non-Compliant (1)')).toBeInTheDocument();
-    expect(screen.queryByText(/Not Tracked/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Unverified/)).not.toBeInTheDocument();
   });
 
-  it('counts an imported device with a source verdict of non-compliant as Non-Compliant', () => {
+  it('counts an imported device with a failed canonical check as Non-Compliant (vendor verdict ignored)', () => {
     render(
       <DeviceComplianceChart
         fleetDevices={[]}
-        agentDevices={[makeIntegrationDevice({ sourceCompliance: { isCompliant: false } })]}
+        agentDevices={[
+          makeIntegrationDevice({
+            sourceCompliance: {
+              // Vendor says compliant — CompAI's canonical standard overrules.
+              isCompliant: true,
+              checks: [{ id: 'disk_encryption', label: 'Disk Encryption', passed: false }],
+            },
+          }),
+        ]}
       />,
     );
     expect(screen.getByText('Non-Compliant (1)')).toBeInTheDocument();
   });
 
-  it('puts an imported device with no source verdict into a Not Tracked segment', () => {
+  it('puts an imported device with partial/no canonical checks into an Unverified segment', () => {
     render(
       <DeviceComplianceChart
         fleetDevices={[]}
@@ -281,14 +298,25 @@ describe('DeviceComplianceChart — integration-imported devices', () => {
     );
     expect(screen.getByText('Compliant (1)')).toBeInTheDocument();
     expect(screen.getByText('Non-Compliant (0)')).toBeInTheDocument();
-    expect(screen.getByText('Not Tracked (1)')).toBeInTheDocument();
+    expect(screen.getByText('Unverified (1)')).toBeInTheDocument();
   });
 
   it('renders the chart (not the empty state) for an org with ONLY imported devices', () => {
     render(
       <DeviceComplianceChart
         fleetDevices={[]}
-        agentDevices={[makeIntegrationDevice({ sourceCompliance: { isCompliant: true } })]}
+        agentDevices={[
+          makeIntegrationDevice({
+            sourceCompliance: {
+              checks: [
+                { id: 'disk_encryption', label: 'Disk Encryption', passed: true },
+                { id: 'antivirus', label: 'Antivirus', passed: true },
+                { id: 'password_policy', label: 'Password Policy', passed: true },
+                { id: 'screen_lock', label: 'Screen Lock', passed: true },
+              ],
+            },
+          }),
+        ]}
       />,
     );
     expect(screen.queryByText(/No device data available/)).not.toBeInTheDocument();

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceComplianceChart.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceComplianceChart.tsx
@@ -50,6 +50,8 @@ export function DeviceComplianceChart({ fleetDevices, agentDevices }: DeviceComp
         const verdict = computeSourceComplianceVerdict(device);
         if (verdict?.kind === 'compliant') compliantCount++;
         else if (verdict?.kind === 'non_compliant') nonCompliantCount++;
+        // Both partial ('unverified') and zero-data ('not_tracked') devices
+        // land in the gray segment: neither has a defensible verdict.
         else unverifiedCount++;
         continue;
       }

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceComplianceChart.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceComplianceChart.tsx
@@ -10,6 +10,7 @@ import {
 import * as React from 'react';
 import { Cell, Label, Pie, PieChart } from 'recharts';
 import type { DeviceWithChecks, Host } from '../types';
+import { computeSourceComplianceVerdict } from '../lib/device-source';
 
 interface DeviceComplianceChartProps {
   fleetDevices: Host[];
@@ -23,14 +24,15 @@ interface DeviceComplianceChartProps {
 const CHART_COLORS = {
   compliant: 'var(--primary)', // brand green
   nonCompliant: 'var(--destructive)', // red
-  notTracked: 'var(--muted-foreground)', // gray — no compliance data available
+  unverified: 'var(--muted-foreground)', // gray — canonical checks not (fully) reported
 };
 
 export function DeviceComplianceChart({ fleetDevices, agentDevices }: DeviceComplianceChartProps) {
   // ALL devices count — the chart total must match the table so the page never
-  // looks self-contradictory. Imported devices use the SOURCE's verdict when
-  // it reports one; imported devices with no verdict land in a gray
-  // "Not tracked" segment rather than being fabricated into a verdict.
+  // looks self-contradictory. Imported devices are judged by CompAI's OWN
+  // standard (the four canonical checks, computed from source-reported data);
+  // partially/un-reported devices land in a gray "Unverified" segment rather
+  // than being fabricated into a verdict.
   const devices = [...(agentDevices ?? []), ...(fleetDevices ?? [])];
 
   const { pieDisplayData, legendDisplayData } = React.useMemo(() => {
@@ -39,15 +41,16 @@ export function DeviceComplianceChart({ fleetDevices, agentDevices }: DeviceComp
     }
     let compliantCount = 0;
     let nonCompliantCount = 0;
-    let notTrackedCount = 0;
+    let unverifiedCount = 0;
 
     for (const device of agentDevices ?? []) {
       if (device.source === 'integration') {
-        // Source-reported verdict (e.g. Intune complianceState), if any.
-        const verdict = device.sourceCompliance?.isCompliant;
-        if (verdict === true) compliantCount++;
-        else if (verdict === false) nonCompliantCount++;
-        else notTrackedCount++;
+        // CompAI's verdict computed from the canonical source-reported checks
+        // (vendor's own verdict is informational-only and never counted).
+        const verdict = computeSourceComplianceVerdict(device);
+        if (verdict?.kind === 'compliant') compliantCount++;
+        else if (verdict?.kind === 'non_compliant') nonCompliantCount++;
+        else unverifiedCount++;
         continue;
       }
       // Device-agent devices. Stale devices (no check-in for >= 7 days)
@@ -81,17 +84,17 @@ export function DeviceComplianceChart({ fleetDevices, agentDevices }: DeviceComp
         fill: CHART_COLORS.nonCompliant,
       },
       {
-        name: 'Not Tracked',
-        value: notTrackedCount,
-        fill: CHART_COLORS.notTracked,
+        name: 'Unverified',
+        value: unverifiedCount,
+        fill: CHART_COLORS.unverified,
       },
     ];
     return {
       pieDisplayData: allItems.filter((item) => item.value > 0),
-      // "Not Tracked" only appears in the legend when it exists — orgs with no
-      // verdict-less imported devices keep the familiar two-entry legend.
+      // "Unverified" only appears in the legend when it exists — orgs with no
+      // partially-verified imported devices keep the familiar two-entry legend.
       legendDisplayData: allItems.filter(
-        (item) => item.name !== 'Not Tracked' || item.value > 0,
+        (item) => item.name !== 'Unverified' || item.value > 0,
       ),
     };
   }, [agentDevices, fleetDevices]);

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceDetails.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceDetails.tsx
@@ -39,7 +39,7 @@ function DeviceComplianceBadge({ device }: { device: DeviceWithChecks }) {
     // the same standard as the Comp agent. The vendor's own overall verdict is
     // informational only (shown in the info grid below).
     const verdict = computeSourceComplianceVerdict(device);
-    if (verdict === null || (verdict.kind === 'unverified' && verdict.reported === 0)) {
+    if (verdict === null || verdict.kind === 'not_tracked') {
       return <NotTrackedBadge device={device} />;
     }
     if (verdict.kind === 'non_compliant') {

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceDetails.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceDetails.tsx
@@ -19,38 +19,46 @@ import { ArrowLeft, Information } from '@trycompai/design-system/icons';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@trycompai/ui/tooltip';
 import type { DeviceWithChecks } from '../types';
 import {
+  CANONICAL_DEVICE_CHECKS,
   CHECK_FIELDS,
   PLATFORM_LABELS,
+  computeSourceComplianceVerdict,
   isDeviceOnline,
   sourceChecks,
-  sourceReportedTooltipCopy,
   sourceVerdict,
   staleLabel,
   staleTooltipCopy,
+  unverifiedTooltipCopy,
 } from '../lib/device-source';
 import { NotTrackedBadge } from './DeviceListCells';
 import { RevokeAgentAccessDialog } from './RevokeAgentAccessDialog';
 
 function DeviceComplianceBadge({ device }: { device: DeviceWithChecks }) {
   if (device.source === 'integration') {
-    // Show the SOURCE's own verdict when it reports one (attributed via the
-    // same tooltip pattern as the stale/not-tracked badges, so the provenance
-    // is reachable by keyboard/touch); otherwise untracked, as before.
-    const verdict = sourceVerdict(device);
-    if (verdict === undefined) {
+    // CompAI's verdict, computed from the source-reported CANONICAL checks —
+    // the same standard as the Comp agent. The vendor's own overall verdict is
+    // informational only (shown in the info grid below).
+    const verdict = computeSourceComplianceVerdict(device);
+    if (verdict === null || (verdict.kind === 'unverified' && verdict.reported === 0)) {
       return <NotTrackedBadge device={device} />;
+    }
+    if (verdict.kind === 'non_compliant') {
+      return <Badge variant="destructive">Non-Compliant</Badge>;
+    }
+    if (verdict.kind === 'compliant') {
+      return <Badge variant="default">Compliant</Badge>;
     }
     return (
       <div className="flex items-center gap-1">
-        <Badge variant={verdict ? 'default' : 'destructive'}>
-          {verdict ? 'Compliant' : 'Non-Compliant'}
+        <Badge variant="secondary">
+          Unverified ({verdict.reported}/{CANONICAL_DEVICE_CHECKS.length})
         </Badge>
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>
               <button
                 type="button"
-                aria-label="Where does this compliance status come from?"
+                aria-label="Why is compliance unverified?"
                 className="inline-flex items-center text-muted-foreground hover:text-foreground"
                 onClick={(e) => e.stopPropagation()}
               >
@@ -58,7 +66,7 @@ function DeviceComplianceBadge({ device }: { device: DeviceWithChecks }) {
               </button>
             </TooltipTrigger>
             <TooltipContent className="max-w-xs text-xs">
-              {sourceReportedTooltipCopy(device)}
+              {unverifiedTooltipCopy(device, verdict)}
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>
@@ -214,6 +222,20 @@ export const DeviceDetails = ({ device, onClose }: DeviceDetailsProps) => {
                 {new Date(device.installedAt).toLocaleDateString()}
               </Text>
             </div>
+            {/* The vendor's own overall verdict — informational only. It
+                reflects the customer's MDM policy configuration; CompAI's
+                Compliant badge above is computed from the canonical checks. */}
+            {device.source === 'integration' && sourceVerdict(device) !== undefined && (
+              <div>
+                <Text size="sm" variant="muted">
+                  {device.integrationProvider?.name ?? 'Provider'} verdict
+                </Text>
+                <Text size="sm" weight="medium">
+                  {sourceVerdict(device) ? 'Compliant' : 'Non-Compliant'} (per
+                  its own policies)
+                </Text>
+              </div>
+            )}
           </div>
         </CardContent>
       </Card>
@@ -228,42 +250,83 @@ export const DeviceDetails = ({ device, onClose }: DeviceDetailsProps) => {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {/* Imported device with SOURCE-reported checks: show those (provider
-              vocabulary) instead of CompAI's fixed agent checks. */}
-          {device.source === 'integration' && sourceChecks(device).length > 0 &&
-            sourceChecks(device).map((check) => (
-              <TableRow key={check.id}>
-                <TableCell>
-                  <Text size="sm" weight="medium">
-                    {check.label}
-                  </Text>
-                </TableCell>
-                <TableCell>
-                  <Text size="sm" variant="muted">
-                    Reported by {device.integrationProvider?.name ?? 'the integration'}
-                  </Text>
-                </TableCell>
-                <TableCell>
-                  <Badge variant={check.passed ? 'default' : 'destructive'}>
-                    {check.passed ? 'Pass' : 'Fail'}
-                  </Badge>
-                </TableCell>
-                <TableCell>
-                  <Text size="sm" variant="muted">
-                    —
-                  </Text>
-                </TableCell>
-              </TableRow>
-            ))}
-          {!(device.source === 'integration' && sourceChecks(device).length > 0) &&
+          {/* Imported device: always render CompAI's FOUR canonical checks —
+              filled from source data where reported, honest "Not reported"
+              otherwise — then any extra provider-specific checks below. */}
+          {device.source === 'integration' &&
+            (() => {
+              const provider = device.integrationProvider?.name ?? 'the integration';
+              const bySourceId = new Map(sourceChecks(device).map((c) => [c.id, c]));
+              const canonicalIds = new Set<string>(
+                CANONICAL_DEVICE_CHECKS.map((c) => c.id),
+              );
+              const extras = sourceChecks(device).filter((c) => !canonicalIds.has(c.id));
+              return [
+                ...CANONICAL_DEVICE_CHECKS.map(({ id, label }) => {
+                  const reported = bySourceId.get(id);
+                  return (
+                    <TableRow key={id}>
+                      <TableCell>
+                        <Text size="sm" weight="medium">
+                          {label}
+                        </Text>
+                      </TableCell>
+                      <TableCell>
+                        <Text size="sm" variant="muted">
+                          {reported
+                            ? `Reported by ${provider}`
+                            : `Not reported by ${provider} — install the CompAI agent to verify`}
+                        </Text>
+                      </TableCell>
+                      <TableCell>
+                        {reported ? (
+                          <Badge variant={reported.passed ? 'default' : 'destructive'}>
+                            {reported.passed ? 'Pass' : 'Fail'}
+                          </Badge>
+                        ) : (
+                          <Badge variant="secondary">Unverified</Badge>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <Text size="sm" variant="muted">
+                          —
+                        </Text>
+                      </TableCell>
+                    </TableRow>
+                  );
+                }),
+                ...extras.map((check) => (
+                  <TableRow key={check.id}>
+                    <TableCell>
+                      <Text size="sm" weight="medium">
+                        {check.label}
+                      </Text>
+                    </TableCell>
+                    <TableCell>
+                      <Text size="sm" variant="muted">
+                        Reported by {provider} (informational — not part of the
+                        compliance verdict)
+                      </Text>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={check.passed ? 'default' : 'destructive'}>
+                        {check.passed ? 'Pass' : 'Fail'}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <Text size="sm" variant="muted">
+                        —
+                      </Text>
+                    </TableCell>
+                  </TableRow>
+                )),
+              ];
+            })()}
+          {device.source !== 'integration' &&
           CHECK_FIELDS.map(({ key, dbKey, label }) => {
-            const isIntegration = device.source === 'integration';
-            const isFleetUnsupported =
+            const isUntracked =
               device.source === 'fleet' && key !== 'diskEncryptionEnabled';
-            const isUntracked = isIntegration || isFleetUnsupported;
-            const untrackedCopy = isIntegration
-              ? 'Not collected for imported devices'
-              : 'Not tracked by Fleet';
+            const untrackedCopy = 'Not tracked by Fleet';
             const isStale = device.complianceStatus === 'stale';
             const passed = device[key];
             const details = device.checkDetails?.[dbKey];

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceListCells.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceListCells.tsx
@@ -120,7 +120,7 @@ export function CompliantBadge({ device }: { device: DeviceWithChecks }) {
   // the customer's MDM policy configuration, not the framework standard.
   if (!isComplianceTracked(device)) {
     const verdict = computeSourceComplianceVerdict(device);
-    if (verdict === null || (verdict.kind === 'unverified' && verdict.reported === 0)) {
+    if (verdict === null || verdict.kind === 'not_tracked') {
       return <NotTrackedBadge device={device} />;
     }
     if (verdict.kind === 'non_compliant') {

--- a/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceListCells.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/components/DeviceListCells.tsx
@@ -24,8 +24,10 @@ import {
 import Link from 'next/link';
 import type { DeviceWithChecks } from '../types';
 import {
+  CANONICAL_DEVICE_CHECKS,
   CHECK_FIELDS,
   PLATFORM_LABELS,
+  computeSourceComplianceVerdict,
   formatTimeAgo,
   isComplianceTracked,
   isDeviceOnline,
@@ -33,9 +35,9 @@ import {
   sourceChecks,
   sourceLabel,
   sourceReportedTooltipCopy,
-  sourceVerdict,
   staleLabel,
   staleTooltipCopy,
+  unverifiedTooltipCopy,
 } from '../lib/device-source';
 
 function InfoTooltip({ label, copy }: { label: string; copy: string }) {
@@ -111,23 +113,30 @@ export function NotTrackedBadge({ device }: { device: DeviceWithChecks }) {
 }
 
 export function CompliantBadge({ device }: { device: DeviceWithChecks }) {
-  // Integration-imported devices: CompAI never ran security checks on them, so
-  // a red "No" from OUR checks would be a false negative. But when the SOURCE
-  // reports its own verdict (e.g. Intune complianceState), show that — clearly
-  // attributed to the provider. No verdict → untracked, as before.
+  // Integration-imported devices are judged by CompAI's OWN standard — the
+  // same four canonical checks the Comp agent measures — computed from the
+  // source-reported check data. The vendor's own verdict (e.g. Intune
+  // complianceState) is informational-only in the details panel: it reflects
+  // the customer's MDM policy configuration, not the framework standard.
   if (!isComplianceTracked(device)) {
-    const verdict = sourceVerdict(device);
-    if (verdict === undefined) {
+    const verdict = computeSourceComplianceVerdict(device);
+    if (verdict === null || (verdict.kind === 'unverified' && verdict.reported === 0)) {
       return <NotTrackedBadge device={device} />;
+    }
+    if (verdict.kind === 'non_compliant') {
+      return <Badge variant="destructive">No</Badge>;
+    }
+    if (verdict.kind === 'compliant') {
+      return <Badge variant="default">Yes</Badge>;
     }
     return (
       <div className="flex items-center gap-1">
-        <Badge variant={verdict ? 'default' : 'destructive'}>
-          {verdict ? 'Yes' : 'No'}
+        <Badge variant="secondary">
+          Unverified ({verdict.reported}/{CANONICAL_DEVICE_CHECKS.length})
         </Badge>
         <InfoTooltip
-          label="Where does this compliance status come from?"
-          copy={sourceReportedTooltipCopy(device)}
+          label="Why is compliance unverified?"
+          copy={unverifiedTooltipCopy(device, verdict)}
         />
       </div>
     );

--- a/apps/app/src/app/(app)/[orgId]/people/devices/lib/device-source.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/lib/device-source.ts
@@ -60,8 +60,10 @@ export const CANONICAL_DEVICE_CHECKS = [
 export type SourceComplianceVerdict =
   | { kind: 'compliant' }
   | { kind: 'non_compliant' }
-  /** Some (or none) of the canonical checks reported, none failed. */
-  | { kind: 'unverified'; reported: number; missing: string[] };
+  /** SOME canonical checks reported (>= 1), none failed. */
+  | { kind: 'unverified'; reported: number; missing: string[] }
+  /** ZERO canonical checks reported — the source gives us nothing to judge. */
+  | { kind: 'not_tracked' };
 
 /**
  * Computes CompAI's compliance verdict for an imported device from the
@@ -69,7 +71,9 @@ export type SourceComplianceVerdict =
  * display-only and never affect the verdict):
  * - any canonical check failed  -> non_compliant (one failure is enough)
  * - all four reported & passed  -> compliant
- * - otherwise                   -> unverified (n of 4), listing what's missing
+ * - some reported, none failed  -> unverified (n of 4), listing what's missing
+ * - zero reported               -> not_tracked (its own kind, so consumers
+ *                                  can't accidentally lump it into unverified)
  */
 export function computeSourceComplianceVerdict(
   device: DeviceWithChecks,
@@ -83,6 +87,9 @@ export function computeSourceComplianceVerdict(
   const reportedIds = new Set(canonical.map((c) => c.id));
   if (reportedIds.size === CANONICAL_DEVICE_CHECKS.length) {
     return { kind: 'compliant' };
+  }
+  if (reportedIds.size === 0) {
+    return { kind: 'not_tracked' };
   }
   return {
     kind: 'unverified',
@@ -99,11 +106,7 @@ export function unverifiedTooltipCopy(
   verdict: Extract<SourceComplianceVerdict, { kind: 'unverified' }>,
 ): string {
   const provider = device.integrationProvider?.name ?? 'The integration';
-  const reportedPart =
-    verdict.reported === 0
-      ? `${provider} reports none of the ${CANONICAL_DEVICE_CHECKS.length} security checks CompAI requires for compliance`
-      : `${provider} reports ${verdict.reported} of the ${CANONICAL_DEVICE_CHECKS.length} security checks CompAI requires for compliance (missing: ${verdict.missing.join(', ')})`;
-  return `${reportedPart}. Install the CompAI agent on this device for full verification.`;
+  return `${provider} reports ${verdict.reported} of the ${CANONICAL_DEVICE_CHECKS.length} security checks CompAI requires for compliance (missing: ${verdict.missing.join(', ')}). Install the CompAI agent on this device for full verification.`;
 }
 
 /**

--- a/apps/app/src/app/(app)/[orgId]/people/devices/lib/device-source.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/lib/device-source.ts
@@ -34,12 +34,76 @@ export function isComplianceTracked(device: DeviceWithChecks): boolean {
 }
 
 /**
- * The SOURCE integration's own compliance verdict for an imported device, or
- * undefined when the provider doesn't report one (renders "Not tracked").
+ * The SOURCE integration's own overall verdict (e.g. Intune complianceState).
+ * INFORMATIONAL ONLY — shown in the details panel, never used for CompAI's
+ * Compliant column/chart: a vendor verdict reflects the customer's MDM policy
+ * configuration, not CompAI's framework standard (a policy-less Intune tenant
+ * calls everything "compliant").
  */
 export function sourceVerdict(device: DeviceWithChecks): boolean | undefined {
   if (device.source !== 'integration') return undefined;
   return device.sourceCompliance?.isCompliant;
+}
+
+/**
+ * CompAI's framework standard for device compliance — the same four checks
+ * the Comp agent measures. A device (from ANY source) is compliant only when
+ * all four pass.
+ */
+export const CANONICAL_DEVICE_CHECKS = [
+  { id: 'disk_encryption', label: 'Disk Encryption' },
+  { id: 'antivirus', label: 'Antivirus' },
+  { id: 'password_policy', label: 'Password Policy' },
+  { id: 'screen_lock', label: 'Screen Lock' },
+] as const;
+
+export type SourceComplianceVerdict =
+  | { kind: 'compliant' }
+  | { kind: 'non_compliant' }
+  /** Some (or none) of the canonical checks reported, none failed. */
+  | { kind: 'unverified'; reported: number; missing: string[] };
+
+/**
+ * Computes CompAI's compliance verdict for an imported device from the
+ * source-reported CANONICAL checks (extra provider-specific checks are
+ * display-only and never affect the verdict):
+ * - any canonical check failed  -> non_compliant (one failure is enough)
+ * - all four reported & passed  -> compliant
+ * - otherwise                   -> unverified (n of 4), listing what's missing
+ */
+export function computeSourceComplianceVerdict(
+  device: DeviceWithChecks,
+): SourceComplianceVerdict | null {
+  if (device.source !== 'integration') return null;
+  const canonicalIds = new Set<string>(CANONICAL_DEVICE_CHECKS.map((c) => c.id));
+  const canonical = sourceChecks(device).filter((c) => canonicalIds.has(c.id));
+  if (canonical.some((c) => !c.passed)) {
+    return { kind: 'non_compliant' };
+  }
+  const reportedIds = new Set(canonical.map((c) => c.id));
+  if (reportedIds.size === CANONICAL_DEVICE_CHECKS.length) {
+    return { kind: 'compliant' };
+  }
+  return {
+    kind: 'unverified',
+    reported: reportedIds.size,
+    missing: CANONICAL_DEVICE_CHECKS.filter((c) => !reportedIds.has(c.id)).map(
+      (c) => c.label,
+    ),
+  };
+}
+
+/** Tooltip copy for the "Unverified (n/4)" badge on imported devices. */
+export function unverifiedTooltipCopy(
+  device: DeviceWithChecks,
+  verdict: Extract<SourceComplianceVerdict, { kind: 'unverified' }>,
+): string {
+  const provider = device.integrationProvider?.name ?? 'The integration';
+  const reportedPart =
+    verdict.reported === 0
+      ? `${provider} reports none of the ${CANONICAL_DEVICE_CHECKS.length} security checks CompAI requires for compliance`
+      : `${provider} reports ${verdict.reported} of the ${CANONICAL_DEVICE_CHECKS.length} security checks CompAI requires for compliance (missing: ${verdict.missing.join(', ')})`;
+  return `${reportedPart}. Install the CompAI agent on this device for full verification.`;
 }
 
 /**

--- a/apps/app/src/app/(app)/[orgId]/people/devices/lib/devices-csv.test.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/lib/devices-csv.test.ts
@@ -94,7 +94,7 @@ describe('buildDevicesCsv', () => {
     expect(cells.slice(9, 13)).toEqual(['no', 'no', 'yes', 'yes']); // the four checks
   });
 
-  it('exports imported devices as not_tracked / n/a with the provider as source', () => {
+  it('exports imported devices as not_tracked / unverified with the provider as source', () => {
     const csv = buildDevicesCsv([
       makeDevice({
         source: 'integration',
@@ -111,7 +111,8 @@ describe('buildDevicesCsv', () => {
     ]);
     const cells = stripBom(csv).slice(0, -2).split('\r\n')[1].split(',');
     expect(cells[8]).toBe('not_tracked'); // status
-    expect(cells.slice(9, 13)).toEqual(['n/a', 'n/a', 'n/a', 'n/a']);
+    // Canonical checks unreported by the source export as 'unverified'.
+    expect(cells.slice(9, 13)).toEqual(['unverified', 'unverified', 'unverified', 'unverified']);
     expect(cells[13]).toBe('Kandji'); // source
   });
 

--- a/apps/app/src/app/(app)/[orgId]/people/devices/lib/devices-csv.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/lib/devices-csv.ts
@@ -1,5 +1,11 @@
 import type { DeviceWithChecks } from '../types';
-import { isComplianceTracked, sourceLabel, sourceVerdict } from './device-source';
+import {
+  CANONICAL_DEVICE_CHECKS,
+  computeSourceComplianceVerdict,
+  isComplianceTracked,
+  sourceChecks,
+  sourceLabel,
+} from './device-source';
 
 export const DEVICES_CSV_HEADER = [
   'Device Name',
@@ -38,19 +44,24 @@ function yesNo(value: boolean): 'yes' | 'no' {
 
 export function buildDevicesCsv(devices: DeviceWithChecks[]): string {
   const rows = devices.map((d) => {
-    // Integration-imported devices are inventory-only for OUR checks; agent +
-    // Fleet carry measured compliance. When the source integration reports its
-    // own verdict, export it with explicit attribution.
+    // Imported devices are judged by CompAI's OWN standard — the same four
+    // canonical checks the agent measures — computed from the data the source
+    // integration reports. Unreported canonical checks export as 'unverified'.
     const tracked = isComplianceTracked(d);
-    const verdict = sourceVerdict(d);
+    const verdict = computeSourceComplianceVerdict(d);
     const status = tracked
       ? d.complianceStatus
-      : verdict === undefined
-        ? 'not_tracked'
-        : verdict
-          ? 'compliant (source-reported)'
-          : 'non_compliant (source-reported)';
-    const check = (value: boolean) => (tracked ? yesNo(value) : 'n/a');
+      : verdict === null || (verdict.kind === 'unverified' && verdict.reported === 0)
+        ? 'not_tracked' // matches the UI: zero canonical checks = Not tracked
+        : verdict.kind === 'unverified'
+          ? `unverified (${verdict.reported}/${CANONICAL_DEVICE_CHECKS.length} checks reported)`
+          : verdict.kind;
+    const bySourceId = new Map(sourceChecks(d).map((c) => [c.id, c.passed]));
+    const check = (agentValue: boolean, canonicalId: string) => {
+      if (tracked) return yesNo(agentValue);
+      const reported = bySourceId.get(canonicalId);
+      return reported === undefined ? 'unverified' : yesNo(reported);
+    };
     return [
       escapeCell(d.name),
       escapeCell(d.user.name),
@@ -61,10 +72,10 @@ export function buildDevicesCsv(devices: DeviceWithChecks[]): string {
       escapeCell(d.lastCheckIn ?? ''),
       escapeCell(d.daysSinceLastCheckIn ?? ''),
       escapeCell(status),
-      escapeCell(check(d.diskEncryptionEnabled)),
-      escapeCell(check(d.antivirusEnabled)),
-      escapeCell(check(d.passwordPolicySet)),
-      escapeCell(check(d.screenLockEnabled)),
+      escapeCell(check(d.diskEncryptionEnabled, 'disk_encryption')),
+      escapeCell(check(d.antivirusEnabled, 'antivirus')),
+      escapeCell(check(d.passwordPolicySet, 'password_policy')),
+      escapeCell(check(d.screenLockEnabled, 'screen_lock')),
       escapeCell(sourceLabel(d)),
     ].join(',');
   });

--- a/apps/app/src/app/(app)/[orgId]/people/devices/lib/devices-csv.ts
+++ b/apps/app/src/app/(app)/[orgId]/people/devices/lib/devices-csv.ts
@@ -51,8 +51,8 @@ export function buildDevicesCsv(devices: DeviceWithChecks[]): string {
     const verdict = computeSourceComplianceVerdict(d);
     const status = tracked
       ? d.complianceStatus
-      : verdict === null || (verdict.kind === 'unverified' && verdict.reported === 0)
-        ? 'not_tracked' // matches the UI: zero canonical checks = Not tracked
+      : verdict === null || verdict.kind === 'not_tracked'
+        ? 'not_tracked'
         : verdict.kind === 'unverified'
           ? `unverified (${verdict.reported}/${CANONICAL_DEVICE_CHECKS.length} checks reported)`
           : verdict.kind;


### PR DESCRIPTION
## The showcase bug

An Intune device showed **Compliant: Yes** with a **failing Disk Encryption check** — because the Compliant column displayed Intune's own `complianceState`, which reflects the customer's MDM policy configuration, not our framework standard. A policy-less Intune tenant marks every device compliant.

## The rule (CompAI's standard, same as the Comp agent)

Imported devices are now judged by the **four canonical checks** — Disk Encryption, Antivirus, Password Policy, Screen Lock — computed from source-reported data:

| Source data | Verdict |
|---|---|
| Any canonical check failed | **No** — one failure is enough, vendor verdict ignored |
| All four reported & passed | **Yes** |
| Some reported, none failed | **Unverified (n/4)** + tooltip listing what's missing, recommending the agent |
| None reported | Not tracked (unchanged) |

- Vendor verdict demoted to an informational "{Provider} verdict" line in device details
- Extra provider checks (e.g. Firewall) stay visible as badges but never affect the verdict
- Details panel now always lists all four canonical checks for imported devices, with honest "Not reported by {provider}" rows
- Chart: same rule; gray bucket renamed **Unverified**; CSV exports per-check yes/no/unverified

## Tests

91/91 devices tests — including the literal showcase scenario (vendor says compliant + disk encryption failed → **No**), extras-don't-affect-verdict, partial → Unverified (2/4), and zero-reported → Not tracked. Typecheck clean.

## Rollout note

The Intune definition gains an Antivirus mapping (Graph `windowsProtectionState` via $expand — verified live on staging, no extra API calls) — applied via the internal API separately. Until THIS PR deploys, the old verdict display remains visible.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect compliance for imported devices by applying the canonical four-check standard (Disk Encryption, Antivirus, Password Policy, Screen Lock). We now compute our own verdict across the UI, chart, and CSV; vendor verdicts are informational only.

- **Bug Fixes**
  - Verdicts for imported devices now follow: any fail → No; all four pass → Yes; partial without fails → Unverified (n/4); none reported → Not tracked.
  - Device details always list the four checks; missing ones show “Not reported by {provider} — install the CompAI agent to verify”. Extra provider checks are informational only. Vendor verdict appears as a "{Provider} verdict" line.
  - Chart uses the canonical verdicts and renames gray to Unverified; the legend hides Unverified when empty.
  - CSV exports status as not_tracked/unverified (n/4)/compliant/non_compliant; per-check values are yes/no/unverified for imported devices.

- **Refactors**
  - Encoded `not_tracked` as its own verdict kind (not a special unverified case), simplifying chart, badge, and CSV logic.

<sup>Written for commit fcf9acda6e3356bd9d78d8b0edadc46e58cc9310. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

