### PR TITLE
fix(api): stop Trigger.dev deploy failing on @trycompai/auth/participation

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -175,6 +175,7 @@
             "^@db$": "<rootDir>/../prisma/index",
             "^@/(.*)$": "<rootDir>/$1",
             "^\\./sku-definitions\\.js$": "<rootDir>/../../../packages/billing/src/sku-definitions.ts",
+            "^@trycompai/auth/participation$": "<rootDir>/../../../packages/auth/src/participation.ts",
             "^@trycompai/auth$": "<rootDir>/../../../packages/auth/src/index.ts",
             "^@trycompai/billing$": "<rootDir>/../../../packages/billing/src/index.ts",
             "^@trycompai/company$": "<rootDir>/../../../packages/company/src/index.ts",

--- a/apps/api/src/task-management/task-item-assignment-notifier.service.ts
+++ b/apps/api/src/task-management/task-item-assignment-notifier.service.ts
@@ -1,5 +1,5 @@
 import { db } from '@db';
-import { isOrgParticipant } from '@trycompai/auth/participation';
+import { isOrgParticipant } from '../utils/org-participation-rule';
 import { Injectable, Logger } from '@nestjs/common';
 import { isUserUnsubscribed } from '@trycompai/email';
 import { triggerEmail } from '../email/trigger-email';

--- a/apps/api/src/utils/org-participation-rule.spec.ts
+++ b/apps/api/src/utils/org-participation-rule.spec.ts
@@ -1,0 +1,56 @@
+import {
+  PLATFORM_ADMIN_ROLE as AUTH_PLATFORM_ADMIN_ROLE,
+  isOrgParticipant as authIsOrgParticipant,
+} from '@trycompai/auth/participation';
+import {
+  isOrgParticipant,
+  PLATFORM_ADMIN_ROLE,
+} from './org-participation-rule';
+
+describe('org-participation-rule (API mirror)', () => {
+  it('excludes platform admins in a customer org', () => {
+    expect(isOrgParticipant(PLATFORM_ADMIN_ROLE, { orgIsInternal: false })).toBe(
+      false,
+    );
+  });
+
+  it('includes platform admins in an internal org', () => {
+    expect(isOrgParticipant(PLATFORM_ADMIN_ROLE, { orgIsInternal: true })).toBe(
+      true,
+    );
+  });
+
+  it('includes non-admin and null roles in a customer org', () => {
+    expect(isOrgParticipant('user', { orgIsInternal: false })).toBe(true);
+    expect(isOrgParticipant('owner', { orgIsInternal: false })).toBe(true);
+    expect(isOrgParticipant(null, { orgIsInternal: false })).toBe(true);
+    expect(isOrgParticipant(undefined, { orgIsInternal: false })).toBe(true);
+  });
+});
+
+// Drift guard: this API-local rule is a deliberate dependency-free mirror of
+// `@trycompai/auth/participation` (files in the Trigger.dev bundle can't import
+// the auth package — its dist isn't built in that deploy). Fail CI if the two
+// ever diverge.
+describe('API rule stays in sync with @trycompai/auth', () => {
+  const roles: Array<string | null | undefined> = [
+    'admin',
+    'owner',
+    'user',
+    'auditor',
+    '',
+    null,
+    undefined,
+  ];
+
+  it('matches the canonical predicate for every role × internal flag', () => {
+    expect(PLATFORM_ADMIN_ROLE).toBe(AUTH_PLATFORM_ADMIN_ROLE);
+    for (const role of roles) {
+      for (const orgIsInternal of [true, false]) {
+        expect(isOrgParticipant(role, { orgIsInternal })).toBe(
+          authIsOrgParticipant(role, { orgIsInternal }),
+        );
+      }
+    }
+  });
+});

--- a/apps/api/src/utils/org-participation-rule.ts
+++ b/apps/api/src/utils/org-participation-rule.ts
@@ -1,0 +1,25 @@
+/**
+ * Pure, dependency-free org-participation rule.
+ *
+ * This is a deliberate mirror of `packages/auth/src/participation.ts`. Files
+ * that end up in the API's Trigger.dev bundle (e.g. task notifiers) cannot
+ * import `@trycompai/auth/participation`: the auth package's dist is not built
+ * in the Trigger.dev deploy workflow, so esbuild fails to resolve the subpath
+ * ("Could not resolve @trycompai/auth/participation"). Keeping this rule free of
+ * imports lets both NestJS services and Trigger.dev tasks share one
+ * implementation. KEEP IN SYNC with the auth package version — the drift-guard
+ * test in `org-participation-rule.spec.ts` fails CI if they diverge.
+ *
+ * Platform admins (`User.role === 'admin'`) are Comp AI staff embedded in
+ * customer orgs for support; they are excluded from an org's business logic
+ * UNLESS the org is internal (platform-operated, e.g. Comp AI's own org).
+ */
+export const PLATFORM_ADMIN_ROLE = 'admin';
+
+export function isOrgParticipant(
+  userRole: string | null | undefined,
+  { orgIsInternal }: { orgIsInternal: boolean },
+): boolean {
+  if (orgIsInternal) return true;
+  return userRole !== PLATFORM_ADMIN_ROLE;
+}

--- a/apps/api/src/utils/org-participation.ts
+++ b/apps/api/src/utils/org-participation.ts
@@ -1,10 +1,9 @@
 import { db, Prisma } from '@db';
-// Import from the dedicated subpath (not the package index) so this stays free
-// of better-auth — keeps the util light and Jest-loadable without ESM interop.
-import {
-  PLATFORM_ADMIN_ROLE,
-  isOrgParticipant,
-} from '@trycompai/auth/participation';
+// Use the dependency-free local mirror (not @trycompai/auth) so this file is
+// safe in the API's Trigger.dev bundle — the auth package's dist isn't built in
+// that deploy, so esbuild can't resolve `@trycompai/auth/participation`. The
+// mirror is kept in sync with the auth package by org-participation-rule.spec.ts.
+import { PLATFORM_ADMIN_ROLE, isOrgParticipant } from './org-participation-rule';
 
 /**
  * Resolve whether an organization is platform-operated ("internal", e.g. Comp


### PR DESCRIPTION
## What

Fixes the broken **Deploy API to Trigger.dev** job on `main` (introduced by #3378):

```
Failed to build code
Error: Build failed with 1 error:
src/utils/org-participation.ts:7:7: ERROR: Could not resolve "@trycompai/auth/participation"
```

## Why

The API's Trigger.dev deploy bundles the task notifiers with esbuild. The trigger deploy workflow builds `db` / `email` / `integration-platform` but **not** `@trycompai/auth`, so its `dist/` doesn't exist. #3378 added `@trycompai/auth/participation` imports into `org-participation.ts` and `task-item-assignment-notifier.ts` — both reachable from the bundled task notifiers — so esbuild had nothing to resolve. (The auth *index* is never reached in the bundle, which is why only the subpath failed.)

## How

Mirror the pattern the **app** already uses for Trigger.dev-bundled code (`apps/app/src/lib/org-participation-rule.ts`): a dependency-free local copy of the tiny participation predicate, so the trigger bundle never imports `@trycompai/auth` (which also pulls in better-auth, unbundleable).

- New `apps/api/src/utils/org-participation-rule.ts` — pure, zero imports.
- `org-participation.ts` + `task-item-assignment-notifier.ts` import the local mirror instead of the subpath.
- Drift-guard spec asserts the mirror stays byte-for-byte equivalent to `@trycompai/auth/participation` across every role × internal-flag combination.
- Jest `moduleNameMapper` resolves `@trycompai/auth/participation` → source, so the guard runs without needing the auth dist built.

This restores the trigger bundle to its known-good pre-#3378 state (no `@trycompai/auth` in the bundle).

## Verify

- No source file imports `@trycompai/auth/participation` anymore (only the spec, which isn't bundled).
- API typecheck clean for the changed files; `org-participation` + `task-item-assignment-notifier` specs pass (15 tests, incl. the drift guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the API `Trigger.dev` deploy by removing the broken `@trycompai/auth/participation` import from bundled code. Uses a local, dependency‑free participation rule and adds a drift guard to keep it in sync.

- **Bug Fixes**
  - Added `apps/api/src/utils/org-participation-rule.ts` (pure, no imports).
  - Updated `org-participation.ts` and the task notifier to import the local rule.
  - Added `org-participation-rule.spec.ts` to compare outputs with `@trycompai/auth/participation`.
  - Mapped `@trycompai/auth/participation` to source in Jest so the guard runs without the auth `dist/`.

<sup>Written for commit 02f24fc86851b99db633c52513d910ca8a6d6735. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

