### PR TITLE
test(api): cover internal-org participant filter in automation-failure notifiers

### DIFF
--- a/apps/api/src/tasks/task-notifier.service.spec.ts
+++ b/apps/api/src/tasks/task-notifier.service.spec.ts
@@ -312,4 +312,105 @@ describe('TaskNotifierService', () => {
       expect(triggerEmailMock).not.toHaveBeenCalled();
     });
   });
+
+  // Regression: the automation-failure recipient query must apply the
+  // internal-org participant filter (orgParticipantMemberWhereForFlag) so
+  // platform admins are excluded from customer orgs but included in internal
+  // ones. A change to that helper must not silently reroute these notifications.
+  const CUSTOMER_PARTICIPANT_WHERE = {
+    AND: [{ user: { OR: [{ role: { not: 'admin' } }, { role: null }] } }],
+  };
+
+  const memberWhere = () => mockDb.member.findMany.mock.calls[0][0].where;
+
+  describe('notifyAutomationFailures — participant filter', () => {
+    it('excludes platform admins for a customer org (isInternal false)', async () => {
+      mockDb.organization.findUnique.mockResolvedValue({
+        name: 'Acme',
+        isInternal: false,
+      });
+      mockDb.task.findUnique.mockResolvedValue({ assignee: null });
+      mockDb.member.findMany.mockResolvedValue([]);
+
+      await service.notifyAutomationFailures({
+        organizationId: 'org_1',
+        taskId: 'tsk_1',
+        taskTitle: '2FA',
+        failedCount: 1,
+        totalCount: 2,
+        taskStatusChanged: false,
+      });
+
+      expect(memberWhere()).toEqual({
+        organizationId: 'org_1',
+        deactivated: false,
+        ...CUSTOMER_PARTICIPANT_WHERE,
+      });
+    });
+
+    it('includes platform admins for an internal org (isInternal true)', async () => {
+      mockDb.organization.findUnique.mockResolvedValue({
+        name: 'Comp AI',
+        isInternal: true,
+      });
+      mockDb.task.findUnique.mockResolvedValue({ assignee: null });
+      mockDb.member.findMany.mockResolvedValue([]);
+
+      await service.notifyAutomationFailures({
+        organizationId: 'org_1',
+        taskId: 'tsk_1',
+        taskTitle: '2FA',
+        failedCount: 1,
+        totalCount: 2,
+        taskStatusChanged: false,
+      });
+
+      expect(memberWhere()).toEqual({
+        organizationId: 'org_1',
+        deactivated: false,
+      });
+    });
+  });
+
+  describe('notifyBulkAutomationFailures — participant filter', () => {
+    const bulkParams = {
+      organizationId: 'org_1',
+      tasks: [
+        { taskId: 'tsk_1', taskTitle: 't1', failedCount: 1, totalCount: 2 },
+      ],
+    };
+
+    it('excludes platform admins for a customer org (isInternal false)', async () => {
+      mockDb.organization.findUnique.mockResolvedValue({
+        name: 'Acme',
+        isInternal: false,
+      });
+      mockDb.task.findMany.mockResolvedValue([{ id: 'tsk_1', assignee: null }]);
+      mockDb.member.findMany.mockResolvedValue([]);
+
+      await service.notifyBulkAutomationFailures(bulkParams);
+
+      expect(memberWhere()).toEqual({
+        organizationId: 'org_1',
+        deactivated: false,
+        ...CUSTOMER_PARTICIPANT_WHERE,
+      });
+    });
+
+    it('includes platform admins for an internal org (isInternal true)', async () => {
+      mockDb.organization.findUnique.mockResolvedValue({
+        name: 'Comp AI',
+        isInternal: true,
+      });
+      mockDb.task.findMany.mockResolvedValue([{ id: 'tsk_1', assignee: null }]);
+      mockDb.member.findMany.mockResolvedValue([]);
+
+      await service.notifyBulkAutomationFailures(bulkParams);
+
+      expect(memberWhere()).toEqual({
+        organizationId: 'org_1',
+        deactivated: false,
+      });
+    });
+  });
 });


### PR DESCRIPTION
## What

Addresses the **P3** finding cubic raised on the release PR (#3392): the automation-failure notifiers had no regression coverage for the internal-org participant filter introduced in #3378.

Adds tests for both `notifyAutomationFailures` and `notifyBulkAutomationFailures` asserting the recipient `member.findMany` query applies `orgParticipantMemberWhereForFlag`:

- **Customer org** (`isInternal: false`) → query excludes platform admins (`AND: [{ user: { OR: [{ role: { not: 'admin' } }, { role: null }] } }]`).
- **Internal org** (`isInternal: true`) → query has no exclusion (everyone participates).

This guards against a future change to the participation helper silently rerouting automation-failure notifications to the wrong recipients.

## Note on the other finding (P2)

cubic's P2 (the `isInternal` toggle hits a `PlatformAdminGuard`-gated route rather than RBAC) is **intentional, not a bug**. The entire `admin-organizations` controller is platform-admin-gated by design; `isInternal` rides on the existing PATCH endpoint exactly like `backgroundCheckStepEnabled`/`hasAccess`. Marking an org "internal" must stay a Comp AI platform-staff operation — customer custom-roles should not be able to do it — so the current gating is the correct (safer) behavior, and this change introduces no new gap. No code change needed there.

## Verify

Test-only change. `task-notifier.service.spec.ts` passes (12 tests, incl. the 4 new participant-filter cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add regression tests for `notifyAutomationFailures` and `notifyBulkAutomationFailures` to verify the internal-org participant filter on recipient queries. Confirms platform admins are excluded for customer orgs and included for internal orgs, preventing misrouted automation-failure notifications.

<sup>Written for commit d3992e56616d438e89f9ab1504715ed43a465d53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

