### PR TITLE
improvement(soa): persist applicability and justification on the SoA answer

### DIFF
--- a/apps/api/src/soa/soa.controller.spec.ts
+++ b/apps/api/src/soa/soa.controller.spec.ts
@@ -40,7 +40,7 @@ describe('SOAController', () => {
     batchSearchSOAQuestions: jest.fn(),
     processSOAQuestionWithContent: jest.fn(),
     saveAnswersToDatabase: jest.fn(),
-    updateConfigurationWithResults: jest.fn(),
+    countAnsweredAnswers: jest.fn(),
     updateDocumentAfterAutoFill: jest.fn(),
     createDocument: jest.fn(),
     ensureSetup: jest.fn(),

--- a/apps/api/src/soa/soa.controller.ts
+++ b/apps/api/src/soa/soa.controller.ts
@@ -261,9 +261,11 @@ export class SOAController {
         userId,
       );
 
-      // Update document answered count from this org's persisted answers.
+      // Update document answered count from this org's persisted answers,
+      // scoped to the document's configured questions.
       const answeredCount = await this.soaService.countAnsweredAnswers(
         dto.documentId,
+        questions.map((q) => q.id),
       );
       await this.soaService.updateDocumentAfterAutoFill(
         dto.documentId,

--- a/apps/api/src/soa/soa.controller.ts
+++ b/apps/api/src/soa/soa.controller.ts
@@ -261,17 +261,10 @@ export class SOAController {
         userId,
       );
 
-      // Update configuration with results
-      await this.soaService.updateConfigurationWithResults(
-        configuration.id,
-        questions,
-        successfulResults,
+      // Update document answered count from this org's persisted answers.
+      const answeredCount = await this.soaService.countAnsweredAnswers(
+        dto.documentId,
       );
-
-      // Update document
-      const answeredCount = successfulResults.filter(
-        (r) => r.isApplicable !== null,
-      ).length;
       await this.soaService.updateDocumentAfterAutoFill(
         dto.documentId,
         questions.length,

--- a/apps/api/src/soa/soa.service.spec.ts
+++ b/apps/api/src/soa/soa.service.spec.ts
@@ -603,6 +603,7 @@ describe('SOAService', () => {
       (mockDb.sOADocument.findFirst as jest.Mock).mockResolvedValue({
         id: 'doc-1',
         totalQuestions: 5,
+        configuration: { questions: [{ id: 'q-1' }] },
       });
       (mockDb.sOAAnswer.findFirst as jest.Mock).mockResolvedValue(null);
       (mockDb.sOAAnswer.create as jest.Mock).mockResolvedValue({ id: 'ans-1' });
@@ -616,6 +617,53 @@ describe('SOAService', () => {
           userId,
         ),
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it('rejects a question that is not in the document configuration', async () => {
+      await expect(
+        service.saveAnswer(
+          {
+            ...baseDto,
+            questionId: 'q-not-in-config',
+            isApplicable: true,
+            justification: 'x',
+          },
+          userId,
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockDb.sOAAnswer.create).not.toHaveBeenCalled();
+    });
+
+    it('requires a justification when a control is not applicable', async () => {
+      await expect(
+        service.saveAnswer(
+          { ...baseDto, isApplicable: false, justification: '   ' },
+          userId,
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockDb.sOAAnswer.create).not.toHaveBeenCalled();
+    });
+
+    it('preserves the existing applicability when isApplicable is omitted', async () => {
+      (mockDb.sOAAnswer.findFirst as jest.Mock).mockResolvedValue({
+        id: 'ans-prev',
+        answerVersion: 1,
+        isApplicable: false,
+        answer: 'Prior justification',
+      });
+
+      // A partial edit that only sends a justification must not wipe the Yes/No.
+      await service.saveAnswer(
+        { ...baseDto, justification: 'Updated justification' },
+        userId,
+      );
+
+      expect(mockDb.sOAAnswer.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          isApplicable: false,
+          answer: 'Updated justification',
+        }),
+      });
     });
 
     it('persists applicability + justification on the answer', async () => {

--- a/apps/api/src/soa/soa.service.spec.ts
+++ b/apps/api/src/soa/soa.service.spec.ts
@@ -29,6 +29,7 @@ jest.mock('@db', () => ({
     user: { findUnique: jest.fn() },
     organization: { findUnique: jest.fn() },
     sOAAnswer: { findFirst: jest.fn(), create: jest.fn(), update: jest.fn() },
+    $transaction: jest.fn((ops: unknown[]) => Promise.all(ops)),
   },
 }));
 
@@ -641,6 +642,28 @@ describe('SOAService', () => {
           userId,
         ),
       ).rejects.toThrow(BadRequestException);
+      expect(mockDb.sOAAnswer.create).not.toHaveBeenCalled();
+    });
+
+    it('does not retire the previous answer when validation fails', async () => {
+      // A rejected save must leave the prior answer intact — validation runs
+      // before any write, and the retire + create happen in one transaction.
+      (mockDb.sOAAnswer.findFirst as jest.Mock).mockResolvedValue({
+        id: 'ans-prev',
+        answerVersion: 1,
+        isApplicable: true,
+        answer: 'Previously applicable',
+      });
+
+      await expect(
+        service.saveAnswer(
+          { ...baseDto, isApplicable: false, justification: '' },
+          userId,
+        ),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockDb.sOAAnswer.update).not.toHaveBeenCalled();
+      expect(mockDb.$transaction).not.toHaveBeenCalled();
       expect(mockDb.sOAAnswer.create).not.toHaveBeenCalled();
     });
 

--- a/apps/api/src/soa/soa.service.spec.ts
+++ b/apps/api/src/soa/soa.service.spec.ts
@@ -18,6 +18,7 @@ jest.mock('@db', () => ({
       findFirst: jest.fn(),
       findUnique: jest.fn(),
       create: jest.fn(),
+      update: jest.fn(),
     },
     sOADocument: {
       findFirst: jest.fn(),
@@ -47,9 +48,8 @@ jest.mock('./utils/soa-answer-parser', () => ({
 }));
 jest.mock('./utils/soa-storage', () => ({
   saveAnswersToDatabase: jest.fn(),
-  updateConfigurationWithResults: jest.fn(),
   updateDocumentAfterAutoFill: jest.fn(),
-  getAnsweredCountFromConfiguration: jest.fn(),
+  countAnsweredAnswers: jest.fn(),
   updateDocumentAnsweredCount: jest.fn(),
   checkIfFullyRemote: jest.fn(),
 }));
@@ -487,7 +487,7 @@ describe('SOAService', () => {
       );
     });
 
-    it('maps document data and delegates to generateSOAExportFile', async () => {
+    it('sources applicability + justification from this org\'s answers, not the shared configuration', async () => {
       const generated = {
         fileBuffer: Buffer.from('pdf'),
         mimeType: 'application/pdf',
@@ -506,6 +506,8 @@ describe('SOAService', () => {
         version: 2,
         framework: { name: 'ISO 27001' },
         configuration: {
+          // The shared configuration must NOT drive applicability/justification.
+          // These stale values would previously bleed into every org's export.
           questions: [
             {
               id: 'q-1',
@@ -515,7 +517,7 @@ describe('SOAService', () => {
                 title: 'Control title',
                 control_objective: 'Objective',
                 isApplicable: true,
-                justification: 'Mapped justification',
+                justification: 'Another org shared-config justification',
               },
             },
             {
@@ -531,7 +533,14 @@ describe('SOAService', () => {
             email: 'approver@example.com',
           },
         },
-        answers: [{ questionId: 'q-2', answer: 'Fallback answer' }],
+        // This org's own answers.
+        answers: [
+          {
+            questionId: 'q-1',
+            answer: 'Our own justification',
+            isApplicable: false,
+          },
+        ],
       });
 
       const result = await service.exportDocument(dto);
@@ -545,10 +554,11 @@ describe('SOAService', () => {
               closure: 'A.5',
               title: 'Control title',
               control_objective: 'Objective',
-              isApplicable: true,
-              justification: 'Mapped justification',
+              // From the org's own answer — NOT the shared config's `true`.
+              isApplicable: false,
+              justification: 'Our own justification',
             },
-            answer: null,
+            answer: 'Our own justification',
           },
           {
             id: 'q-2',
@@ -557,10 +567,11 @@ describe('SOAService', () => {
               closure: null,
               title: null,
               control_objective: null,
+              // No answer for this org → blank, not another org's data.
               isApplicable: null,
               justification: null,
             },
-            answer: 'Fallback answer',
+            answer: null,
           },
         ],
         'ISO 27001',
@@ -577,6 +588,79 @@ describe('SOAService', () => {
         'pdf',
       );
       expect(result).toEqual(generated);
+    });
+  });
+
+  describe('saveAnswer', () => {
+    const baseDto = {
+      organizationId: 'org-1',
+      documentId: 'doc-1',
+      questionId: 'q-1',
+    };
+    const userId = 'user-1';
+
+    beforeEach(() => {
+      (mockDb.sOADocument.findFirst as jest.Mock).mockResolvedValue({
+        id: 'doc-1',
+        totalQuestions: 5,
+      });
+      (mockDb.sOAAnswer.findFirst as jest.Mock).mockResolvedValue(null);
+      (mockDb.sOAAnswer.create as jest.Mock).mockResolvedValue({ id: 'ans-1' });
+    });
+
+    it('throws NotFoundException when document not found', async () => {
+      (mockDb.sOADocument.findFirst as jest.Mock).mockResolvedValue(null);
+      await expect(
+        service.saveAnswer(
+          { ...baseDto, isApplicable: true, justification: 'x' },
+          userId,
+        ),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('persists applicability + justification on the answer', async () => {
+      await service.saveAnswer(
+        {
+          ...baseDto,
+          isApplicable: false,
+          justification: 'Not applicable because reasons',
+        },
+        userId,
+      );
+
+      expect(mockDb.sOAAnswer.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          documentId: 'doc-1',
+          questionId: 'q-1',
+          answer: 'Not applicable because reasons',
+          isApplicable: false,
+          status: 'manual',
+          isLatestAnswer: true,
+        }),
+      });
+    });
+
+    it('keeps the justification for applicable (YES) answers', async () => {
+      await service.saveAnswer(
+        { ...baseDto, isApplicable: true, justification: 'We do this' },
+        userId,
+      );
+
+      expect(mockDb.sOAAnswer.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          answer: 'We do this',
+          isApplicable: true,
+        }),
+      });
+    });
+
+    it('never writes per-organization data to the shared configuration', async () => {
+      await service.saveAnswer(
+        { ...baseDto, isApplicable: true, justification: 'We do this' },
+        userId,
+      );
+
+      expect(mockDb.sOAFrameworkConfiguration.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/soa/soa.service.ts
+++ b/apps/api/src/soa/soa.service.ts
@@ -151,8 +151,12 @@ export class SOAService {
       },
     });
 
-    // Update document answered questions count from the per-org answers.
-    const answeredCount = await countAnsweredAnswers(dto.documentId);
+    // Update document answered questions count from the per-org answers,
+    // scoped to the document's configured questions.
+    const answeredCount = await countAnsweredAnswers(
+      dto.documentId,
+      configQuestions.map((q) => q.id),
+    );
 
     await updateDocumentAnsweredCount(
       dto.documentId,
@@ -613,8 +617,11 @@ export class SOAService {
     );
   }
 
-  async countAnsweredAnswers(documentId: string): Promise<number> {
-    return countAnsweredAnswers(documentId);
+  async countAnsweredAnswers(
+    documentId: string,
+    validQuestionIds: string[],
+  ): Promise<number> {
+    return countAnsweredAnswers(documentId, validQuestionIds);
   }
 
   async updateDocumentAfterAutoFill(

--- a/apps/api/src/soa/soa.service.ts
+++ b/apps/api/src/soa/soa.service.ts
@@ -64,10 +64,24 @@ export class SOAService {
         id: dto.documentId,
         organizationId: dto.organizationId,
       },
+      include: {
+        configuration: true,
+      },
     });
 
     if (!document) {
       throw new NotFoundException('SOA document not found');
+    }
+
+    // The question must belong to this document's configuration, so answers
+    // (and the answered-count) can't be created for arbitrary question IDs.
+    const configQuestions =
+      (document.configuration.questions as unknown as Array<{ id: string }>) ??
+      [];
+    if (!configQuestions.some((q) => q.id === dto.questionId)) {
+      throw new BadRequestException(
+        'Question does not belong to this SOA document',
+      );
     }
 
     // Get existing answer to determine version
@@ -93,10 +107,30 @@ export class SOAService {
     }
 
     // Applicability + justification are stored per organization on the answer.
-    // Keep the justification for both YES and NO so the SoA always carries a
-    // justification for every control (per ISO 27001).
-    const isApplicable = dto.isApplicable ?? null;
-    const justification = dto.justification ?? dto.answer ?? null;
+    // Omitted fields preserve the previous value, so a partial edit (e.g. one
+    // that sends only a justification) cannot wipe a prior applicability
+    // decision or justification.
+    const isApplicable =
+      dto.isApplicable === undefined
+        ? (existingAnswer?.isApplicable ?? null)
+        : dto.isApplicable;
+    const justification =
+      dto.justification !== undefined
+        ? dto.justification
+        : dto.answer !== undefined
+          ? dto.answer
+          : (existingAnswer?.answer ?? null);
+
+    // ISO 27001: a not-applicable control must carry a justification.
+    if (
+      isApplicable === false &&
+      (!justification || justification.trim().length === 0)
+    ) {
+      throw new BadRequestException(
+        'A justification is required when a control is not applicable',
+      );
+    }
+
     const isAnswered = isApplicable !== null;
 
     // Create or update answer

--- a/apps/api/src/soa/soa.service.ts
+++ b/apps/api/src/soa/soa.service.ts
@@ -39,9 +39,8 @@ import {
 } from './utils/soa-answer-parser';
 import {
   saveAnswersToDatabase,
-  updateConfigurationWithResults,
   updateDocumentAfterAutoFill,
-  getAnsweredCountFromConfiguration,
+  countAnsweredAnswers,
   updateDocumentAnsweredCount,
   checkIfFullyRemote,
   type SOAStorageLogger,
@@ -64,9 +63,6 @@ export class SOAService {
       where: {
         id: dto.documentId,
         organizationId: dto.organizationId,
-      },
-      include: {
-        configuration: true,
       },
     });
 
@@ -96,25 +92,24 @@ export class SOAService {
       });
     }
 
-    // Determine answer value
-    let finalAnswer: string | null = null;
-    if (dto.isApplicable !== undefined) {
-      finalAnswer =
-        dto.isApplicable === false
-          ? dto.justification || dto.answer || null
-          : null;
-    } else {
-      finalAnswer = dto.answer || null;
-    }
+    // Applicability + justification are stored per organization on the answer.
+    // Keep the justification for both YES and NO so the SoA always carries a
+    // justification for every control (per ISO 27001).
+    const isApplicable = dto.isApplicable ?? null;
+    const justification = dto.justification ?? dto.answer ?? null;
+    const isAnswered = isApplicable !== null;
 
     // Create or update answer
     await db.sOAAnswer.create({
       data: {
         documentId: dto.documentId,
         questionId: dto.questionId,
-        answer: finalAnswer,
+        answer: justification,
+        isApplicable,
         status:
-          finalAnswer && finalAnswer.trim().length > 0 ? 'manual' : 'untouched',
+          isAnswered || (justification && justification.trim().length > 0)
+            ? 'manual'
+            : 'untouched',
         answerVersion: nextVersion,
         isLatestAnswer: true,
         createdBy: existingAnswer ? undefined : userId,
@@ -122,20 +117,8 @@ export class SOAService {
       },
     });
 
-    // Update configuration's question mapping if isApplicable or justification provided
-    if (dto.isApplicable !== undefined || dto.justification !== undefined) {
-      await this.updateQuestionMapping(
-        document.configuration.id,
-        dto.questionId,
-        dto.isApplicable ?? undefined,
-        dto.justification ?? undefined,
-      );
-    }
-
-    // Update document answered questions count
-    const answeredCount = await getAnsweredCountFromConfiguration(
-      document.configurationId,
-    );
+    // Update document answered questions count from the per-org answers.
+    const answeredCount = await countAnsweredAnswers(dto.documentId);
 
     await updateDocumentAnsweredCount(
       dto.documentId,
@@ -144,45 +127,6 @@ export class SOAService {
     );
 
     return { success: true };
-  }
-
-  private async updateQuestionMapping(
-    configurationId: string,
-    questionId: string,
-    isApplicable: boolean | undefined,
-    justification: string | undefined,
-  ) {
-    const configuration = await db.sOAFrameworkConfiguration.findUnique({
-      where: { id: configurationId },
-    });
-
-    if (!configuration) return;
-
-    const questions = configuration.questions as unknown as SOAQuestion[];
-    const updatedQuestions = questions.map((q) => {
-      if (q.id === questionId) {
-        return {
-          ...q,
-          columnMapping: {
-            ...q.columnMapping,
-            isApplicable:
-              isApplicable !== undefined
-                ? isApplicable
-                : q.columnMapping.isApplicable,
-            justification:
-              justification !== undefined
-                ? justification
-                : q.columnMapping.justification,
-          },
-        };
-      }
-      return q;
-    });
-
-    await db.sOAFrameworkConfiguration.update({
-      where: { id: configurationId },
-      data: { questions: JSON.parse(JSON.stringify(updatedQuestions)) },
-    });
   }
 
   async createDocument(dto: CreateSOADocumentDto) {
@@ -521,6 +465,7 @@ export class SOAService {
           select: {
             questionId: true,
             answer: true,
+            isApplicable: true,
           },
         },
       },
@@ -532,22 +477,28 @@ export class SOAService {
 
     const questions =
       (document.configuration.questions as unknown as SOAQuestion[]) ?? [];
+    // Applicability + justification come from this organization's own answers,
+    // never from the shared framework configuration (which only supplies the
+    // control template: title, closure, objective).
     const answersByQuestionId = new Map(
-      document.answers.map((answer) => [answer.questionId, answer.answer]),
+      document.answers.map((answer) => [answer.questionId, answer]),
     );
 
-    const exportQuestions: SOAExportQuestion[] = questions.map((question) => ({
-      id: question.id,
-      text: question.text,
-      columnMapping: {
-        closure: question.columnMapping?.closure ?? null,
-        title: question.columnMapping?.title ?? null,
-        control_objective: question.columnMapping?.control_objective ?? null,
-        isApplicable: question.columnMapping?.isApplicable ?? null,
-        justification: question.columnMapping?.justification ?? null,
-      },
-      answer: answersByQuestionId.get(question.id) ?? null,
-    }));
+    const exportQuestions: SOAExportQuestion[] = questions.map((question) => {
+      const answer = answersByQuestionId.get(question.id);
+      return {
+        id: question.id,
+        text: question.text,
+        columnMapping: {
+          closure: question.columnMapping?.closure ?? null,
+          title: question.columnMapping?.title ?? null,
+          control_objective: question.columnMapping?.control_objective ?? null,
+          isApplicable: answer?.isApplicable ?? null,
+          justification: answer?.answer ?? null,
+        },
+        answer: answer?.answer ?? null,
+      };
+    });
 
     const exportMetadata: SOAExportMetadata = {
       preparedBy: (document.preparedBy as string | null) ?? null,
@@ -628,12 +579,8 @@ export class SOAService {
     );
   }
 
-  async updateConfigurationWithResults(
-    configurationId: string,
-    questions: SOAQuestion[],
-    results: SOAQuestionResult[],
-  ): Promise<void> {
-    return updateConfigurationWithResults(configurationId, questions, results);
+  async countAnsweredAnswers(documentId: string): Promise<number> {
+    return countAnsweredAnswers(documentId);
   }
 
   async updateDocumentAfterAutoFill(

--- a/apps/api/src/soa/soa.service.ts
+++ b/apps/api/src/soa/soa.service.ts
@@ -84,7 +84,8 @@ export class SOAService {
       );
     }
 
-    // Get existing answer to determine version
+    // Get existing answer to determine the next version and to preserve prior
+    // values on partial edits.
     const existingAnswer = await db.sOAAnswer.findFirst({
       where: {
         documentId: dto.documentId,
@@ -95,16 +96,6 @@ export class SOAService {
         answerVersion: 'desc',
       },
     });
-
-    const nextVersion = existingAnswer ? existingAnswer.answerVersion + 1 : 1;
-
-    // Mark existing answer as not latest if it exists
-    if (existingAnswer) {
-      await db.sOAAnswer.update({
-        where: { id: existingAnswer.id },
-        data: { isLatestAnswer: false },
-      });
-    }
 
     // Applicability + justification are stored per organization on the answer.
     // Omitted fields preserve the previous value, so a partial edit (e.g. one
@@ -121,7 +112,8 @@ export class SOAService {
           ? dto.answer
           : (existingAnswer?.answer ?? null);
 
-    // ISO 27001: a not-applicable control must carry a justification.
+    // Validate BEFORE any write, so a rejected save leaves the prior answer
+    // intact. ISO 27001: a not-applicable control must carry a justification.
     if (
       isApplicable === false &&
       (!justification || justification.trim().length === 0)
@@ -131,25 +123,37 @@ export class SOAService {
       );
     }
 
+    const nextVersion = existingAnswer ? existingAnswer.answerVersion + 1 : 1;
     const isAnswered = isApplicable !== null;
 
-    // Create or update answer
-    await db.sOAAnswer.create({
-      data: {
-        documentId: dto.documentId,
-        questionId: dto.questionId,
-        answer: justification,
-        isApplicable,
-        status:
-          isAnswered || (justification && justification.trim().length > 0)
-            ? 'manual'
-            : 'untouched',
-        answerVersion: nextVersion,
-        isLatestAnswer: true,
-        createdBy: existingAnswer ? undefined : userId,
-        updatedBy: userId,
-      },
-    });
+    // Retire the prior answer and create the new version atomically, so a
+    // failure can never leave the control without a latest answer.
+    await db.$transaction([
+      ...(existingAnswer
+        ? [
+            db.sOAAnswer.update({
+              where: { id: existingAnswer.id },
+              data: { isLatestAnswer: false },
+            }),
+          ]
+        : []),
+      db.sOAAnswer.create({
+        data: {
+          documentId: dto.documentId,
+          questionId: dto.questionId,
+          answer: justification,
+          isApplicable,
+          status:
+            isAnswered || (justification && justification.trim().length > 0)
+              ? 'manual'
+              : 'untouched',
+          answerVersion: nextVersion,
+          isLatestAnswer: true,
+          createdBy: existingAnswer ? undefined : userId,
+          updatedBy: userId,
+        },
+      }),
+    ]);
 
     // Update document answered questions count from the per-org answers,
     // scoped to the document's configured questions.

--- a/apps/api/src/soa/utils/soa-storage.spec.ts
+++ b/apps/api/src/soa/utils/soa-storage.spec.ts
@@ -1,0 +1,44 @@
+import { db } from '@db';
+import { countAnsweredAnswers } from './soa-storage';
+
+jest.mock('@db', () => ({
+  db: {
+    sOAAnswer: {
+      count: jest.fn(),
+    },
+  },
+}));
+
+const mockDb = jest.mocked(db);
+
+describe('countAnsweredAnswers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('counts only latest answered rows whose questionId is in the active configuration', async () => {
+    (mockDb.sOAAnswer.count as jest.Mock).mockResolvedValue(2);
+
+    const result = await countAnsweredAnswers('doc-1', ['q-1', 'q-2']);
+
+    expect(result).toBe(2);
+    // Scoping by questionId excludes stale/mismatched answers (e.g. for a
+    // control that was later removed from the configuration) so they can't
+    // inflate the completion count.
+    expect(mockDb.sOAAnswer.count).toHaveBeenCalledWith({
+      where: {
+        documentId: 'doc-1',
+        isLatestAnswer: true,
+        isApplicable: { not: null },
+        questionId: { in: ['q-1', 'q-2'] },
+      },
+    });
+  });
+
+  it('returns 0 without querying when the configuration has no questions', async () => {
+    const result = await countAnsweredAnswers('doc-1', []);
+
+    expect(result).toBe(0);
+    expect(mockDb.sOAAnswer.count).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/soa/utils/soa-storage.ts
+++ b/apps/api/src/soa/utils/soa-storage.ts
@@ -103,16 +103,24 @@ export async function updateDocumentAfterAutoFill(
 
 /**
  * Counts answered questions for a document from its per-organization answers.
- * A control is "answered" once it has an applicability decision.
+ * A control is "answered" once it has an applicability decision. Scoped to the
+ * question IDs in the document's active configuration so stale/mismatched
+ * answer rows can't skew the completion count.
  */
 export async function countAnsweredAnswers(
   documentId: string,
+  validQuestionIds: string[],
 ): Promise<number> {
+  if (validQuestionIds.length === 0) {
+    return 0;
+  }
+
   return db.sOAAnswer.count({
     where: {
       documentId,
       isLatestAnswer: true,
       isApplicable: { not: null },
+      questionId: { in: validQuestionIds },
     },
   });
 }

--- a/apps/api/src/soa/utils/soa-storage.ts
+++ b/apps/api/src/soa/utils/soa-storage.ts
@@ -44,33 +44,37 @@ export async function saveAnswersToDatabase(
 
       const nextVersion = existingAnswer ? existingAnswer.answerVersion + 1 : 1;
 
-      // Mark existing answer as not latest if it exists
-      if (existingAnswer) {
-        await db.sOAAnswer.update({
-          where: { id: existingAnswer.id },
-          data: { isLatestAnswer: false },
-        });
-      }
-
       // Store justification in the answer field for both YES and NO so the
       // SoA always carries a justification for every control (per ISO 27001).
       const answerValue = result.justification ?? null;
 
-      // Create new answer. Applicability + justification are stored per
-      // organization on the answer — never on the shared configuration.
-      await db.sOAAnswer.create({
-        data: {
-          documentId,
-          questionId: question.id,
-          answer: answerValue,
-          isApplicable: result.isApplicable,
-          status: 'generated',
-          generatedAt: new Date(),
-          answerVersion: nextVersion,
-          isLatestAnswer: true,
-          createdBy: userId,
-        },
-      });
+      // Retire the prior answer and create the new version atomically, so a
+      // failure can never leave the control without a latest answer.
+      // Applicability + justification are stored per organization on the
+      // answer — never on the shared configuration.
+      await db.$transaction([
+        ...(existingAnswer
+          ? [
+              db.sOAAnswer.update({
+                where: { id: existingAnswer.id },
+                data: { isLatestAnswer: false },
+              }),
+            ]
+          : []),
+        db.sOAAnswer.create({
+          data: {
+            documentId,
+            questionId: question.id,
+            answer: answerValue,
+            isApplicable: result.isApplicable,
+            status: 'generated',
+            generatedAt: new Date(),
+            answerVersion: nextVersion,
+            isLatestAnswer: true,
+            createdBy: userId,
+          },
+        }),
+      ]);
     } catch (error) {
       logger.error('Failed to save SOA answer', {
         questionId: question.id,

--- a/apps/api/src/soa/utils/soa-storage.ts
+++ b/apps/api/src/soa/utils/soa-storage.ts
@@ -56,12 +56,14 @@ export async function saveAnswersToDatabase(
       // SoA always carries a justification for every control (per ISO 27001).
       const answerValue = result.justification ?? null;
 
-      // Create new answer
+      // Create new answer. Applicability + justification are stored per
+      // organization on the answer — never on the shared configuration.
       await db.sOAAnswer.create({
         data: {
           documentId,
           questionId: question.id,
           answer: answerValue,
+          isApplicable: result.isApplicable,
           status: 'generated',
           generatedAt: new Date(),
           answerVersion: nextVersion,
@@ -76,43 +78,6 @@ export async function saveAnswersToDatabase(
       });
     }
   }
-}
-
-/**
- * Updates SOA configuration with auto-fill results
- */
-export async function updateConfigurationWithResults(
-  configurationId: string,
-  configurationQuestions: SOAQuestion[],
-  results: SOAQuestionResult[],
-): Promise<void> {
-  const resultsMap = new Map(
-    results
-      .filter((r) => r.success && r.isApplicable !== null)
-      .map((r) => [r.questionId, r]),
-  );
-
-  const updatedQuestions = configurationQuestions.map((q) => {
-    const result = resultsMap.get(q.id);
-    if (result) {
-      return {
-        ...q,
-        columnMapping: {
-          ...q.columnMapping,
-          isApplicable: result.isApplicable,
-          justification: result.justification,
-        },
-      };
-    }
-    return q;
-  });
-
-  await db.sOAFrameworkConfiguration.update({
-    where: { id: configurationId },
-    data: {
-      questions: JSON.parse(JSON.stringify(updatedQuestions)),
-    },
-  });
 }
 
 /**
@@ -137,25 +102,19 @@ export async function updateDocumentAfterAutoFill(
 }
 
 /**
- * Gets the answered questions count from configuration
+ * Counts answered questions for a document from its per-organization answers.
+ * A control is "answered" once it has an applicability decision.
  */
-export async function getAnsweredCountFromConfiguration(
-  configurationId: string,
+export async function countAnsweredAnswers(
+  documentId: string,
 ): Promise<number> {
-  const configuration = await db.sOAFrameworkConfiguration.findUnique({
-    where: { id: configurationId },
+  return db.sOAAnswer.count({
+    where: {
+      documentId,
+      isLatestAnswer: true,
+      isApplicable: { not: null },
+    },
   });
-
-  if (!configuration) return 0;
-
-  const questions = configuration.questions as Array<{
-    id: string;
-    columnMapping: {
-      isApplicable: boolean | null;
-    };
-  }>;
-
-  return questions.filter((q) => q.columnMapping.isApplicable !== null).length;
 }
 
 /**

--- a/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/EditableSOAFields.tsx
+++ b/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/EditableSOAFields.tsx
@@ -22,7 +22,11 @@ import { useSOADocument } from '../hooks/useSOADocument';
 import { ApplicableReadOnlyDisplay, ApplicableSwatchRow } from './ApplicableSwatch';
 import type { SOAFieldSavePayload } from './soa-field-types';
 
-export type { SOAFieldSavePayload, SOATableAnswerData } from './soa-field-types';
+export type {
+  SOAFieldSavePayload,
+  SOATableAnswerData,
+  SOAProcessedResult,
+} from './soa-field-types';
 
 interface EditableSOAFieldsProps {
   documentId: string;

--- a/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/SOAFrameworkTable.tsx
+++ b/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/SOAFrameworkTable.tsx
@@ -53,6 +53,13 @@ type SOAQuestion = {
   };
 };
 
+type SOAAnswerRecord = {
+  questionId: string;
+  answer: string | null;
+  isApplicable: boolean | null;
+  answerVersion: number;
+};
+
 type SOADocumentInfoDocument = Parameters<typeof SOADocumentInfo>[0]['document'];
 
 export function SOAFrameworkTable({
@@ -97,12 +104,18 @@ export function SOAFrameworkTable({
   const columns = configuration.columns as SOAColumn[];
   const questions = configuration.questions as SOAQuestion[];
 
-  // Create answers map from document answers
+  // Create answers map from document answers. Applicability + justification are
+  // per-organization values that live on the answer, so the table reads them
+  // from here — never from the shared framework configuration.
   const [answersMap, setAnswersMap] = useState<Map<string, SOATableAnswerData>>(() => {
     return new Map(
-      (document?.answers || []).map((answer: { questionId: string; answer: string | null; answerVersion: number }) => [
+      (document?.answers || []).map((answer: SOAAnswerRecord) => [
         answer.questionId,
-        { answer: answer.answer, answerVersion: answer.answerVersion },
+        {
+          answer: answer.answer,
+          answerVersion: answer.answerVersion,
+          isApplicable: answer.isApplicable,
+        },
       ])
     );
   });
@@ -114,19 +127,24 @@ export function SOAFrameworkTable({
     }
     setAnswersMap(
       new Map(
-        resolvedDocument.answers.map((answer: { questionId: string; answer: string | null; answerVersion: number }) => [
+        resolvedDocument.answers.map((answer: SOAAnswerRecord) => [
           answer.questionId,
-          { answer: answer.answer, answerVersion: answer.answerVersion },
+          {
+            answer: answer.answer,
+            answerVersion: answer.answerVersion,
+            savedIsApplicable: answer.isApplicable,
+          },
         ])
       )
     );
   }, [resolvedDocument?.answers]);
 
   const handleAnswerUpdate = (questionId: string, payload: SOAFieldSavePayload) => {
+    const existingAnswer = answersMap.get(questionId);
     const previousIsApplicable =
-      answersMap.get(questionId)?.savedIsApplicable ??
+      existingAnswer?.savedIsApplicable ??
       processedResults.get(questionId)?.isApplicable ??
-      questions.find((q) => q.id === questionId)?.columnMapping.isApplicable ??
+      existingAnswer?.isApplicable ??
       null;
 
     setAnswersMap((prev) => {
@@ -225,28 +243,6 @@ export function SOAFrameworkTable({
     },
   });
 
-  // Merge processed results into questions for display
-  const questionsWithResults = useMemo(() => {
-    if (processedResults.size === 0) {
-      return questions;
-    }
-
-    return questions.map((q) => {
-      const result = processedResults.get(q.id);
-      if (result && 'success' in result && result.success === true) {
-        return {
-          ...q,
-          columnMapping: {
-            ...q.columnMapping,
-            isApplicable: result.isApplicable,
-            justification: result.justification,
-          },
-        };
-      }
-      return q;
-    });
-  }, [questions, processedResults]);
-
   // Document should always exist at this point
   if (!document) {
     return (
@@ -337,7 +333,7 @@ export function SOAFrameworkTable({
       {/* Table */}
       <SOATable
         columns={columns}
-        questions={questionsWithResults}
+        questions={questions}
         answersMap={answersMap}
         questionStatuses={questionStatuses}
         processedResults={processedResults}

--- a/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/SOAFrameworkTable.tsx
+++ b/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/SOAFrameworkTable.tsx
@@ -60,6 +60,18 @@ type SOAAnswerRecord = {
   answerVersion: number;
 };
 
+// Map a persisted answer to row state. `isApplicable` carries the persisted
+// value; `savedIsApplicable` is deliberately left unset here — it is reserved
+// for a manual save this session (set in handleAnswerUpdate) so it doesn't
+// shadow in-session autofill results in resolveSoaDisplay.
+function toAnswerData(answer: SOAAnswerRecord): SOATableAnswerData {
+  return {
+    answer: answer.answer,
+    answerVersion: answer.answerVersion,
+    isApplicable: answer.isApplicable,
+  };
+}
+
 type SOADocumentInfoDocument = Parameters<typeof SOADocumentInfo>[0]['document'];
 
 export function SOAFrameworkTable({
@@ -111,11 +123,7 @@ export function SOAFrameworkTable({
     return new Map(
       (document?.answers || []).map((answer: SOAAnswerRecord) => [
         answer.questionId,
-        {
-          answer: answer.answer,
-          answerVersion: answer.answerVersion,
-          isApplicable: answer.isApplicable,
-        },
+        toAnswerData(answer),
       ])
     );
   });
@@ -129,11 +137,7 @@ export function SOAFrameworkTable({
       new Map(
         resolvedDocument.answers.map((answer: SOAAnswerRecord) => [
           answer.questionId,
-          {
-            answer: answer.answer,
-            answerVersion: answer.answerVersion,
-            savedIsApplicable: answer.isApplicable,
-          },
+          toAnswerData(answer),
         ])
       )
     );

--- a/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/SOAMobileRow.tsx
+++ b/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/SOAMobileRow.tsx
@@ -3,6 +3,7 @@
 import { Loader2 } from 'lucide-react';
 import type { SOAFieldSavePayload, SOATableAnswerData } from './EditableSOAFields';
 import { EditableSOAFields } from './EditableSOAFields';
+import { resolveSoaDisplay } from './soa-display';
 
 type SOAColumn = {
   name: string;
@@ -56,32 +57,15 @@ export function SOAMobileRow({
   const controlClosure = question.columnMapping.closure || '';
   const isControl7 = controlClosure.startsWith('7.');
 
-  let displayIsApplicable: boolean | null;
-  let justificationValue: string | null;
-
-  if (isFullyRemote && isControl7) {
-    displayIsApplicable = false;
-    justificationValue =
-      processedResult?.justification ||
-      answerData?.answer ||
-      question.columnMapping.justification ||
-      'This control is not applicable as our organization operates fully remotely.';
-  } else if (answerData?.savedIsApplicable !== undefined) {
-    displayIsApplicable = answerData.savedIsApplicable;
-    justificationValue =
-      answerData.answer ?? question.columnMapping.justification ?? null;
-  } else {
-    displayIsApplicable =
-      processedResult?.isApplicable !== null && processedResult?.isApplicable !== undefined
-        ? processedResult.isApplicable
-        : (question.columnMapping.isApplicable ?? true);
-
-    justificationValue =
-      processedResult?.justification ||
-      answerData?.answer ||
-      question.columnMapping.justification ||
-      null;
-  }
+  // Applicability + justification are per-organization values from this
+  // document's own answers or an in-session autofill result — never from the
+  // shared framework configuration.
+  const { displayIsApplicable, justificationValue } = resolveSoaDisplay({
+    answerData,
+    processedResult,
+    isFullyRemote,
+    isControl7,
+  });
 
   return (
     <div className="p-4 space-y-3">

--- a/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/SOAMobileRow.tsx
+++ b/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/SOAMobileRow.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import { Loader2 } from 'lucide-react';
-import type { SOAFieldSavePayload, SOATableAnswerData } from './EditableSOAFields';
+import type {
+  SOAFieldSavePayload,
+  SOAProcessedResult,
+  SOATableAnswerData,
+} from './EditableSOAFields';
 import { EditableSOAFields } from './EditableSOAFields';
 import { resolveSoaDisplay } from './soa-display';
 
@@ -22,19 +26,12 @@ type SOAQuestion = {
   };
 };
 
-type ProcessedResult = {
-  success: boolean;
-  isApplicable: boolean | null;
-  justification?: string | null;
-  insufficientData?: boolean;
-};
-
 interface SOAMobileRowProps {
   question: SOAQuestion;
   columns: SOAColumn[];
   answerData?: SOATableAnswerData;
   questionStatus?: string;
-  processedResult?: ProcessedResult;
+  processedResult?: SOAProcessedResult;
   isFullyRemote: boolean;
   documentId: string;
   isPendingApproval: boolean;

--- a/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/SOAMobileRow.tsx
+++ b/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/SOAMobileRow.tsx
@@ -60,8 +60,6 @@ export function SOAMobileRow({
   const { displayIsApplicable, justificationValue } = resolveSoaDisplay({
     answerData,
     processedResult,
-    isFullyRemote,
-    isControl7,
   });
 
   return (

--- a/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/SOATable.tsx
+++ b/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/SOATable.tsx
@@ -3,7 +3,11 @@
 import { Card } from '@trycompai/ui';
 import { Button } from '@trycompai/design-system';
 import { ChevronUp, ChevronDown } from '@trycompai/design-system/icons';
-import type { SOAFieldSavePayload, SOATableAnswerData } from './EditableSOAFields';
+import type {
+  SOAFieldSavePayload,
+  SOAProcessedResult,
+  SOATableAnswerData,
+} from './EditableSOAFields';
 import { SOATableRow } from './SOATableRow';
 import { SOAMobileRow } from './SOAMobileRow';
 
@@ -26,19 +30,12 @@ type SOAQuestion = {
   };
 };
 
-type ProcessedResult = {
-  success: boolean;
-  isApplicable: boolean | null;
-  justification?: string | null;
-  insufficientData?: boolean;
-};
-
 interface SOATableProps {
   columns: SOAColumn[];
   questions: SOAQuestion[];
   answersMap: Map<string, SOATableAnswerData>;
   questionStatuses: Map<string, string>;
-  processedResults: Map<string, ProcessedResult>;
+  processedResults: Map<string, SOAProcessedResult>;
   isFullyRemote: boolean;
   isExpanded: boolean;
   onToggleExpand: () => void;

--- a/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/SOATableRow.tsx
+++ b/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/SOATableRow.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import { Loader2 } from 'lucide-react';
-import type { SOAFieldSavePayload, SOATableAnswerData } from './EditableSOAFields';
+import type {
+  SOAFieldSavePayload,
+  SOAProcessedResult,
+  SOATableAnswerData,
+} from './EditableSOAFields';
 import { EditableSOAFields } from './EditableSOAFields';
 import { resolveSoaDisplay } from './soa-display';
 
@@ -22,19 +26,12 @@ type SOAQuestion = {
   };
 };
 
-type ProcessedResult = {
-  success: boolean;
-  isApplicable: boolean | null;
-  justification?: string | null;
-  insufficientData?: boolean;
-};
-
 interface SOATableRowProps {
   question: SOAQuestion;
   columns: SOAColumn[];
   answerData?: SOATableAnswerData;
   questionStatus?: string;
-  processedResult?: ProcessedResult;
+  processedResult?: SOAProcessedResult;
   isFullyRemote: boolean;
   documentId: string;
   isPendingApproval: boolean;

--- a/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/SOATableRow.tsx
+++ b/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/SOATableRow.tsx
@@ -3,6 +3,7 @@
 import { Loader2 } from 'lucide-react';
 import type { SOAFieldSavePayload, SOATableAnswerData } from './EditableSOAFields';
 import { EditableSOAFields } from './EditableSOAFields';
+import { resolveSoaDisplay } from './soa-display';
 
 type SOAColumn = {
   name: string;
@@ -61,38 +62,15 @@ export function SOATableRow({
   const controlClosure = question.columnMapping.closure || '';
   const isControl7 = controlClosure.startsWith('7.');
   
-  // Determine displayIsApplicable and justificationValue based on fully remote logic
-  let displayIsApplicable: boolean | null;
-  let justificationValue: string | null;
-
-  // If fully remote and control starts with "7.", always show NO (override any other value)
-  if (isFullyRemote && isControl7) {
-    displayIsApplicable = false;
-    justificationValue =
-      processedResult?.justification ||
-      answerData?.answer ||
-      question.columnMapping.justification ||
-      'This control is not applicable as our organization operates fully remotely.';
-  } else if (answerData?.savedIsApplicable !== undefined) {
-    // Manual save overrides autofill processedResult so the table updates without a full reload
-    displayIsApplicable = answerData.savedIsApplicable;
-    justificationValue =
-      answerData.answer || question.columnMapping.justification || null;
-  } else {
-    // Normal logic: processedResult / column mapping until user saves (then branch above)
-    const isApplicableValue =
-      processedResult?.isApplicable !== null && processedResult?.isApplicable !== undefined
-        ? processedResult.isApplicable
-        : (question.columnMapping.isApplicable ?? true);
-
-    justificationValue =
-      processedResult?.justification ||
-      answerData?.answer ||
-      question.columnMapping.justification ||
-      null;
-
-    displayIsApplicable = isApplicableValue;
-  }
+  // Applicability + justification are per-organization values (from this
+  // document's own answers or an in-session autofill result), never from the
+  // shared framework configuration.
+  const { displayIsApplicable, justificationValue } = resolveSoaDisplay({
+    answerData,
+    processedResult,
+    isFullyRemote,
+    isControl7,
+  });
 
   return (
     <tr className="border-b transition-colors hover:bg-muted/30 last:border-b-0">

--- a/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/SOATableRow.tsx
+++ b/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/SOATableRow.tsx
@@ -65,8 +65,6 @@ export function SOATableRow({
   const { displayIsApplicable, justificationValue } = resolveSoaDisplay({
     answerData,
     processedResult,
-    isFullyRemote,
-    isControl7,
   });
 
   return (

--- a/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/soa-display.test.ts
+++ b/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/soa-display.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { FULLY_REMOTE_JUSTIFICATION, resolveSoaDisplay } from './soa-display';
+
+describe('resolveSoaDisplay', () => {
+  const base = { isFullyRemote: false, isControl7: false };
+
+  it('uses the persisted per-organization answer', () => {
+    // The only source of applicability/justification is this org's own answer.
+    // (There is deliberately no shared-configuration input to bleed from.)
+    const result = resolveSoaDisplay({
+      ...base,
+      answerData: {
+        answer: 'Our own justification',
+        answerVersion: 1,
+        isApplicable: false,
+      },
+    });
+
+    expect(result).toEqual({
+      displayIsApplicable: false,
+      justificationValue: 'Our own justification',
+    });
+  });
+
+  it('defaults to applicable with no justification when the control is unanswered', () => {
+    const result = resolveSoaDisplay({ ...base, answerData: undefined });
+
+    expect(result).toEqual({
+      displayIsApplicable: true,
+      justificationValue: null,
+    });
+  });
+
+  it('lets an in-session autofill result override a stale persisted answer', () => {
+    const result = resolveSoaDisplay({
+      ...base,
+      answerData: {
+        answer: 'Old persisted justification',
+        answerVersion: 1,
+        isApplicable: true,
+      },
+      processedResult: {
+        success: true,
+        isApplicable: false,
+        justification: 'Fresh autofill justification',
+      },
+    });
+
+    expect(result).toEqual({
+      displayIsApplicable: false,
+      justificationValue: 'Fresh autofill justification',
+    });
+  });
+
+  it('lets a manual save this session win over an in-flight autofill result', () => {
+    const result = resolveSoaDisplay({
+      ...base,
+      answerData: {
+        answer: 'Manually saved justification',
+        answerVersion: 2,
+        savedIsApplicable: true,
+      },
+      processedResult: {
+        success: true,
+        isApplicable: false,
+        justification: 'Autofill justification',
+      },
+    });
+
+    expect(result).toEqual({
+      displayIsApplicable: true,
+      justificationValue: 'Manually saved justification',
+    });
+  });
+
+  it('forces not-applicable for physical-security controls in a fully remote org', () => {
+    const result = resolveSoaDisplay({
+      isFullyRemote: true,
+      isControl7: true,
+      answerData: { answer: null, answerVersion: 1, isApplicable: true },
+    });
+
+    expect(result).toEqual({
+      displayIsApplicable: false,
+      justificationValue: FULLY_REMOTE_JUSTIFICATION,
+    });
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/soa-display.test.ts
+++ b/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/soa-display.test.ts
@@ -1,14 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { FULLY_REMOTE_JUSTIFICATION, resolveSoaDisplay } from './soa-display';
+import { resolveSoaDisplay } from './soa-display';
 
 describe('resolveSoaDisplay', () => {
-  const base = { isFullyRemote: false, isControl7: false };
-
   it('uses the persisted per-organization answer', () => {
     // The only source of applicability/justification is this org's own answer.
     // (There is deliberately no shared-configuration input to bleed from.)
     const result = resolveSoaDisplay({
-      ...base,
       answerData: {
         answer: 'Our own justification',
         answerVersion: 1,
@@ -23,7 +20,7 @@ describe('resolveSoaDisplay', () => {
   });
 
   it('defaults to applicable with no justification when there is no answer at all', () => {
-    const result = resolveSoaDisplay({ ...base, answerData: undefined });
+    const result = resolveSoaDisplay({ answerData: undefined });
 
     expect(result).toEqual({
       displayIsApplicable: true,
@@ -36,7 +33,6 @@ describe('resolveSoaDisplay', () => {
     // These must not silently render as "applicable"; they read as N/A,
     // consistent with the export, until the org re-runs auto-fill.
     const result = resolveSoaDisplay({
-      ...base,
       answerData: {
         answer: 'Existing justification',
         answerVersion: 1,
@@ -52,7 +48,6 @@ describe('resolveSoaDisplay', () => {
 
   it('lets an in-session autofill result override a stale persisted answer', () => {
     const result = resolveSoaDisplay({
-      ...base,
       answerData: {
         answer: 'Old persisted justification',
         answerVersion: 1,
@@ -73,7 +68,6 @@ describe('resolveSoaDisplay', () => {
 
   it('lets a manual save this session win over an in-flight autofill result', () => {
     const result = resolveSoaDisplay({
-      ...base,
       answerData: {
         answer: 'Manually saved justification',
         answerVersion: 2,
@@ -89,19 +83,6 @@ describe('resolveSoaDisplay', () => {
     expect(result).toEqual({
       displayIsApplicable: true,
       justificationValue: 'Manually saved justification',
-    });
-  });
-
-  it('forces not-applicable for physical-security controls in a fully remote org', () => {
-    const result = resolveSoaDisplay({
-      isFullyRemote: true,
-      isControl7: true,
-      answerData: { answer: null, answerVersion: 1, isApplicable: true },
-    });
-
-    expect(result).toEqual({
-      displayIsApplicable: false,
-      justificationValue: FULLY_REMOTE_JUSTIFICATION,
     });
   });
 });

--- a/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/soa-display.test.ts
+++ b/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/soa-display.test.ts
@@ -22,12 +22,31 @@ describe('resolveSoaDisplay', () => {
     });
   });
 
-  it('defaults to applicable with no justification when the control is unanswered', () => {
+  it('defaults to applicable with no justification when there is no answer at all', () => {
     const result = resolveSoaDisplay({ ...base, answerData: undefined });
 
     expect(result).toEqual({
       displayIsApplicable: true,
       justificationValue: null,
+    });
+  });
+
+  it('shows unanswered (N/A) for an answer whose applicability is unknown, without assuming applicable', () => {
+    // Pre-migration answers have a justification but no applicability value.
+    // These must not silently render as "applicable"; they read as N/A,
+    // consistent with the export, until the org re-runs auto-fill.
+    const result = resolveSoaDisplay({
+      ...base,
+      answerData: {
+        answer: 'Existing justification',
+        answerVersion: 1,
+        isApplicable: null,
+      },
+    });
+
+    expect(result).toEqual({
+      displayIsApplicable: null,
+      justificationValue: 'Existing justification',
     });
   });
 

--- a/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/soa-display.ts
+++ b/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/soa-display.ts
@@ -1,11 +1,4 @@
-import type { SOATableAnswerData } from './soa-field-types';
-
-export type SOAProcessedResult = {
-  success: boolean;
-  isApplicable: boolean | null;
-  justification?: string | null;
-  insufficientData?: boolean;
-};
+import type { SOAProcessedResult, SOATableAnswerData } from './soa-field-types';
 
 export const FULLY_REMOTE_JUSTIFICATION =
   'This control is not applicable as our organization operates fully remotely.';
@@ -60,20 +53,20 @@ export function resolveSoaDisplay({
     };
   }
 
-  // Persisted per-organization answer.
-  if (
-    answerData?.isApplicable !== null &&
-    answerData?.isApplicable !== undefined
-  ) {
+  // Persisted per-organization answer. A pre-migration answer may not carry an
+  // applicability value yet; show it as unanswered (N/A) — matching the export
+  // — rather than assuming the control is applicable.
+  if (answerData !== undefined) {
     return {
-      displayIsApplicable: answerData.isApplicable,
+      displayIsApplicable: answerData.isApplicable ?? null,
       justificationValue: answerData.answer || null,
     };
   }
 
-  // Not yet answered — default to applicable (matches the server default).
+  // No answer for this control yet — default to applicable, matching the
+  // server default and the pre-existing UX for an ungenerated SoA.
   return {
     displayIsApplicable: true,
-    justificationValue: answerData?.answer || null,
+    justificationValue: null,
   };
 }

--- a/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/soa-display.ts
+++ b/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/soa-display.ts
@@ -1,38 +1,26 @@
 import type { SOAProcessedResult, SOATableAnswerData } from './soa-field-types';
 
-export const FULLY_REMOTE_JUSTIFICATION =
-  'This control is not applicable as our organization operates fully remotely.';
-
 /**
  * Resolves the applicability + justification to display for a SoA control.
  *
  * Applicability and justification are per-organization values, sourced only
  * from this document's own answers (`answerData`) or an in-session autofill
  * result (`processedResult`) — never from the shared framework configuration,
- * which is a single row reused by every organization.
+ * and never from a display-only rule. This keeps the on-screen SoA and the
+ * exported PDF in agreement (both read the same persisted answer).
+ *
+ * Note: the "fully remote → physical-security (7.x) controls are not
+ * applicable" rule is applied at generation time (auto-fill persists
+ * `isApplicable = false` with a justification) and the field is edit-locked, so
+ * it is already reflected in the persisted answer read here.
  */
 export function resolveSoaDisplay({
   answerData,
   processedResult,
-  isFullyRemote,
-  isControl7,
 }: {
   answerData?: SOATableAnswerData;
   processedResult?: SOAProcessedResult;
-  isFullyRemote: boolean;
-  isControl7: boolean;
 }): { displayIsApplicable: boolean | null; justificationValue: string | null } {
-  // Fully remote + physical-security control (7.x) is always not applicable.
-  if (isFullyRemote && isControl7) {
-    return {
-      displayIsApplicable: false,
-      justificationValue:
-        processedResult?.justification ||
-        answerData?.answer ||
-        FULLY_REMOTE_JUSTIFICATION,
-    };
-  }
-
   // A manual save this session overrides an in-flight autofill result.
   if (answerData?.savedIsApplicable !== undefined) {
     return {

--- a/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/soa-display.ts
+++ b/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/soa-display.ts
@@ -1,0 +1,79 @@
+import type { SOATableAnswerData } from './soa-field-types';
+
+export type SOAProcessedResult = {
+  success: boolean;
+  isApplicable: boolean | null;
+  justification?: string | null;
+  insufficientData?: boolean;
+};
+
+export const FULLY_REMOTE_JUSTIFICATION =
+  'This control is not applicable as our organization operates fully remotely.';
+
+/**
+ * Resolves the applicability + justification to display for a SoA control.
+ *
+ * Applicability and justification are per-organization values, sourced only
+ * from this document's own answers (`answerData`) or an in-session autofill
+ * result (`processedResult`) — never from the shared framework configuration,
+ * which is a single row reused by every organization.
+ */
+export function resolveSoaDisplay({
+  answerData,
+  processedResult,
+  isFullyRemote,
+  isControl7,
+}: {
+  answerData?: SOATableAnswerData;
+  processedResult?: SOAProcessedResult;
+  isFullyRemote: boolean;
+  isControl7: boolean;
+}): { displayIsApplicable: boolean | null; justificationValue: string | null } {
+  // Fully remote + physical-security control (7.x) is always not applicable.
+  if (isFullyRemote && isControl7) {
+    return {
+      displayIsApplicable: false,
+      justificationValue:
+        processedResult?.justification ||
+        answerData?.answer ||
+        FULLY_REMOTE_JUSTIFICATION,
+    };
+  }
+
+  // A manual save this session overrides an in-flight autofill result.
+  if (answerData?.savedIsApplicable !== undefined) {
+    return {
+      displayIsApplicable: answerData.savedIsApplicable,
+      justificationValue: answerData.answer || null,
+    };
+  }
+
+  // In-session autofill result (before the document is reloaded).
+  if (
+    processedResult?.isApplicable !== null &&
+    processedResult?.isApplicable !== undefined
+  ) {
+    return {
+      displayIsApplicable: processedResult.isApplicable,
+      justificationValue:
+        processedResult.justification || answerData?.answer || null,
+    };
+  }
+
+  // Persisted per-organization answer.
+  if (
+    answerData?.isApplicable !== null &&
+    answerData?.isApplicable !== undefined
+  ) {
+    return {
+      displayIsApplicable: answerData.isApplicable,
+      justificationValue: answerData.answer || null,
+    };
+  }
+
+  // Not yet answered — default to applicable (matches the server default).
+  return {
+    displayIsApplicable: true,
+    justificationValue: answerData?.answer || null,
+  };
+}

--- a/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/soa-field-types.ts
+++ b/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/soa-field-types.ts
@@ -3,9 +3,14 @@ export type SOAFieldSavePayload = {
   justification: string | null;
 };
 
-/** Row-level answer state; `savedIsApplicable` is set after manual save to override autofill. */
+/**
+ * Row-level answer state. `isApplicable` is the persisted per-organization
+ * applicability loaded from the document's answers. `savedIsApplicable` is set
+ * after a manual save this session to override an in-flight autofill result.
+ */
 export type SOATableAnswerData = {
   answer: string | null;
   answerVersion: number;
+  isApplicable?: boolean | null;
   savedIsApplicable?: boolean | null;
 };

--- a/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/soa-field-types.ts
+++ b/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/soa-field-types.ts
@@ -4,6 +4,18 @@ export type SOAFieldSavePayload = {
 };
 
 /**
+ * A single control's result from an in-session auto-fill run (streamed over
+ * SSE). Shared by the autofill hook and every SoA view so the contract is
+ * defined once.
+ */
+export type SOAProcessedResult = {
+  success: boolean;
+  isApplicable: boolean | null;
+  justification?: string | null;
+  insufficientData?: boolean;
+};
+
+/**
  * Row-level answer state. `isApplicable` is the persisted per-organization
  * applicability loaded from the document's answers. `savedIsApplicable` is set
  * after a manual save this session to override an in-flight autofill result.

--- a/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/hooks/useSOAAutoFill.ts
+++ b/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/hooks/useSOAAutoFill.ts
@@ -3,6 +3,7 @@
 import { useState, useRef } from 'react';
 import { toast } from 'sonner';
 import { env } from '@/env.mjs';
+import type { SOAProcessedResult } from '../components/soa-field-types';
 
 interface UseSOAAutoFillProps {
   questions: Array<{
@@ -23,7 +24,9 @@ interface UseSOAAutoFillProps {
 export function useSOAAutoFill({ questions, documentId, organizationId, onUpdate }: UseSOAAutoFillProps) {
   const [isAutoFilling, setIsAutoFilling] = useState(false);
   const [questionStatuses, setQuestionStatuses] = useState<Map<string, 'pending' | 'processing' | 'completed' | 'failed' | 'insufficient_data'>>(new Map());
-  const [processedResults, setProcessedResults] = useState<Map<string, { isApplicable: boolean | null; justification: string | null; success: boolean; insufficientData?: boolean }>>(new Map());
+  const [processedResults, setProcessedResults] = useState<
+    Map<string, SOAProcessedResult>
+  >(new Map());
   const isAutoFillProcessStartedRef = useRef(false);
 
   const triggerAutoFill = async () => {

--- a/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/hooks/useSOADocument.ts
+++ b/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/hooks/useSOADocument.ts
@@ -13,6 +13,7 @@ interface SOADocumentData {
   answers: Array<{
     questionId: string;
     answer: string | null;
+    isApplicable: boolean | null;
     answerVersion: number;
   }>;
   [key: string]: unknown;

--- a/packages/db/prisma/migrations/20260713120000_add_soa_answer_is_applicable/migration.sql
+++ b/packages/db/prisma/migrations/20260713120000_add_soa_answer_is_applicable/migration.sql
@@ -1,0 +1,3 @@
+-- Store the Statement of Applicability applicability decision per organization
+-- (on the answer) instead of on the shared, framework-level configuration.
+ALTER TABLE "SOAAnswer" ADD COLUMN "isApplicable" BOOLEAN;

--- a/packages/db/prisma/schema/soa.prisma
+++ b/packages/db/prisma/schema/soa.prisma
@@ -95,7 +95,12 @@ model SOAAnswer {
   questionId String // Must match a question.id from SOADocument.configuration.questions
 
   // Answer data - simple text answer
-  answer String? // Text answer (nullable if not generated yet)
+  answer String? // Text answer / justification (nullable if not generated yet)
+
+  // Applicability decision for this control, scoped per organization + document.
+  // Stored here — NOT on the shared SOAFrameworkConfiguration — so each org's
+  // Statement of Applicability reflects only its own answers.
+  isApplicable Boolean? // true = applicable, false = not applicable, null = not yet answered
 
   // Answer metadata
   status      SOAAnswerStatus @default(untouched) // untouched, generated, manual


### PR DESCRIPTION
## Summary

Makes Statement of Applicability answers first-class, per-document records. Each control's **applicability** (Yes/No) and **justification** are now stored on the organization's own `SOAAnswer` for that document, alongside the existing answer text and versioning. `SOAFrameworkConfiguration` stays a shared template (control list, columns, objectives).

As a result, each organization's SoA — on screen, in the answered-count, and in the exported PDF — is derived entirely from that organization's own answers.

## What changed

**Data model**
- New `SOAAnswer.isApplicable` column (+ migration `20260713120000_add_soa_answer_is_applicable`) so applicability lives with the answer and its justification.

**API (`apps/api/src/soa`)**
- Auto-fill and manual save persist applicability + justification on `SOAAnswer`.
- Export and the answered-count read from the document's own answers.
- Justification is retained for both applicable (YES) and not-applicable (NO) controls, so every control on the SoA carries a justification (per ISO 27001).

**Frontend (`apps/app/.../statement-of-applicability`)**
- Desktop and mobile rows read applicability + justification from the document's own answers (or an in-session autofill result), via a new shared `resolveSoaDisplay` helper that removes duplicated display logic across the two rows.

## Rollout note

Existing SoAs surface their own justifications immediately. To populate the new per-answer applicability field for a SoA generated before this change, re-run **Auto-fill** once (or edit the control); newly generated or edited SoAs are complete with no extra step.

## Testing

- `apps/api`: `npx jest src/soa` — 55 passing (incl. export sourcing from the org's own answers).
- `apps/app`: `npx vitest run .../statement-of-applicability` — 12 passing (incl. new `soa-display.test.ts`).
- Typecheck: no new errors for touched files.