### PR TITLE
fix(soa): apply the fully-remote physical-control rule consistently

### DIFF
--- a/apps/api/src/soa/soa.service.spec.ts
+++ b/apps/api/src/soa/soa.service.spec.ts
@@ -643,6 +643,13 @@ describe('SOAService', () => {
         },
         approver: null,
         answers: [
+          // A stale justification persisted before the org went remote — must
+          // NOT leak into the forced Not Applicable output.
+          {
+            questionId: 'q-phys',
+            answer: 'We maintain physical access controls at our office',
+            isApplicable: true,
+          },
           { questionId: 'q-other', answer: 'Our own 5.1 justification', isApplicable: true },
         ],
       });
@@ -654,9 +661,12 @@ describe('SOAService', () => {
       const other = passedQuestions.find((q) => q.id === 'q-other');
 
       // Fully remote + 7.x → forced Not Applicable with the remote justification,
-      // even though this org has no persisted answer for it.
+      // overriding the stale persisted answer.
       expect(phys?.columnMapping.isApplicable).toBe(false);
       expect(phys?.columnMapping.justification).toBe(
+        'This control is not applicable as our organization operates fully remotely.',
+      );
+      expect(phys?.answer).toBe(
         'This control is not applicable as our organization operates fully remotely.',
       );
       // Non-physical controls are unaffected and use the org's own answer.

--- a/apps/api/src/soa/soa.service.spec.ts
+++ b/apps/api/src/soa/soa.service.spec.ts
@@ -7,6 +7,7 @@ import {
 import { db } from '@db';
 import { SOAService } from './soa.service';
 import { generateSOAExportFile } from './utils/export-generator';
+import { checkIfFullyRemote } from './utils/soa-storage';
 
 jest.mock('@db', () => ({
   db: {
@@ -45,7 +46,9 @@ jest.mock('./utils/soa-answer-parser', () => ({
   parseAndProcessSOAAnswer: jest.fn(),
   createDefaultYesResult: jest.fn(),
   createFullyRemoteResult: jest.fn(),
-  isPhysicalSecurityControl: jest.fn(),
+  isPhysicalSecurityControl: jest.fn(
+    (closure: string) => typeof closure === 'string' && closure.startsWith('7.'),
+  ),
 }));
 jest.mock('./utils/soa-storage', () => ({
   saveAnswersToDatabase: jest.fn(),
@@ -60,6 +63,7 @@ jest.mock('./utils/export-generator', () => ({
 
 const mockDb = jest.mocked(db);
 const mockGenerateSOAExportFile = jest.mocked(generateSOAExportFile);
+const mockCheckIfFullyRemote = jest.mocked(checkIfFullyRemote);
 
 describe('SOAService', () => {
   let service: SOAService;
@@ -495,6 +499,7 @@ describe('SOAService', () => {
         filename: 'statement-of-applicability-iso-27001-v2.pdf',
       };
       mockGenerateSOAExportFile.mockReturnValue(generated);
+      mockCheckIfFullyRemote.mockResolvedValue(false);
       (mockDb.sOADocument.findFirst as jest.Mock).mockResolvedValue({
         id: 'doc-1',
         organizationId: 'org-1',
@@ -589,6 +594,74 @@ describe('SOAService', () => {
         'pdf',
       );
       expect(result).toEqual(generated);
+    });
+
+    it('forces Not Applicable on physical-security (7.x) controls for a fully remote org', async () => {
+      const generated = {
+        fileBuffer: Buffer.from('pdf'),
+        mimeType: 'application/pdf',
+        filename: 'statement-of-applicability-iso-27001-v1.pdf',
+      };
+      mockGenerateSOAExportFile.mockReturnValue(generated);
+      mockCheckIfFullyRemote.mockResolvedValue(true);
+      (mockDb.sOADocument.findFirst as jest.Mock).mockResolvedValue({
+        id: 'doc-1',
+        organizationId: 'org-1',
+        preparedBy: 'Comp AI',
+        answeredQuestions: 2,
+        totalQuestions: 2,
+        approvedAt: null,
+        declinedAt: null,
+        status: 'completed',
+        version: 1,
+        framework: { name: 'ISO 27001' },
+        configuration: {
+          questions: [
+            {
+              id: 'q-phys',
+              text: 'Physical entry',
+              columnMapping: {
+                closure: '7.2',
+                title: 'Physical entry',
+                control_objective: 'obj',
+                isApplicable: true,
+                justification: 'another org shared-config text',
+              },
+            },
+            {
+              id: 'q-other',
+              text: 'Policies',
+              columnMapping: {
+                closure: '5.1',
+                title: 'Policies',
+                control_objective: 'obj',
+                isApplicable: true,
+                justification: 'another org shared-config text',
+              },
+            },
+          ],
+        },
+        approver: null,
+        answers: [
+          { questionId: 'q-other', answer: 'Our own 5.1 justification', isApplicable: true },
+        ],
+      });
+
+      await service.exportDocument(dto);
+
+      const passedQuestions = mockGenerateSOAExportFile.mock.calls[0][0];
+      const phys = passedQuestions.find((q) => q.id === 'q-phys');
+      const other = passedQuestions.find((q) => q.id === 'q-other');
+
+      // Fully remote + 7.x → forced Not Applicable with the remote justification,
+      // even though this org has no persisted answer for it.
+      expect(phys?.columnMapping.isApplicable).toBe(false);
+      expect(phys?.columnMapping.justification).toBe(
+        'This control is not applicable as our organization operates fully remotely.',
+      );
+      // Non-physical controls are unaffected and use the org's own answer.
+      expect(other?.columnMapping.isApplicable).toBe(true);
+      expect(other?.columnMapping.justification).toBe('Our own 5.1 justification');
     });
   });
 

--- a/apps/api/src/soa/soa.service.ts
+++ b/apps/api/src/soa/soa.service.ts
@@ -541,8 +541,10 @@ export class SOAService {
       const closure = question.columnMapping?.closure ?? null;
       const forceNotApplicable =
         isFullyRemote && isPhysicalSecurityControl(closure ?? '');
+      // Forced-remote controls always use the remote rationale, never a stale
+      // persisted justification that could contradict the Not Applicable status.
       const justification = forceNotApplicable
-        ? (answer?.answer ?? FULLY_REMOTE_JUSTIFICATION)
+        ? FULLY_REMOTE_JUSTIFICATION
         : (answer?.answer ?? null);
       return {
         id: question.id,

--- a/apps/api/src/soa/soa.service.ts
+++ b/apps/api/src/soa/soa.service.ts
@@ -17,7 +17,10 @@ import { SubmitSOAForApprovalDto } from './dto/submit-soa-for-approval.dto';
 import { ExportSOADocumentDto } from './dto/export-soa-document.dto';
 import type { SimilarContentResult } from '@/vector-store/lib';
 import { loadISOConfig } from './utils/transform-iso-config';
-import { ISO27001_FRAMEWORK_NAMES } from './utils/constants';
+import {
+  FULLY_REMOTE_JUSTIFICATION,
+  ISO27001_FRAMEWORK_NAMES,
+} from './utils/constants';
 import {
   generateSOAExportFile,
   type SOAExportMetadata,
@@ -526,19 +529,32 @@ export class SOAService {
       document.answers.map((answer) => [answer.questionId, answer]),
     );
 
+    // Enforced rule, applied identically on screen and in this export: a fully
+    // remote org's physical-security (7.x) controls are Not Applicable.
+    const isFullyRemote = await checkIfFullyRemote(
+      dto.organizationId,
+      this.storageLogger,
+    );
+
     const exportQuestions: SOAExportQuestion[] = questions.map((question) => {
       const answer = answersByQuestionId.get(question.id);
+      const closure = question.columnMapping?.closure ?? null;
+      const forceNotApplicable =
+        isFullyRemote && isPhysicalSecurityControl(closure ?? '');
+      const justification = forceNotApplicable
+        ? (answer?.answer ?? FULLY_REMOTE_JUSTIFICATION)
+        : (answer?.answer ?? null);
       return {
         id: question.id,
         text: question.text,
         columnMapping: {
-          closure: question.columnMapping?.closure ?? null,
+          closure,
           title: question.columnMapping?.title ?? null,
           control_objective: question.columnMapping?.control_objective ?? null,
-          isApplicable: answer?.isApplicable ?? null,
-          justification: answer?.answer ?? null,
+          isApplicable: forceNotApplicable ? false : (answer?.isApplicable ?? null),
+          justification,
         },
-        answer: answer?.answer ?? null,
+        answer: justification,
       };
     });
 

--- a/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/SOAMobileRow.tsx
+++ b/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/SOAMobileRow.tsx
@@ -60,6 +60,8 @@ export function SOAMobileRow({
   const { displayIsApplicable, justificationValue } = resolveSoaDisplay({
     answerData,
     processedResult,
+    isFullyRemote,
+    isControl7,
   });
 
   return (

--- a/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/SOATableRow.tsx
+++ b/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/SOATableRow.tsx
@@ -65,6 +65,8 @@ export function SOATableRow({
   const { displayIsApplicable, justificationValue } = resolveSoaDisplay({
     answerData,
     processedResult,
+    isFullyRemote,
+    isControl7,
   });
 
   return (

--- a/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/soa-display.test.ts
+++ b/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/soa-display.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { resolveSoaDisplay } from './soa-display';
+import { FULLY_REMOTE_JUSTIFICATION, resolveSoaDisplay } from './soa-display';
 
 describe('resolveSoaDisplay', () => {
+  const base = { isFullyRemote: false, isControl7: false };
+
   it('uses the persisted per-organization answer', () => {
     // The only source of applicability/justification is this org's own answer.
     // (There is deliberately no shared-configuration input to bleed from.)
     const result = resolveSoaDisplay({
+      ...base,
       answerData: {
         answer: 'Our own justification',
         answerVersion: 1,
@@ -20,7 +23,7 @@ describe('resolveSoaDisplay', () => {
   });
 
   it('defaults to applicable with no justification when there is no answer at all', () => {
-    const result = resolveSoaDisplay({ answerData: undefined });
+    const result = resolveSoaDisplay({ ...base, answerData: undefined });
 
     expect(result).toEqual({
       displayIsApplicable: true,
@@ -33,6 +36,7 @@ describe('resolveSoaDisplay', () => {
     // These must not silently render as "applicable"; they read as N/A,
     // consistent with the export, until the org re-runs auto-fill.
     const result = resolveSoaDisplay({
+      ...base,
       answerData: {
         answer: 'Existing justification',
         answerVersion: 1,
@@ -48,6 +52,7 @@ describe('resolveSoaDisplay', () => {
 
   it('lets an in-session autofill result override a stale persisted answer', () => {
     const result = resolveSoaDisplay({
+      ...base,
       answerData: {
         answer: 'Old persisted justification',
         answerVersion: 1,
@@ -68,6 +73,7 @@ describe('resolveSoaDisplay', () => {
 
   it('lets a manual save this session win over an in-flight autofill result', () => {
     const result = resolveSoaDisplay({
+      ...base,
       answerData: {
         answer: 'Manually saved justification',
         answerVersion: 2,
@@ -83,6 +89,19 @@ describe('resolveSoaDisplay', () => {
     expect(result).toEqual({
       displayIsApplicable: true,
       justificationValue: 'Manually saved justification',
+    });
+  });
+
+  it('forces Not Applicable for a fully remote org on physical-security (7.x) controls, even before an answer is persisted', () => {
+    const result = resolveSoaDisplay({
+      isFullyRemote: true,
+      isControl7: true,
+      answerData: undefined,
+    });
+
+    expect(result).toEqual({
+      displayIsApplicable: false,
+      justificationValue: FULLY_REMOTE_JUSTIFICATION,
     });
   });
 });

--- a/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/soa-display.test.ts
+++ b/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/soa-display.test.ts
@@ -92,11 +92,23 @@ describe('resolveSoaDisplay', () => {
     });
   });
 
-  it('forces Not Applicable for a fully remote org on physical-security (7.x) controls, even before an answer is persisted', () => {
+  it('forces Not Applicable + the remote rationale for a fully remote org on physical-security (7.x) controls, ignoring any stale persisted justification', () => {
+    // Even if a stale justification is persisted (e.g. written before the org
+    // went remote), the locked forced-remote control must show the remote
+    // rationale, not the contradictory old text.
     const result = resolveSoaDisplay({
       isFullyRemote: true,
       isControl7: true,
-      answerData: undefined,
+      answerData: {
+        answer: 'We maintain physical access controls at our office',
+        answerVersion: 1,
+        isApplicable: true,
+      },
+      processedResult: {
+        success: true,
+        isApplicable: true,
+        justification: 'stale autofill text',
+      },
     });
 
     expect(result).toEqual({

--- a/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/soa-display.ts
+++ b/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/soa-display.ts
@@ -28,14 +28,13 @@ export function resolveSoaDisplay({
   isControl7: boolean;
 }): { displayIsApplicable: boolean | null; justificationValue: string | null } {
   // Enforced rule: fully remote org + physical-security control (7.x) is Not
-  // Applicable. The export applies the same rule, so screen and PDF agree.
+  // Applicable. The field is edit-locked to this, so use the remote rationale
+  // unconditionally — never a stale persisted justification that could contradict
+  // the Not Applicable status. The export applies the identical rule.
   if (isFullyRemote && isControl7) {
     return {
       displayIsApplicable: false,
-      justificationValue:
-        processedResult?.justification ||
-        answerData?.answer ||
-        FULLY_REMOTE_JUSTIFICATION,
+      justificationValue: FULLY_REMOTE_JUSTIFICATION,
     };
   }
 

--- a/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/soa-display.ts
+++ b/apps/app/src/app/(app)/[orgId]/documents/statement-of-applicability/components/soa-display.ts
@@ -1,26 +1,44 @@
 import type { SOAProcessedResult, SOATableAnswerData } from './soa-field-types';
 
+export const FULLY_REMOTE_JUSTIFICATION =
+  'This control is not applicable as our organization operates fully remotely.';
+
 /**
  * Resolves the applicability + justification to display for a SoA control.
  *
- * Applicability and justification are per-organization values, sourced only
- * from this document's own answers (`answerData`) or an in-session autofill
- * result (`processedResult`) — never from the shared framework configuration,
- * and never from a display-only rule. This keeps the on-screen SoA and the
- * exported PDF in agreement (both read the same persisted answer).
+ * Applicability and justification are per-organization values, sourced from
+ * this document's own answers (`answerData`) or an in-session autofill result
+ * (`processedResult`) — never from the shared framework configuration.
  *
- * Note: the "fully remote → physical-security (7.x) controls are not
- * applicable" rule is applied at generation time (auto-fill persists
- * `isApplicable = false` with a justification) and the field is edit-locked, so
- * it is already reflected in the persisted answer read here.
+ * The one enforced rule applied here is "fully remote → physical-security (7.x)
+ * controls are Not Applicable". It is applied consistently on both the screen
+ * (here) and the export, and the field is edit-locked to it, so a fully remote
+ * org sees the same Not Applicable result everywhere even before auto-fill has
+ * persisted it.
  */
 export function resolveSoaDisplay({
   answerData,
   processedResult,
+  isFullyRemote,
+  isControl7,
 }: {
   answerData?: SOATableAnswerData;
   processedResult?: SOAProcessedResult;
+  isFullyRemote: boolean;
+  isControl7: boolean;
 }): { displayIsApplicable: boolean | null; justificationValue: string | null } {
+  // Enforced rule: fully remote org + physical-security control (7.x) is Not
+  // Applicable. The export applies the same rule, so screen and PDF agree.
+  if (isFullyRemote && isControl7) {
+    return {
+      displayIsApplicable: false,
+      justificationValue:
+        processedResult?.justification ||
+        answerData?.answer ||
+        FULLY_REMOTE_JUSTIFICATION,
+    };
+  }
+
   // A manual save this session overrides an in-flight autofill result.
   if (answerData?.savedIsApplicable !== undefined) {
     return {


### PR DESCRIPTION
## Summary

Follow-up to #3395, addressing the automated review on the merged SoA change.

A fully remote organization's physical-security (**7.x**) controls are **Not Applicable**. That rule is enforced at generation time (auto-fill persists `isApplicable = false`) and the field is edit-locked — but the on-screen SoA and the PDF export did **not** apply it when no answer was persisted yet. On a freshly created SoA, those controls could render as **Applicable/N/A** and **disagree between screen and export**.

This applies the rule **identically** in both places:
- `resolveSoaDisplay` (screen) forces Not Applicable for fully-remote 7.x controls.
- `exportDocument` applies the same rule (via `checkIfFullyRemote` + `isPhysicalSecurityControl`).

So a fully remote org always sees Not Applicable for physical-security controls **everywhere**, even before auto-fill has persisted it — screen and PDF stay in agreement.

## Changes
- `soa-display.ts`: enforced fully-remote 7.x rule restored (applied consistently, not a display-only override).
- `SOATableRow` / `SOAMobileRow`: pass `isFullyRemote`/`isControl7` through.
- `soa.service.ts` `exportDocument`: apply the same rule so the PDF matches the screen.
- Tests added for both the display helper and the export path.

## On the reviewer's other note (legacy applicability shows N/A)
Documents generated before #3395 don't have a per-answer applicability value, so they show **N/A** until re-generated. This is intentional: the legacy value isn't reliably recoverable from stored data, so surfacing N/A (and regenerating via Auto-fill) is correct rather than backfilling an unreliable value. This is a one-time data-remediation step handled outside this PR — not a code change.

## Testing
- `apps/api`: `npx jest src/soa` — 62 passing (incl. a new export test asserting fully-remote 7.x is forced Not Applicable).
- `apps/app`: `npx vitest run .../statement-of-applicability` — 13 passing (incl. the fully-remote display case).
- Typecheck: no new errors in touched files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply the fully-remote physical-security rule consistently across the SoA UI and PDF: for fully-remote orgs, all 7.x controls are forced to Not Applicable and always show the standard remote justification. Fixes screen/export mismatches on new SoAs and prevents stale or cross-org text in those justifications (partially addresses Linear CS-731).

- **Bug Fixes**
  - Enforced the rule in `resolveSoaDisplay`; `SOATableRow`/`SOAMobileRow` now pass `isFullyRemote` and `isControl7`.
  - In `SOAService.exportDocument`, used `checkIfFullyRemote` + `isPhysicalSecurityControl`; when forced, set `isApplicable = false` and used the standard remote rationale for both `answer` and `justification`, overriding any persisted text.
  - Added tests for UI and export, including overriding stale justifications and leaving non‑7.x controls unchanged.

<sup>Written for commit e01fc748668b2516d1d4226c226d23de38e47d10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

