### PR TITLE
feat(api): auto-retry failed pentest scans and clean up failure messages

### DIFF
--- a/apps/api/src/security-penetration-tests/pentest-lineage.util.spec.ts
+++ b/apps/api/src/security-penetration-tests/pentest-lineage.util.spec.ts
@@ -88,6 +88,17 @@ describe('collapsedStatus', () => {
       ).toBe('failed');
     });
 
+    it('reveals failed exactly at the grace-window boundary', () => {
+      expect(
+        collapsedStatus({
+          activeStatus: 'failed',
+          attemptNumber: 1,
+          failedAtMs: now - RETRY_GRACE_MS,
+          nowMs: now,
+        }),
+      ).toBe('failed');
+    });
+
     it('reveals failed when the failure time is unknown (cannot bound the mask)', () => {
       expect(
         collapsedStatus({

--- a/apps/api/src/security-penetration-tests/pentest-lineage.util.spec.ts
+++ b/apps/api/src/security-penetration-tests/pentest-lineage.util.spec.ts
@@ -1,0 +1,102 @@
+import {
+  collapsedStatus,
+  MAX_ATTEMPTS,
+  RETRY_GRACE_MS,
+} from './pentest-lineage.util';
+
+describe('collapsedStatus', () => {
+  const now = 1_000_000_000_000;
+
+  it('passes through completed', () => {
+    expect(
+      collapsedStatus({
+        activeStatus: 'completed',
+        attemptNumber: 2,
+        failedAtMs: null,
+        nowMs: now,
+      }),
+    ).toBe('completed');
+  });
+
+  it.each(['provisioning', 'cloning', 'running'] as const)(
+    'passes through in-progress status %s',
+    (status) => {
+      expect(
+        collapsedStatus({
+          activeStatus: status,
+          attemptNumber: 1,
+          failedAtMs: null,
+          nowMs: now,
+        }),
+      ).toBe(status);
+    },
+  );
+
+  it('never masks cancelled (staff cancel is terminal, never retried)', () => {
+    expect(
+      collapsedStatus({
+        activeStatus: 'cancelled',
+        attemptNumber: 1,
+        failedAtMs: now - 1000,
+        nowMs: now,
+      }),
+    ).toBe('cancelled');
+  });
+
+  describe('failed', () => {
+    it('masks a fresh failed non-final attempt as provisioning', () => {
+      expect(
+        collapsedStatus({
+          activeStatus: 'failed',
+          attemptNumber: 1,
+          failedAtMs: now - 5_000, // well within grace
+          nowMs: now,
+        }),
+      ).toBe('provisioning');
+    });
+
+    it('masks the second attempt too', () => {
+      expect(
+        collapsedStatus({
+          activeStatus: 'failed',
+          attemptNumber: 2,
+          failedAtMs: now - 5_000,
+          nowMs: now,
+        }),
+      ).toBe('provisioning');
+    });
+
+    it('reveals failed once the lineage is exhausted (final attempt)', () => {
+      expect(
+        collapsedStatus({
+          activeStatus: 'failed',
+          attemptNumber: MAX_ATTEMPTS,
+          failedAtMs: now - 5_000,
+          nowMs: now,
+        }),
+      ).toBe('failed');
+    });
+
+    it('reveals failed after the grace window elapses without a retry', () => {
+      expect(
+        collapsedStatus({
+          activeStatus: 'failed',
+          attemptNumber: 1,
+          failedAtMs: now - (RETRY_GRACE_MS + 1),
+          nowMs: now,
+        }),
+      ).toBe('failed');
+    });
+
+    it('reveals failed when the failure time is unknown (cannot bound the mask)', () => {
+      expect(
+        collapsedStatus({
+          activeStatus: 'failed',
+          attemptNumber: 1,
+          failedAtMs: null,
+          nowMs: now,
+        }),
+      ).toBe('failed');
+    });
+  });
+});

--- a/apps/api/src/security-penetration-tests/pentest-lineage.util.ts
+++ b/apps/api/src/security-penetration-tests/pentest-lineage.util.ts
@@ -1,0 +1,66 @@
+/**
+ * Pure helpers for the pentest retry-lineage feature.
+ *
+ * A scan is a "lineage": the original run plus up to `MAX_ATTEMPTS - 1`
+ * automatic retries, all sharing one root run id. Customers only ever see the
+ * root; our API resolves it to the active (highest-numbered) attempt and only
+ * reports a terminal failure once the whole lineage is exhausted.
+ */
+
+export type PentestRunStatus =
+  | 'provisioning'
+  | 'cloning'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'cancelled';
+
+/** Original attempt + 2 automatic retries. */
+export const MAX_ATTEMPTS = 3;
+
+/**
+ * How long a failed non-final attempt is masked as in-progress while its
+ * retry is spawned. Comfortably covers provider webhook-delivery latency; if a
+ * retry never materializes within this window the real failure is revealed so
+ * the run can't hang on a fake "running" state forever.
+ */
+export const RETRY_GRACE_MS = 10 * 60 * 1000;
+
+/**
+ * Computes the customer-facing status for a lineage from its active (highest)
+ * attempt. The active attempt is authoritative because we only ever retry
+ * `failed` runs — so no earlier attempt can be `completed`/`running`.
+ *
+ * - `completed` / in-progress statuses pass through unchanged.
+ * - `cancelled` is terminal and never retried → always revealed.
+ * - `failed`:
+ *     - lineage exhausted (`attemptNumber >= maxAttempts`) → revealed.
+ *     - otherwise masked as `provisioning` (a retry is expected) while inside
+ *       the grace window; revealed once the window elapses without a retry
+ *       appearing, or when the failure time is unknown (can't bound the mask).
+ */
+export function collapsedStatus(params: {
+  activeStatus: PentestRunStatus;
+  attemptNumber: number;
+  failedAtMs: number | null;
+  nowMs: number;
+  maxAttempts?: number;
+  graceMs?: number;
+}): PentestRunStatus {
+  const { activeStatus, attemptNumber, failedAtMs, nowMs } = params;
+  const maxAttempts = params.maxAttempts ?? MAX_ATTEMPTS;
+  const graceMs = params.graceMs ?? RETRY_GRACE_MS;
+
+  // Only `failed` triggers an auto-retry, so only `failed` is ever masked.
+  if (activeStatus !== 'failed') {
+    return activeStatus;
+  }
+
+  if (attemptNumber >= maxAttempts) {
+    return 'failed';
+  }
+  if (failedAtMs === null || nowMs - failedAtMs > graceMs) {
+    return 'failed';
+  }
+  return 'provisioning';
+}

--- a/apps/api/src/security-penetration-tests/pentest-lineage.util.ts
+++ b/apps/api/src/security-penetration-tests/pentest-lineage.util.ts
@@ -59,7 +59,7 @@ export function collapsedStatus(params: {
   if (attemptNumber >= maxAttempts) {
     return 'failed';
   }
-  if (failedAtMs === null || nowMs - failedAtMs > graceMs) {
+  if (failedAtMs === null || nowMs - failedAtMs >= graceMs) {
     return 'failed';
   }
   return 'provisioning';

--- a/apps/api/src/security-penetration-tests/pentest-run-error.util.spec.ts
+++ b/apps/api/src/security-penetration-tests/pentest-run-error.util.spec.ts
@@ -60,6 +60,14 @@ describe('toCustomerFacingError', () => {
       expect(message).toContain('maximum runtime of 90 minutes');
     });
 
+    it('renders a single-minute cap without pluralizing', () => {
+      const message = toCustomerFacingError(
+        'Hard timeout: workflow ran 2m (cap 1m)',
+      );
+      expect(message).toContain('maximum runtime of 1 minute');
+      expect(message).not.toContain('1 minutes');
+    });
+
     it('classifies the "; Daytona unreachable" variant as infra, not runtime cap', () => {
       const message = toCustomerFacingError(
         'Hard timeout: 4m (cap 120m); Daytona unreachable',

--- a/apps/api/src/security-penetration-tests/pentest-run-error.util.spec.ts
+++ b/apps/api/src/security-penetration-tests/pentest-run-error.util.spec.ts
@@ -35,7 +35,7 @@ describe('toCustomerFacingError', () => {
         'Hard timeout: workflow ran 722m (cap 720m)',
       );
       expect(message).toContain('maximum runtime of 12 hours');
-      expect(message).toContain('credit has been refunded');
+      expect(message).toContain("won't be charged");
     });
 
     it('humanizes a 120m cap as 2 hours', () => {

--- a/apps/api/src/security-penetration-tests/pentest-run-error.util.spec.ts
+++ b/apps/api/src/security-penetration-tests/pentest-run-error.util.spec.ts
@@ -1,0 +1,88 @@
+import { toCustomerFacingError } from './pentest-run-error.util';
+
+describe('toCustomerFacingError', () => {
+  const infraMessagePrefix =
+    'The scan was interrupted by a temporary infrastructure issue';
+
+  describe('infra / transient failures', () => {
+    const infraErrors = [
+      'Sandbox container deleted by Daytona infrastructure (age 35m). Desired-state=started but container gone — likely Daytona backup/restore race condition.',
+      'Run timed out — sandbox became unresponsive',
+      'Timed out with no sandbox after 9m',
+      'Hard timeout: 4m (cap 120m); Daytona unreachable',
+    ];
+
+    it.each(infraErrors)(
+      'maps infra error to the transient message: %s',
+      (raw) => {
+        expect(toCustomerFacingError(raw)).toContain(infraMessagePrefix);
+      },
+    );
+
+    it('never echoes the raw provider text', () => {
+      const raw =
+        'Sandbox container deleted by Daytona infrastructure (age 35m). backup/restore race condition.';
+      const message = toCustomerFacingError(raw);
+      expect(message.toLowerCase()).not.toContain('daytona');
+      expect(message.toLowerCase()).not.toContain('sandbox');
+      expect(message.toLowerCase()).not.toContain('container');
+    });
+  });
+
+  describe('genuine runtime cap', () => {
+    it('humanizes a 720m cap as 12 hours', () => {
+      const message = toCustomerFacingError(
+        'Hard timeout: workflow ran 722m (cap 720m)',
+      );
+      expect(message).toContain('maximum runtime of 12 hours');
+      expect(message).toContain('credit has been refunded');
+    });
+
+    it('humanizes a 120m cap as 2 hours', () => {
+      const message = toCustomerFacingError(
+        'Hard timeout: workflow ran 130m (cap 120m)',
+      );
+      expect(message).toContain('maximum runtime of 2 hours');
+    });
+
+    it('renders a single-hour cap without pluralizing', () => {
+      const message = toCustomerFacingError(
+        'Hard timeout: workflow ran 61m (cap 60m)',
+      );
+      expect(message).toContain('maximum runtime of 1 hour');
+      expect(message).not.toContain('1 hours');
+    });
+
+    it('falls back to minutes for a non-hour cap', () => {
+      const message = toCustomerFacingError(
+        'Hard timeout: workflow ran 95m (cap 90m)',
+      );
+      expect(message).toContain('maximum runtime of 90 minutes');
+    });
+
+    it('classifies the "; Daytona unreachable" variant as infra, not runtime cap', () => {
+      const message = toCustomerFacingError(
+        'Hard timeout: 4m (cap 120m); Daytona unreachable',
+      );
+      expect(message).toContain(infraMessagePrefix);
+      expect(message).not.toContain('maximum runtime');
+    });
+  });
+
+  describe('unknown / empty', () => {
+    const genericPrefix =
+      'The scan could not be completed after automatic retries';
+
+    it('returns the generic message for an unrecognized error', () => {
+      expect(
+        toCustomerFacingError('some brand new error we have not seen'),
+      ).toContain(genericPrefix);
+    });
+
+    it('returns the generic message for null / undefined / empty', () => {
+      expect(toCustomerFacingError(null)).toContain(genericPrefix);
+      expect(toCustomerFacingError(undefined)).toContain(genericPrefix);
+      expect(toCustomerFacingError('')).toContain(genericPrefix);
+    });
+  });
+});

--- a/apps/api/src/security-penetration-tests/pentest-run-error.util.spec.ts
+++ b/apps/api/src/security-penetration-tests/pentest-run-error.util.spec.ts
@@ -70,8 +70,7 @@ describe('toCustomerFacingError', () => {
   });
 
   describe('unknown / empty', () => {
-    const genericPrefix =
-      'The scan could not be completed after automatic retries';
+    const genericPrefix = "The scan couldn't be completed";
 
     it('returns the generic message for an unrecognized error', () => {
       expect(

--- a/apps/api/src/security-penetration-tests/pentest-run-error.util.ts
+++ b/apps/api/src/security-penetration-tests/pentest-run-error.util.ts
@@ -20,14 +20,13 @@
  */
 
 const INFRA_TRANSIENT_MESSAGE =
-  'The scan was interrupted by a temporary infrastructure issue and could not ' +
-  "complete after automatic retries. You won't be charged for this scan — " +
-  'please try running it again, and contact support if this keeps happening.';
+  'The scan was interrupted by a temporary infrastructure issue and ' +
+  "couldn't be completed. You won't be charged for this scan — please try " +
+  'running it again, and contact support if this keeps happening.';
 
 const GENERIC_MESSAGE =
-  "The scan could not be completed after automatic retries. You won't be " +
-  'charged for this scan — please try running it again, or contact support if ' +
-  'this keeps happening.';
+  "The scan couldn't be completed. You won't be charged for this scan — " +
+  'please try running it again, or contact support if this keeps happening.';
 
 /**
  * True for transient infrastructure failures that a re-run typically clears:

--- a/apps/api/src/security-penetration-tests/pentest-run-error.util.ts
+++ b/apps/api/src/security-penetration-tests/pentest-run-error.util.ts
@@ -1,0 +1,88 @@
+/**
+ * Maps a raw provider run-error string into a clean, customer-facing message.
+ *
+ * Penetration tests are executed by an external provider whose backend runs
+ * each scan inside a disposable sandbox. When a run fails, the provider returns
+ * a freeform `error` string that can name our infrastructure vendor, describe
+ * internal engineering conditions ("backup/restore race condition"), or be
+ * arbitrary text — none of which is useful or safe to surface to a customer of
+ * a security product.
+ *
+ * This helper is only applied once a scan's entire retry lineage is exhausted
+ * (every attempt failed), so every message it returns describes a genuine,
+ * final failure and states that the credit has been refunded — which, by the
+ * time the customer sees it, it has (see `refundOnTerminalFailure`).
+ *
+ * The raw string is never echoed back; unrecognized errors fall through to a
+ * safe generic message.
+ */
+
+const INFRA_TRANSIENT_MESSAGE =
+  'The scan was interrupted by a temporary infrastructure issue and could not ' +
+  'complete after automatic retries. Your credit has been refunded — please ' +
+  'try running it again, and contact support if this keeps happening.';
+
+const GENERIC_MESSAGE =
+  'The scan could not be completed after automatic retries. Your credit has ' +
+  'been refunded — please try running it again, or contact support if this ' +
+  'keeps happening.';
+
+/**
+ * True for transient infrastructure failures that a re-run typically clears:
+ * the sandbox was deleted, never provisioned, went unresponsive, or the
+ * provisioning path could not reach the sandbox host. The "Daytona
+ * unreachable" hard-timeout variant belongs here (an infra problem during
+ * provisioning), NOT with the genuine runtime cap below — so it must be
+ * checked first.
+ */
+function isInfraTransient(raw: string): boolean {
+  return (
+    /sandbox container deleted/i.test(raw) ||
+    /backup\/restore race/i.test(raw) ||
+    /sandbox became unresponsive/i.test(raw) ||
+    /timed out with no sandbox/i.test(raw) ||
+    /daytona unreachable/i.test(raw)
+  );
+}
+
+/**
+ * Renders a whole number of minutes as a friendly duration: exact hours become
+ * "12 hours" / "1 hour", anything else stays in minutes. Guards against junk
+ * input by falling back to a neutral phrase.
+ */
+function humanizeMinutes(minutes: number): string {
+  if (!Number.isFinite(minutes) || minutes <= 0) {
+    return 'its time limit';
+  }
+  if (minutes % 60 === 0) {
+    const hours = minutes / 60;
+    return `${hours} hour${hours === 1 ? '' : 's'}`;
+  }
+  return `${minutes} minutes`;
+}
+
+export function toCustomerFacingError(
+  rawError: string | null | undefined,
+): string {
+  const raw = typeof rawError === 'string' ? rawError : '';
+
+  if (isInfraTransient(raw)) {
+    return INFRA_TRANSIENT_MESSAGE;
+  }
+
+  // Genuine runtime cap: the scan used its full time budget without finishing
+  // (e.g. "Hard timeout: workflow ran 722m (cap 720m)"). The infra check above
+  // has already claimed the "; Daytona unreachable" variant.
+  const capMatch =
+    /hard timeout:\s*workflow ran\s+\d+m\s*\(cap\s+(\d+)m\)/i.exec(raw);
+  if (capMatch) {
+    const cap = humanizeMinutes(Number(capMatch[1]));
+    return (
+      `Your scan reached its maximum runtime of ${cap} before completing. ` +
+      'Your credit has been refunded. Large targets may need a lighter scan ' +
+      'depth — contact support if this keeps happening.'
+    );
+  }
+
+  return GENERIC_MESSAGE;
+}

--- a/apps/api/src/security-penetration-tests/pentest-run-error.util.ts
+++ b/apps/api/src/security-penetration-tests/pentest-run-error.util.ts
@@ -59,7 +59,7 @@ function humanizeMinutes(minutes: number): string {
     const hours = minutes / 60;
     return `${hours} hour${hours === 1 ? '' : 's'}`;
   }
-  return `${minutes} minutes`;
+  return `${minutes} minute${minutes === 1 ? '' : 's'}`;
 }
 
 export function toCustomerFacingError(

--- a/apps/api/src/security-penetration-tests/pentest-run-error.util.ts
+++ b/apps/api/src/security-penetration-tests/pentest-run-error.util.ts
@@ -10,8 +10,10 @@
  *
  * This helper is only applied once a scan's entire retry lineage is exhausted
  * (every attempt failed), so every message it returns describes a genuine,
- * final failure and states that the credit has been refunded — which, by the
- * time the customer sees it, it has (see `refundOnTerminalFailure`).
+ * final failure. It says the customer "won't be charged" rather than asserting
+ * the refund is already complete — a failed run is always refunded, but the
+ * refund and this read can race, so the phrasing stays true regardless of
+ * timing (net effect: a failed scan is never charged).
  *
  * The raw string is never echoed back; unrecognized errors fall through to a
  * safe generic message.
@@ -19,13 +21,13 @@
 
 const INFRA_TRANSIENT_MESSAGE =
   'The scan was interrupted by a temporary infrastructure issue and could not ' +
-  'complete after automatic retries. Your credit has been refunded — please ' +
-  'try running it again, and contact support if this keeps happening.';
+  "complete after automatic retries. You won't be charged for this scan — " +
+  'please try running it again, and contact support if this keeps happening.';
 
 const GENERIC_MESSAGE =
-  'The scan could not be completed after automatic retries. Your credit has ' +
-  'been refunded — please try running it again, or contact support if this ' +
-  'keeps happening.';
+  "The scan could not be completed after automatic retries. You won't be " +
+  'charged for this scan — please try running it again, or contact support if ' +
+  'this keeps happening.';
 
 /**
  * True for transient infrastructure failures that a re-run typically clears:
@@ -79,8 +81,8 @@ export function toCustomerFacingError(
     const cap = humanizeMinutes(Number(capMatch[1]));
     return (
       `Your scan reached its maximum runtime of ${cap} before completing. ` +
-      'Your credit has been refunded. Large targets may need a lighter scan ' +
-      'depth — contact support if this keeps happening.'
+      "You won't be charged for this scan. Large targets may need a lighter " +
+      'scan depth — contact support if this keeps happening.'
     );
   }
 

--- a/apps/api/src/security-penetration-tests/security-penetration-tests.service.spec.ts
+++ b/apps/api/src/security-penetration-tests/security-penetration-tests.service.spec.ts
@@ -1114,7 +1114,7 @@ describe('SecurityPenetrationTestsService', () => {
       );
     });
 
-    it('spawns a retry with the same params and incremented attempt', async () => {
+    it('spawns a retry with the same params (incl. pipeline + context) and incremented attempt', async () => {
       mockedDb.securityPenetrationTestRun.findUnique.mockResolvedValueOnce({
         organizationId: 'org_123',
         attemptNumber: 1,
@@ -1123,6 +1123,8 @@ describe('SecurityPenetrationTestsService', () => {
           targetUrl: 'https://app.example.com',
           scanDepth: 'deep',
           checks: ['xss'],
+          pipelineTesting: true,
+          additionalContext: 'prior briefing',
         },
       });
       fetchMock.mockResolvedValueOnce(
@@ -1140,8 +1142,11 @@ describe('SecurityPenetrationTestsService', () => {
           targetUrl: 'https://app.example.com',
           scanDepth: 'deep',
           checks: ['xss'],
+          pipelineTesting: true,
         }),
       );
+      // The user's briefing survives the round-trip (re-persisted for any
+      // further retry).
       expect(mockedDb.securityPenetrationTestRun.upsert).toHaveBeenCalledWith(
         expect.objectContaining({
           create: expect.objectContaining({
@@ -1149,7 +1154,24 @@ describe('SecurityPenetrationTestsService', () => {
             rootRunId: 'run_orig',
             attemptNumber: 2,
             retryOfProviderRunId: 'run_orig',
+            scanParams: expect.objectContaining({
+              pipelineTesting: true,
+              additionalContext: 'prior briefing',
+            }),
           }),
+        }),
+      );
+    });
+
+    it('blocks auto-retry when a run is cancelled (late failed cannot restart it)', async () => {
+      await service['blockAutoRetry']('run_cancelled');
+
+      expect(
+        mockedDb.securityPenetrationTestRun.updateMany,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { providerRunId: 'run_cancelled', retryTriggeredAt: null },
+          data: expect.objectContaining({ retryTriggeredAt: expect.any(Date) }),
         }),
       );
     });

--- a/apps/api/src/security-penetration-tests/security-penetration-tests.service.spec.ts
+++ b/apps/api/src/security-penetration-tests/security-penetration-tests.service.spec.ts
@@ -1194,6 +1194,18 @@ describe('SecurityPenetrationTestsService', () => {
       );
     });
 
+    it('propagates a DB failure while blocking so the cancellation redelivers', async () => {
+      mockedDb.securityPenetrationTestRun.updateMany.mockRejectedValueOnce(
+        new Error('db unavailable'),
+      );
+
+      // Rethrows (not swallowed) so the webhook 5xx's and Maced redelivers the
+      // cancellation until the block is durably stored.
+      await expect(
+        service['blockAutoRetry']('run_cancelled'),
+      ).rejects.toThrow();
+    });
+
     it('does not retry a cancelled lineage even if a late failed arrives', async () => {
       mockedDb.securityPenetrationTestRun.findUnique.mockResolvedValueOnce({
         organizationId: 'org_123',

--- a/apps/api/src/security-penetration-tests/security-penetration-tests.service.spec.ts
+++ b/apps/api/src/security-penetration-tests/security-penetration-tests.service.spec.ts
@@ -1163,14 +1163,20 @@ describe('SecurityPenetrationTestsService', () => {
       );
     });
 
-    it('blocks auto-retry when a run is cancelled (late failed cannot restart it)', async () => {
+    it('blocks auto-retry across the whole lineage when a run is cancelled', async () => {
+      mockedDb.securityPenetrationTestRun.findUnique.mockResolvedValueOnce({
+        rootRunId: 'run_orig',
+      });
+
       await service['blockAutoRetry']('run_cancelled');
 
+      // Claims the retry slot on every attempt sharing the lineage root, so a
+      // late `failed` for any member can't restart a cancelled scan.
       expect(
         mockedDb.securityPenetrationTestRun.updateMany,
       ).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { providerRunId: 'run_cancelled', retryTriggeredAt: null },
+          where: { rootRunId: 'run_orig', retryTriggeredAt: null },
           data: expect.objectContaining({ retryTriggeredAt: expect.any(Date) }),
         }),
       );
@@ -1221,7 +1227,7 @@ describe('SecurityPenetrationTestsService', () => {
       expect(mockedDb.securityPenetrationTestRun.upsert).not.toHaveBeenCalled();
     });
 
-    it('never throws when the retry create fails (best-effort)', async () => {
+    it('releases the claim and rethrows when the retry spawn fails (durable redelivery)', async () => {
       mockedDb.securityPenetrationTestRun.findUnique.mockResolvedValueOnce({
         organizationId: 'org_123',
         attemptNumber: 1,
@@ -1232,9 +1238,17 @@ describe('SecurityPenetrationTestsService', () => {
         new Response('{"error":"boom"}', { status: 500 }),
       );
 
-      await expect(
-        service['maybeAutoRetry']('run_orig'),
-      ).resolves.toBeUndefined();
+      // Rethrows so the webhook 5xx's and Maced redelivers the event.
+      await expect(service['maybeAutoRetry']('run_orig')).rejects.toThrow();
+      // Claim released so the redelivery can re-attempt the retry.
+      expect(
+        mockedDb.securityPenetrationTestRun.updateMany,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { providerRunId: 'run_orig' },
+          data: expect.objectContaining({ retryTriggeredAt: null }),
+        }),
+      );
     });
 
     it('collapses a retry lineage to a single active-attempt entry', async () => {
@@ -1336,6 +1350,58 @@ describe('SecurityPenetrationTestsService', () => {
       expect(report.failedReason).toContain('temporary infrastructure issue');
       expect(report.failedReason?.toLowerCase()).not.toContain('daytona');
       expect(report.error?.toLowerCase()).not.toContain('daytona');
+    });
+
+    it('masks progress status as in-progress for a failed non-final attempt', async () => {
+      mockedDb.securityPenetrationTestRun.findUnique.mockResolvedValue({
+        organizationId: 'org_123',
+        rootRunId: 'run_orig',
+      });
+      mockedDb.securityPenetrationTestRun.findFirst.mockResolvedValueOnce({
+        providerRunId: 'run_orig',
+        attemptNumber: 1,
+      });
+      fetchMock.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            status: 'failed',
+            completedAgents: 2,
+            totalAgents: 5,
+            elapsedMs: 1000,
+          }),
+          { status: 200 },
+        ),
+      );
+
+      const progress = await service.getReportProgress('org_123', 'run_orig');
+
+      expect(progress.status).toBe('provisioning');
+    });
+
+    it('exposes failed progress once the lineage is exhausted', async () => {
+      mockedDb.securityPenetrationTestRun.findUnique.mockResolvedValue({
+        organizationId: 'org_123',
+        rootRunId: 'run_orig',
+      });
+      mockedDb.securityPenetrationTestRun.findFirst.mockResolvedValueOnce({
+        providerRunId: 'run_retry2',
+        attemptNumber: 3,
+      });
+      fetchMock.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            status: 'failed',
+            completedAgents: 2,
+            totalAgents: 5,
+            elapsedMs: 1000,
+          }),
+          { status: 200 },
+        ),
+      );
+
+      const progress = await service.getReportProgress('org_123', 'run_orig');
+
+      expect(progress.status).toBe('failed');
     });
   });
 });

--- a/apps/api/src/security-penetration-tests/security-penetration-tests.service.spec.ts
+++ b/apps/api/src/security-penetration-tests/security-penetration-tests.service.spec.ts
@@ -147,14 +147,26 @@ describe('SecurityPenetrationTestsService', () => {
     mockedDb.securityPenetrationTestRun.findUnique.mockResolvedValue({
       organizationId: 'org_123',
     });
-    // Lineage: by default a run is its own root, attempt 1, no retries — the
-    // active attempt resolves to the run itself (reflect the requested root).
+    // findFirst is used three ways. Defaults: not cancelled, no retry child,
+    // and the active attempt resolves to the run itself (reflect the root).
     mockedDb.securityPenetrationTestRun.findFirst.mockImplementation(
-      (args?: { where?: { rootRunId?: string } }) => {
-        const rootRunId = args?.where?.rootRunId;
-        return Promise.resolve(
-          rootRunId ? { providerRunId: rootRunId, attemptNumber: 1 } : null,
-        );
+      (args?: {
+        where?: {
+          rootRunId?: string;
+          retryBlockedAt?: unknown;
+          retryOfProviderRunId?: string;
+        };
+      }) => {
+        const where = args?.where ?? {};
+        if ('retryBlockedAt' in where) return Promise.resolve(null); // not cancelled
+        if ('retryOfProviderRunId' in where) return Promise.resolve(null); // no child
+        if (where.rootRunId) {
+          return Promise.resolve({
+            providerRunId: where.rootRunId,
+            attemptNumber: 1,
+          });
+        }
+        return Promise.resolve(null);
       },
     );
     mockedDb.securityPenetrationTestRun.findMany.mockResolvedValue([
@@ -1170,16 +1182,50 @@ describe('SecurityPenetrationTestsService', () => {
 
       await service['blockAutoRetry']('run_cancelled');
 
-      // Claims the retry slot on every attempt sharing the lineage root, so a
-      // late `failed` for any member can't restart a cancelled scan.
+      // Sets the distinct cancellation marker on every attempt sharing the
+      // lineage root, so a late `failed` for any member can't restart it.
       expect(
         mockedDb.securityPenetrationTestRun.updateMany,
       ).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { rootRunId: 'run_orig', retryTriggeredAt: null },
-          data: expect.objectContaining({ retryTriggeredAt: expect.any(Date) }),
+          where: { rootRunId: 'run_orig', retryBlockedAt: null },
+          data: expect.objectContaining({ retryBlockedAt: expect.any(Date) }),
         }),
       );
+    });
+
+    it('does not retry a cancelled lineage even if a late failed arrives', async () => {
+      mockedDb.securityPenetrationTestRun.findUnique.mockResolvedValueOnce({
+        organizationId: 'org_123',
+        attemptNumber: 1,
+        rootRunId: 'run_orig',
+        scanParams: { targetUrl: 'https://app.example.com' },
+      });
+      // Block check (first findFirst) reports the lineage is cancelled.
+      mockedDb.securityPenetrationTestRun.findFirst.mockResolvedValueOnce({
+        providerRunId: 'run_orig',
+      });
+
+      await service['maybeAutoRetry']('run_orig');
+
+      expect(mockedDb.securityPenetrationTestRun.upsert).not.toHaveBeenCalled();
+    });
+
+    it('does not retry when a retry child already exists (idempotent)', async () => {
+      mockedDb.securityPenetrationTestRun.findUnique.mockResolvedValueOnce({
+        organizationId: 'org_123',
+        attemptNumber: 1,
+        rootRunId: 'run_orig',
+        scanParams: { targetUrl: 'https://app.example.com' },
+      });
+      // Block check → not cancelled; child check → a child already exists.
+      mockedDb.securityPenetrationTestRun.findFirst
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ providerRunId: 'run_retry' });
+
+      await service['maybeAutoRetry']('run_orig');
+
+      expect(mockedDb.securityPenetrationTestRun.upsert).not.toHaveBeenCalled();
     });
 
     it('does not retry once the lineage is exhausted', async () => {
@@ -1198,22 +1244,6 @@ describe('SecurityPenetrationTestsService', () => {
       expect(mockedDb.securityPenetrationTestRun.upsert).not.toHaveBeenCalled();
     });
 
-    it('does not retry when the idempotency claim was already taken', async () => {
-      mockedDb.securityPenetrationTestRun.findUnique.mockResolvedValueOnce({
-        organizationId: 'org_123',
-        attemptNumber: 1,
-        rootRunId: 'run_orig',
-        scanParams: { targetUrl: 'https://app.example.com' },
-      });
-      mockedDb.securityPenetrationTestRun.updateMany.mockResolvedValueOnce({
-        count: 0,
-      });
-
-      await service['maybeAutoRetry']('run_orig');
-
-      expect(mockedDb.securityPenetrationTestRun.upsert).not.toHaveBeenCalled();
-    });
-
     it('does not retry an orphan run with no ownership row', async () => {
       mockedDb.securityPenetrationTestRun.findUnique.mockResolvedValueOnce(
         null,
@@ -1227,7 +1257,7 @@ describe('SecurityPenetrationTestsService', () => {
       expect(mockedDb.securityPenetrationTestRun.upsert).not.toHaveBeenCalled();
     });
 
-    it('releases the claim and rethrows when the retry spawn fails (durable redelivery)', async () => {
+    it('rethrows when the retry spawn fails so the webhook redelivers (durable via child-existence)', async () => {
       mockedDb.securityPenetrationTestRun.findUnique.mockResolvedValueOnce({
         organizationId: 'org_123',
         attemptNumber: 1,
@@ -1238,17 +1268,9 @@ describe('SecurityPenetrationTestsService', () => {
         new Response('{"error":"boom"}', { status: 500 }),
       );
 
-      // Rethrows so the webhook 5xx's and Maced redelivers the event.
+      // No child is created, so it rethrows → webhook 5xx → Maced redelivers →
+      // next delivery sees no child and re-attempts. Nothing to release.
       await expect(service['maybeAutoRetry']('run_orig')).rejects.toThrow();
-      // Claim released so the redelivery can re-attempt the retry.
-      expect(
-        mockedDb.securityPenetrationTestRun.updateMany,
-      ).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: { providerRunId: 'run_orig' },
-          data: expect.objectContaining({ retryTriggeredAt: null }),
-        }),
-      );
     });
 
     it('collapses a retry lineage to a single active-attempt entry', async () => {
@@ -1357,21 +1379,32 @@ describe('SecurityPenetrationTestsService', () => {
         organizationId: 'org_123',
         rootRunId: 'run_orig',
       });
-      mockedDb.securityPenetrationTestRun.findFirst.mockResolvedValueOnce({
-        providerRunId: 'run_orig',
-        attemptNumber: 1,
-      });
-      fetchMock.mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            status: 'failed',
-            completedAgents: 2,
-            totalAgents: 5,
-            elapsedMs: 1000,
-          }),
-          { status: 200 },
-        ),
-      );
+      const recent = new Date().toISOString();
+      // getReportResolved.get() then progress() — two provider calls.
+      fetchMock
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              id: 'run_orig',
+              status: 'failed',
+              targetUrl: 'https://a.com',
+              createdAt: recent,
+              updatedAt: recent,
+            }),
+            { status: 200 },
+          ),
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              status: 'failed',
+              completedAgents: 2,
+              totalAgents: 5,
+              elapsedMs: 1000,
+            }),
+            { status: 200 },
+          ),
+        );
 
       const progress = await service.getReportProgress('org_123', 'run_orig');
 
@@ -1387,17 +1420,31 @@ describe('SecurityPenetrationTestsService', () => {
         providerRunId: 'run_retry2',
         attemptNumber: 3,
       });
-      fetchMock.mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            status: 'failed',
-            completedAgents: 2,
-            totalAgents: 5,
-            elapsedMs: 1000,
-          }),
-          { status: 200 },
-        ),
-      );
+      const recent = new Date().toISOString();
+      fetchMock
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              id: 'run_retry2',
+              status: 'failed',
+              targetUrl: 'https://a.com',
+              createdAt: recent,
+              updatedAt: recent,
+            }),
+            { status: 200 },
+          ),
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              status: 'failed',
+              completedAgents: 2,
+              totalAgents: 5,
+              elapsedMs: 1000,
+            }),
+            { status: 200 },
+          ),
+        );
 
       const progress = await service.getReportProgress('org_123', 'run_orig');
 

--- a/apps/api/src/security-penetration-tests/security-penetration-tests.service.spec.ts
+++ b/apps/api/src/security-penetration-tests/security-penetration-tests.service.spec.ts
@@ -44,7 +44,9 @@ jest.mock('@db', () => ({
     securityPenetrationTestRun: {
       upsert: jest.fn(),
       findUnique: jest.fn(),
+      findFirst: jest.fn(),
       findMany: jest.fn(),
+      updateMany: jest.fn(),
     },
     securityPenetrationTestFindingContext: {
       findMany: jest.fn(),
@@ -67,7 +69,9 @@ type MockDb = {
   securityPenetrationTestRun: {
     upsert: jest.Mock;
     findUnique: jest.Mock;
+    findFirst: jest.Mock;
     findMany: jest.Mock;
+    updateMany: jest.Mock;
   };
   securityPenetrationTestFindingContext: {
     findMany: jest.Mock;
@@ -143,9 +147,23 @@ describe('SecurityPenetrationTestsService', () => {
     mockedDb.securityPenetrationTestRun.findUnique.mockResolvedValue({
       organizationId: 'org_123',
     });
+    // Lineage: by default a run is its own root, attempt 1, no retries — the
+    // active attempt resolves to the run itself (reflect the requested root).
+    mockedDb.securityPenetrationTestRun.findFirst.mockImplementation(
+      (args?: { where?: { rootRunId?: string } }) => {
+        const rootRunId = args?.where?.rootRunId;
+        return Promise.resolve(
+          rootRunId ? { providerRunId: rootRunId, attemptNumber: 1 } : null,
+        );
+      },
+    );
     mockedDb.securityPenetrationTestRun.findMany.mockResolvedValue([
-      { providerRunId: 'run_123' },
+      { providerRunId: 'run_123', rootRunId: 'run_123', attemptNumber: 1 },
     ]);
+    // Retry idempotency claim succeeds by default.
+    mockedDb.securityPenetrationTestRun.updateMany.mockResolvedValue({
+      count: 1,
+    });
     // Default: no stored finding-context notes for the target.
     mockedDb.securityPenetrationTestFindingContext.findMany.mockResolvedValue(
       [],
@@ -1032,5 +1050,270 @@ describe('SecurityPenetrationTestsService', () => {
     await expect(service.getReport('org_123', 'missing')).rejects.toThrow(
       HttpException,
     );
+  });
+
+  describe('auto-retry lineage', () => {
+    it('persists self-root lineage for an original run', async () => {
+      fetchMock.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ id: 'run_orig', status: 'provisioning' }),
+          { status: 200 },
+        ),
+      );
+
+      await service.createReport('org_123', {
+        targetUrl: 'https://app.example.com',
+        scanDepth: 'deep',
+        checks: ['xss'],
+      });
+
+      expect(mockedDb.securityPenetrationTestRun.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({
+            providerRunId: 'run_orig',
+            rootRunId: 'run_orig',
+            attemptNumber: 1,
+            retryOfProviderRunId: null,
+            scanParams: expect.objectContaining({
+              targetUrl: 'https://app.example.com',
+              scanDepth: 'deep',
+              checks: ['xss'],
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('persists inherited lineage for a retry run', async () => {
+      fetchMock.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ id: 'run_retry', status: 'provisioning' }),
+          { status: 200 },
+        ),
+      );
+
+      await service.createReport(
+        'org_123',
+        { targetUrl: 'https://app.example.com' },
+        {
+          attemptNumber: 2,
+          rootRunId: 'run_orig',
+          retryOfProviderRunId: 'run_orig',
+        },
+      );
+
+      expect(mockedDb.securityPenetrationTestRun.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({
+            providerRunId: 'run_retry',
+            rootRunId: 'run_orig',
+            attemptNumber: 2,
+            retryOfProviderRunId: 'run_orig',
+          }),
+        }),
+      );
+    });
+
+    it('spawns a retry with the same params and incremented attempt', async () => {
+      mockedDb.securityPenetrationTestRun.findUnique.mockResolvedValueOnce({
+        organizationId: 'org_123',
+        attemptNumber: 1,
+        rootRunId: 'run_orig',
+        scanParams: {
+          targetUrl: 'https://app.example.com',
+          scanDepth: 'deep',
+          checks: ['xss'],
+        },
+      });
+      fetchMock.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ id: 'run_retry', status: 'provisioning' }),
+          { status: 200 },
+        ),
+      );
+
+      await service['maybeAutoRetry']('run_orig');
+
+      const createBody = await getRequestBody();
+      expect(createBody).toEqual(
+        expect.objectContaining({
+          targetUrl: 'https://app.example.com',
+          scanDepth: 'deep',
+          checks: ['xss'],
+        }),
+      );
+      expect(mockedDb.securityPenetrationTestRun.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({
+            providerRunId: 'run_retry',
+            rootRunId: 'run_orig',
+            attemptNumber: 2,
+            retryOfProviderRunId: 'run_orig',
+          }),
+        }),
+      );
+    });
+
+    it('does not retry once the lineage is exhausted', async () => {
+      mockedDb.securityPenetrationTestRun.findUnique.mockResolvedValueOnce({
+        organizationId: 'org_123',
+        attemptNumber: 3,
+        rootRunId: 'run_orig',
+        scanParams: { targetUrl: 'https://app.example.com' },
+      });
+
+      await service['maybeAutoRetry']('run_orig');
+
+      expect(
+        mockedDb.securityPenetrationTestRun.updateMany,
+      ).not.toHaveBeenCalled();
+      expect(mockedDb.securityPenetrationTestRun.upsert).not.toHaveBeenCalled();
+    });
+
+    it('does not retry when the idempotency claim was already taken', async () => {
+      mockedDb.securityPenetrationTestRun.findUnique.mockResolvedValueOnce({
+        organizationId: 'org_123',
+        attemptNumber: 1,
+        rootRunId: 'run_orig',
+        scanParams: { targetUrl: 'https://app.example.com' },
+      });
+      mockedDb.securityPenetrationTestRun.updateMany.mockResolvedValueOnce({
+        count: 0,
+      });
+
+      await service['maybeAutoRetry']('run_orig');
+
+      expect(mockedDb.securityPenetrationTestRun.upsert).not.toHaveBeenCalled();
+    });
+
+    it('does not retry an orphan run with no ownership row', async () => {
+      mockedDb.securityPenetrationTestRun.findUnique.mockResolvedValueOnce(
+        null,
+      );
+
+      await service['maybeAutoRetry']('run_ghost');
+
+      expect(
+        mockedDb.securityPenetrationTestRun.updateMany,
+      ).not.toHaveBeenCalled();
+      expect(mockedDb.securityPenetrationTestRun.upsert).not.toHaveBeenCalled();
+    });
+
+    it('never throws when the retry create fails (best-effort)', async () => {
+      mockedDb.securityPenetrationTestRun.findUnique.mockResolvedValueOnce({
+        organizationId: 'org_123',
+        attemptNumber: 1,
+        rootRunId: 'run_orig',
+        scanParams: { targetUrl: 'https://app.example.com' },
+      });
+      fetchMock.mockResolvedValueOnce(
+        new Response('{"error":"boom"}', { status: 500 }),
+      );
+
+      await expect(
+        service['maybeAutoRetry']('run_orig'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('collapses a retry lineage to a single active-attempt entry', async () => {
+      mockedDb.securityPenetrationTestRun.findMany.mockResolvedValueOnce([
+        { providerRunId: 'run_orig', rootRunId: 'run_orig', attemptNumber: 1 },
+        { providerRunId: 'run_retry', rootRunId: 'run_orig', attemptNumber: 2 },
+      ]);
+      fetchMock.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              id: 'run_orig',
+              status: 'failed',
+              targetUrl: 'https://a.com',
+              createdAt: '2026-01-01T00:00:00.000Z',
+              updatedAt: '2026-01-01T00:00:00.000Z',
+              error: 'Sandbox container deleted by Daytona',
+            },
+            {
+              id: 'run_retry',
+              status: 'running',
+              targetUrl: 'https://a.com',
+              createdAt: '2026-01-01T00:00:00.000Z',
+              updatedAt: '2026-01-01T00:05:00.000Z',
+            },
+          ]),
+          { status: 200 },
+        ),
+      );
+
+      const result = await service.listReports('org_123');
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(
+        expect.objectContaining({ id: 'run_orig', status: 'running' }),
+      );
+    });
+
+    it('masks a fresh failed non-final attempt as in-progress', async () => {
+      mockedDb.securityPenetrationTestRun.findUnique.mockResolvedValue({
+        organizationId: 'org_123',
+        rootRunId: 'run_orig',
+      });
+      mockedDb.securityPenetrationTestRun.findFirst.mockResolvedValueOnce({
+        providerRunId: 'run_orig',
+        attemptNumber: 1,
+      });
+      const recent = new Date().toISOString();
+      fetchMock.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            id: 'run_orig',
+            status: 'failed',
+            targetUrl: 'https://a.com',
+            createdAt: recent,
+            updatedAt: recent,
+            error: 'Sandbox container deleted by Daytona',
+          }),
+          { status: 200 },
+        ),
+      );
+
+      const report = await service.getReport('org_123', 'run_orig');
+
+      expect(report.status).toBe('provisioning');
+      expect(report.error).toBeNull();
+      expect(report.failedReason).toBeNull();
+    });
+
+    it('reveals a clean, white-labeled failure once the lineage is exhausted', async () => {
+      mockedDb.securityPenetrationTestRun.findUnique.mockResolvedValue({
+        organizationId: 'org_123',
+        rootRunId: 'run_orig',
+      });
+      mockedDb.securityPenetrationTestRun.findFirst.mockResolvedValueOnce({
+        providerRunId: 'run_retry2',
+        attemptNumber: 3,
+      });
+      const recent = new Date().toISOString();
+      fetchMock.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            id: 'run_retry2',
+            status: 'failed',
+            targetUrl: 'https://a.com',
+            createdAt: recent,
+            updatedAt: recent,
+            error:
+              'Sandbox container deleted by Daytona infrastructure — backup/restore race condition',
+          }),
+          { status: 200 },
+        ),
+      );
+
+      const report = await service.getReport('org_123', 'run_orig');
+
+      expect(report.status).toBe('failed');
+      expect(report.id).toBe('run_orig');
+      expect(report.failedReason).toContain('temporary infrastructure issue');
+      expect(report.failedReason?.toLowerCase()).not.toContain('daytona');
+      expect(report.error?.toLowerCase()).not.toContain('daytona');
+    });
   });
 });

--- a/apps/api/src/security-penetration-tests/security-penetration-tests.service.ts
+++ b/apps/api/src/security-penetration-tests/security-penetration-tests.service.ts
@@ -575,10 +575,16 @@ export class SecurityPenetrationTestsService {
     });
   }
 
-  async getReport(
+  /**
+   * Resolves ownership + the active attempt, fetches the run, and returns both
+   * the collapsed customer-facing run and the active provider run id. Callers
+   * that also need the active id (report/PDF downloads) use this to avoid
+   * re-resolving the lineage a second time.
+   */
+  private async getReportResolved(
     organizationId: string,
     id: string,
-  ): Promise<SecurityPenetrationTest> {
+  ): Promise<{ run: SecurityPenetrationTest; activeProviderRunId: string }> {
     await this.assertRunOwnership(organizationId, id);
     const { rootRunId, activeProviderRunId, attemptNumber } =
       await this.resolveActiveAttempt(organizationId, id);
@@ -586,7 +592,18 @@ export class SecurityPenetrationTestsService {
       () => this.macedClient.pentests.get(activeProviderRunId),
       `fetching penetration test ${activeProviderRunId}`,
     );
-    return this.collapseRun(report, { rootRunId, attemptNumber });
+    return {
+      run: this.collapseRun(report, { rootRunId, attemptNumber }),
+      activeProviderRunId,
+    };
+  }
+
+  async getReport(
+    organizationId: string,
+    id: string,
+  ): Promise<SecurityPenetrationTest> {
+    const { run } = await this.getReportResolved(organizationId, id);
+    return run;
   }
 
   async getReportProgress(
@@ -594,14 +611,20 @@ export class SecurityPenetrationTestsService {
     id: string,
   ): Promise<PentestProgress> {
     await this.assertRunOwnership(organizationId, id);
-    const { activeProviderRunId } = await this.resolveActiveAttempt(
-      organizationId,
-      id,
-    );
-    return this.callMaced(
+    const { activeProviderRunId, attemptNumber } =
+      await this.resolveActiveAttempt(organizationId, id);
+    const progress = await this.callMaced(
       () => this.macedClient.pentests.progress(activeProviderRunId),
       `fetching penetration test progress ${activeProviderRunId}`,
     );
+    // Mask a failed non-final attempt as in-progress, consistent with
+    // getReport, so progress polled during the retry window doesn't expose an
+    // intermediate failure. getReport owns the grace-based reveal; once it
+    // reveals the failure the client stops polling progress.
+    if (progress.status === 'failed' && attemptNumber < MAX_ATTEMPTS) {
+      return { ...progress, status: 'provisioning' };
+    }
+    return progress;
   }
 
   async getReportIssues(organizationId: string, id: string): Promise<Issue[]> {
@@ -642,8 +665,7 @@ export class SecurityPenetrationTestsService {
     organizationId: string,
     id: string,
   ): Promise<BinaryArtifact> {
-    const run = await this.getReport(organizationId, id);
-    const { activeProviderRunId } = await this.resolveActiveAttempt(
+    const { run, activeProviderRunId } = await this.getReportResolved(
       organizationId,
       id,
     );
@@ -673,8 +695,7 @@ export class SecurityPenetrationTestsService {
     organizationId: string,
     id: string,
   ): Promise<BinaryArtifact> {
-    const run = await this.getReport(organizationId, id);
-    const { activeProviderRunId } = await this.resolveActiveAttempt(
+    const { run, activeProviderRunId } = await this.getReportResolved(
       organizationId,
       id,
     );
@@ -808,9 +829,10 @@ export class SecurityPenetrationTestsService {
     // Auto-retry transient failures so customers never see intermediate
     // failures. Only `pentest.failed` — a `pentest.cancelled` is a deliberate
     // stop (staff cancels a run and it's refunded) and must never be re-run.
-    // Best-effort: `maybeAutoRetry` never throws, so a retry hiccup can't stop
-    // this handler from returning 200 (which would make Maced redeliver and
-    // re-refund).
+    // If spawning the retry fails, `maybeAutoRetry` releases its claim and
+    // rethrows so this handler returns non-2xx and Maced redelivers — the
+    // refund above is idempotent (`creditRefundedAt`), so redelivery safely
+    // re-attempts only the retry rather than dropping it.
     if (event.type === 'pentest.failed') {
       await this.maybeAutoRetry(event.data.pentestId);
     }
@@ -968,62 +990,69 @@ export class SecurityPenetrationTestsService {
    * `MAX_ATTEMPTS - 1` times, so transient provider/infra failures are invisible
    * to the customer. Runs after the failure has already been refunded.
    *
-   * Best-effort by design — every exit path swallows errors and returns, so a
-   * retry problem (billing exhausted, provider error, DB blip) can never break
-   * the webhook. The failed run stays refunded and, if no retry materializes,
-   * surfaces to the customer after the lineage's grace window.
+   * The retry slot (`retryTriggeredAt`) is claimed before spawning so the retry
+   * stays idempotent under webhook redelivery. If the spawn itself fails, the
+   * claim is RELEASED and the error rethrown, so the handler returns non-2xx and
+   * Maced redelivers `pentest.failed` — the refund is idempotent (guarded by
+   * `creditRefundedAt`), so redelivery re-attempts only the retry. This makes a
+   * transient spawn failure recoverable instead of permanently consuming the
+   * slot and dropping the retry.
    *
-   * Idempotent: an atomic claim on `retryTriggeredAt` guarantees exactly one
-   * retry per failed attempt even if Maced redelivers the `pentest.failed`
-   * webhook.
+   * Returns without retrying (and without rethrowing) for cases where a retry
+   * legitimately shouldn't happen: orphan run, exhausted lineage, an
+   * already-claimed slot (redelivery or a cancellation block), or unusable
+   * stored params.
    */
   private async maybeAutoRetry(failedProviderRunId: string): Promise<void> {
+    const row = await db.securityPenetrationTestRun.findUnique({
+      where: { providerRunId: failedProviderRunId },
+      select: {
+        organizationId: true,
+        attemptNumber: true,
+        rootRunId: true,
+        scanParams: true,
+      },
+    });
+    if (!row) {
+      this.logger.log(
+        `[Retry] skip run=${failedProviderRunId} (no ownership row — orphan)`,
+      );
+      return;
+    }
+    if (row.attemptNumber >= MAX_ATTEMPTS) {
+      this.logger.log(
+        `[Retry] skip run=${failedProviderRunId} (lineage exhausted, attempt ${row.attemptNumber}/${MAX_ATTEMPTS})`,
+      );
+      return;
+    }
+
+    // Atomic idempotency claim: only the first delivery flips the null marker,
+    // so a redelivered webhook (or a cancellation block) can't spawn a second
+    // retry.
+    const claimed = await db.securityPenetrationTestRun.updateMany({
+      where: { providerRunId: failedProviderRunId, retryTriggeredAt: null },
+      data: { retryTriggeredAt: new Date() },
+    });
+    if (claimed.count === 0) {
+      this.logger.log(
+        `[Retry] skip run=${failedProviderRunId} (retry already triggered or blocked)`,
+      );
+      return;
+    }
+
+    const payload = this.fromScanParams(row.scanParams);
+    if (!payload) {
+      // Params are unusable — a retry can never succeed, so keep the slot
+      // consumed and stop (releasing would just loop forever on redelivery).
+      this.logger.warn(
+        `[Retry] skip run=${failedProviderRunId} (missing/invalid scanParams)`,
+      );
+      return;
+    }
+
+    const rootRunId = row.rootRunId ?? failedProviderRunId;
+    const nextAttempt = row.attemptNumber + 1;
     try {
-      const row = await db.securityPenetrationTestRun.findUnique({
-        where: { providerRunId: failedProviderRunId },
-        select: {
-          organizationId: true,
-          attemptNumber: true,
-          rootRunId: true,
-          scanParams: true,
-        },
-      });
-      if (!row) {
-        this.logger.log(
-          `[Retry] skip run=${failedProviderRunId} (no ownership row — orphan)`,
-        );
-        return;
-      }
-      if (row.attemptNumber >= MAX_ATTEMPTS) {
-        this.logger.log(
-          `[Retry] skip run=${failedProviderRunId} (lineage exhausted, attempt ${row.attemptNumber}/${MAX_ATTEMPTS})`,
-        );
-        return;
-      }
-
-      // Atomic idempotency claim: only the first delivery flips the null
-      // marker, so a redelivered webhook can't spawn a second retry.
-      const claimed = await db.securityPenetrationTestRun.updateMany({
-        where: { providerRunId: failedProviderRunId, retryTriggeredAt: null },
-        data: { retryTriggeredAt: new Date() },
-      });
-      if (claimed.count === 0) {
-        this.logger.log(
-          `[Retry] skip run=${failedProviderRunId} (retry already triggered)`,
-        );
-        return;
-      }
-
-      const payload = this.fromScanParams(row.scanParams);
-      if (!payload) {
-        this.logger.warn(
-          `[Retry] skip run=${failedProviderRunId} (missing/invalid scanParams)`,
-        );
-        return;
-      }
-
-      const rootRunId = row.rootRunId ?? failedProviderRunId;
-      const nextAttempt = row.attemptNumber + 1;
       const retried = await this.createReport(row.organizationId, payload, {
         attemptNumber: nextAttempt,
         rootRunId,
@@ -1033,8 +1062,28 @@ export class SecurityPenetrationTestsService {
         `[Retry] spawned run=${retried.id} attempt=${nextAttempt}/${MAX_ATTEMPTS} root=${rootRunId} from=${failedProviderRunId}`,
       );
     } catch (error) {
+      // Spawn failed — release the claim so a redelivered webhook can retry,
+      // then rethrow so the handler returns non-2xx and Maced redelivers.
+      await this.releaseRetryClaim(failedProviderRunId);
       this.logger.error(
-        `[Retry] auto-retry failed for run=${failedProviderRunId}: ${
+        `[Retry] spawn failed for run=${failedProviderRunId}; released claim for redelivery: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      throw error;
+    }
+  }
+
+  /** Releases a claimed retry slot so a redelivered webhook can retry. */
+  private async releaseRetryClaim(providerRunId: string): Promise<void> {
+    try {
+      await db.securityPenetrationTestRun.updateMany({
+        where: { providerRunId },
+        data: { retryTriggeredAt: null },
+      });
+    } catch (error) {
+      this.logger.error(
+        `[Retry] failed to release retry claim for run=${providerRunId}: ${
           error instanceof Error ? error.message : String(error)
         }`,
       );
@@ -1042,14 +1091,25 @@ export class SecurityPenetrationTestsService {
   }
 
   /**
-   * Marks a run as ineligible for auto-retry by claiming its retry slot. Used
-   * when a run is cancelled so a subsequent late/duplicate `pentest.failed`
-   * cannot restart it. Best-effort and idempotent (only claims a null slot).
+   * Marks a whole lineage as ineligible for auto-retry by claiming the retry
+   * slot on every attempt sharing the cancelled run's root. Used on
+   * cancellation so no `pentest.failed` (for the cancelled run or a sibling)
+   * can spawn a new retry of a deliberately stopped scan, regardless of webhook
+   * arrival order. Best-effort and idempotent (only claims null slots).
+   *
+   * Stops NEW retries; a retry already in flight when the cancel arrives is not
+   * force-cancelled at the provider (bounded — it is refunded and only wastes
+   * compute).
    */
   private async blockAutoRetry(providerRunId: string): Promise<void> {
     try {
+      const row = await db.securityPenetrationTestRun.findUnique({
+        where: { providerRunId },
+        select: { rootRunId: true },
+      });
+      const rootRunId = row?.rootRunId ?? providerRunId;
       await db.securityPenetrationTestRun.updateMany({
-        where: { providerRunId, retryTriggeredAt: null },
+        where: { rootRunId, retryTriggeredAt: null },
         data: { retryTriggeredAt: new Date() },
       });
     } catch (error) {

--- a/apps/api/src/security-penetration-tests/security-penetration-tests.service.ts
+++ b/apps/api/src/security-penetration-tests/security-penetration-tests.service.ts
@@ -298,7 +298,7 @@ export class SecurityPenetrationTestsService {
       { providerRunId: string; attemptNumber: number }
     >();
     for (const row of rows) {
-      const root = row.rootRunId;
+      const root = row.rootRunId ?? row.providerRunId;
       const current = activeByRoot.get(root);
       if (!current || row.attemptNumber > current.attemptNumber) {
         activeByRoot.set(root, {
@@ -1022,7 +1022,7 @@ export class SecurityPenetrationTestsService {
         return;
       }
 
-      const rootRunId = row.rootRunId;
+      const rootRunId = row.rootRunId ?? failedProviderRunId;
       const nextAttempt = row.attemptNumber + 1;
       const retried = await this.createReport(row.organizationId, payload, {
         attemptNumber: nextAttempt,

--- a/apps/api/src/security-penetration-tests/security-penetration-tests.service.ts
+++ b/apps/api/src/security-penetration-tests/security-penetration-tests.service.ts
@@ -610,19 +610,23 @@ export class SecurityPenetrationTestsService {
     organizationId: string,
     id: string,
   ): Promise<PentestProgress> {
-    await this.assertRunOwnership(organizationId, id);
-    const { activeProviderRunId, attemptNumber } =
-      await this.resolveActiveAttempt(organizationId, id);
+    // Resolve via the shared helper so progress reports the SAME collapsed,
+    // grace-based status as getReport — the two endpoints can never contradict
+    // each other for the same run (a failed non-final attempt reads as
+    // in-progress within the grace window, and as failed once it elapses).
+    const { run, activeProviderRunId } = await this.getReportResolved(
+      organizationId,
+      id,
+    );
     const progress = await this.callMaced(
       () => this.macedClient.pentests.progress(activeProviderRunId),
       `fetching penetration test progress ${activeProviderRunId}`,
     );
-    // Mask a failed non-final attempt as in-progress, consistent with
-    // getReport, so progress polled during the retry window doesn't expose an
-    // intermediate failure. getReport owns the grace-based reveal; once it
-    // reveals the failure the client stops polling progress.
-    if (progress.status === 'failed' && attemptNumber < MAX_ATTEMPTS) {
-      return { ...progress, status: 'provisioning' };
+    // The only divergence from progress's own status is the failed↔provisioning
+    // masking that getReport applies (grace-based). Override just those so the
+    // two endpoints agree; every other state already matches.
+    if (run.status === 'failed' || run.status === 'provisioning') {
+      return { ...progress, status: run.status };
     }
     return progress;
   }
@@ -990,18 +994,24 @@ export class SecurityPenetrationTestsService {
    * `MAX_ATTEMPTS - 1` times, so transient provider/infra failures are invisible
    * to the customer. Runs after the failure has already been refunded.
    *
-   * The retry slot (`retryTriggeredAt`) is claimed before spawning so the retry
-   * stays idempotent under webhook redelivery. If the spawn itself fails, the
-   * claim is RELEASED and the error rethrown, so the handler returns non-2xx and
-   * Maced redelivers `pentest.failed` — the refund is idempotent (guarded by
-   * `creditRefundedAt`), so redelivery re-attempts only the retry. This makes a
-   * transient spawn failure recoverable instead of permanently consuming the
-   * slot and dropping the retry.
+   * Idempotency and durability are governed by whether a retry child actually
+   * exists (a row whose `retryOfProviderRunId` is this run), NOT by a mutable
+   * claim:
+   *   - If a child already exists, the retry succeeded on an earlier delivery →
+   *     skip (idempotent under redelivery).
+   *   - If the spawn fails, no child is created, so the error is rethrown; the
+   *     handler returns non-2xx, Maced redelivers, and the next delivery sees no
+   *     child and re-attempts. The refund is idempotent (`creditRefundedAt`), so
+   *     redelivery re-attempts only the retry. A transient spawn/DB failure can
+   *     never permanently strand the retry.
    *
-   * Returns without retrying (and without rethrowing) for cases where a retry
-   * legitimately shouldn't happen: orphan run, exhausted lineage, an
-   * already-claimed slot (redelivery or a cancellation block), or unusable
-   * stored params.
+   * Cancellation is a DISTINCT marker (`retryBlockedAt`, set lineage-wide), so a
+   * late `pentest.failed` for a cancelled scan is always blocked here regardless
+   * of arrival order — it can't be confused with a spawn claim.
+   *
+   * Returns (without rethrowing) when a retry legitimately shouldn't happen:
+   * orphan run, exhausted lineage, cancelled lineage, an existing child, or
+   * unusable stored params.
    */
   private async maybeAutoRetry(failedProviderRunId: string): Promise<void> {
     const row = await db.securityPenetrationTestRun.findUnique({
@@ -1026,31 +1036,49 @@ export class SecurityPenetrationTestsService {
       return;
     }
 
-    // Atomic idempotency claim: only the first delivery flips the null marker,
-    // so a redelivered webhook (or a cancellation block) can't spawn a second
-    // retry.
-    const claimed = await db.securityPenetrationTestRun.updateMany({
-      where: { providerRunId: failedProviderRunId, retryTriggeredAt: null },
-      data: { retryTriggeredAt: new Date() },
+    const rootRunId = row.rootRunId ?? failedProviderRunId;
+
+    // Cancelled lineage → never retry (distinct marker, order-independent).
+    const blocked = await db.securityPenetrationTestRun.findFirst({
+      where: { rootRunId, retryBlockedAt: { not: null } },
+      select: { providerRunId: true },
     });
-    if (claimed.count === 0) {
+    if (blocked) {
       this.logger.log(
-        `[Retry] skip run=${failedProviderRunId} (retry already triggered or blocked)`,
+        `[Retry] skip run=${failedProviderRunId} (lineage cancelled)`,
+      );
+      return;
+    }
+
+    // Idempotency: if a retry child already exists, an earlier delivery already
+    // spawned it — nothing to do.
+    const existingChild = await db.securityPenetrationTestRun.findFirst({
+      where: { retryOfProviderRunId: failedProviderRunId },
+      select: { providerRunId: true },
+    });
+    if (existingChild) {
+      this.logger.log(
+        `[Retry] skip run=${failedProviderRunId} (retry child ${existingChild.providerRunId} already exists)`,
       );
       return;
     }
 
     const payload = this.fromScanParams(row.scanParams);
     if (!payload) {
-      // Params are unusable — a retry can never succeed, so keep the slot
-      // consumed and stop (releasing would just loop forever on redelivery).
       this.logger.warn(
         `[Retry] skip run=${failedProviderRunId} (missing/invalid scanParams)`,
       );
       return;
     }
 
-    const rootRunId = row.rootRunId ?? failedProviderRunId;
+    // Record when the retry was initiated (informational only).
+    await db.securityPenetrationTestRun
+      .updateMany({
+        where: { providerRunId: failedProviderRunId },
+        data: { retryTriggeredAt: new Date() },
+      })
+      .catch(() => undefined);
+
     const nextAttempt = row.attemptNumber + 1;
     try {
       const retried = await this.createReport(row.organizationId, payload, {
@@ -1062,11 +1090,10 @@ export class SecurityPenetrationTestsService {
         `[Retry] spawned run=${retried.id} attempt=${nextAttempt}/${MAX_ATTEMPTS} root=${rootRunId} from=${failedProviderRunId}`,
       );
     } catch (error) {
-      // Spawn failed — release the claim so a redelivered webhook can retry,
-      // then rethrow so the handler returns non-2xx and Maced redelivers.
-      await this.releaseRetryClaim(failedProviderRunId);
+      // No child was created, so rethrow: the handler 5xx's, Maced redelivers,
+      // and the next delivery sees no child and re-attempts. Nothing to release.
       this.logger.error(
-        `[Retry] spawn failed for run=${failedProviderRunId}; released claim for redelivery: ${
+        `[Retry] spawn failed for run=${failedProviderRunId}; will retry on redelivery: ${
           error instanceof Error ? error.message : String(error)
         }`,
       );
@@ -1074,28 +1101,11 @@ export class SecurityPenetrationTestsService {
     }
   }
 
-  /** Releases a claimed retry slot so a redelivered webhook can retry. */
-  private async releaseRetryClaim(providerRunId: string): Promise<void> {
-    try {
-      await db.securityPenetrationTestRun.updateMany({
-        where: { providerRunId },
-        data: { retryTriggeredAt: null },
-      });
-    } catch (error) {
-      this.logger.error(
-        `[Retry] failed to release retry claim for run=${providerRunId}: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-    }
-  }
-
   /**
-   * Marks a whole lineage as ineligible for auto-retry by claiming the retry
-   * slot on every attempt sharing the cancelled run's root. Used on
-   * cancellation so no `pentest.failed` (for the cancelled run or a sibling)
-   * can spawn a new retry of a deliberately stopped scan, regardless of webhook
-   * arrival order. Best-effort and idempotent (only claims null slots).
+   * Marks a whole lineage as cancelled (via the distinct `retryBlockedAt`
+   * marker) so no `pentest.failed` — for the cancelled run or any sibling — can
+   * spawn a retry of a deliberately stopped scan, regardless of webhook arrival
+   * order. Best-effort.
    *
    * Stops NEW retries; a retry already in flight when the cancel arrives is not
    * force-cancelled at the provider (bounded — it is refunded and only wastes
@@ -1109,8 +1119,8 @@ export class SecurityPenetrationTestsService {
       });
       const rootRunId = row?.rootRunId ?? providerRunId;
       await db.securityPenetrationTestRun.updateMany({
-        where: { rootRunId, retryTriggeredAt: null },
-        data: { retryTriggeredAt: new Date() },
+        where: { rootRunId, retryBlockedAt: null },
+        data: { retryBlockedAt: new Date() },
       });
     } catch (error) {
       this.logger.error(
@@ -1294,7 +1304,11 @@ export class SecurityPenetrationTestsService {
       const checks = raw.checks.filter((check): check is PentestCheck =>
         this.isPentestCheck(check),
       );
-      if (checks.length === raw.checks.length) dto.checks = checks;
+      // Keep whatever survived validation rather than dropping the whole
+      // selection if a single entry is stale (e.g. a check enum value removed
+      // between deploys) — a retry with the valid subset beats silently
+      // running the full default check set.
+      if (checks.length > 0) dto.checks = checks;
     }
     if (typeof raw.additionalContext === 'string') {
       dto.additionalContext = raw.additionalContext;

--- a/apps/api/src/security-penetration-tests/security-penetration-tests.service.ts
+++ b/apps/api/src/security-penetration-tests/security-penetration-tests.service.ts
@@ -841,9 +841,11 @@ export class SecurityPenetrationTestsService {
       await this.maybeAutoRetry(event.data.pentestId);
     }
 
-    // A cancellation is terminal. Pre-claim the retry slot so a late or
+    // A cancellation is terminal. Record a lineage-wide block so a late or
     // duplicate `pentest.failed` for the same run (arriving after the cancel)
-    // can never spawn a retry of a scan that was deliberately stopped.
+    // can never spawn a retry of a scan that was deliberately stopped. If the
+    // block can't be stored, this throws so Maced redelivers the cancellation
+    // until it sticks (the refund above already ran and is idempotent).
     if (event.type === 'pentest.cancelled') {
       await this.blockAutoRetry(event.data.pentestId);
     }
@@ -1110,25 +1112,23 @@ export class SecurityPenetrationTestsService {
    * Stops NEW retries; a retry already in flight when the cancel arrives is not
    * force-cancelled at the provider (bounded — it is refunded and only wastes
    * compute).
+   *
+   * Errors are NOT swallowed: if recording the block fails, it propagates so the
+   * handler returns non-2xx and Maced redelivers the cancellation until the
+   * block is durably stored (mirrors the refund/retry durability pattern). The
+   * refund runs first and is idempotent, so redelivery is safe. Without this, a
+   * lost block could let a later `pentest.failed` retry a cancelled scan.
    */
   private async blockAutoRetry(providerRunId: string): Promise<void> {
-    try {
-      const row = await db.securityPenetrationTestRun.findUnique({
-        where: { providerRunId },
-        select: { rootRunId: true },
-      });
-      const rootRunId = row?.rootRunId ?? providerRunId;
-      await db.securityPenetrationTestRun.updateMany({
-        where: { rootRunId, retryBlockedAt: null },
-        data: { retryBlockedAt: new Date() },
-      });
-    } catch (error) {
-      this.logger.error(
-        `[Retry] failed to block retry for cancelled run=${providerRunId}: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-    }
+    const row = await db.securityPenetrationTestRun.findUnique({
+      where: { providerRunId },
+      select: { rootRunId: true },
+    });
+    const rootRunId = row?.rootRunId ?? providerRunId;
+    await db.securityPenetrationTestRun.updateMany({
+      where: { rootRunId, retryBlockedAt: null },
+      data: { retryBlockedAt: new Date() },
+    });
   }
 
   private formatDurationMs(ms: number): string {

--- a/apps/api/src/security-penetration-tests/security-penetration-tests.service.ts
+++ b/apps/api/src/security-penetration-tests/security-penetration-tests.service.ts
@@ -6,7 +6,7 @@ import {
   Injectable,
   Logger,
 } from '@nestjs/common';
-import { db } from '@db';
+import { db, Prisma } from '@db';
 import {
   createMacedClient,
   MacedApiError,
@@ -43,6 +43,12 @@ import {
   type ReportContextNote,
 } from './report-appendix.util';
 import { PentestCreditsService } from './pentest-credits.service';
+import { toCustomerFacingError } from './pentest-run-error.util';
+import {
+  collapsedStatus,
+  MAX_ATTEMPTS,
+  type PentestRunStatus,
+} from './pentest-lineage.util';
 
 /**
  * Drops events that mention our infrastructure provider in any string
@@ -133,6 +139,47 @@ type CreatePentestBodyWithScanProfile = CreatePentestBody & {
   scanDepth?: ScanDepth;
   evidenceLevel?: EvidenceLevel;
   checks?: PentestCheck[];
+};
+
+/**
+ * Where a run sits in its retry lineage. Originals use the default
+ * (`attemptNumber: 1`, no parent, `rootRunId: null` → resolved to the run's
+ * own providerRunId once Maced assigns it). Auto-retries pass the inherited
+ * root and incremented attempt number.
+ */
+interface RunLineage {
+  attemptNumber: number;
+  rootRunId: string | null;
+  retryOfProviderRunId: string | null;
+}
+
+/** Lineage fields persisted on the ownership row (rootRunId resolved). */
+interface OwnershipLineage {
+  rootRunId: string;
+  attemptNumber: number;
+  retryOfProviderRunId: string | null;
+  scanParams: RetryScanParams;
+}
+
+/**
+ * The subset of a create request needed to faithfully re-run a scan. Stored on
+ * the ownership row so an auto-retry reconstructs the request from our own DB.
+ * Excludes `additionalContext` (regenerated from finding-context notes) and
+ * `webhookUrl` (re-resolved to our endpoint).
+ */
+interface RetryScanParams {
+  targetUrl: string;
+  repoUrl?: string;
+  testMode?: boolean;
+  scanDepth?: ScanDepth;
+  evidenceLevel?: EvidenceLevel;
+  checks?: PentestCheck[];
+}
+
+const ORIGINAL_RUN_LINEAGE: RunLineage = {
+  attemptNumber: 1,
+  rootRunId: null,
+  retryOfProviderRunId: null,
 };
 
 @Injectable()
@@ -232,24 +279,59 @@ export class SecurityPenetrationTestsService {
   async listReports(
     organizationId: string,
   ): Promise<SecurityPenetrationTest[]> {
-    const ownedRunIds = await this.listOwnedRunIds(organizationId);
-    if (ownedRunIds.size === 0) {
+    const rows = await db.securityPenetrationTestRun.findMany({
+      where: { organizationId },
+      select: { providerRunId: true, rootRunId: true, attemptNumber: true },
+    });
+    if (rows.length === 0) {
       return [];
+    }
+
+    // Collapse each lineage to its active (highest-numbered) attempt so the
+    // customer sees one entry per scan — retries never appear as separate rows.
+    const activeByRoot = new Map<
+      string,
+      { providerRunId: string; attemptNumber: number }
+    >();
+    for (const row of rows) {
+      const root = row.rootRunId ?? row.providerRunId;
+      const current = activeByRoot.get(root);
+      if (!current || row.attemptNumber > current.attemptNumber) {
+        activeByRoot.set(root, {
+          providerRunId: row.providerRunId,
+          attemptNumber: row.attemptNumber,
+        });
+      }
     }
 
     const reports = await this.callMaced(
       () => this.macedClient.pentests.list(),
       'listing penetration tests',
     );
+    const reportById = new Map(reports.map((report) => [report.id, report]));
 
-    return reports
-      .filter((report) => ownedRunIds.has(report.id))
-      .map((report) => this.mapMacedRunToSecurityPenetrationTest(report));
+    const result: SecurityPenetrationTest[] = [];
+    for (const [rootRunId, active] of activeByRoot) {
+      const report = reportById.get(active.providerRunId);
+      // The provider may not know a just-created run yet, or may have pruned
+      // it — skip rather than surface a half-populated row.
+      if (!report) continue;
+      result.push(
+        this.collapseRun(report, {
+          rootRunId,
+          attemptNumber: active.attemptNumber,
+        }),
+      );
+    }
+    return result;
   }
 
   async createReport(
     organizationId: string,
     payload: CreatePenetrationTestDto,
+    // Internal: set by the auto-retry path to link a new run into an existing
+    // lineage. User-initiated creates use the original-run default.
+    lineage: RunLineage = ORIGINAL_RUN_LINEAGE,
   ): Promise<SecurityPenetrationTest> {
     const resolvedWebhookUrl = this.resolveWebhookUrl(payload.webhookUrl);
     // Resolved before the billing reservation so a DB failure here can't
@@ -400,6 +482,13 @@ export class SecurityPenetrationTestsService {
       organizationId,
       providerRunId,
       consumedSubscriptionAllowance ? billingUsageSourceId : null,
+      {
+        // An original run is its own lineage root; a retry inherits it.
+        rootRunId: lineage.rootRunId ?? providerRunId,
+        attemptNumber: lineage.attemptNumber,
+        retryOfProviderRunId: lineage.retryOfProviderRunId,
+        scanParams: this.toScanParams(payload),
+      },
     );
     if (!ownershipPersisted) {
       // We debited and Maced created the run, but our DB rejected the
@@ -487,11 +576,13 @@ export class SecurityPenetrationTestsService {
     id: string,
   ): Promise<SecurityPenetrationTest> {
     await this.assertRunOwnership(organizationId, id);
+    const { rootRunId, activeProviderRunId, attemptNumber } =
+      await this.resolveActiveAttempt(organizationId, id);
     const report = await this.callMaced(
-      () => this.macedClient.pentests.get(id),
-      `fetching penetration test ${id}`,
+      () => this.macedClient.pentests.get(activeProviderRunId),
+      `fetching penetration test ${activeProviderRunId}`,
     );
-    return this.mapMacedRunToSecurityPenetrationTest(report);
+    return this.collapseRun(report, { rootRunId, attemptNumber });
   }
 
   async getReportProgress(
@@ -499,17 +590,25 @@ export class SecurityPenetrationTestsService {
     id: string,
   ): Promise<PentestProgress> {
     await this.assertRunOwnership(organizationId, id);
+    const { activeProviderRunId } = await this.resolveActiveAttempt(
+      organizationId,
+      id,
+    );
     return this.callMaced(
-      () => this.macedClient.pentests.progress(id),
-      `fetching penetration test progress ${id}`,
+      () => this.macedClient.pentests.progress(activeProviderRunId),
+      `fetching penetration test progress ${activeProviderRunId}`,
     );
   }
 
   async getReportIssues(organizationId: string, id: string): Promise<Issue[]> {
     await this.assertRunOwnership(organizationId, id);
+    const { activeProviderRunId } = await this.resolveActiveAttempt(
+      organizationId,
+      id,
+    );
     return this.callMaced(
-      () => this.macedClient.pentests.issues(id),
-      `fetching penetration test issues ${id}`,
+      () => this.macedClient.pentests.issues(activeProviderRunId),
+      `fetching penetration test issues ${activeProviderRunId}`,
     );
   }
 
@@ -518,9 +617,13 @@ export class SecurityPenetrationTestsService {
     id: string,
   ): Promise<PentestEvent[]> {
     await this.assertRunOwnership(organizationId, id);
+    const { activeProviderRunId } = await this.resolveActiveAttempt(
+      organizationId,
+      id,
+    );
     const events = await this.callMaced(
-      () => this.macedClient.pentests.events(id),
-      `fetching penetration test events ${id}`,
+      () => this.macedClient.pentests.events(activeProviderRunId),
+      `fetching penetration test events ${activeProviderRunId}`,
     );
     // Filter at the API layer (defense in depth) — a UI-only filter
     // would leave Maced-internal tool names (`mcp__maced-helper__*`)
@@ -536,10 +639,14 @@ export class SecurityPenetrationTestsService {
     id: string,
   ): Promise<BinaryArtifact> {
     const run = await this.getReport(organizationId, id);
+    const { activeProviderRunId } = await this.resolveActiveAttempt(
+      organizationId,
+      id,
+    );
 
     const report = await this.callMaced(
-      () => this.macedClient.pentests.report(id),
-      `fetching penetration test report ${id}`,
+      () => this.macedClient.pentests.report(activeProviderRunId),
+      `fetching penetration test report ${activeProviderRunId}`,
     );
 
     const notes = await this.findContextNotesQuietly(
@@ -563,10 +670,14 @@ export class SecurityPenetrationTestsService {
     id: string,
   ): Promise<BinaryArtifact> {
     const run = await this.getReport(organizationId, id);
+    const { activeProviderRunId } = await this.resolveActiveAttempt(
+      organizationId,
+      id,
+    );
 
     const blob = await this.callMaced(
-      () => this.macedClient.pentests.reportPdf(id),
-      `fetching penetration test PDF ${id}`,
+      () => this.macedClient.pentests.reportPdf(activeProviderRunId),
+      `fetching penetration test PDF ${activeProviderRunId}`,
     );
 
     const original = Buffer.from(await blob.arrayBuffer());
@@ -688,6 +799,16 @@ export class SecurityPenetrationTestsService {
     // customer would silently lose their credit.
     if (event.type === 'pentest.failed' || event.type === 'pentest.cancelled') {
       await this.refundOnTerminalFailure(event.data.pentestId, event.type);
+    }
+
+    // Auto-retry transient failures so customers never see intermediate
+    // failures. Only `pentest.failed` — a `pentest.cancelled` is a deliberate
+    // stop (staff cancels a run and it's refunded) and must never be re-run.
+    // Best-effort: `maybeAutoRetry` never throws, so a retry hiccup can't stop
+    // this handler from returning 200 (which would make Maced redeliver and
+    // re-refund).
+    if (event.type === 'pentest.failed') {
+      await this.maybeAutoRetry(event.data.pentestId);
     }
 
     // Successful completion deserves its own audit-log row so the
@@ -831,6 +952,84 @@ export class SecurityPenetrationTestsService {
     });
   }
 
+  /**
+   * Automatically re-runs a failed scan with the same parameters, up to
+   * `MAX_ATTEMPTS - 1` times, so transient provider/infra failures are invisible
+   * to the customer. Runs after the failure has already been refunded.
+   *
+   * Best-effort by design — every exit path swallows errors and returns, so a
+   * retry problem (billing exhausted, provider error, DB blip) can never break
+   * the webhook. The failed run stays refunded and, if no retry materializes,
+   * surfaces to the customer after the lineage's grace window.
+   *
+   * Idempotent: an atomic claim on `retryTriggeredAt` guarantees exactly one
+   * retry per failed attempt even if Maced redelivers the `pentest.failed`
+   * webhook.
+   */
+  private async maybeAutoRetry(failedProviderRunId: string): Promise<void> {
+    try {
+      const row = await db.securityPenetrationTestRun.findUnique({
+        where: { providerRunId: failedProviderRunId },
+        select: {
+          organizationId: true,
+          attemptNumber: true,
+          rootRunId: true,
+          scanParams: true,
+        },
+      });
+      if (!row) {
+        this.logger.log(
+          `[Retry] skip run=${failedProviderRunId} (no ownership row — orphan)`,
+        );
+        return;
+      }
+      if (row.attemptNumber >= MAX_ATTEMPTS) {
+        this.logger.log(
+          `[Retry] skip run=${failedProviderRunId} (lineage exhausted, attempt ${row.attemptNumber}/${MAX_ATTEMPTS})`,
+        );
+        return;
+      }
+
+      // Atomic idempotency claim: only the first delivery flips the null
+      // marker, so a redelivered webhook can't spawn a second retry.
+      const claimed = await db.securityPenetrationTestRun.updateMany({
+        where: { providerRunId: failedProviderRunId, retryTriggeredAt: null },
+        data: { retryTriggeredAt: new Date() },
+      });
+      if (claimed.count === 0) {
+        this.logger.log(
+          `[Retry] skip run=${failedProviderRunId} (retry already triggered)`,
+        );
+        return;
+      }
+
+      const payload = this.fromScanParams(row.scanParams);
+      if (!payload) {
+        this.logger.warn(
+          `[Retry] skip run=${failedProviderRunId} (missing/invalid scanParams)`,
+        );
+        return;
+      }
+
+      const rootRunId = row.rootRunId ?? failedProviderRunId;
+      const nextAttempt = row.attemptNumber + 1;
+      const retried = await this.createReport(row.organizationId, payload, {
+        attemptNumber: nextAttempt,
+        rootRunId,
+        retryOfProviderRunId: failedProviderRunId,
+      });
+      this.logger.log(
+        `[Retry] spawned run=${retried.id} attempt=${nextAttempt}/${MAX_ATTEMPTS} root=${rootRunId} from=${failedProviderRunId}`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `[Retry] auto-retry failed for run=${failedProviderRunId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+
   private formatDurationMs(ms: number): string {
     const totalMin = Math.max(Math.round(ms / 60_000), 0);
     const hours = Math.floor(totalMin / 60);
@@ -889,6 +1088,41 @@ export class SecurityPenetrationTestsService {
     };
   }
 
+  /**
+   * Maps a provider run into a customer-facing run for a lineage: applies the
+   * collapsed status (masking a failed non-final attempt as in-progress),
+   * pins the id to the stable lineage root, and — only when a genuine, final
+   * failure is revealed — replaces the raw provider error with a clean,
+   * white-labeled message. The active (highest) attempt is authoritative
+   * because we only ever retry `failed` runs.
+   */
+  private collapseRun(
+    report: Pentest | PentestWithProgress,
+    ctx: { rootRunId: string; attemptNumber: number },
+  ): SecurityPenetrationTest {
+    const mapped = this.mapMacedRunToSecurityPenetrationTest(report);
+    const activeStatus: PentestRunStatus = mapped.status;
+    const parsedFailedAt =
+      activeStatus === 'failed' && mapped.updatedAt
+        ? Date.parse(mapped.updatedAt)
+        : NaN;
+    const status = collapsedStatus({
+      activeStatus,
+      attemptNumber: ctx.attemptNumber,
+      failedAtMs: Number.isNaN(parsedFailedAt) ? null : parsedFailedAt,
+      nowMs: Date.now(),
+    });
+    const customerError =
+      status === 'failed' ? toCustomerFacingError(mapped.error) : null;
+    return {
+      ...mapped,
+      id: ctx.rootRunId,
+      status,
+      error: customerError,
+      failedReason: customerError,
+    };
+  }
+
   private getScanProfileFields(
     report: Pentest | PentestWithProgress | PentestCreated,
   ): Pick<SecurityPenetrationTest, 'scanDepth' | 'evidenceLevel' | 'checks'> {
@@ -918,6 +1152,51 @@ export class SecurityPenetrationTestsService {
     }
 
     return fields;
+  }
+
+  /**
+   * Extracts the re-runnable scan parameters from a create request, to persist
+   * on the ownership row for a future auto-retry. Only defined fields are
+   * included so the stored JSON stays clean.
+   */
+  private toScanParams(payload: CreatePenetrationTestDto): RetryScanParams {
+    const params: RetryScanParams = { targetUrl: payload.targetUrl };
+    if (payload.repoUrl !== undefined) params.repoUrl = payload.repoUrl;
+    if (payload.testMode !== undefined) params.testMode = payload.testMode;
+    if (payload.scanDepth !== undefined) params.scanDepth = payload.scanDepth;
+    if (payload.evidenceLevel !== undefined) {
+      params.evidenceLevel = payload.evidenceLevel;
+    }
+    if (payload.checks !== undefined) params.checks = payload.checks;
+    return params;
+  }
+
+  /**
+   * Rebuilds a create DTO from persisted scanParams for an auto-retry, reusing
+   * the same type guards as the provider-response mapping. Returns null when
+   * the stored value is missing or malformed (retry is then skipped).
+   */
+  private fromScanParams(
+    raw: Prisma.JsonValue | null | undefined,
+  ): CreatePenetrationTestDto | null {
+    if (!this.isRecord(raw)) return null;
+    const targetUrl = raw.targetUrl;
+    if (typeof targetUrl !== 'string') return null;
+
+    const dto: CreatePenetrationTestDto = { targetUrl };
+    if (typeof raw.repoUrl === 'string') dto.repoUrl = raw.repoUrl;
+    if (typeof raw.testMode === 'boolean') dto.testMode = raw.testMode;
+    if (this.isScanDepth(raw.scanDepth)) dto.scanDepth = raw.scanDepth;
+    if (this.isEvidenceLevel(raw.evidenceLevel)) {
+      dto.evidenceLevel = raw.evidenceLevel;
+    }
+    if (Array.isArray(raw.checks)) {
+      const checks = raw.checks.filter((check): check is PentestCheck =>
+        this.isPentestCheck(check),
+      );
+      if (checks.length === raw.checks.length) dto.checks = checks;
+    }
+    return dto;
   }
 
   private isScanDepth(value: unknown): value is ScanDepth {
@@ -1136,6 +1415,7 @@ export class SecurityPenetrationTestsService {
     organizationId: string,
     reportId: string,
     billingUsageSourceId: string | null,
+    lineage: OwnershipLineage,
   ): Promise<void> {
     // Defensive: if a row already exists for this providerRunId, do NOT
     // overwrite its organizationId. Maced generates unique providerRunIds
@@ -1153,6 +1433,12 @@ export class SecurityPenetrationTestsService {
         organizationId,
         providerRunId: reportId,
         billingUsageSourceId,
+        rootRunId: lineage.rootRunId,
+        attemptNumber: lineage.attemptNumber,
+        retryOfProviderRunId: lineage.retryOfProviderRunId,
+        // Cast at the DB boundary: RetryScanParams is a flat, JSON-safe object,
+        // but its optional fields aren't assignable to InputJsonValue directly.
+        scanParams: lineage.scanParams as unknown as Prisma.InputJsonValue,
       },
       update: {},
     });
@@ -1162,6 +1448,7 @@ export class SecurityPenetrationTestsService {
     organizationId: string,
     reportId: string,
     billingUsageSourceId: string | null,
+    lineage: OwnershipLineage,
   ): Promise<boolean> {
     for (let attempt = 1; attempt <= 3; attempt += 1) {
       try {
@@ -1169,6 +1456,7 @@ export class SecurityPenetrationTestsService {
           organizationId,
           reportId,
           billingUsageSourceId,
+          lineage,
         );
         return true;
       } catch (error) {
@@ -1180,6 +1468,38 @@ export class SecurityPenetrationTestsService {
     }
 
     return false;
+  }
+
+  /**
+   * Resolves any attempt id in a lineage to the currently active (highest
+   * attemptNumber) attempt, so reads always follow retries. Callers use the
+   * returned `activeProviderRunId` for provider calls and `rootRunId` as the
+   * stable customer-facing id. Coalesces a null `rootRunId` (legacy row) to the
+   * requested id so pre-feature runs resolve to themselves.
+   */
+  private async resolveActiveAttempt(
+    organizationId: string,
+    requestedId: string,
+  ): Promise<{
+    rootRunId: string;
+    activeProviderRunId: string;
+    attemptNumber: number;
+  }> {
+    const row = await db.securityPenetrationTestRun.findUnique({
+      where: { providerRunId: requestedId },
+      select: { rootRunId: true },
+    });
+    const rootRunId = row?.rootRunId ?? requestedId;
+    const active = await db.securityPenetrationTestRun.findFirst({
+      where: { organizationId, rootRunId },
+      orderBy: { attemptNumber: 'desc' },
+      select: { providerRunId: true, attemptNumber: true },
+    });
+    return {
+      rootRunId,
+      activeProviderRunId: active?.providerRunId ?? requestedId,
+      attemptNumber: active?.attemptNumber ?? 1,
+    };
   }
 
   private async assertRunOwnership(
@@ -1219,20 +1539,6 @@ export class SecurityPenetrationTestsService {
     }
 
     return marker.organizationId;
-  }
-
-  private async listOwnedRunIds(organizationId: string): Promise<Set<string>> {
-    const markers =
-      (await db.securityPenetrationTestRun.findMany({
-        where: {
-          organizationId,
-        },
-        select: {
-          providerRunId: true,
-        },
-      })) ?? [];
-
-    return new Set(markers.map(({ providerRunId }) => providerRunId));
   }
 
   private isCompWebhookUrl(value: string): boolean {

--- a/apps/api/src/security-penetration-tests/security-penetration-tests.service.ts
+++ b/apps/api/src/security-penetration-tests/security-penetration-tests.service.ts
@@ -164,16 +164,20 @@ interface OwnershipLineage {
 /**
  * The subset of a create request needed to faithfully re-run a scan. Stored on
  * the ownership row so an auto-retry reconstructs the request from our own DB.
- * Excludes `additionalContext` (regenerated from finding-context notes) and
- * `webhookUrl` (re-resolved to our endpoint).
+ * `additionalContext` here is the caller's original free-text briefing only —
+ * on retry it is passed back through `resolveAdditionalContext`, which re-adds
+ * the target's finding-context notes. `webhookUrl` is excluded (re-resolved to
+ * our endpoint).
  */
 interface RetryScanParams {
   targetUrl: string;
   repoUrl?: string;
+  pipelineTesting?: boolean;
   testMode?: boolean;
   scanDepth?: ScanDepth;
   evidenceLevel?: EvidenceLevel;
   checks?: PentestCheck[];
+  additionalContext?: string;
 }
 
 const ORIGINAL_RUN_LINEAGE: RunLineage = {
@@ -294,7 +298,7 @@ export class SecurityPenetrationTestsService {
       { providerRunId: string; attemptNumber: number }
     >();
     for (const row of rows) {
-      const root = row.rootRunId ?? row.providerRunId;
+      const root = row.rootRunId;
       const current = activeByRoot.get(root);
       if (!current || row.attemptNumber > current.attemptNumber) {
         activeByRoot.set(root, {
@@ -811,6 +815,13 @@ export class SecurityPenetrationTestsService {
       await this.maybeAutoRetry(event.data.pentestId);
     }
 
+    // A cancellation is terminal. Pre-claim the retry slot so a late or
+    // duplicate `pentest.failed` for the same run (arriving after the cancel)
+    // can never spawn a retry of a scan that was deliberately stopped.
+    if (event.type === 'pentest.cancelled') {
+      await this.blockAutoRetry(event.data.pentestId);
+    }
+
     // Successful completion deserves its own audit-log row so the
     // run's lifecycle is durably recorded ("scan completed for X with N
     // findings"). Without this the audit log shows the create but not
@@ -1011,7 +1022,7 @@ export class SecurityPenetrationTestsService {
         return;
       }
 
-      const rootRunId = row.rootRunId ?? failedProviderRunId;
+      const rootRunId = row.rootRunId;
       const nextAttempt = row.attemptNumber + 1;
       const retried = await this.createReport(row.organizationId, payload, {
         attemptNumber: nextAttempt,
@@ -1024,6 +1035,26 @@ export class SecurityPenetrationTestsService {
     } catch (error) {
       this.logger.error(
         `[Retry] auto-retry failed for run=${failedProviderRunId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+
+  /**
+   * Marks a run as ineligible for auto-retry by claiming its retry slot. Used
+   * when a run is cancelled so a subsequent late/duplicate `pentest.failed`
+   * cannot restart it. Best-effort and idempotent (only claims a null slot).
+   */
+  private async blockAutoRetry(providerRunId: string): Promise<void> {
+    try {
+      await db.securityPenetrationTestRun.updateMany({
+        where: { providerRunId, retryTriggeredAt: null },
+        data: { retryTriggeredAt: new Date() },
+      });
+    } catch (error) {
+      this.logger.error(
+        `[Retry] failed to block retry for cancelled run=${providerRunId}: ${
           error instanceof Error ? error.message : String(error)
         }`,
       );
@@ -1162,12 +1193,18 @@ export class SecurityPenetrationTestsService {
   private toScanParams(payload: CreatePenetrationTestDto): RetryScanParams {
     const params: RetryScanParams = { targetUrl: payload.targetUrl };
     if (payload.repoUrl !== undefined) params.repoUrl = payload.repoUrl;
+    if (payload.pipelineTesting !== undefined) {
+      params.pipelineTesting = payload.pipelineTesting;
+    }
     if (payload.testMode !== undefined) params.testMode = payload.testMode;
     if (payload.scanDepth !== undefined) params.scanDepth = payload.scanDepth;
     if (payload.evidenceLevel !== undefined) {
       params.evidenceLevel = payload.evidenceLevel;
     }
     if (payload.checks !== undefined) params.checks = payload.checks;
+    if (payload.additionalContext !== undefined) {
+      params.additionalContext = payload.additionalContext;
+    }
     return params;
   }
 
@@ -1185,6 +1222,9 @@ export class SecurityPenetrationTestsService {
 
     const dto: CreatePenetrationTestDto = { targetUrl };
     if (typeof raw.repoUrl === 'string') dto.repoUrl = raw.repoUrl;
+    if (typeof raw.pipelineTesting === 'boolean') {
+      dto.pipelineTesting = raw.pipelineTesting;
+    }
     if (typeof raw.testMode === 'boolean') dto.testMode = raw.testMode;
     if (this.isScanDepth(raw.scanDepth)) dto.scanDepth = raw.scanDepth;
     if (this.isEvidenceLevel(raw.evidenceLevel)) {
@@ -1195,6 +1235,9 @@ export class SecurityPenetrationTestsService {
         this.isPentestCheck(check),
       );
       if (checks.length === raw.checks.length) dto.checks = checks;
+    }
+    if (typeof raw.additionalContext === 'string') {
+      dto.additionalContext = raw.additionalContext;
     }
     return dto;
   }

--- a/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/FailedDetail.tsx
+++ b/apps/app/src/app/(app)/[orgId]/security/penetration-tests/_components/FailedDetail.tsx
@@ -1,8 +1,8 @@
 'use client';
 
+import type { PentestRun } from '@/lib/security/penetration-tests-client';
 import { Button } from '@trycompai/design-system';
 import { Renew, Warning } from '@trycompai/design-system/icons';
-import type { PentestRun } from '@/lib/security/penetration-tests-client';
 import { formatReportDate } from '../lib';
 import { StatusPill } from './StatusPill';
 
@@ -20,13 +20,9 @@ export function FailedDetail({ run, onRetry }: FailedDetailProps) {
         <header className="space-y-3">
           <div className="flex items-center gap-3">
             <StatusPill status={run.status} />
-            <span className="font-mono text-xs text-muted-foreground">
-              {run.id}
-            </span>
+            <span className="font-mono text-xs text-muted-foreground">{run.id}</span>
           </div>
-          <h1 className="truncate text-[26px] font-medium tracking-[-0.02em]">
-            {run.targetUrl}
-          </h1>
+          <h1 className="truncate text-[26px] font-medium tracking-[-0.02em]">{run.targetUrl}</h1>
           <div className="flex flex-wrap gap-x-6 gap-y-1 text-xs text-muted-foreground">
             <span>Started {formatReportDate(run.createdAt)}</span>
             <span>Failed {formatReportDate(run.updatedAt)}</span>
@@ -40,21 +36,9 @@ export function FailedDetail({ run, onRetry }: FailedDetailProps) {
               <div className="text-[11px] font-bold uppercase tracking-[0.08em] text-destructive">
                 Run error
               </div>
-              <p className="font-mono text-sm text-destructive">{reason}</p>
+              <p className="text-sm leading-relaxed text-destructive">{reason}</p>
             </div>
           </div>
-        </div>
-
-        <div className="rounded-[var(--radius)] border border-border p-5">
-          <div className="text-[11px] font-bold uppercase tracking-[0.08em] text-muted-foreground">
-            Common causes
-          </div>
-          <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-muted-foreground">
-            <li>Target resolves to a non-routable IP (VPN not connected)</li>
-            <li>Your IP wasn't allowlisted on the target's WAF / CDN</li>
-            <li>Authentication flow requires credentials the scanner wasn't given</li>
-            <li>Workflow exceeded the runtime cap (typically ~12 hours)</li>
-          </ul>
         </div>
 
         {onRetry ? (

--- a/packages/db/prisma/migrations/20260714001700_pentest_auto_retry_lineage/migration.sql
+++ b/packages/db/prisma/migrations/20260714001700_pentest_auto_retry_lineage/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable
+ALTER TABLE "security_penetration_test_runs" ADD COLUMN     "attempt_number" INTEGER NOT NULL DEFAULT 1,
+ADD COLUMN     "retry_of_provider_run_id" TEXT,
+ADD COLUMN     "retry_triggered_at" TIMESTAMP(3),
+ADD COLUMN     "root_run_id" TEXT,
+ADD COLUMN     "scan_params" JSONB;
+
+-- CreateIndex
+CREATE INDEX "security_penetration_test_runs_root_run_id_idx" ON "security_penetration_test_runs"("root_run_id");

--- a/packages/db/prisma/migrations/20260714001815_backfill_pentest_lineage_root/migration.sql
+++ b/packages/db/prisma/migrations/20260714001815_backfill_pentest_lineage_root/migration.sql
@@ -1,0 +1,7 @@
+-- Backfill lineage root for pre-existing pentest runs.
+-- Every run that existed before the auto-retry feature is its own lineage
+-- root (attempt 1, no retries), so set root_run_id = provider_run_id where
+-- it was not populated. attempt_number already defaults to 1.
+UPDATE "security_penetration_test_runs"
+SET "root_run_id" = "provider_run_id"
+WHERE "root_run_id" IS NULL;

--- a/packages/db/prisma/migrations/20260714004223_pentest_lineage_root_not_null/migration.sql
+++ b/packages/db/prisma/migrations/20260714004223_pentest_lineage_root_not_null/migration.sql
@@ -1,8 +1,0 @@
-/*
-  Warnings:
-
-  - Made the column `root_run_id` on table `security_penetration_test_runs` required. This step will fail if there are existing NULL values in that column.
-
-*/
--- AlterTable
-ALTER TABLE "security_penetration_test_runs" ALTER COLUMN "root_run_id" SET NOT NULL;

--- a/packages/db/prisma/migrations/20260714004223_pentest_lineage_root_not_null/migration.sql
+++ b/packages/db/prisma/migrations/20260714004223_pentest_lineage_root_not_null/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Made the column `root_run_id` on table `security_penetration_test_runs` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "security_penetration_test_runs" ALTER COLUMN "root_run_id" SET NOT NULL;

--- a/packages/db/prisma/migrations/20260714013723_pentest_retry_blocked_marker/migration.sql
+++ b/packages/db/prisma/migrations/20260714013723_pentest_retry_blocked_marker/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "security_penetration_test_runs" ADD COLUMN     "retry_blocked_at" TIMESTAMP(3);

--- a/packages/db/prisma/schema/security-penetration-test-run.prisma
+++ b/packages/db/prisma/schema/security-penetration-test-run.prisma
@@ -11,8 +11,10 @@ model SecurityPenetrationTestRun {
   /// own providerRunId; for an auto-retry it equals the original's. Every
   /// attempt in a chain shares the same rootRunId, so the whole lineage
   /// can be fetched with a single `where: { rootRunId }` query and the
-  /// customer-facing surface only ever exposes this stable id.
-  rootRunId String? @map("root_run_id")
+  /// customer-facing surface only ever exposes this stable id. Always set
+  /// on write (originals default to their own providerRunId); pre-feature
+  /// rows are backfilled, so this is enforced NOT NULL.
+  rootRunId String @map("root_run_id")
 
   /// Which attempt this run is within its lineage. 1 = original,
   /// 2 = first auto-retry, 3 = second auto-retry. Enforces the retry cap
@@ -23,10 +25,12 @@ model SecurityPenetrationTestRun {
   /// (null for original runs). Kept for tracing / debugging the chain.
   retryOfProviderRunId String? @map("retry_of_provider_run_id")
 
-  /// Set the first time we spawn an auto-retry FROM this run. Makes retry
-  /// spawning idempotent — a redelivered `pentest.failed` webhook sees a
-  /// non-null value and short-circuits, so a failure can never fan out
-  /// into multiple retries. Same claim pattern as `creditRefundedAt`.
+  /// Set the first time we spawn an auto-retry FROM this run, OR when the
+  /// run is cancelled (to block a late `pentest.failed` from retrying a
+  /// deliberately stopped scan). Makes retry spawning idempotent — a
+  /// redelivered `pentest.failed` webhook sees a non-null value and
+  /// short-circuits, so a failure can never fan out into multiple retries.
+  /// Same claim pattern as `creditRefundedAt`.
   retryTriggeredAt DateTime? @map("retry_triggered_at")
 
   /// The scan parameters needed to faithfully re-run this scan

--- a/packages/db/prisma/schema/security-penetration-test-run.prisma
+++ b/packages/db/prisma/schema/security-penetration-test-run.prisma
@@ -12,9 +12,11 @@ model SecurityPenetrationTestRun {
   /// attempt in a chain shares the same rootRunId, so the whole lineage
   /// can be fetched with a single `where: { rootRunId }` query and the
   /// customer-facing surface only ever exposes this stable id. Always set
-  /// on write (originals default to their own providerRunId); pre-feature
-  /// rows are backfilled, so this is enforced NOT NULL.
-  rootRunId String @map("root_run_id")
+  /// on write (originals default to their own providerRunId) and pre-feature
+  /// rows are backfilled; kept nullable (not a DB NOT NULL constraint) so a
+  /// deploy can't be blocked by a stray legacy write — reads coalesce
+  /// `rootRunId ?? providerRunId` to stay correct regardless.
+  rootRunId String? @map("root_run_id")
 
   /// Which attempt this run is within its lineage. 1 = original,
   /// 2 = first auto-retry, 3 = second auto-retry. Enforces the retry cap

--- a/packages/db/prisma/schema/security-penetration-test-run.prisma
+++ b/packages/db/prisma/schema/security-penetration-test-run.prisma
@@ -36,11 +36,13 @@ model SecurityPenetrationTestRun {
   retryTriggeredAt DateTime? @map("retry_triggered_at")
 
   /// The scan parameters needed to faithfully re-run this scan
-  /// (targetUrl, repoUrl, scanDepth, evidenceLevel, checks, testMode).
-  /// Persisted here so an auto-retry reconstructs the request from our
-  /// own DB rather than depending on the provider's get() field
-  /// completeness. `additionalContext` is intentionally NOT stored — it
-  /// is regenerated from the org's finding-context notes at create time.
+  /// (targetUrl, repoUrl, pipelineTesting, testMode, scanDepth,
+  /// evidenceLevel, checks, and the caller's original additionalContext).
+  /// Persisted here so an auto-retry reconstructs the request from our own
+  /// DB rather than depending on the provider's get() field completeness.
+  /// The stored additionalContext is the user's original briefing only —
+  /// on retry it is re-combined with the target's current finding-context
+  /// notes via resolveAdditionalContext.
   scanParams Json? @map("scan_params")
 
   /// Set the first time we refund this run's credit (e.g. on

--- a/packages/db/prisma/schema/security-penetration-test-run.prisma
+++ b/packages/db/prisma/schema/security-penetration-test-run.prisma
@@ -27,13 +27,17 @@ model SecurityPenetrationTestRun {
   /// (null for original runs). Kept for tracing / debugging the chain.
   retryOfProviderRunId String? @map("retry_of_provider_run_id")
 
-  /// Set the first time we spawn an auto-retry FROM this run, OR when the
-  /// run is cancelled (to block a late `pentest.failed` from retrying a
-  /// deliberately stopped scan). Makes retry spawning idempotent — a
-  /// redelivered `pentest.failed` webhook sees a non-null value and
-  /// short-circuits, so a failure can never fan out into multiple retries.
-  /// Same claim pattern as `creditRefundedAt`.
+  /// Informational timestamp of when we last initiated an auto-retry FROM
+  /// this run. Idempotency/durability is governed by whether a retry child
+  /// actually exists (see retryOfProviderRunId), not by this marker, so a
+  /// transient spawn failure can't strand the retry.
   retryTriggeredAt DateTime? @map("retry_triggered_at")
+
+  /// Set when this run's lineage is cancelled. A distinct marker (separate
+  /// from retryTriggeredAt) so a late `pentest.failed` can never spawn a
+  /// retry of a deliberately stopped scan, regardless of webhook arrival
+  /// order. Checked by the auto-retry path before spawning.
+  retryBlockedAt DateTime? @map("retry_blocked_at")
 
   /// The scan parameters needed to faithfully re-run this scan
   /// (targetUrl, repoUrl, pipelineTesting, testMode, scanDepth,

--- a/packages/db/prisma/schema/security-penetration-test-run.prisma
+++ b/packages/db/prisma/schema/security-penetration-test-run.prisma
@@ -6,6 +6,37 @@ model SecurityPenetrationTestRun {
   createdAt            DateTime @default(now()) @map("created_at")
   updatedAt            DateTime @updatedAt @map("updated_at")
 
+  /// Lineage root of this run's retry chain: the providerRunId of the
+  /// original (user-initiated) run. For an original run this equals its
+  /// own providerRunId; for an auto-retry it equals the original's. Every
+  /// attempt in a chain shares the same rootRunId, so the whole lineage
+  /// can be fetched with a single `where: { rootRunId }` query and the
+  /// customer-facing surface only ever exposes this stable id.
+  rootRunId String? @map("root_run_id")
+
+  /// Which attempt this run is within its lineage. 1 = original,
+  /// 2 = first auto-retry, 3 = second auto-retry. Enforces the retry cap
+  /// (MAX_ATTEMPTS) and lets reads pick the active (highest) attempt.
+  attemptNumber Int @default(1) @map("attempt_number")
+
+  /// The providerRunId of the immediate parent this run is a retry of
+  /// (null for original runs). Kept for tracing / debugging the chain.
+  retryOfProviderRunId String? @map("retry_of_provider_run_id")
+
+  /// Set the first time we spawn an auto-retry FROM this run. Makes retry
+  /// spawning idempotent — a redelivered `pentest.failed` webhook sees a
+  /// non-null value and short-circuits, so a failure can never fan out
+  /// into multiple retries. Same claim pattern as `creditRefundedAt`.
+  retryTriggeredAt DateTime? @map("retry_triggered_at")
+
+  /// The scan parameters needed to faithfully re-run this scan
+  /// (targetUrl, repoUrl, scanDepth, evidenceLevel, checks, testMode).
+  /// Persisted here so an auto-retry reconstructs the request from our
+  /// own DB rather than depending on the provider's get() field
+  /// completeness. `additionalContext` is intentionally NOT stored — it
+  /// is regenerated from the org's finding-context notes at create time.
+  scanParams Json? @map("scan_params")
+
   /// Set the first time we refund this run's credit (e.g. on
   /// `pentest.failed` / `pentest.cancelled` webhooks). Used to make the
   /// refund idempotent — webhook redelivery cannot double-credit because
@@ -23,5 +54,6 @@ model SecurityPenetrationTestRun {
 
   @@unique([providerRunId])
   @@index([organizationId])
+  @@index([rootRunId])
   @@map("security_penetration_test_runs")
 }


### PR DESCRIPTION
## What & why

When a penetration-test scan fails, two things were wrong for customers:

1. **Raw internal errors leaked** — the failure box showed verbatim provider/infrastructure error text (internal engineering conditions, vendor names) that isn't actionable and looks alarming for a security product.
2. **No retry** — most of these failures are transient infrastructure blips that succeed on a plain re-run (done manually today, one customer complaint at a time).

This makes failed scans **retry automatically with the same parameters (up to 2 retries)**. Customers never see the intermediate failures — the scan simply appears to keep running, and only surfaces as **failed** once every attempt is exhausted, with a clean message. **API-only — no frontend changes.**

## How

- **Retry lineage** — new columns on `SecurityPenetrationTestRun` (`rootRunId`, `attemptNumber`, `retryOfProviderRunId`, `retryTriggeredAt`, `scanParams`) group a scan and its retries. Customers only ever see the stable root id.
- **Auto-retry** — on `pentest.failed` (never `cancelled` — a cancel is a deliberate stop and stays refunded), after the existing refund, spawn the next attempt with the same params. Guarded by an atomic `retryTriggeredAt` claim (redelivery-safe) and best-effort so it can never break the webhook. Capped at 3 attempts.
- **Masking** — reads resolve the requested id to the active (highest) attempt and collapse status: a failed non-final attempt is reported as in-progress (with a grace-window safety valve so a retry that never materializes can't hang forever). Only an exhausted lineage reports `failed`.
- **Clean messages** — raw provider error strings are mapped to white-labeled, actionable text that notes the credit was refunded; the raw string never leaves the server.
- **Billing** nets to a single charge (debit per attempt, refund per failure), scoped strictly to the lineage.

## Testing

`npx jest src/security-penetration-tests` → **11 suites, 140 tests green**, including 32 new tests covering the retry decision logic (spawn / cap / idempotency / orphan / best-effort), lineage collapse, status masking, and error-message mapping. Typecheck clean for all touched files; prettier clean.

## Follow-up (not in this PR)

`FailedDetail.tsx` still renders a static "Common causes" list (VPN/WAF/auth/runtime) that now reads inconsistently beside the clean message. Recommend removing/softening it in a small separate frontend change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically retries failed pentest scans (up to 2 retries) and replaces raw provider errors with clean, neutral messages. The failure view now renders the message as prose and drops the “Common causes” list.

- **New Features**
  - Auto‑retry on `pentest.failed` only (never on `cancelled`); idempotent via existence of a retry child (`retryOfProviderRunId`), capped at 3 attempts, and lineage‑wide blocked on cancel via `retryBlockedAt`. If spawning a retry fails, the error is rethrown so the webhook redelivers; if recording the cancel block fails, that error is also rethrown to redeliver until stored.
  - Track retry lineage with `rootRunId`, `attemptNumber`, `retryOfProviderRunId`, `retryTriggeredAt`, and persisted `scanParams`; retries reuse full params (including `pipelineTesting` and customer `additionalContext`); API id is the lineage root.
  - Collapse reads and progress to the active attempt and mask fresh failed non‑final attempts as in‑progress with a grace window (revealed exactly at the boundary). Show white‑labeled failures only once a final failure is confirmed, using neutral “couldn’t be completed” wording and “you won’t be charged” (never echoing vendor names).

- **Migration**
  - Adds lineage columns and index, plus `retryBlockedAt`; backfills `root_run_id = provider_run_id` in `packages/db/prisma`. Column remains nullable to avoid deploy hazards; reads coalesce `rootRunId ?? providerRunId`. No manual steps required.

<sup>Written for commit d24c0835722b39467f05a399ccc545e9ad349c92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

