### PR TITLE
fix(api): revert deterministic retry billing id (free-scan on redelivery)

### DIFF
--- a/apps/api/src/security-penetration-tests/security-penetration-tests.service.spec.ts
+++ b/apps/api/src/security-penetration-tests/security-penetration-tests.service.spec.ts
@@ -1169,15 +1169,16 @@ describe('SecurityPenetrationTestsService', () => {
       // Deterministic idempotency key tied to the parent → Maced dedupes
       // concurrent duplicate failure webhooks into one provider scan.
       expect(getRequestHeader('Idempotency-Key')).toBe('retry:run_orig');
-      // Deterministic billing reservation id (idempotent on sourceResourceId)
-      // so concurrent duplicates debit the allowance exactly once.
+      // Billing reservation uses a unique (non-deterministic) id so a
+      // failed-then-redelivered retry re-debits correctly instead of reusing a
+      // refunded-but-still-recorded consume key (which would run the scan free).
       expect(
         mockBillingEntitlementsService.tryConsumeIncludedUsageForProduct,
       ).toHaveBeenCalledWith(
         expect.objectContaining({
           organizationId: 'org_123',
           productKey: 'pentest',
-          sourceResourceId: 'pending:retry:run_orig',
+          sourceResourceId: expect.not.stringContaining('retry:run_orig'),
         }),
       );
       // The user's briefing survives the round-trip (re-persisted for any

--- a/apps/api/src/security-penetration-tests/security-penetration-tests.service.ts
+++ b/apps/api/src/security-penetration-tests/security-penetration-tests.service.ts
@@ -354,15 +354,14 @@ export class SecurityPenetrationTestsService {
       organizationId,
       payload,
     );
-    // For a retry, derive a DETERMINISTIC reservation id from the parent run so
-    // concurrent duplicate failure webhooks reserve the same allowance. Billing
-    // consumption is idempotent on this id (billingUsageEvent.idempotencyKey),
-    // so duplicates debit exactly once — otherwise two random ids would debit
-    // twice and only one would land on the shared ownership row, orphaning the
-    // other. User-initiated creates keep a unique random id.
-    const billingUsageSourceId = lineage.retryOfProviderRunId
-      ? `pending:retry:${lineage.retryOfProviderRunId}`
-      : `pending:${randomUUID()}`;
+    // Always a unique reservation id per create call. A deterministic
+    // per-parent id (to dedupe concurrent duplicate retries) is NOT safe here:
+    // the billing consume is idempotent on this id AND a refund leaves the
+    // consume event in place, so after a failed-create-then-refund the next
+    // (redelivered) attempt would reuse the key, skip the debit, and run the
+    // scan for free. Provider-scan de-duplication for concurrent duplicates is
+    // handled by the Maced idempotency key below instead.
+    const billingUsageSourceId = `pending:${randomUUID()}`;
     let consumedSubscriptionAllowance = false;
 
     // Reserve subscription allowance before calling Maced so fast double-clicks


### PR DESCRIPTION
Follow-up to #3400. The deterministic `pending:retry:<parent>` billing reservation id it introduced has a realistic bug, so this reverts it to a unique random id.

## The bug

Billing consumption is idempotent on `sourceResourceId`, and a refund creates a separate `refund` event while **leaving the original `consume` event in place** (`billing-included-usage-refunds.ts`). With a deterministic per-parent reservation id:

1. A retry reserves (debits) `pending:retry:<parent>`.
2. The Maced create fails transiently → we refund it (net zero, but the `consume` idempotency key remains).
3. Standard webhook **redelivery** re-runs the retry → reserves the **same** id → billing sees the existing consume key → returns "consumed" **without debiting** → the scan runs **for free**.

This is the normal sequential retry-on-failure path, so it's realistic — a worse trade than the (unverified, concurrent-only) over-charge the deterministic id was meant to prevent.

## Fix

Revert to a unique random reservation id per create call, so a redelivered retry re-debits correctly. Concurrent duplicate **scans** are still deduped by the Maced idempotency key (unchanged); the residual concurrent-only reservation over-charge requires Maced to deliver duplicate webhooks *concurrently* (unverified) and isn't worth reintroducing a realistic free-scan to close.

## Testing

`npx jest src/security-penetration-tests` → 154 green, typecheck + prettier clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the retry billing reservation id to a unique random id to prevent free scans on webhook redelivery after a refunded failure. Concurrent duplicate scans are still deduped by the Maced idempotency key, and billing now re-debits on redelivery.

- **Bug Fixes**
  - Always generate a unique `pending:<uuid>` `sourceResourceId`; remove `pending:retry:<parent>`.
  - Avoids idempotency skip when a refund leaves the original consume event in place.
  - Updated tests to expect a non-deterministic billing id while keeping the same Maced idempotency behavior.

<sup>Written for commit ba6886c99f68dc82eaaf69c492e4327e157286ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

