### PR TITLE
fix(security): prevent SSRF in task-automation enterprise API calls (CodeQL #116)

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/automation/[automationId]/actions/task-automation-actions.ts
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/automation/[automationId]/actions/task-automation-actions.ts
@@ -55,7 +55,15 @@ async function callEnterpriseApi<T>(
 ): Promise<T> {
   const { enterpriseApiUrl, enterpriseApiKey } = getEnterpriseConfig();
 
-  const url = new URL(endpoint, enterpriseApiUrl);
+  const baseUrl = new URL(enterpriseApiUrl);
+  const url = new URL(endpoint, baseUrl);
+
+  // SSRF guard: `endpoint` and params can carry user-derived values, so pin the
+  // request to the configured enterprise API origin — never allow it to be
+  // redirected to another host.
+  if (url.origin !== baseUrl.origin) {
+    throw new EnterpriseApiError('Invalid enterprise API endpoint', 400);
+  }
 
   if (options.params) {
     Object.entries(options.params).forEach(([key, value]) => {
@@ -243,8 +251,10 @@ export async function analyzeAutomationWorkflow(scriptContent: string) {
 
 export const getAutomationRunStatus = async (runId: string) => {
   try {
-    const result = await callEnterpriseApi(`/api/tasks-automations/runs/${runId}`, {
-    });
+    const result = await callEnterpriseApi(
+      `/api/tasks-automations/runs/${encodeURIComponent(runId)}`,
+      {},
+    );
 
     return {
       success: true,


### PR DESCRIPTION
## Summary

Fixes **CodeQL `js/request-forgery` (alert #116, critical)** — a server-side request forgery in the task-automation server actions.

`callEnterpriseApi()` builds `new URL(endpoint, enterpriseApiUrl)` and `fetch`es it. `getAutomationRunStatus()` interpolated a **user-provided `runId` directly into the endpoint path** (`/api/tasks-automations/runs/${runId}`) with no encoding, so a crafted `runId` could inject extra path segments into the outgoing request URL. (The other callers pass user data via `searchParams.append` or the POST body, which don't influence the request target.)

## Fix

Two layers:

1. **Encode the user value in the path** — `encodeURIComponent(runId)` so it can only ever be a single, inert path segment.
2. **Origin allowlist guard at the sink** (`callEnterpriseApi`) — resolve the URL against the configured enterprise API base and reject anything whose `origin` differs from it. This pins every request to the trusted host regardless of caller, so no user-derived value can redirect a request elsewhere.

```ts
const baseUrl = new URL(enterpriseApiUrl);
const url = new URL(endpoint, baseUrl);
if (url.origin !== baseUrl.origin) {
  throw new EnterpriseApiError('Invalid enterprise API endpoint', 400);
}
```

## Notes / verification
- No behavior change for legitimate calls — endpoints are already absolute paths on the configured base, so the origin always matches; `runId` values (trigger.dev run ids) are unaffected by `encodeURIComponent`.
- `@trycompai/app` typecheck: the changed file compiles clean (the only typecheck failures are pre-existing test-file debt on `main`, unrelated to this change).
- Single-file change; no dependency or lockfile changes.

Closes the code-scanning alert once CodeQL re-runs on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents SSRF in task-automation enterprise API requests by pinning requests to the configured origin and encoding user input in URL paths. Fixes CodeQL js/request-forgery alert #116 without changing valid behavior.

- **Bug Fixes**
  - Enforce origin check in `callEnterpriseApi`: resolve against base URL and reject endpoints whose `origin` differs.
  - Encode `runId` in `getAutomationRunStatus` with `encodeURIComponent` to prevent path injection.

<sup>Written for commit 8be58dce46f07f849da9429764f66caecf819174. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

