### PR TITLE
fix(deps): patch tmp & js-yaml in mcp-server (Dependabot #58/#59/#71)

### DIFF
--- a/apps/mcp-server/package-lock.json
+++ b/apps/mcp-server/package-lock.json
@@ -208,6 +208,29 @@
         "node": ">= 4"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -2555,19 +2578,6 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
-    "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -2822,16 +2832,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/p-limit": {
@@ -3316,16 +3316,13 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/toidentifier": {

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -29,7 +29,9 @@
   "overrides": {
     "@modelcontextprotocol/sdk": "1.26.0",
     "hono": ">=4.12.25",
-    "fast-uri": ">=3.1.2"
+    "fast-uri": ">=3.1.2",
+    "tmp": "^0.2.6",
+    "js-yaml": "^4.2.0"
   },
   "devDependencies": {
     "@anthropic-ai/mcpb": "^1.2.0",


### PR DESCRIPTION
## Summary

Clears the **3 open Dependabot alerts**, all in `apps/mcp-server/package-lock.json` (a standalone npm project, excluded from the bun workspaces). All are dev-scope transitives.

| Alert | Sev | Package | Via | Fix |
|---|---|---|---|---|
| #59 | High | `tmp` (path traversal via prefix/postfix) | `external-editor` → `tmp@0.0.33` | `tmp ≥ 0.2.6` |
| #58 | Low | `tmp` (symlink `dir` write) | same | `tmp ≥ 0.2.6` |
| #71 | Moderate | `js-yaml` (quadratic-complexity DoS) | `@eslint/eslintrc` → `js-yaml@4.1.1` | `js-yaml ≥ 4.2.0` |

## Fix

Added two `overrides` in `apps/mcp-server/package.json`, **caret-pinned to stay within the safe major**:

```json
"tmp": "^0.2.6",       // → 0.2.7
"js-yaml": "^4.2.0"    // → 4.3.0
```

- **js-yaml** deliberately capped at `^4.2.0`. An open `>=4.2.0` floats to **v5.2.1**, but `@eslint/eslintrc` declares `^4.1.1` — forcing an unvetted v5 major onto it is risky, and 4.3.0 already clears the DoS while satisfying eslintrc.
- **tmp** `^0.2.6` → 0.2.7. `external-editor` requests `^0.0.33`, but tmp's `fileSync` API is stable across the jump and it's dev-only (interactive editor prompts in `@anthropic-ai/mcpb`).

## Verification
- ✅ `npm audit` — **0 vulnerabilities**
- ✅ `npm run build` (bun bundle + `tsc`) passes
- ✅ `npm run lint` (eslint, which consumes js-yaml) passes
- Only `package.json` + `package-lock.json` change. `bun.lock` is gitignored and re-migrated from `package-lock.json` at build, so it inherits the patched versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patches dev transitive dependencies in `apps/mcp-server` to clear 3 Dependabot alerts. Uses npm overrides for `tmp` and `js-yaml`; no runtime changes, and build/lint/audit all pass.

- **Dependencies**
  - Added `overrides` in `apps/mcp-server/package.json`.
  - `tmp`: `^0.2.6` → resolves to `0.2.7` (fixes path traversal/symlink issues via `external-editor`).
  - `js-yaml`: `^4.2.0` → resolves to `4.3.0` under `@eslint/eslintrc` (fixes DoS; stays on 4.x to avoid unvetted 5.x).
  - Verified: npm audit 0; build and lint pass.

<sup>Written for commit 9d364b2548780bd3a999c374cfb0554ca127ba22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

