### PR TITLE
ci: submit resolved bun tree to GitHub dependency graph (accurate SBOM/Dependabot)

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,50 @@
+name: SBOM
+
+# Publishes an accurate SBOM to GitHub's dependency graph.
+#
+# GitHub does NOT natively parse `bun.lock`, so out of the box its dependency
+# graph, exported SBOM, and Dependabot are blind to the bun dependency tree
+# (they only see declared package.json ranges + the npm package-lock.json in
+# apps/mcp-server). Syft DOES parse bun.lock with fully resolved versions
+# (overrides applied), so this workflow scans the repo with Syft and submits
+# the resolved tree via GitHub's Dependency Submission API. After this runs on
+# `main`, GitHub's own "Export SBOM" and Dependabot reflect the real bun tree.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'bun.lock'
+      - 'apps/mcp-server/package-lock.json'
+      - '**/package.json'
+      - '.github/workflows/sbom.yml'
+  schedule:
+    - cron: '0 6 * * 1' # weekly, Monday 06:00 UTC — refresh against new advisories
+  workflow_dispatch:
+
+permissions:
+  contents: write # required by the Dependency Submission API
+
+concurrency:
+  group: sbom-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sbom:
+    name: Generate & submit SBOM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Scans the whole repo: Syft reads bun.lock (resolved) and
+      # apps/mcp-server/package-lock.json. `dependency-snapshot: true` submits
+      # the result to the dependency graph; the SBOM is also uploaded as a
+      # workflow artifact for anyone who wants the file directly.
+      - name: Generate SBOM & submit to dependency graph
+        uses: anchore/sbom-action@v0
+        with:
+          path: .
+          format: spdx-json
+          artifact-name: sbom.spdx.json
+          dependency-snapshot: true

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -42,7 +42,10 @@ jobs:
       # the result to the dependency graph; the SBOM is also uploaded as a
       # workflow artifact for anyone who wants the file directly.
       - name: Generate SBOM & submit to dependency graph
-        uses: anchore/sbom-action@v0
+        # Pinned to a full commit SHA (not the mutable @v0 tag): this action
+        # runs with contents:write, so a retag/compromise must not be able to
+        # swap in altered code. Bump the SHA + comment together to upgrade.
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           path: .
           format: spdx-json


### PR DESCRIPTION
## Summary

Makes GitHub's own dependency graph — and therefore its **exported SBOM and Dependabot** — accurate for the **bun** dependency tree.

**The problem:** GitHub does not natively parse `bun.lock` (confirmed against GitHub's docs and this repo). Out of the box its dependency graph sees only declared `package.json` *ranges* plus the one npm `package-lock.json` (`apps/mcp-server`). So anyone who exports the SBOM or self-generates a scan gets a picture that's blind to the entire bun tree — missing both the real transitive versions and the `overrides` we use to patch them. This is exactly what produced the earlier inflated/misleading scans.

**The fix:** Syft *does* parse `bun.lock` with fully resolved versions (verified locally: 2508 packages, overrides applied — e.g. `axios 1.18.1`, `form-data 4.0.6`, `ws 8.21.0`). This workflow runs Syft via `anchore/sbom-action` and submits the resolved tree through GitHub's **Dependency Submission API** (`dependency-snapshot: true`). Once it runs on `main`:
- GitHub's **Export SBOM** includes the resolved bun tree.
- **Dependabot** covers the bun side (not just mcp-server).
- The SBOM is also uploaded as a **workflow artifact** for anyone who wants the file directly.

## Triggers
`push` to `main` (when a lockfile/manifest or this workflow changes), a weekly schedule, and `workflow_dispatch`. Requires `contents: write` (the Dependency Submission API needs it). No `run:` steps and no event-input interpolation, so there's no workflow-injection surface.

## Heads-up (expected, not a bug)
Once the resolved bun tree is in the graph, **Dependabot will start alerting on the bun side too** — including the ~15 dev/build-time / no-upstream-fix findings that `bun audit` reports (0 critical). That's accurate; they can be triaged/dismissed-with-rationale as they appear. This is the intended trade-off for making self-service reports correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Submits the resolved Bun dependency tree to GitHub’s dependency graph so Export SBOM and Dependabot reflect real versions and overrides. Adds a CI workflow that builds an SPDX SBOM, submits a dependency snapshot, and uploads the file as an artifact.

- **New Features**
  - Scans the repo with `anchore/sbom-action` (Syft) to parse `bun.lock` and `apps/mcp-server/package-lock.json`, then submits a dependency snapshot and uploads `sbom.spdx.json`.
  - Triggers on push to `main` when lockfiles/manifests or the workflow change, weekly cron, and manual dispatch.
  - Dependabot will now alert on the Bun tree; triage as needed.

- **Refactors**
  - Pins `anchore/sbom-action` to the commit for v0.24.0 (Syft v1.42.3) to avoid mutable tag risk with `contents: write`.

<sup>Written for commit 5b24cf995592acec4e3200978b4acd2cc0eee5be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

