### PR TITLE
fix(ci): scan bun.lock via file: input so the SBOM isn't empty

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -6,17 +6,22 @@ name: SBOM
 # graph, exported SBOM, and Dependabot are blind to the bun dependency tree
 # (they only see declared package.json ranges + the npm package-lock.json in
 # apps/mcp-server). Syft DOES parse bun.lock with fully resolved versions
-# (overrides applied), so this workflow scans the repo with Syft and submits
-# the resolved tree via GitHub's Dependency Submission API. After this runs on
-# `main`, GitHub's own "Export SBOM" and Dependabot reflect the real bun tree.
+# (overrides applied), so this workflow scans bun.lock with Syft and submits
+# the resolved tree via GitHub's Dependency Submission API. (apps/mcp-server's
+# package-lock.json is already covered by GitHub's native npm parsing, so we
+# only need to submit the bun tree.) After this runs on `main`, GitHub's own
+# "Export SBOM" and Dependabot reflect the real bun tree.
+#
+# NOTE: we scan bun.lock via the `file:` input, not `path: .`. Syft's default
+# DIRECTORY catalogers do not include the bun cataloger, so a directory scan
+# silently skips bun.lock (it only picks up package-lock.json + actions). A
+# file scan forces the bun cataloger and yields the full resolved tree.
 
 on:
   push:
     branches: [main]
     paths:
       - 'bun.lock'
-      - 'apps/mcp-server/package-lock.json'
-      - '**/package.json'
       - '.github/workflows/sbom.yml'
   schedule:
     - cron: '0 6 * * 1' # weekly, Monday 06:00 UTC — refresh against new advisories
@@ -37,17 +42,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Scans the whole repo: Syft reads bun.lock (resolved) and
-      # apps/mcp-server/package-lock.json. `dependency-snapshot: true` submits
-      # the result to the dependency graph; the SBOM is also uploaded as a
-      # workflow artifact for anyone who wants the file directly.
+      # Scans bun.lock directly (see NOTE above). `dependency-snapshot: true`
+      # submits the resolved tree to the dependency graph; the SBOM is also
+      # uploaded as a workflow artifact for anyone who wants the file directly.
       - name: Generate SBOM & submit to dependency graph
         # Pinned to a full commit SHA (not the mutable @v0 tag): this action
         # runs with contents:write, so a retag/compromise must not be able to
         # swap in altered code. Bump the SHA + comment together to upgrade.
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          path: .
+          file: bun.lock
           format: spdx-json
           artifact-name: sbom.spdx.json
           dependency-snapshot: true


### PR DESCRIPTION
## Summary

Follow-up fix to the SBOM workflow (merged in #3413). That workflow **ran green but submitted a near-empty snapshot**, so it didn't actually fix GitHub's blindness to the bun tree.

## Root cause

The workflow scanned with `path: .` (a **directory** scan). Syft's default *directory* catalogers **do not include the bun cataloger**, so it silently skipped `bun.lock` and only picked up `apps/mcp-server/package-lock.json` (npm) + the GitHub Actions in the workflows.

Verified against the first run's artifact: **138 packages, and none of the bun tree** — `axios`, `better-auth`, `next`, `form-data` all absent. (94 npm from mcp-server + 41 github-actions + 3 misc.)

## Fix

Scan `bun.lock` via the action's **`file:` input** instead. A file scan forces Syft's bun cataloger and yields the **full resolved tree** — verified locally: **2487 packages** with `axios 1.18.1`, `form-data 4.0.6`, `ws 8.21.0`, `better-auth`, `next`, `systeminformation` all present (overrides applied).

`apps/mcp-server/package-lock.json` is **already covered by GitHub's native npm parsing** (it's why Dependabot already alerts on it), so submitting just the bun tree completes the graph — no need to scan it here. Also tightened the `push` path filter accordingly.

## Verification
- ✅ YAML valid; `with: { file: bun.lock, format: spdx-json, dependency-snapshot: true }`
- ✅ `syft scan file:bun.lock` → 2487 pkgs, full bun tree resolved
- After merge, the workflow re-runs on `main`; then GitHub's Export SBOM + Dependabot should reflect ~2500 bun packages (up from the empty 138).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix SBOM workflow to scan `bun.lock` via the action’s `file:` input so Syft captures the full Bun dependency tree. This restores accurate dependency graph, Export SBOM, and Dependabot coverage.

- **Bug Fixes**
  - Switch `anchore/sbom-action` from `path: .` to `file: bun.lock` to trigger the Bun cataloger.
  - Narrow push paths to `bun.lock` and the workflow file.
  - Keep `format: spdx-json` and `dependency-snapshot: true` to submit the resolved tree.

<sup>Written for commit 0d86e419ded9306020ca6a221e4b93e882011121. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

