### PR TITLE
fix(ci): pin Syft 1.46.0 in SBOM action (1.42.3 can't parse bun.lock)

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -55,3 +55,7 @@ jobs:
           format: spdx-json
           artifact-name: sbom.spdx.json
           dependency-snapshot: true
+          # sbom-action v0.24.0 bundles Syft 1.42.3, which CANNOT parse bun.lock
+          # (it yields 1 package — an empty snapshot). Pin a Syft that can:
+          # verified 1.46.0 → 2496 resolved deps. Bump alongside the action SHA.
+          syft-version: v1.46.0


### PR DESCRIPTION
## Root cause (proven)

After #3414 switched to `file: bun.lock`, the SBOM run *still* submitted an empty snapshot (artifact had **1 package**). The CI log shows the action ran `syft scan file:bun.lock` with **Syft 1.42.3** (bundled in `anchore/sbom-action@v0.24.0`).

Reproduced both versions locally against this repo's `bun.lock`:
| Syft | `file:bun.lock` result |
|---|---|
| **1.42.3** (action default) | **1 package** — no working bun.lock support |
| **1.46.0** | **2484 packages** (spdx) / **2496 resolved deps** (github snapshot format) |

So it was never the scan target — it's the Syft version.

## Fix
Pin `syft-version: v1.46.0` in the action so it uses a Syft that can parse `bun.lock`.

## After merge
The workflow re-runs on `main`; the `sbom.spdx.json` artifact should jump from 1 → ~2484 packages, and the submitted snapshot (~2496 deps) populates the dependency graph. Then GitHub's Export SBOM + Dependabot finally reflect the bun tree. (Expect Dependabot to then surface the ~15 dev/build `bun audit` findings — accurate, 0 critical.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin Syft to v1.46.0 in the SBOM workflow so `bun.lock` is parsed correctly and the dependency snapshot is fully populated.

- **Bug Fixes**
  - `anchore/sbom-action@v0.24.0` bundles Syft 1.42.3, which can’t read `bun.lock` (yields 1 package).
  - Pinning `syft-version: v1.46.0` fixes parsing. Expect `sbom.spdx.json` to include ~2484 packages and the snapshot ~2496 deps.

<sup>Written for commit ffc942377cf39882c6ea630ac5fada90f34ed505. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

