### PR TITLE
fix(deps): override uuid to ^11.1.1 (Dependabot #85)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -864,6 +864,7 @@
     "shell-quote": "^1.8.4",
     "systeminformation": "^5.31.17",
     "tmp": "^0.2.7",
+    "uuid": "^11.1.1",
     "vite": "^6.4.3",
     "vitest": "^3.2.7",
     "ws": "^8.21.0",
@@ -6321,7 +6322,7 @@
 
     "utrie": ["utrie@1.0.2", "", { "dependencies": { "base64-arraybuffer": "^1.0.2" } }, "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw=="],
 
-    "uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
+    "uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
 
     "v8-compile-cache-lib": ["v8-compile-cache-lib@3.0.1", "", {}, "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="],
 
@@ -6602,8 +6603,6 @@
     "@browserbasehq/stagehand/@ai-sdk/provider": ["@ai-sdk/provider@2.0.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww=="],
 
     "@browserbasehq/stagehand/@browserbasehq/sdk": ["@browserbasehq/sdk@2.16.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-mPAuLRU9jWR7o0KJi9+gQnOBDUSIkoKbbFv4HjrA+80qWVcFacrNPlZmf4mguQnfZ0oP2t5c3ws6yuFyAX9vpA=="],
-
-    "@browserbasehq/stagehand/uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
 
     "@commitlint/config-validator/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
@@ -7151,8 +7150,6 @@
 
     "@trigger.dev/sdk/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
-    "@trigger.dev/sdk/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
-
     "@trycompai/api/@react-email/render": ["@react-email/render@2.1.0", "", { "dependencies": { "entities": "^4.5.0", "html-to-text": "^9.0.5", "html5parser": "^3.0.0", "prettier": "^3.5.3" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-F+zE3O6d6sW6Aj2UjvZAA17R7tJKM7kcq2mgV6k4HCT8jeLLFaVP2txMtH1lgqYFRMZ0Gxsd37q2PRyiXLXXxA=="],
 
     "@trycompai/api/ai": ["ai@6.0.225", "", { "dependencies": { "@ai-sdk/gateway": "3.0.149", "@ai-sdk/provider": "3.0.14", "@ai-sdk/provider-utils": "4.0.38", "@opentelemetry/api": "^1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-TCkt/NxyZFyXyHeGO/4FMsdTIoCdwV/e78jG9iEHIjnwrAHYlqOwVj7WDFsNRqXUeoUefgbiOkNuE5k8jdpFRg=="],
@@ -7664,8 +7661,6 @@
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "mermaid/marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
-
-    "mermaid/uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
 
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "@sigstore/core": "3.2.1",
     "markdown-it": "^14.3.0",
     "@babel/core": "^7.29.7",
+    "uuid": "^11.1.1",
     "@tiptap/core": "3.22.1",
     "@tiptap/extension-blockquote": "3.22.1",
     "@tiptap/extension-bold": "3.22.1",


### PR DESCRIPTION
## Summary
Fixes the one Dependabot alert (of the 8 open bun.lock alerts) that has a safe, published fix and is prod-reachable.

**#85 — uuid** (medium): `uuid < 11.1.1` missing buffer-bounds check in v3/v5/v6 when a buffer is passed. Vulnerable copies: `uuid@8.3.2` (via **exceljs** in `@trycompai/api` — prod-reachable xlsx export) and `uuid@9.0.1` (via `@trigger.dev/sdk`).

**Fix:** flat override `uuid: ^11.1.1` → resolves to a single `uuid@11.1.1`. uuid's `v1/v3/v4/v5` named API is stable across 8→11 and v11 keeps a dual CJS/ESM build (verified `require('uuid').v4` works), so exceljs / @azure/core-http / @trigger.dev/sdk stay drop-in compatible. Caret stops before the still-vulnerable 12.0.0.

## Verification
- ✅ `turbo build` 20/20 (uuid@11 force-applied to all consumers)
- ✅ `bun audit` 15 → 14 (uuid cleared)
- Only `package.json` + `bun.lock` change

## The other 7 alerts — no override, by design
Per our policy (bump/override to a *published* fix, else dismiss-with-rationale — never patch lib source), these have no safe fix and aren't prod-runtime-reachable, so they'll be **dismissed with rationale** rather than force-overridden:
- **minimatch** ×3 (#82/83/84) — vulnerable copy only via `syncpack` (dev CLI, own globs); a flat override would break the 3.x/5.x/10.x toolchain
- **esbuild** ×2 (#81/87) — dev-server-only advisories; we never run `esbuild serve`; override would force vite up 3 esbuild minors (build risk) for a non-reachable issue
- **@ai-sdk/provider-utils** (#86) — no published fix for the 3.x line; only via dev/optional tooling
- **cookie** (#80) — only in trigger's engine.io *server*, which we don't run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Override `uuid` to `^11.1.1` to resolve the security alert (missing buffer-bounds check) and enforce a single safe version across the repo. No runtime changes; existing uses via `exceljs` in `@trycompai/api` and `@trigger.dev/sdk` stay compatible.

- **Dependencies**
  - Add flat override `uuid: ^11.1.1` (stays within 11.x; avoids vulnerable 12.0.0).
  - Verified: builds pass; `bun audit` reduced by 1.

<sup>Written for commit 7cfcea21e5a0156680585fd47a4caf4965e3e4f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

