### PR TITLE
fix(security): resolve open CodeQL alerts (XSS, sanitization, workflow perms)

### DIFF
--- a/.github/workflows/database-migrations-main.yml
+++ b/.github/workflows/database-migrations-main.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
   workflow_dispatch: # Allows manual triggering
+
+permissions:
+  contents: read # only needs to check out the repo to run migrations
+
 jobs:
   migrate:
     name: Run Database Migrations

--- a/.github/workflows/database-migrations-release.yml
+++ b/.github/workflows/database-migrations-release.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - release
   workflow_dispatch: # Allows manual triggering
+
+permissions:
+  contents: read # only needs to check out the repo to run migrations
+
 jobs:
   migrate:
     name: Run Database Migrations

--- a/.github/workflows/trigger-tasks-deploy-main.yml
+++ b/.github/workflows/trigger-tasks-deploy-main.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - main
+
+permissions:
+  contents: read # only needs to check out the repo to build & deploy
+
 jobs:
   deploy:
     runs-on: warp-ubuntu-latest-arm64-4x

--- a/.github/workflows/trigger-tasks-deploy-release.yml
+++ b/.github/workflows/trigger-tasks-deploy-release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - release
 
+permissions:
+  contents: read # only needs to check out the repo to build & deploy
+
 jobs:
   deploy:
     runs-on: warp-ubuntu-latest-arm64-4x

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/automation/[automationId]/components/preview/preview.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/automation/[automationId]/components/preview/preview.tsx
@@ -13,6 +13,24 @@ interface Props {
   url?: string;
 }
 
+/**
+ * Only allow http(s) URLs to reach an iframe `src` or anchor `href`. User-typed
+ * input flows into the preview iframe, so an unvalidated value like
+ * `javascript:...` or `data:text/html,...` would execute in the preview context
+ * (XSS). Returns the normalized href, or undefined if the value isn't http(s).
+ */
+function toSafeUrl(value: string | undefined | null): string | undefined {
+  if (!value) return undefined;
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+      ? parsed.href
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function Preview({ className, disabled, url }: Props) {
   const [currentUrl, setCurrentUrl] = useState(url);
   const [error, setError] = useState<string | null>(null);
@@ -21,35 +39,42 @@ export function Preview({ className, disabled, url }: Props) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const loadStartTime = useRef<number | null>(null);
 
+  // Sanitized view of currentUrl used for every DOM sink (iframe src, anchor href).
+  const safeUrl = toSafeUrl(currentUrl);
+
   useEffect(() => {
     setCurrentUrl(url);
     setInputValue(url || '');
   }, [url]);
 
   const refreshIframe = () => {
-    if (iframeRef.current && currentUrl) {
+    if (iframeRef.current && safeUrl) {
       setIsLoading(true);
       setError(null);
       loadStartTime.current = Date.now();
       iframeRef.current.src = '';
       setTimeout(() => {
         if (iframeRef.current) {
-          iframeRef.current.src = currentUrl;
+          iframeRef.current.src = safeUrl;
         }
       }, 10);
     }
   };
 
   const loadNewUrl = () => {
-    if (iframeRef.current && inputValue) {
-      if (inputValue !== currentUrl) {
-        setIsLoading(true);
-        setError(null);
-        loadStartTime.current = Date.now();
-        iframeRef.current.src = inputValue;
-      } else {
-        refreshIframe();
-      }
+    if (!iframeRef.current || !inputValue) return;
+    const safeInput = toSafeUrl(inputValue);
+    if (!safeInput) {
+      setError('Enter a valid http(s) URL');
+      return;
+    }
+    if (safeInput !== currentUrl) {
+      setIsLoading(true);
+      setError(null);
+      loadStartTime.current = Date.now();
+      iframeRef.current.src = safeInput;
+    } else {
+      refreshIframe();
     }
   };
 
@@ -67,7 +92,12 @@ export function Preview({ className, disabled, url }: Props) {
     <Panel className={className}>
       <PanelHeader>
         <div className="absolute flex items-center space-x-1">
-          <a href={currentUrl} target="_blank" className="cursor-pointer px-1">
+          <a
+            href={safeUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="cursor-pointer px-1"
+          >
             <CompassIcon className="w-4" />
           </a>
           <button
@@ -101,12 +131,12 @@ export function Preview({ className, disabled, url }: Props) {
       </PanelHeader>
 
       <div className="flex h-[calc(100%-2rem-1px)] relative">
-        {currentUrl && !disabled && (
+        {safeUrl && !disabled && (
           <>
             <ScrollArea className="w-full">
               <iframe
                 ref={iframeRef}
-                src={currentUrl}
+                src={safeUrl}
                 className="w-full h-full"
                 onLoad={handleIframeLoad}
                 onError={handleIframeError}
@@ -128,10 +158,10 @@ export function Preview({ className, disabled, url }: Props) {
                   className="text-primary hover:underline text-sm"
                   type="button"
                   onClick={() => {
-                    if (currentUrl) {
+                    if (safeUrl) {
                       setIsLoading(true);
                       setError(null);
-                      const newUrl = new URL(currentUrl);
+                      const newUrl = new URL(safeUrl);
                       newUrl.searchParams.set('t', Date.now().toString());
                       setCurrentUrl(newUrl.toString());
                     }

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/automation/[automationId]/components/preview/preview.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/automation/[automationId]/components/preview/preview.tsx
@@ -62,20 +62,23 @@ export function Preview({ className, disabled, url }: Props) {
   };
 
   const loadNewUrl = () => {
-    if (!iframeRef.current || !inputValue) return;
+    if (!inputValue) return;
     const safeInput = toSafeUrl(inputValue);
     if (!safeInput) {
       setError('Enter a valid http(s) URL');
       return;
     }
-    if (safeInput !== currentUrl) {
-      setIsLoading(true);
-      setError(null);
-      loadStartTime.current = Date.now();
-      iframeRef.current.src = safeInput;
-    } else {
+    if (safeInput === safeUrl) {
       refreshIframe();
+      return;
     }
+    // Drive the iframe through state (not iframeRef.current.src) so the src
+    // prop, the external-link href, and refresh/try-again all stay in sync
+    // with the URL actually shown.
+    setIsLoading(true);
+    setError(null);
+    loadStartTime.current = Date.now();
+    setCurrentUrl(safeInput);
   };
 
   const handleIframeLoad = () => {

--- a/packages/integration-platform/scripts/generate-task-types.ts
+++ b/packages/integration-platform/scripts/generate-task-types.ts
@@ -87,19 +87,24 @@ function generateTaskTypes() {
   lines.push('  { name: string; description: string; department: string; frequency: string }');
   lines.push('> = {');
 
+  // Escape a value for embedding inside a single-quoted TS string literal.
+  // Backslash MUST be escaped first, otherwise the quote-escaping is incomplete
+  // (e.g. a trailing "\" or "\'" would break out of the literal).
+  const sq = (value: string) => `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+
   for (const task of tasks) {
-    // Escape description for use in template literal
+    // Escape description for use in a template literal (backslash first).
     const escapedDesc = task.description
       .replace(/\\/g, '\\\\')
       .replace(/`/g, '\\`')
       .replace(/\$/g, '\\$')
       .substring(0, 100); // Truncate for readability
 
-    lines.push(`  '${task.id}': {`);
-    lines.push(`    name: '${task.name.replace(/'/g, "\\'")}',`);
+    lines.push(`  ${sq(task.id)}: {`);
+    lines.push(`    name: ${sq(task.name)},`);
     lines.push(`    description: \`${escapedDesc}...\`,`);
-    lines.push(`    department: '${task.department}',`);
-    lines.push(`    frequency: '${task.frequency}',`);
+    lines.push(`    department: ${sq(task.department)},`);
+    lines.push(`    frequency: ${sq(task.frequency)},`);
     lines.push('  },');
   }
 


### PR DESCRIPTION
## Summary
Resolves the 6 open CodeQL code-scanning alerts.

### #108 — DOM XSS (High, `js/xss-through-dom`) — the real one
`preview.tsx` (automation preview) assigned **user-typed input** straight to `iframe.src` and `<a href>`, so a value like `javascript:alert(document.cookie)` or `data:text/html,...` would execute in the preview context.
**Fix:** a `toSafeUrl()` validator that only passes `http:`/`https:` URLs; every URL sink (iframe src, anchor href, refresh, load-new-url) now goes through it, and invalid input shows an error instead of navigating. Also added `rel="noopener noreferrer"` to the external link.

### #95 — Incomplete sanitization (High, `js/incomplete-sanitization`)
`generate-task-types.ts` (codegen) escaped single quotes but **not backslashes** when embedding task fields in single-quoted TS literals (a trailing `\` or `\'` breaks out). `department`/`frequency`/`id` weren't escaped at all.
**Fix:** a `sq()` helper that escapes **backslash-first, then quote**, applied to id/name/department/frequency. (Codegen script, non-runtime, but now correct.)

### #80 / #81 / #84 / #85 — Missing workflow permissions (Medium ×4)
The two Trigger.dev deploy + two DB-migration workflows had no `permissions:` block (inheriting broad default token scope).
**Fix:** top-level `permissions: contents: read` on each — they only check out to build/deploy/migrate, no repo writes.

## Verification
- ✅ app typecheck: **0 errors in preview.tsx** (remaining are pre-existing test-file debt)
- ✅ codegen script typechecks
- ✅ all 4 workflow YAMLs valid, `permissions: {contents: read}`
- No library source patched; no untrusted input introduced into workflows.

Closes CodeQL #108, #95, #80, #81, #84, #85 (on next scan of `main` after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 6 CodeQL alerts by blocking unsafe URLs in the automation preview, fixing string escaping in codegen, and restricting GitHub Actions permissions. Also drives preview navigation through state to keep links/refresh in sync and avoid double loads.

- **Bug Fixes**
  - DOM XSS: Added http(s)-only `toSafeUrl()` and used it for iframe `src`, anchor `href`, refresh, and load; invalid input shows an error; added `rel="noopener noreferrer"`; navigation now goes through state so the external link, refresh, and retry match the shown URL and don’t double-load.
  - Codegen sanitization: Introduced `sq()` to escape backslash first, then quote; applied to `id`, `name`, `department`, `frequency`; kept template literal description with backslash-first escaping.
  - GitHub Actions: Added `permissions: contents: read` to the two deploy and two database migration workflows.

<sup>Written for commit e0690fbfa312ab4d7b530c5ae3daa1797b682d29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

