### PR TITLE
feat(framework-editor): raise requirement description limit to 100,000 chars (FRAME-2)

### DIFF
--- a/apps/api/src/framework-editor/constants.ts
+++ b/apps/api/src/framework-editor/constants.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared framework-editor DTO limits.
+ *
+ * Requirement descriptions carry full regulatory control text, which can be very
+ * long: NIST SP800-53r5 PL-2 exceeds 6,000 chars and many HITRUST CSF
+ * requirements run past 70,000 (FRAME-2). The DB column is unbounded `text`; the
+ * only ceiling is API-side `@MaxLength` validation, so this single constant is
+ * the source of truth across every requirement-description path (create /
+ * update / batch-update / framework import) to keep them from drifting.
+ */
+export const REQUIREMENT_DESCRIPTION_MAX_LENGTH = 100_000;

--- a/apps/api/src/framework-editor/framework/dto/import-framework.dto.spec.ts
+++ b/apps/api/src/framework-editor/framework/dto/import-framework.dto.spec.ts
@@ -64,23 +64,25 @@ describe('ImportFrameworkDto', () => {
     expect(await validatePayload(basePayload())).toHaveLength(0);
   });
 
-  // Bug A — the import path must allow the same 10,000-char requirement
-  // descriptions the standalone requirement editor allows (NIST PL-2 > 6000).
-  it('accepts a 10,000-char requirement description', async () => {
+  // Bug A — the import path must allow the same 100,000-char requirement
+  // descriptions the standalone requirement editor allows (FRAME-2: NIST PL-2
+  // > 6000, HITRUST CSF requirements exceed 70,000).
+  it('accepts a 100,000-char requirement description', async () => {
     expect(
-      await validatePayload(basePayload({ requirementDescription: 'x'.repeat(10_000) })),
+      await validatePayload(basePayload({ requirementDescription: 'x'.repeat(100_000) })),
     ).toHaveLength(0);
   });
 
-  it('rejects a requirement description longer than 10,000 chars', async () => {
+  it('rejects a requirement description longer than 100,000 chars', async () => {
     const messages = await validatePayload(
-      basePayload({ requirementDescription: 'x'.repeat(10_001) }),
+      basePayload({ requirementDescription: 'x'.repeat(100_001) }),
     );
-    expect(messages.some((m) => m.includes('10000'))).toBe(true);
+    expect(messages.some((m) => m.includes('100000'))).toBe(true);
   });
 
-  // Import is the bulk-load path for externally-authored frameworks (NIST), so
-  // every description field accepts 10,000 — not just requirements.
+  // FRAME-2 raised requirement descriptions to 100,000, but control / policy /
+  // task template descriptions keep their existing 10,000 cap — the ticket is
+  // requirements-only, so this divergence is deliberate.
   it('accepts 10,000-char control / policy / task descriptions', async () => {
     const long = 'x'.repeat(10_000);
     const payload = {

--- a/apps/api/src/framework-editor/framework/dto/import-framework.dto.ts
+++ b/apps/api/src/framework-editor/framework/dto/import-framework.dto.ts
@@ -21,6 +21,7 @@ import {
 } from '@db';
 import { MaxJsonSize } from '../../validators/max-json-size.validator';
 import { IsObjectOrArray } from '../../validators/is-object-or-array.validator';
+import { REQUIREMENT_DESCRIPTION_MAX_LENGTH } from '../../constants';
 
 class ImportFrameworkMetaDto {
   @ApiProperty()
@@ -60,12 +61,13 @@ class ImportRequirementDto {
   @MaxLength(255)
   identifier?: string;
 
-  // Matches the standalone requirement DTOs (FRAME-2). NIST SP800-53 control
-  // text routinely exceeds 5000 chars (e.g. PL-2 > 6000).
+  // Matches the standalone requirement DTOs (FRAME-2). Regulatory control text
+  // can be very long: NIST SP800-53r5 PL-2 > 6000 chars, and many HITRUST CSF
+  // requirements exceed 70,000 — hence the shared 100,000 ceiling.
   @ApiProperty()
   @IsString()
   @IsNotEmpty()
-  @MaxLength(10000)
+  @MaxLength(REQUIREMENT_DESCRIPTION_MAX_LENGTH)
   description: string;
 
   @ApiPropertyOptional()

--- a/apps/api/src/framework-editor/requirement/dto/batch-update-requirements.dto.spec.ts
+++ b/apps/api/src/framework-editor/requirement/dto/batch-update-requirements.dto.spec.ts
@@ -24,10 +24,10 @@ describe('BatchUpdateRequirementsDto', () => {
     expect(errors).toHaveLength(0);
   });
 
-  // ── nested description length (FRAME-2: limit raised 5,000 → 10,000) ─
-  it('accepts a nested description at the 10,000-char limit', async () => {
+  // ── nested description length (FRAME-2: limit raised 10,000 → 100,000) ─
+  it('accepts a nested description at the 100,000-char limit', async () => {
     const dto = toDto({
-      updates: [{ id: 'frq_1', description: 'x'.repeat(10_000) }],
+      updates: [{ id: 'frq_1', description: 'x'.repeat(100_000) }],
     });
     const errors = await validate(dto, {
       whitelist: true,
@@ -36,9 +36,9 @@ describe('BatchUpdateRequirementsDto', () => {
     expect(errors).toHaveLength(0);
   });
 
-  it('rejects a nested description longer than 10,000 chars', async () => {
+  it('rejects a nested description longer than 100,000 chars', async () => {
     const dto = toDto({
-      updates: [{ id: 'frq_1', description: 'x'.repeat(10_001) }],
+      updates: [{ id: 'frq_1', description: 'x'.repeat(100_001) }],
     });
     const errors = await validate(dto, {
       whitelist: true,

--- a/apps/api/src/framework-editor/requirement/dto/batch-update-requirements.dto.ts
+++ b/apps/api/src/framework-editor/requirement/dto/batch-update-requirements.dto.ts
@@ -10,6 +10,7 @@ import {
   Min,
   ValidateNested,
 } from 'class-validator';
+import { REQUIREMENT_DESCRIPTION_MAX_LENGTH } from '../../constants';
 
 class BatchUpdateRequirementItem {
   @ApiProperty()
@@ -32,7 +33,7 @@ class BatchUpdateRequirementItem {
   @ApiProperty()
   @IsString()
   @IsOptional()
-  @MaxLength(10000)
+  @MaxLength(REQUIREMENT_DESCRIPTION_MAX_LENGTH)
   description?: string;
 
   @ApiProperty()

--- a/apps/api/src/framework-editor/requirement/dto/create-requirement.dto.spec.ts
+++ b/apps/api/src/framework-editor/requirement/dto/create-requirement.dto.spec.ts
@@ -28,9 +28,9 @@ describe('CreateRequirementDto', () => {
     expect(errors).toHaveLength(0);
   });
 
-  // ── description length (FRAME-2: limit raised 5,000 → 10,000) ──────
-  it('accepts a description at the 10,000-char limit', async () => {
-    const dto = toDto({ ...VALID_BASE, description: 'x'.repeat(10_000) });
+  // ── description length (FRAME-2: limit raised 10,000 → 100,000) ────
+  it('accepts a description at the 100,000-char limit', async () => {
+    const dto = toDto({ ...VALID_BASE, description: 'x'.repeat(100_000) });
     const errors = await validate(dto, {
       whitelist: true,
       forbidNonWhitelisted: true,
@@ -38,8 +38,8 @@ describe('CreateRequirementDto', () => {
     expect(errors).toHaveLength(0);
   });
 
-  it('rejects a description longer than 10,000 chars', async () => {
-    const dto = toDto({ ...VALID_BASE, description: 'x'.repeat(10_001) });
+  it('rejects a description longer than 100,000 chars', async () => {
+    const dto = toDto({ ...VALID_BASE, description: 'x'.repeat(100_001) });
     const errors = await validate(dto, {
       whitelist: true,
       forbidNonWhitelisted: true,

--- a/apps/api/src/framework-editor/requirement/dto/create-requirement.dto.ts
+++ b/apps/api/src/framework-editor/requirement/dto/create-requirement.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsInt, IsNotEmpty, IsOptional, IsString, MaxLength, Min } from 'class-validator';
+import { REQUIREMENT_DESCRIPTION_MAX_LENGTH } from '../../constants';
 
 export class CreateRequirementDto {
   @ApiProperty({ example: 'frk_abc123' })
@@ -22,7 +23,7 @@ export class CreateRequirementDto {
 
   @ApiProperty({ example: 'Control environment requirements' })
   @IsString()
-  @MaxLength(10000)
+  @MaxLength(REQUIREMENT_DESCRIPTION_MAX_LENGTH)
   description: string;
 
   @ApiPropertyOptional({ example: 'Access Control' })

--- a/apps/api/src/framework-editor/requirement/dto/update-requirement.dto.spec.ts
+++ b/apps/api/src/framework-editor/requirement/dto/update-requirement.dto.spec.ts
@@ -22,9 +22,9 @@ describe('UpdateRequirementDto', () => {
     expect(errors).toHaveLength(0);
   });
 
-  // ── description length (FRAME-2: limit raised 5,000 → 10,000) ──────
-  it('accepts a description at the 10,000-char limit', async () => {
-    const dto = toDto({ description: 'x'.repeat(10_000) });
+  // ── description length (FRAME-2: limit raised 10,000 → 100,000) ────
+  it('accepts a description at the 100,000-char limit', async () => {
+    const dto = toDto({ description: 'x'.repeat(100_000) });
     const errors = await validate(dto, {
       whitelist: true,
       forbidNonWhitelisted: true,
@@ -32,8 +32,8 @@ describe('UpdateRequirementDto', () => {
     expect(errors).toHaveLength(0);
   });
 
-  it('rejects a description longer than 10,000 chars', async () => {
-    const dto = toDto({ description: 'x'.repeat(10_001) });
+  it('rejects a description longer than 100,000 chars', async () => {
+    const dto = toDto({ description: 'x'.repeat(100_001) });
     const errors = await validate(dto, {
       whitelist: true,
       forbidNonWhitelisted: true,

--- a/apps/api/src/framework-editor/requirement/dto/update-requirement.dto.ts
+++ b/apps/api/src/framework-editor/requirement/dto/update-requirement.dto.ts
@@ -1,5 +1,6 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsInt, IsOptional, IsString, MaxLength, Min } from 'class-validator';
+import { REQUIREMENT_DESCRIPTION_MAX_LENGTH } from '../../constants';
 
 export class UpdateRequirementDto {
   @ApiPropertyOptional()
@@ -17,7 +18,7 @@ export class UpdateRequirementDto {
   @ApiPropertyOptional()
   @IsString()
   @IsOptional()
-  @MaxLength(10000)
+  @MaxLength(REQUIREMENT_DESCRIPTION_MAX_LENGTH)
   description?: string;
 
   @ApiPropertyOptional()


### PR DESCRIPTION
## FRAME-2 (reopened)

The build-out and promotion of the HITRUST frameworks is paused because many requirement descriptions run well past the current **10,000-character** limit — some exceed **70,000 characters** — and were being rejected by API-side validation. Joe asked to raise the ceiling to **100,000** so this doesn't need revisiting again.

## What changed

Raised the requirement **description** limit from `10,000` → `100,000` across **every path that carries it**:

- `POST /requirement` — `CreateRequirementDto`
- `PATCH /requirement/:id` — `UpdateRequirementDto`
- `PATCH /requirement/batch` — `BatchUpdateRequirementsDto` (editor's save path)
- Framework import — `ImportFrameworkDto.requirements[].description`

All four now reference a single shared `REQUIREMENT_DESCRIPTION_MAX_LENGTH` constant (`apps/api/src/framework-editor/constants.ts`) so they can't drift apart again — historically they were bumped separately and fell out of sync.

## Why this is the whole fix

The limit was purely API-side `@MaxLength` validation. The DB column is already unbounded `text`, the framework-editor's client-side zod schema has no max, and the Express body limit is 150 MB — so lifting the DTO cap raises the ceiling end-to-end. No migration, no client change needed.

## Scope note

Control / policy / task **template** descriptions keep their existing 10,000 cap — this ticket is requirements-only. Easy follow-up if HITRUST needs those raised too.

## Testing

- Updated the 4 DTO validation specs to assert the new 100,000 boundary (100,000 accepted, 100,001 rejected).
- `npx jest src/framework-editor/requirement/dto src/framework-editor/framework/dto/import-framework.dto.spec.ts` → **21 passed**.
- `npx turbo run typecheck --filter=@trycompai/api` → no new errors in any framework-editor file (pre-existing failures on `main` in unrelated modules are untouched).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised the requirement description limit to 100,000 to stop API validation rejections and unblock HITRUST framework imports (FRAME-2). Applies to create, update, batch update, and import; control/policy/task templates stay at 10,000.

- **New Features**
  - Added a shared REQUIREMENT_DESCRIPTION_MAX_LENGTH constant and applied it across all requirement DTOs (create, update, batch, import).
  - Updated validation and tests to the 100,000 boundary; no DB or client changes needed (DB column is unbounded text).

<sup>Written for commit 67c9f4a01b0cf7b33d6ecaaf341385ca520556a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

