### PR TITLE
feat(auth): add self-serve and admin login email change

### DIFF
--- a/apps/api/src/auth/auth.server.ts
+++ b/apps/api/src/auth/auth.server.ts
@@ -1,5 +1,6 @@
 import '../config/load-env';
 import {
+  ChangeEmailConfirmationEmail,
   MagicLinkEmail,
   OTPVerificationEmail,
   VerifyEmail,
@@ -572,6 +573,23 @@ export const auth = betterAuth({
   socialProviders,
   user: {
     modelName: 'User',
+    changeEmail: {
+      enabled: true,
+      // Double opt-in: this link goes to the CURRENT address; confirming it
+      // makes better-auth send a verification link to the NEW address (via
+      // emailVerification.sendVerificationEmail), which applies the change.
+      sendChangeEmailConfirmation: async ({ user, newEmail, url }) => {
+        await triggerEmail({
+          to: user.email,
+          subject: 'Confirm your email change for Comp AI',
+          react: ChangeEmailConfirmationEmail({
+            currentEmail: user.email,
+            newEmail,
+            url,
+          }),
+        });
+      },
+    },
   },
   organization: {
     modelName: 'Organization',

--- a/apps/api/src/email/templates/login-email-changed.tsx
+++ b/apps/api/src/email/templates/login-email-changed.tsx
@@ -1,6 +1,7 @@
 import {
   Body,
   Container,
+  Font,
   Heading,
   Html,
   Preview,
@@ -21,7 +22,20 @@ export const LoginEmailChangedEmail = ({ organizationName, oldEmail, newEmail }:
   return (
     <Html>
       <Tailwind>
-        <head />
+        <head>
+          <Font
+            fontFamily="Geist"
+            fallbackFontFamily="Helvetica"
+            fontWeight={400}
+            fontStyle="normal"
+          />
+          <Font
+            fontFamily="Geist"
+            fallbackFontFamily="Helvetica"
+            fontWeight={500}
+            fontStyle="normal"
+          />
+        </head>
         <Preview>Your Comp AI login email was changed</Preview>
 
         <Body className="mx-auto my-auto bg-[#fff] font-sans">

--- a/apps/api/src/email/templates/login-email-changed.tsx
+++ b/apps/api/src/email/templates/login-email-changed.tsx
@@ -1,0 +1,66 @@
+import {
+  Body,
+  Container,
+  Heading,
+  Html,
+  Preview,
+  Section,
+  Tailwind,
+  Text,
+} from '@react-email/components';
+import { Footer } from '../components/footer';
+import { Logo } from '../components/logo';
+
+interface Props {
+  organizationName: string;
+  oldEmail: string;
+  newEmail: string;
+}
+
+export const LoginEmailChangedEmail = ({ organizationName, oldEmail, newEmail }: Props) => {
+  return (
+    <Html>
+      <Tailwind>
+        <head />
+        <Preview>Your Comp AI login email was changed</Preview>
+
+        <Body className="mx-auto my-auto bg-[#fff] font-sans">
+          <Container
+            className="mx-auto my-[40px] max-w-[600px] border-transparent p-[20px] md:border-[#E8E7E1]"
+            style={{ borderStyle: 'solid', borderWidth: 1 }}
+          >
+            <Logo />
+            <Heading className="mx-0 my-[30px] p-0 text-center text-[24px] font-normal text-[#121212]">
+              Your login email was changed
+            </Heading>
+
+            <Text className="text-[14px] leading-[24px] text-[#121212]">
+              An administrator of <span className="font-medium">{organizationName}</span>{' '}
+              changed your Comp AI login email from{' '}
+              <span className="font-medium">{oldEmail}</span> to{' '}
+              <span className="font-medium">{newEmail}</span>.
+            </Text>
+            <Text className="text-[14px] leading-[24px] text-[#121212]">
+              From now on, use <span className="font-medium">{newEmail}</span> to
+              sign in.
+            </Text>
+
+            <br />
+            <Section>
+              <Text className="text-[12px] leading-[24px] text-[#666666]">
+                If you did not expect this change, contact your organization
+                administrator or support@trycomp.ai.
+              </Text>
+            </Section>
+
+            <br />
+
+            <Footer />
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+};
+
+export default LoginEmailChangedEmail;

--- a/apps/api/src/people/people.controller.ts
+++ b/apps/api/src/people/people.controller.ts
@@ -470,6 +470,7 @@ export class PeopleController {
   @ApiResponse(UPDATE_MEMBER_RESPONSES[400])
   @ApiResponse(UPDATE_MEMBER_RESPONSES[401])
   @ApiResponse(UPDATE_MEMBER_RESPONSES[404])
+  @ApiResponse(UPDATE_MEMBER_RESPONSES[409])
   @ApiResponse(UPDATE_MEMBER_RESPONSES[500])
   async updateMember(
     @Param('id') memberId: string,

--- a/apps/api/src/people/people.service.spec.ts
+++ b/apps/api/src/people/people.service.spec.ts
@@ -3,6 +3,7 @@ import {
   NotFoundException,
   ForbiddenException,
   BadRequestException,
+  ConflictException,
 } from '@nestjs/common';
 import { PeopleService } from './people.service';
 import { FleetService } from '../lib/fleet.service';
@@ -86,8 +87,13 @@ jest.mock('@trycompai/email', () => ({
 
 jest.mock('./utils/member-validator');
 jest.mock('./utils/member-queries');
+jest.mock('./utils/login-email-change');
 
 import { db } from '@db';
+import {
+  notifyLoginEmailChanged,
+  validateLoginEmailChange,
+} from './utils/login-email-change';
 
 describe('PeopleService', () => {
   let service: PeopleService;
@@ -296,6 +302,93 @@ describe('PeopleService', () => {
         'org_123',
         updateData,
       );
+    });
+
+    describe('login email change', () => {
+      const existingMember = {
+        id: 'mem_1',
+        userId: 'usr_target',
+        role: 'employee',
+      };
+      const updatedMember = {
+        id: 'mem_1',
+        user: { name: 'Alice' },
+        role: 'employee',
+      };
+
+      beforeEach(() => {
+        (MemberValidator.validateOrganization as jest.Mock).mockResolvedValue(
+          undefined,
+        );
+        (MemberValidator.validateMemberExists as jest.Mock).mockResolvedValue(
+          existingMember,
+        );
+        (MemberQueries.updateMember as jest.Mock).mockResolvedValue(
+          updatedMember,
+        );
+      });
+
+      it('applies the normalized email and notifies both addresses', async () => {
+        (validateLoginEmailChange as jest.Mock).mockResolvedValue({
+          oldEmail: 'old@company.dev',
+          newEmail: 'new@company.io',
+        });
+
+        await service.updateById('mem_1', 'org_123', {
+          email: ' New@Company.IO ',
+        });
+
+        expect(validateLoginEmailChange).toHaveBeenCalledWith({
+          userId: 'usr_target',
+          organizationId: 'org_123',
+          requestedEmail: ' New@Company.IO ',
+        });
+        expect(MemberQueries.updateMember).toHaveBeenCalledWith(
+          'mem_1',
+          'org_123',
+          { email: 'new@company.io' },
+        );
+        expect(notifyLoginEmailChanged).toHaveBeenCalledWith(
+          expect.objectContaining({
+            organizationId: 'org_123',
+            change: {
+              oldEmail: 'old@company.dev',
+              newEmail: 'new@company.io',
+            },
+          }),
+        );
+      });
+
+      it('drops a no-op email change and does not notify', async () => {
+        (validateLoginEmailChange as jest.Mock).mockResolvedValue(null);
+
+        await service.updateById('mem_1', 'org_123', {
+          email: 'old@company.dev',
+          department: 'it',
+        });
+
+        expect(MemberQueries.updateMember).toHaveBeenCalledWith(
+          'mem_1',
+          'org_123',
+          { department: 'it' },
+        );
+        expect(notifyLoginEmailChanged).not.toHaveBeenCalled();
+      });
+
+      it('propagates ConflictException from validation without wrapping', async () => {
+        (validateLoginEmailChange as jest.Mock).mockRejectedValue(
+          new ConflictException('That email is already used by another account'),
+        );
+
+        await expect(
+          service.updateById('mem_1', 'org_123', {
+            email: 'taken@company.io',
+          }),
+        ).rejects.toThrow(ConflictException);
+
+        expect(MemberQueries.updateMember).not.toHaveBeenCalled();
+        expect(notifyLoginEmailChanged).not.toHaveBeenCalled();
+      });
     });
 
     it('should validate new userId when changing user', async () => {

--- a/apps/api/src/people/people.service.spec.ts
+++ b/apps/api/src/people/people.service.spec.ts
@@ -410,6 +410,13 @@ describe('PeopleService', () => {
 
         expect(result).toEqual(updatedMember);
         expect(MemberQueries.updateMember).not.toHaveBeenCalled();
+        // Must include deactivated members — the update path accepts them,
+        // so the no-op return can't silently 404 on a deactivated member.
+        expect(MemberQueries.findByIdInOrganization).toHaveBeenCalledWith(
+          'mem_1',
+          'org_123',
+          { includeDeactivated: true },
+        );
       });
 
       it('translates a unique-constraint race on the write into a 409', async () => {

--- a/apps/api/src/people/people.service.spec.ts
+++ b/apps/api/src/people/people.service.spec.ts
@@ -11,8 +11,19 @@ import { TimelinesService } from '../timelines/timelines.service';
 import { MemberValidator } from './utils/member-validator';
 import { MemberQueries } from './utils/member-queries';
 
-// Mock the database
+// Mock the database. Includes a stand-in Prisma.PrismaClientKnownRequestError
+// so the service's `instanceof` error-code branches can be exercised.
 jest.mock('@db', () => ({
+  Prisma: {
+    PrismaClientKnownRequestError: class PrismaClientKnownRequestError extends Error {
+      code: string;
+      constructor(message: string, { code }: { code: string }) {
+        super(message);
+        this.code = code;
+        this.name = 'PrismaClientKnownRequestError';
+      }
+    },
+  },
   db: {
     member: {
       findFirst: jest.fn(),
@@ -89,7 +100,7 @@ jest.mock('./utils/member-validator');
 jest.mock('./utils/member-queries');
 jest.mock('./utils/login-email-change');
 
-import { db } from '@db';
+import { db, Prisma } from '@db';
 import {
   notifyLoginEmailChanged,
   validateLoginEmailChange,
@@ -373,6 +384,49 @@ describe('PeopleService', () => {
           { department: 'it' },
         );
         expect(notifyLoginEmailChanged).not.toHaveBeenCalled();
+      });
+
+      it('rejects combining a userId reassignment with an email change', async () => {
+        await expect(
+          service.updateById('mem_1', 'org_123', {
+            userId: 'usr_other',
+            email: 'new@company.io',
+          }),
+        ).rejects.toThrow(BadRequestException);
+
+        expect(validateLoginEmailChange).not.toHaveBeenCalled();
+        expect(MemberQueries.updateMember).not.toHaveBeenCalled();
+      });
+
+      it('returns the member without writing when the no-op email is the only field', async () => {
+        (validateLoginEmailChange as jest.Mock).mockResolvedValue(null);
+        (MemberQueries.findByIdInOrganization as jest.Mock).mockResolvedValue(
+          updatedMember,
+        );
+
+        const result = await service.updateById('mem_1', 'org_123', {
+          email: 'old@company.dev',
+        });
+
+        expect(result).toEqual(updatedMember);
+        expect(MemberQueries.updateMember).not.toHaveBeenCalled();
+      });
+
+      it('translates a unique-constraint race on the write into a 409', async () => {
+        (validateLoginEmailChange as jest.Mock).mockResolvedValue({
+          oldEmail: 'old@company.dev',
+          newEmail: 'new@company.io',
+        });
+        (MemberQueries.updateMember as jest.Mock).mockRejectedValue(
+          new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+            code: 'P2002',
+            clientVersion: 'test',
+          }),
+        );
+
+        await expect(
+          service.updateById('mem_1', 'org_123', { email: 'new@company.io' }),
+        ).rejects.toThrow(ConflictException);
       });
 
       it('propagates ConflictException from validation without wrapping', async () => {

--- a/apps/api/src/people/people.service.ts
+++ b/apps/api/src/people/people.service.ts
@@ -360,7 +360,19 @@ export class PeopleService {
         } else {
           delete updateData.email;
           if (Object.keys(updateData).length === 0) {
-            return this.findById(memberId, organizationId);
+            // No-op: return the member without writing. Unlike findById, this
+            // must include deactivated members — the update path accepts them.
+            const member = await MemberQueries.findByIdInOrganization(
+              memberId,
+              organizationId,
+              { includeDeactivated: true },
+            );
+            if (!member) {
+              throw new NotFoundException(
+                `Member with ID ${memberId} not found in organization ${organizationId}`,
+              );
+            }
+            return member;
           }
         }
       }

--- a/apps/api/src/people/people.service.ts
+++ b/apps/api/src/people/people.service.ts
@@ -3,6 +3,7 @@ import {
   NotFoundException,
   Logger,
   BadRequestException,
+  ConflictException,
   ForbiddenException,
 } from '@nestjs/common';
 import { db } from '@db';
@@ -15,6 +16,11 @@ import type { BulkCreatePeopleDto } from './dto/bulk-create-people.dto';
 import { MemberValidator } from './utils/member-validator';
 import { MemberQueries } from './utils/member-queries';
 import { authorizeRoleChange } from './utils/role-authorization';
+import {
+  notifyLoginEmailChanged,
+  validateLoginEmailChange,
+  type LoginEmailChange,
+} from './utils/login-email-change';
 import {
   collectAssignedItems,
   clearAssignments,
@@ -333,11 +339,35 @@ export class PeopleService {
         );
       }
 
+      // Changing the email here changes the LOGIN email (User.email, global),
+      // so it needs uniqueness + cross-org guards before the raw write.
+      let emailChange: LoginEmailChange | null = null;
+      if (updateData.email !== undefined) {
+        emailChange = await validateLoginEmailChange({
+          userId: existingMember.userId,
+          organizationId,
+          requestedEmail: updateData.email,
+        });
+        if (emailChange) {
+          updateData.email = emailChange.newEmail;
+        } else {
+          delete updateData.email;
+        }
+      }
+
       const updatedMember = await MemberQueries.updateMember(
         memberId,
         organizationId,
         updateData,
       );
+
+      if (emailChange) {
+        await notifyLoginEmailChanged({
+          organizationId,
+          change: emailChange,
+          logger: this.logger,
+        });
+      }
 
       this.logger.log(
         `Updated member: ${updatedMember.user.name} (${memberId})`,
@@ -347,7 +377,8 @@ export class PeopleService {
       if (
         error instanceof NotFoundException ||
         error instanceof BadRequestException ||
-        error instanceof ForbiddenException
+        error instanceof ForbiddenException ||
+        error instanceof ConflictException
       ) {
         throw error;
       }

--- a/apps/api/src/people/people.service.ts
+++ b/apps/api/src/people/people.service.ts
@@ -6,7 +6,7 @@ import {
   ConflictException,
   ForbiddenException,
 } from '@nestjs/common';
-import { db } from '@db';
+import { db, Prisma } from '@db';
 import { FleetService } from '../lib/fleet.service';
 import { BUILT_IN_ROLE_PERMISSIONS } from '@trycompai/auth';
 import type { PeopleResponseDto } from './dto/people-responses.dto';
@@ -343,6 +343,13 @@ export class PeopleService {
       // so it needs uniqueness + cross-org guards before the raw write.
       let emailChange: LoginEmailChange | null = null;
       if (updateData.email !== undefined) {
+        if (updateData.userId && updateData.userId !== existingMember.userId) {
+          // The email write targets the member's CURRENT user, so combining it
+          // with a userId reassignment would rename the wrong account.
+          throw new BadRequestException(
+            'Cannot change userId and email in the same request',
+          );
+        }
         emailChange = await validateLoginEmailChange({
           userId: existingMember.userId,
           organizationId,
@@ -352,6 +359,9 @@ export class PeopleService {
           updateData.email = emailChange.newEmail;
         } else {
           delete updateData.email;
+          if (Object.keys(updateData).length === 0) {
+            return this.findById(memberId, organizationId);
+          }
         }
       }
 
@@ -362,7 +372,9 @@ export class PeopleService {
       );
 
       if (emailChange) {
-        await notifyLoginEmailChanged({
+        // Fire-and-forget: notification latency/failure must not block the
+        // update response. notifyLoginEmailChanged handles its own errors.
+        void notifyLoginEmailChanged({
           organizationId,
           change: emailChange,
           logger: this.logger,
@@ -381,6 +393,16 @@ export class PeopleService {
         error instanceof ConflictException
       ) {
         throw error;
+      }
+      // A concurrent email change can slip past the preflight uniqueness
+      // check; translate the unique-constraint violation to the same 409.
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2002'
+      ) {
+        throw new ConflictException(
+          'That email is already used by another account',
+        );
       }
       this.logger.error(
         `Failed to update member ${memberId} in organization ${organizationId}:`,

--- a/apps/api/src/people/schemas/update-member.responses.ts
+++ b/apps/api/src/people/schemas/update-member.responses.ts
@@ -63,6 +63,24 @@ export const UPDATE_MEMBER_RESPONSES: Record<string, ApiResponseOptions> = {
       },
     },
   },
+  409: {
+    status: 409,
+    description:
+      'Conflict - Login email already used by another account, or the member belongs to other organizations',
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          properties: {
+            message: {
+              type: 'string',
+              example: 'That email is already used by another account',
+            },
+          },
+        },
+      },
+    },
+  },
   404: {
     status: 404,
     description: 'Organization, member, or user not found',

--- a/apps/api/src/people/utils/login-email-change.spec.ts
+++ b/apps/api/src/people/utils/login-email-change.spec.ts
@@ -1,0 +1,141 @@
+import { ConflictException, Logger } from '@nestjs/common';
+
+jest.mock('@db', () => ({
+  db: {
+    user: {
+      findUniqueOrThrow: jest.fn(),
+      findFirst: jest.fn(),
+    },
+    member: {
+      count: jest.fn(),
+    },
+    organization: {
+      findUniqueOrThrow: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('../../email/trigger-email', () => ({
+  triggerEmail: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { db } from '@db';
+import { triggerEmail } from '../../email/trigger-email';
+import {
+  notifyLoginEmailChanged,
+  validateLoginEmailChange,
+} from './login-email-change';
+
+describe('validateLoginEmailChange', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (db.user.findUniqueOrThrow as jest.Mock).mockResolvedValue({
+      email: 'old@company.dev',
+    });
+    (db.user.findFirst as jest.Mock).mockResolvedValue(null);
+    (db.member.count as jest.Mock).mockResolvedValue(0);
+  });
+
+  it('normalizes the requested email and returns the change', async () => {
+    const change = await validateLoginEmailChange({
+      userId: 'usr_1',
+      organizationId: 'org_1',
+      requestedEmail: '  New@Company.IO ',
+    });
+
+    expect(change).toEqual({
+      oldEmail: 'old@company.dev',
+      newEmail: 'new@company.io',
+    });
+  });
+
+  it('returns null when the requested email is already the login email', async () => {
+    const change = await validateLoginEmailChange({
+      userId: 'usr_1',
+      organizationId: 'org_1',
+      requestedEmail: 'OLD@company.dev',
+    });
+
+    expect(change).toBeNull();
+    expect(db.user.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('throws ConflictException when the email belongs to another account', async () => {
+    (db.user.findFirst as jest.Mock).mockResolvedValue({ id: 'usr_other' });
+
+    await expect(
+      validateLoginEmailChange({
+        userId: 'usr_1',
+        organizationId: 'org_1',
+        requestedEmail: 'taken@company.io',
+      }),
+    ).rejects.toThrow(ConflictException);
+
+    expect(db.user.findFirst).toHaveBeenCalledWith({
+      where: {
+        email: { equals: 'taken@company.io', mode: 'insensitive' },
+        id: { not: 'usr_1' },
+      },
+      select: { id: true },
+    });
+  });
+
+  it('throws ConflictException when the user is active in other organizations', async () => {
+    (db.member.count as jest.Mock).mockResolvedValue(1);
+
+    await expect(
+      validateLoginEmailChange({
+        userId: 'usr_1',
+        organizationId: 'org_1',
+        requestedEmail: 'new@company.io',
+      }),
+    ).rejects.toThrow(ConflictException);
+
+    expect(db.member.count).toHaveBeenCalledWith({
+      where: {
+        userId: 'usr_1',
+        organizationId: { not: 'org_1' },
+        isActive: true,
+        deactivated: false,
+      },
+    });
+  });
+});
+
+describe('notifyLoginEmailChanged', () => {
+  const logger = { error: jest.fn() } as unknown as Logger;
+  const change = { oldEmail: 'old@company.dev', newEmail: 'new@company.io' };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (db.organization.findUniqueOrThrow as jest.Mock).mockResolvedValue({
+      name: 'Acme',
+    });
+  });
+
+  it('notifies both the old and new address', async () => {
+    await notifyLoginEmailChanged({
+      organizationId: 'org_1',
+      change,
+      logger,
+    });
+
+    expect(triggerEmail).toHaveBeenCalledTimes(2);
+    const recipients = (triggerEmail as jest.Mock).mock.calls.map(
+      ([params]) => params.to,
+    );
+    expect(recipients).toEqual(
+      expect.arrayContaining(['old@company.dev', 'new@company.io']),
+    );
+  });
+
+  it('swallows notification failures instead of failing the update', async () => {
+    (triggerEmail as jest.Mock).mockRejectedValue(new Error('smtp down'));
+
+    await expect(
+      notifyLoginEmailChanged({ organizationId: 'org_1', change, logger }),
+    ).resolves.toBeUndefined();
+
+    expect(logger.error).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/people/utils/login-email-change.ts
+++ b/apps/api/src/people/utils/login-email-change.ts
@@ -1,0 +1,104 @@
+import { ConflictException, Logger } from '@nestjs/common';
+import { db } from '@db';
+import { triggerEmail } from '../../email/trigger-email';
+import { LoginEmailChangedEmail } from '../../email/templates/login-email-changed';
+
+export interface LoginEmailChange {
+  oldEmail: string;
+  newEmail: string;
+}
+
+/**
+ * Validates an admin-initiated login email change for a member.
+ *
+ * Returns the normalized change to apply, or null when the requested email
+ * is already the member's login email (no-op). Throws ConflictException when
+ * the email belongs to another account, or when the target user also belongs
+ * to other organizations (a login email is global, so one org's admin must
+ * not change it for a user shared with other orgs — that user can change it
+ * themselves from Settings → User).
+ */
+export async function validateLoginEmailChange(params: {
+  userId: string;
+  organizationId: string;
+  requestedEmail: string;
+}): Promise<LoginEmailChange | null> {
+  const { userId, organizationId, requestedEmail } = params;
+  const newEmail = requestedEmail.trim().toLowerCase();
+
+  const user = await db.user.findUniqueOrThrow({
+    where: { id: userId },
+    select: { email: true },
+  });
+
+  if (user.email.toLowerCase() === newEmail) {
+    return null;
+  }
+
+  const emailTaken = await db.user.findFirst({
+    where: {
+      email: { equals: newEmail, mode: 'insensitive' },
+      id: { not: userId },
+    },
+    select: { id: true },
+  });
+  if (emailTaken) {
+    throw new ConflictException(
+      'That email is already used by another account',
+    );
+  }
+
+  const otherOrgMemberships = await db.member.count({
+    where: {
+      userId,
+      organizationId: { not: organizationId },
+      isActive: true,
+      deactivated: false,
+    },
+  });
+  if (otherOrgMemberships > 0) {
+    throw new ConflictException(
+      'This member also belongs to other organizations, so their login email cannot be changed from here. They can change it themselves under Settings → User.',
+    );
+  }
+
+  return { oldEmail: user.email, newEmail };
+}
+
+/**
+ * Notifies both the old and new address that the login email changed.
+ * Fire-and-forget: a notification failure must not fail the update itself.
+ */
+export async function notifyLoginEmailChanged(params: {
+  organizationId: string;
+  change: LoginEmailChange;
+  logger: Logger;
+}): Promise<void> {
+  const { organizationId, change, logger } = params;
+
+  try {
+    const organization = await db.organization.findUniqueOrThrow({
+      where: { id: organizationId },
+      select: { name: true },
+    });
+
+    await Promise.all(
+      [change.oldEmail, change.newEmail].map((to) =>
+        triggerEmail({
+          to,
+          subject: 'Your Comp AI login email was changed',
+          react: LoginEmailChangedEmail({
+            organizationName: organization.name,
+            oldEmail: change.oldEmail,
+            newEmail: change.newEmail,
+          }),
+        }),
+      ),
+    );
+  } catch (error) {
+    logger.error(
+      `Failed to send login email change notifications (${change.oldEmail} -> ${change.newEmail}):`,
+      error,
+    );
+  }
+}

--- a/apps/api/src/people/utils/member-queries.ts
+++ b/apps/api/src/people/utils/member-queries.ts
@@ -95,12 +95,13 @@ export class MemberQueries {
   static async findByIdInOrganization(
     memberId: string,
     organizationId: string,
+    options?: { includeDeactivated?: boolean },
   ): Promise<PeopleResponseDto | null> {
     return db.member.findFirst({
       where: {
         id: memberId,
         organizationId,
-        deactivated: false,
+        ...(options?.includeDeactivated ? {} : { deactivated: false }),
       },
       select: this.MEMBER_SELECT,
     });

--- a/apps/app/src/app/(app)/[orgId]/settings/user/components/LoginEmailSettings.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/settings/user/components/LoginEmailSettings.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { HTMLAttributes, LabelHTMLAttributes, ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockChangeEmail = vi.fn();
+
+vi.mock('@/utils/auth-client', () => ({
+  authClient: {
+    changeEmail: (...args: unknown[]) => mockChangeEmail(...args),
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@trycompai/design-system', () => ({
+  Button: ({ children, ...props }: HTMLAttributes<HTMLButtonElement> & { disabled?: boolean; type?: 'submit' | 'button' }) => (
+    <button {...props}>{children}</button>
+  ),
+  Input: (props: HTMLAttributes<HTMLInputElement>) => <input {...props} />,
+  Label: ({ children, ...props }: LabelHTMLAttributes<HTMLLabelElement>) => (
+    <label {...props}>{children}</label>
+  ),
+  Section: ({
+    title,
+    description,
+    children,
+  }: {
+    title?: ReactNode;
+    description?: ReactNode;
+    children?: ReactNode;
+  }) => (
+    <section>
+      <h2>{title}</h2>
+      <p>{description}</p>
+      {children}
+    </section>
+  ),
+  Stack: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  Text: ({ children }: { children?: ReactNode }) => <p>{children}</p>,
+}));
+
+import { toast } from 'sonner';
+import { LoginEmailSettings } from './LoginEmailSettings';
+
+const CURRENT_EMAIL = 'admin@old-domain.com';
+
+const submitWithEmail = async (email: string) => {
+  fireEvent.change(screen.getByLabelText('New email address'), {
+    target: { value: email },
+  });
+  fireEvent.click(screen.getByRole('button', { name: 'Change email' }));
+};
+
+describe('LoginEmailSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the current login email', () => {
+    render(<LoginEmailSettings currentEmail={CURRENT_EMAIL} />);
+    expect(
+      screen.getByText(`You currently sign in as ${CURRENT_EMAIL}.`),
+    ).toBeInTheDocument();
+  });
+
+  it('requests the change and shows the pending notice on success', async () => {
+    mockChangeEmail.mockResolvedValue({ data: { status: true }, error: null });
+    render(<LoginEmailSettings currentEmail={CURRENT_EMAIL} />);
+
+    await submitWithEmail('Admin@New-Domain.com');
+
+    await waitFor(() => {
+      expect(mockChangeEmail).toHaveBeenCalledWith({
+        newEmail: 'admin@new-domain.com',
+        callbackURL: `${window.location.origin}/`,
+      });
+    });
+    expect(toast.success).toHaveBeenCalledWith(
+      `Confirmation link sent to ${CURRENT_EMAIL}`,
+    );
+    expect(
+      screen.getByText(/We sent a confirmation link to admin@old-domain.com/),
+    ).toBeInTheDocument();
+  });
+
+  it('rejects the current email as the new address', async () => {
+    render(<LoginEmailSettings currentEmail={CURRENT_EMAIL} />);
+
+    await submitWithEmail(CURRENT_EMAIL.toUpperCase());
+
+    expect(
+      await screen.findByText('This is already your login email'),
+    ).toBeInTheDocument();
+    expect(mockChangeEmail).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid email without calling the API', async () => {
+    render(<LoginEmailSettings currentEmail={CURRENT_EMAIL} />);
+
+    await submitWithEmail('not-an-email');
+
+    expect(
+      await screen.findByText('Enter a valid email address'),
+    ).toBeInTheDocument();
+    expect(mockChangeEmail).not.toHaveBeenCalled();
+  });
+
+  it('surfaces API errors as a toast', async () => {
+    mockChangeEmail.mockResolvedValue({
+      data: null,
+      error: { message: 'Change email is disabled' },
+    });
+    render(<LoginEmailSettings currentEmail={CURRENT_EMAIL} />);
+
+    await submitWithEmail('someone@new-domain.com');
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Change email is disabled');
+    });
+    expect(
+      screen.queryByText(/We sent a confirmation link/),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/settings/user/components/LoginEmailSettings.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/settings/user/components/LoginEmailSettings.test.tsx
@@ -107,6 +107,25 @@ describe('LoginEmailSettings', () => {
     expect(mockChangeEmail).not.toHaveBeenCalled();
   });
 
+  it('hides the pending notice once the login email actually changes', async () => {
+    mockChangeEmail.mockResolvedValue({ data: { status: true }, error: null });
+    const { rerender } = render(
+      <LoginEmailSettings currentEmail={CURRENT_EMAIL} />,
+    );
+
+    await submitWithEmail('admin@new-domain.com');
+    expect(
+      await screen.findByText(/We sent a confirmation link/),
+    ).toBeInTheDocument();
+
+    // Verification completed elsewhere; the server re-renders with the new email.
+    rerender(<LoginEmailSettings currentEmail="admin@new-domain.com" />);
+
+    expect(
+      screen.queryByText(/We sent a confirmation link/),
+    ).not.toBeInTheDocument();
+  });
+
   it('surfaces API errors as a toast', async () => {
     mockChangeEmail.mockResolvedValue({
       data: null,

--- a/apps/app/src/app/(app)/[orgId]/settings/user/components/LoginEmailSettings.tsx
+++ b/apps/app/src/app/(app)/[orgId]/settings/user/components/LoginEmailSettings.tsx
@@ -47,19 +47,25 @@ export function LoginEmailSettings({ currentEmail }: Props) {
   });
 
   const handleChangeEmail = handleSubmit(async ({ newEmail }) => {
-    const { error } = await authClient.changeEmail({
-      newEmail,
-      callbackURL: `${window.location.origin}/`,
-    });
+    try {
+      const { error } = await authClient.changeEmail({
+        newEmail,
+        callbackURL: `${window.location.origin}/`,
+      });
 
-    if (error) {
-      toast.error(error.message ?? 'Failed to request the email change');
-      return;
+      if (error) {
+        setPendingEmail(null);
+        toast.error(error.message ?? 'Failed to request the email change');
+        return;
+      }
+
+      setPendingEmail(newEmail);
+      reset();
+      toast.success(`Confirmation link sent to ${currentEmail}`);
+    } catch {
+      setPendingEmail(null);
+      toast.error('Failed to request the email change');
     }
-
-    setPendingEmail(newEmail);
-    reset();
-    toast.success(`Confirmation link sent to ${currentEmail}`);
   });
 
   return (
@@ -76,13 +82,19 @@ export function LoginEmailSettings({ currentEmail }: Props) {
                 id="newEmail"
                 type="email"
                 placeholder="you@company.com"
+                aria-invalid={errors.newEmail ? true : undefined}
+                aria-describedby={
+                  errors.newEmail ? 'newEmail-error' : undefined
+                }
                 {...register('newEmail')}
               />
             </div>
             {errors.newEmail ? (
-              <Text size="sm" variant="destructive">
-                {errors.newEmail.message}
-              </Text>
+              <div id="newEmail-error" role="alert">
+                <Text size="sm" variant="destructive">
+                  {errors.newEmail.message}
+                </Text>
+              </div>
             ) : (
               <Text size="sm" variant="muted">
                 We'll send a confirmation link to your current email first,
@@ -99,7 +111,7 @@ export function LoginEmailSettings({ currentEmail }: Props) {
           </div>
 
           {pendingEmail && (
-            <div className="bg-muted rounded-md p-3">
+            <div className="bg-muted rounded-md p-3" role="status">
               <Text size="sm" variant="muted">
                 We sent a confirmation link to {currentEmail}. Once you confirm
                 it, a verification link goes to {pendingEmail} to finish the

--- a/apps/app/src/app/(app)/[orgId]/settings/user/components/LoginEmailSettings.tsx
+++ b/apps/app/src/app/(app)/[orgId]/settings/user/components/LoginEmailSettings.tsx
@@ -34,7 +34,16 @@ const buildChangeEmailSchema = (currentEmail: string) =>
 type ChangeEmailFormValues = z.infer<ReturnType<typeof buildChangeEmailSchema>>;
 
 export function LoginEmailSettings({ currentEmail }: Props) {
-  const [pendingEmail, setPendingEmail] = useState<string | null>(null);
+  // Tracks which login email the pending request was made against, so the
+  // notice disappears once the change completes and currentEmail moves on.
+  const [pendingRequest, setPendingRequest] = useState<{
+    from: string;
+    to: string;
+  } | null>(null);
+  const pendingEmail =
+    pendingRequest && pendingRequest.from === currentEmail
+      ? pendingRequest.to
+      : null;
 
   const {
     register,
@@ -54,16 +63,16 @@ export function LoginEmailSettings({ currentEmail }: Props) {
       });
 
       if (error) {
-        setPendingEmail(null);
+        setPendingRequest(null);
         toast.error(error.message ?? 'Failed to request the email change');
         return;
       }
 
-      setPendingEmail(newEmail);
+      setPendingRequest({ from: currentEmail, to: newEmail });
       reset();
       toast.success(`Confirmation link sent to ${currentEmail}`);
     } catch {
-      setPendingEmail(null);
+      setPendingRequest(null);
       toast.error('Failed to request the email change');
     }
   });

--- a/apps/app/src/app/(app)/[orgId]/settings/user/components/LoginEmailSettings.tsx
+++ b/apps/app/src/app/(app)/[orgId]/settings/user/components/LoginEmailSettings.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { authClient } from '@/utils/auth-client';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  Button,
+  Input,
+  Label,
+  Section,
+  Stack,
+  Text,
+} from '@trycompai/design-system';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+import { z } from 'zod';
+
+interface Props {
+  currentEmail: string;
+}
+
+const buildChangeEmailSchema = (currentEmail: string) =>
+  z.object({
+    newEmail: z
+      .string()
+      .trim()
+      .toLowerCase()
+      .email('Enter a valid email address')
+      .refine((value) => value !== currentEmail.toLowerCase(), {
+        message: 'This is already your login email',
+      }),
+  });
+
+type ChangeEmailFormValues = z.infer<ReturnType<typeof buildChangeEmailSchema>>;
+
+export function LoginEmailSettings({ currentEmail }: Props) {
+  const [pendingEmail, setPendingEmail] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    reset,
+  } = useForm<ChangeEmailFormValues>({
+    resolver: zodResolver(buildChangeEmailSchema(currentEmail)),
+    defaultValues: { newEmail: '' },
+  });
+
+  const handleChangeEmail = handleSubmit(async ({ newEmail }) => {
+    const { error } = await authClient.changeEmail({
+      newEmail,
+      callbackURL: `${window.location.origin}/`,
+    });
+
+    if (error) {
+      toast.error(error.message ?? 'Failed to request the email change');
+      return;
+    }
+
+    setPendingEmail(newEmail);
+    reset();
+    toast.success(`Confirmation link sent to ${currentEmail}`);
+  });
+
+  return (
+    <Section
+      title="Login Email"
+      description={`You currently sign in as ${currentEmail}.`}
+    >
+      <form onSubmit={handleChangeEmail} noValidate>
+        <Stack gap="md">
+          <Stack gap="sm">
+            <Label htmlFor="newEmail">New email address</Label>
+            <div className="w-full md:max-w-sm">
+              <Input
+                id="newEmail"
+                type="email"
+                placeholder="you@company.com"
+                {...register('newEmail')}
+              />
+            </div>
+            {errors.newEmail ? (
+              <Text size="sm" variant="destructive">
+                {errors.newEmail.message}
+              </Text>
+            ) : (
+              <Text size="sm" variant="muted">
+                We'll send a confirmation link to your current email first,
+                then a verification link to the new address to complete the
+                change.
+              </Text>
+            )}
+          </Stack>
+
+          <div>
+            <Button type="submit" loading={isSubmitting}>
+              Change email
+            </Button>
+          </div>
+
+          {pendingEmail && (
+            <div className="bg-muted rounded-md p-3">
+              <Text size="sm" variant="muted">
+                We sent a confirmation link to {currentEmail}. Once you confirm
+                it, a verification link goes to {pendingEmail} to finish the
+                change. If it doesn't arrive, the new address may already be in
+                use.
+              </Text>
+            </div>
+          )}
+        </Stack>
+      </form>
+    </Section>
+  );
+}

--- a/apps/app/src/app/(app)/[orgId]/settings/user/page.tsx
+++ b/apps/app/src/app/(app)/[orgId]/settings/user/page.tsx
@@ -1,6 +1,7 @@
 import { serverApi } from '@/lib/api-server';
 import type { Metadata } from 'next';
 import { EmailNotificationPreferences } from './components/EmailNotificationPreferences';
+import { LoginEmailSettings } from './components/LoginEmailSettings';
 import { McpOrganizationSelector } from './components/McpOrganizationSelector';
 import type { McpOrganizationData } from './hooks/useMcpOrganization';
 
@@ -41,6 +42,7 @@ export default async function UserSettings({
 
   return (
     <div className="space-y-6">
+      <LoginEmailSettings currentEmail={emailRes.data.email} />
       <EmailNotificationPreferences
         initialPreferences={emailRes.data.preferences}
         email={emailRes.data.email}

--- a/packages/docs/openapi.json
+++ b/packages/docs/openapi.json
@@ -2066,6 +2066,22 @@
               }
             }
           },
+          "409": {
+            "description": "Conflict - Login email already used by another account, or the member belongs to other organizations",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "That email is already used by another account"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal server error",
             "content": {

--- a/packages/email/emails/change-email-confirmation.tsx
+++ b/packages/email/emails/change-email-confirmation.tsx
@@ -1,0 +1,81 @@
+import {
+  Body,
+  Button,
+  Container,
+  Heading,
+  Html,
+  Link,
+  Preview,
+  Section,
+  Tailwind,
+  Text,
+} from '@react-email/components';
+import { Footer } from '../components/footer';
+import { Logo } from '../components/logo';
+
+interface Props {
+  currentEmail: string;
+  newEmail: string;
+  url: string;
+}
+
+export const ChangeEmailConfirmationEmail = ({ currentEmail, newEmail, url }: Props) => {
+  return (
+    <Html>
+      <Tailwind>
+        <head />
+        <Preview>Confirm your email change for Comp AI</Preview>
+
+        <Body className="mx-auto my-auto bg-[#fff] font-sans">
+          <Container
+            className="mx-auto my-[40px] max-w-[600px] border-transparent p-[20px] md:border-[#E8E7E1]"
+            style={{ borderStyle: 'solid', borderWidth: 1 }}
+          >
+            <Logo />
+            <Heading className="mx-0 my-[30px] p-0 text-center text-[24px] font-normal text-[#121212]">
+              Confirm your email change
+            </Heading>
+
+            <Text className="text-[14px] leading-[24px] text-[#121212]">
+              You requested to change your Comp AI login email from{' '}
+              <span className="font-medium">{currentEmail}</span> to{' '}
+              <span className="font-medium">{newEmail}</span>. Confirm below,
+              then follow the verification link we send to your new address to
+              finish the change.
+            </Text>
+            <Section className="mt-[32px] mb-[42px] text-center">
+              <Button
+                className="text-primary border border-solid border-[#121212] bg-transparent px-6 py-3 text-center text-[14px] font-medium text-[#121212] no-underline"
+                href={url}
+              >
+                Confirm email change
+              </Button>
+            </Section>
+
+            <Text className="text-[14px] leading-[24px] break-all text-[#707070]">
+              or copy and paste this URL into your browser{' '}
+              <Link href={url} className="text-[#707070] underline">
+                {url}
+              </Link>
+            </Text>
+
+            <br />
+            <Section>
+              <Text className="text-[12px] leading-[24px] text-[#666666]">
+                If you did not request this change, you can safely ignore this
+                email — your login email will stay{' '}
+                <span className="text-[#121212]">{currentEmail}</span>.
+              </Text>
+            </Section>
+
+            <br />
+
+            <Footer />
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+};
+
+export default ChangeEmailConfirmationEmail;

--- a/packages/email/emails/render.test.tsx
+++ b/packages/email/emails/render.test.tsx
@@ -1,6 +1,7 @@
 import { render } from '@react-email/render';
 import { describe, expect, it } from 'vitest';
 import { AllPolicyNotificationEmail } from './all-policy-notification';
+import { ChangeEmailConfirmationEmail } from './change-email-confirmation';
 import { InviteEmail } from './invite';
 import { InvitePortalEmail } from './invite-portal';
 import { MagicLinkEmail } from './magic-link';
@@ -119,6 +120,16 @@ const cases = [
   {
     name: 'verify-email',
     el: <VerifyEmail email="user@example.com" url="https://app.trycomp.ai/verify" />,
+  },
+  {
+    name: 'change-email-confirmation',
+    el: (
+      <ChangeEmailConfirmationEmail
+        currentEmail="old@example.com"
+        newEmail="new@example.com"
+        url="https://app.trycomp.ai/verify"
+      />
+    ),
   },
   {
     name: 'training-completed',

--- a/packages/email/index.ts
+++ b/packages/email/index.ts
@@ -1,5 +1,6 @@
 // Email templates
 export * from './emails/all-policy-notification';
+export * from './emails/change-email-confirmation';
 export * from './emails/invite';
 export * from './emails/invite-portal';
 export * from './emails/magic-link';


### PR DESCRIPTION
## Why

Domain migrations keep generating lockout tickets (three customers so far): a user's company changes email domains, there is no way to change a login email, so people invite a new account + offboard the old one — which splits their identity across two accounts and ends in support-driven database fixes. This PR adds both self-serve and admin paths so the email changes on the existing account and no duplicate is ever created.

## What

### Self-serve (Settings → User → Login Email)
- Enables better-auth `changeEmail` with double opt-in: a confirmation link is sent to the **current** address; confirming it sends a verification link to the **new** address, which applies the change. Sessions, OAuth links, and org memberships are keyed by user id and are unaffected.
- New `ChangeEmailConfirmationEmail` template; the second step reuses the existing `VerifyEmail` template.
- New `LoginEmailSettings` component (RHF + Zod, design system, responsive). Note: better-auth intentionally returns success without sending anything when the requested email is already taken, so the UI copy explains what to do if no email arrives.

### Admin (People → member details)
The email field there already updated the login email (`User.email`, global) through `PATCH /v1/people/:id` — with no validation: a taken email surfaced as a Prisma P2002 500, and the change was allowed even when the user belongs to other organizations. Now, in `updateById`:
- **Uniqueness check** (case-insensitive) → 409 "That email is already used by another account"
- **Cross-org guard**: users active in other orgs must change their own email via settings → 409 with that guidance
- **Lowercase normalization** (auth lookups are case-folded) and a **no-op guard** when the email is unchanged
- **Notifications** to both the old and new address (non-blocking)
- 409 documented in the OpenAPI spec (minimal hand-applied spec change; a full dev-boot regen produced ~24k lines of unrelated churn, so I kept the diff scoped)

## Tests
- `login-email-change.spec.ts`: 6 unit tests (normalization, no-op, both conflict paths, notifications, notification-failure resilience)
- `people.service.spec.ts`: 3 wiring tests (normalized write + notify, no-op drop, 409 propagation)
- `LoginEmailSettings.test.tsx`: 5 component tests (render, happy path, same-email rejection, invalid email, API error toast)
- `render.test.tsx`: new template added to the email render regression suite

All people-module (98), settings-user (5), and email (16) tests green. Typecheck clean in every touched package (pre-existing failures in unrelated spec files verified against main).

## Notes for review
- `noValidate` on the settings form: native `type=email` constraint validation would otherwise swallow submissions before Zod runs (and show browser tooltips instead of styled errors).
- `ConflictException` added to `updateById`'s rethrow allowlist so it isn't wrapped into a generic 500.
- Deliberately NOT enabled: `updateEmailWithoutVerification` (unverified users still get a verification step via the fallback path).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds self-serve and admin-controlled login email changes with double opt-in, conflict checks, and notifications to prevent lockouts and duplicate accounts. Also documents 409 conflict responses.

- **New Features**
  - Self-serve: enabled `changeEmail` in `better-auth` with double opt-in; new Login Email section in Settings (`LoginEmailSettings`) with confirmation to the current address and verification to the new one; sessions and org links stay intact.
  - Admin: `PATCH /v1/people/:id` now normalizes to lowercase, validates uniqueness (case-insensitive), guards cross-org users, no-ops unchanged emails, and notifies both old and new emails; OpenAPI adds 409.

- **Bug Fixes**
  - Reject combining `userId` reassignment with an email change.
  - Translate unique-constraint races to 409 and send notifications asynchronously so updates don’t block.
  - No‑op same‑email PATCH returns the member (including deactivated), and the settings pending notice is keyed to the requested email so it disappears once the change completes; also handle client errors and add aria-invalid/aria-describedby with a status live region.

<sup>Written for commit c2d3b16d3d0963556b8a1336b91793672ac75d44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

