### PR TITLE
chore(docs): regenerate public openapi spec

### DIFF
--- a/apps/api/src/gen-openapi.spec.ts
+++ b/apps/api/src/gen-openapi.spec.ts
@@ -32,6 +32,12 @@ jest.mock('@thallesp/nestjs-better-auth', () => {
   return { AuthModule: AuthModuleStub };
 });
 
+// @inference/tracing is ESM-only, same as better-auth above.
+jest.mock('@inference/tracing', () => ({ setup: jest.fn() }));
+jest.mock('@inference/tracing/ai-sdk', () => ({
+  createAISdkTelemetrySettings: jest.fn(() => ({})),
+}));
+
 jest.mock('better-auth/plugins/access', () => ({
   createAccessControl: () => ({
     newRole: () => ({}),
@@ -98,6 +104,7 @@ process.env.APP_AWS_ACCESS_KEY_ID = 'test-access-key-id';
 process.env.APP_AWS_SECRET_ACCESS_KEY = 'test-secret-access-key';
 process.env.APP_AWS_BUCKET_NAME = 'test-bucket';
 process.env.APP_AWS_REGION = 'us-east-1';
+process.env.MACED_API_KEY = 'mc_dev_test-openapi-gen';
 
 import path from 'path';
 import { writeFileSync, mkdirSync, existsSync } from 'fs';

--- a/apps/api/src/openapi-docs.spec.ts
+++ b/apps/api/src/openapi-docs.spec.ts
@@ -29,6 +29,12 @@ jest.mock('@thallesp/nestjs-better-auth', () => {
   return { AuthModule: AuthModuleStub };
 });
 
+// @inference/tracing is ESM-only, same as better-auth above.
+jest.mock('@inference/tracing', () => ({ setup: jest.fn() }));
+jest.mock('@inference/tracing/ai-sdk', () => ({
+  createAISdkTelemetrySettings: jest.fn(() => ({})),
+}));
+
 jest.mock('better-auth/plugins/access', () => ({
   createAccessControl: () => ({
     newRole: () => ({}),
@@ -101,6 +107,7 @@ process.env.APP_AWS_ACCESS_KEY_ID = 'test-access-key-id';
 process.env.APP_AWS_SECRET_ACCESS_KEY = 'test-secret-access-key';
 process.env.APP_AWS_BUCKET_NAME = 'test-bucket';
 process.env.APP_AWS_REGION = 'us-east-1';
+process.env.MACED_API_KEY = 'mc_dev_test-openapi-gen';
 
 import { Test } from '@nestjs/testing';
 import {

--- a/packages/docs/openapi.json
+++ b/packages/docs/openapi.json
@@ -190,11 +190,6 @@
                     "description": "Whether onboarding is completed",
                     "example": true
                   },
-                  "hasAccess": {
-                    "type": "boolean",
-                    "description": "Whether organization has access to the platform",
-                    "example": true
-                  },
                   "fleetDmLabelId": {
                     "type": "integer",
                     "description": "FleetDM label ID for device management",
@@ -218,6 +213,31 @@
                   "backgroundCheckStepEnabled": {
                     "type": "boolean",
                     "description": "Whether the background-check step is required during member onboarding. Set to false to turn off the \"Require background checks\" setting; true to require it.",
+                    "example": true
+                  },
+                  "evidenceApprovalEnabled": {
+                    "type": "boolean",
+                    "description": "Whether evidence requires approval before it is accepted.",
+                    "example": false
+                  },
+                  "deviceAgentStepEnabled": {
+                    "type": "boolean",
+                    "description": "Whether the device-agent step is enabled during member onboarding.",
+                    "example": true
+                  },
+                  "securityTrainingStepEnabled": {
+                    "type": "boolean",
+                    "description": "Whether the security-training step is enabled during member onboarding.",
+                    "example": true
+                  },
+                  "whistleblowerReportEnabled": {
+                    "type": "boolean",
+                    "description": "Whether the whistleblower reporting feature is enabled.",
+                    "example": true
+                  },
+                  "accessRequestFormEnabled": {
+                    "type": "boolean",
+                    "description": "Whether the trust-portal access request form is enabled.",
                     "example": true
                   }
                 },
@@ -2246,6 +2266,50 @@
         }
       }
     },
+    "/v1/people/{id}/access": {
+      "get": {
+        "description": "Aggregates the latest Employee Access check results from every connected integration bound to the Employee Access task, matched to the member by email.",
+        "operationId": "PeopleController_getMemberAccess_v1",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "Member ID",
+            "schema": {
+              "example": "mem_abc123def456",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Member's access across connected integrations",
+        "tags": [
+          "People"
+        ],
+        "x-mint": {
+          "metadata": {
+            "title": "Member's access across connected integrations | Comp AI API",
+            "sidebarTitle": "Member's access across connected integrations",
+            "description": "Aggregates the latest Employee Access check results from every connected integration bound to the Employee Access task, matched to the member by email.",
+            "og:title": "Member's access across connected integrations | Comp AI API",
+            "og:description": "Aggregates the latest Employee Access check results from every connected integration bound to the Employee Access task, matched to the member by email."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "get-member-access"
+        }
+      }
+    },
     "/v1/people/{id}/training-videos": {
       "get": {
         "operationId": "PeopleController_getTrainingVideos_v1",
@@ -3223,6 +3287,2574 @@
         },
         "x-speakeasy-mcp": {
           "name": "mark-ready-for-review"
+        }
+      }
+    },
+    "/v1/integrations/connections/providers": {
+      "get": {
+        "operationId": "ConnectionsController_listProviders_v1",
+        "parameters": [
+          {
+            "name": "activeOnly",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "List integration providers",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "List available integration providers that can connect to the organization for automated evidence collection and compliance checks.",
+        "x-mint": {
+          "metadata": {
+            "title": "List integration providers | Comp AI API",
+            "sidebarTitle": "List integration providers",
+            "description": "List available integration providers that can connect to the organization for automated evidence collection and compliance checks.",
+            "og:title": "List integration providers | Comp AI API",
+            "og:description": "List available integration providers that can connect to the organization for automated evidence collection and compliance checks."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "list-providers"
+        }
+      }
+    },
+    "/v1/integrations/connections/providers/{slug}": {
+      "get": {
+        "operationId": "ConnectionsController_getProvider_v1",
+        "parameters": [
+          {
+            "name": "slug",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Get an integration provider by slug",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Get an integration provider by slug in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Get an integration provider by slug | Comp AI API",
+            "sidebarTitle": "Get an integration provider by slug",
+            "description": "Get an integration provider by slug in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
+            "og:title": "Get an integration provider by slug | Comp AI API",
+            "og:description": "Get an integration provider by slug in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "get-provider"
+        }
+      }
+    },
+    "/v1/integrations/connections": {
+      "get": {
+        "operationId": "ConnectionsController_listConnections_v1",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "List integration connections",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "List integration connections in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "List integration connections | Comp AI API",
+            "sidebarTitle": "List integration connections",
+            "description": "List integration connections in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
+            "og:title": "List integration connections | Comp AI API",
+            "og:description": "List integration connections in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "list-connections"
+        }
+      },
+      "post": {
+        "operationId": "ConnectionsController_createConnection_v1",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateConnectionDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Create integration connection",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Create an integration connection so Comp AI can collect evidence, run checks, or sync data from a connected provider.",
+        "x-mint": {
+          "metadata": {
+            "title": "Create integration connection | Comp AI API",
+            "sidebarTitle": "Create integration connection",
+            "description": "Create an integration connection so Comp AI can collect evidence, run checks, or sync data from a connected provider.",
+            "og:title": "Create integration connection | Comp AI API",
+            "og:description": "Create an integration connection so Comp AI can collect evidence, run checks, or sync data from a connected provider."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "create-connection"
+        }
+      }
+    },
+    "/v1/integrations/connections/{id}": {
+      "get": {
+        "operationId": "ConnectionsController_getConnection_v1",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Get an integration connection by ID",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Get an integration connection by ID in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Get an integration connection by ID | Comp AI API",
+            "sidebarTitle": "Get an integration connection by ID",
+            "description": "Get an integration connection by ID in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
+            "og:title": "Get an integration connection by ID | Comp AI API",
+            "og:description": "Get an integration connection by ID in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "get-connection"
+        }
+      },
+      "delete": {
+        "operationId": "ConnectionsController_deleteConnection_v1",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Delete an integration connection",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Delete an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Delete an integration connection | Comp AI API",
+            "sidebarTitle": "Delete an integration connection",
+            "description": "Delete an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
+            "og:title": "Delete an integration connection | Comp AI API",
+            "og:description": "Delete an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "delete-connection"
+        }
+      },
+      "patch": {
+        "operationId": "ConnectionsController_updateConnection_v1",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateConnectionDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Update an integration connection",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Update an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Update an integration connection | Comp AI API",
+            "sidebarTitle": "Update an integration connection",
+            "description": "Update an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
+            "og:title": "Update an integration connection | Comp AI API",
+            "og:description": "Update an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "update-connection"
+        }
+      }
+    },
+    "/v1/integrations/connections/{id}/test": {
+      "post": {
+        "operationId": "ConnectionsController_testConnection_v1",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Test an integration connection",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Test an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Test an integration connection | Comp AI API",
+            "sidebarTitle": "Test an integration connection",
+            "description": "Test an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
+            "og:title": "Test an integration connection | Comp AI API",
+            "og:description": "Test an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "test-connection"
+        }
+      }
+    },
+    "/v1/integrations/connections/{id}/pause": {
+      "post": {
+        "operationId": "ConnectionsController_pauseConnection_v1",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Pause an integration connection",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Pause an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Pause an integration connection | Comp AI API",
+            "sidebarTitle": "Pause an integration connection",
+            "description": "Pause an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
+            "og:title": "Pause an integration connection | Comp AI API",
+            "og:description": "Pause an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "pause-connection"
+        }
+      }
+    },
+    "/v1/integrations/connections/{id}/resume": {
+      "post": {
+        "operationId": "ConnectionsController_resumeConnection_v1",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Resume an integration connection",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Resume an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Resume an integration connection | Comp AI API",
+            "sidebarTitle": "Resume an integration connection",
+            "description": "Resume an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
+            "og:title": "Resume an integration connection | Comp AI API",
+            "og:description": "Resume an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "resume-connection"
+        }
+      }
+    },
+    "/v1/integrations/connections/{id}/disconnect": {
+      "post": {
+        "operationId": "ConnectionsController_disconnectConnection_v1",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Disconnect an integration",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Disconnect an integration in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Disconnect an integration | Comp AI API",
+            "sidebarTitle": "Disconnect an integration",
+            "description": "Disconnect an integration in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
+            "og:title": "Disconnect an integration | Comp AI API",
+            "og:description": "Disconnect an integration in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "disconnect-connection"
+        }
+      }
+    },
+    "/v1/integrations/connections/{id}/services": {
+      "put": {
+        "operationId": "ConnectionsController_updateConnectionServices_v1",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateConnectionServicesDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Set services enabled on a connection",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Set services enabled on a connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Set services enabled on a connection | Comp AI API",
+            "sidebarTitle": "Set services enabled on a connection",
+            "description": "Set services enabled on a connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
+            "og:title": "Set services enabled on a connection | Comp AI API",
+            "og:description": "Set services enabled on a connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "update-connection-services"
+        }
+      },
+      "get": {
+        "operationId": "ServicesController_getConnectionServices_v1",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "List services enabled on a connection",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "List services enabled on a connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "List services enabled on a connection | Comp AI API",
+            "sidebarTitle": "List services enabled on a connection",
+            "description": "List services enabled on a connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
+            "og:title": "List services enabled on a connection | Comp AI API",
+            "og:description": "List services enabled on a connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "get-connection-services"
+        }
+      }
+    },
+    "/v1/integrations/checks/providers/{providerSlug}": {
+      "get": {
+        "operationId": "ChecksController_listProviderChecks_v1",
+        "parameters": [
+          {
+            "name": "providerSlug",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "List check definitions for a provider",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "List check definitions for a provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "List check definitions for a provider | Comp AI API",
+            "sidebarTitle": "List check definitions for a provider",
+            "description": "List check definitions for a provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
+            "og:title": "List check definitions for a provider | Comp AI API",
+            "og:description": "List check definitions for a provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "list-provider-checks"
+        }
+      }
+    },
+    "/v1/integrations/checks/connections/{connectionId}": {
+      "get": {
+        "operationId": "ChecksController_listConnectionChecks_v1",
+        "parameters": [
+          {
+            "name": "connectionId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "List checks for a connection",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "List checks for a connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "List checks for a connection | Comp AI API",
+            "sidebarTitle": "List checks for a connection",
+            "description": "List checks for a connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
+            "og:title": "List checks for a connection | Comp AI API",
+            "og:description": "List checks for a connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "list-connection-checks"
+        }
+      }
+    },
+    "/v1/integrations/checks/connections/{connectionId}/run": {
+      "post": {
+        "operationId": "ChecksController_runConnectionChecks_v1",
+        "parameters": [
+          {
+            "name": "connectionId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RunChecksDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Run integration checks",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Run all compliance checks for an integration connection and capture results as automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Run integration checks | Comp AI API",
+            "sidebarTitle": "Run integration checks",
+            "description": "Run all compliance checks for an integration connection and capture results as automated evidence.",
+            "og:title": "Run integration checks | Comp AI API",
+            "og:description": "Run all compliance checks for an integration connection and capture results as automated evidence."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "run-connection-checks"
+        }
+      }
+    },
+    "/v1/integrations/checks/connections/{connectionId}/run/{checkId}": {
+      "post": {
+        "operationId": "ChecksController_runSingleCheck_v1",
+        "parameters": [
+          {
+            "name": "connectionId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "checkId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Run a single check on a connection",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Run a single check on a connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Run a single check on a connection | Comp AI API",
+            "sidebarTitle": "Run a single check on a connection",
+            "description": "Run a single check on a connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
+            "og:title": "Run a single check on a connection | Comp AI API",
+            "og:description": "Run a single check on a connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "run-single-check"
+        }
+      }
+    },
+    "/v1/integrations/variables/providers/{providerSlug}": {
+      "get": {
+        "operationId": "VariablesController_getProviderVariables_v1",
+        "parameters": [
+          {
+            "name": "providerSlug",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "List variable definitions for a provider",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "List variable definitions for a provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "List variable definitions for a provider | Comp AI API",
+            "sidebarTitle": "List variable definitions for a provider",
+            "description": "List variable definitions for a provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
+            "og:title": "List variable definitions for a provider | Comp AI API",
+            "og:description": "List variable definitions for a provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "get-provider-variables"
+        }
+      }
+    },
+    "/v1/integrations/variables/connections/{connectionId}": {
+      "get": {
+        "operationId": "VariablesController_getConnectionVariables_v1",
+        "parameters": [
+          {
+            "name": "connectionId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "List connection variables",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "List connection variables in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "List connection variables | Comp AI API",
+            "sidebarTitle": "List connection variables",
+            "description": "List connection variables in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
+            "og:title": "List connection variables | Comp AI API",
+            "og:description": "List connection variables in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "get-connection-variables"
+        }
+      },
+      "post": {
+        "operationId": "VariablesController_saveConnectionVariables_v1",
+        "parameters": [
+          {
+            "name": "connectionId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SaveVariablesDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Update connection variables",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Update connection variables in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Update connection variables | Comp AI API",
+            "sidebarTitle": "Update connection variables",
+            "description": "Update connection variables in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
+            "og:title": "Update connection variables | Comp AI API",
+            "og:description": "Update connection variables in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "save-connection-variables"
+        }
+      }
+    },
+    "/v1/integrations/variables/connections/{connectionId}/options/{variableId}": {
+      "get": {
+        "operationId": "VariablesController_fetchVariableOptions_v1",
+        "parameters": [
+          {
+            "name": "connectionId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "variableId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Get options for a connection variable",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Get options for a connection variable in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Get options for a connection variable | Comp AI API",
+            "sidebarTitle": "Get options for a connection variable",
+            "description": "Get options for a connection variable in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
+            "og:title": "Get options for a connection variable | Comp AI API",
+            "og:description": "Get options for a connection variable in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "fetch-variable-options"
+        }
+      }
+    },
+    "/v1/integrations/tasks/template/{templateId}/checks": {
+      "get": {
+        "operationId": "TaskIntegrationsController_getChecksForTaskTemplate_v1",
+        "parameters": [
+          {
+            "name": "templateId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "List checks for a task template",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "List checks for a task template in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "List checks for a task template | Comp AI API",
+            "sidebarTitle": "List checks for a task template",
+            "description": "List checks for a task template in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
+            "og:title": "List checks for a task template | Comp AI API",
+            "og:description": "List checks for a task template in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "get-checks-for-task-template"
+        }
+      }
+    },
+    "/v1/integrations/tasks/{taskId}/checks": {
+      "get": {
+        "operationId": "TaskIntegrationsController_getChecksForTask_v1",
+        "parameters": [
+          {
+            "name": "taskId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "List checks attached to a task",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "List checks attached to a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "List checks attached to a task | Comp AI API",
+            "sidebarTitle": "List checks attached to a task",
+            "description": "List checks attached to a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
+            "og:title": "List checks attached to a task | Comp AI API",
+            "og:description": "List checks attached to a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "get-checks-for-task"
+        }
+      }
+    },
+    "/v1/integrations/tasks/{taskId}/run-check": {
+      "post": {
+        "operationId": "TaskIntegrationsController_runCheckForTask_v1",
+        "parameters": [
+          {
+            "name": "taskId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RunCheckForTaskDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Run a check for a task",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Run a check for a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Run a check for a task | Comp AI API",
+            "sidebarTitle": "Run a check for a task",
+            "description": "Run a check for a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
+            "og:title": "Run a check for a task | Comp AI API",
+            "og:description": "Run a check for a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "run-check-for-task"
+        }
+      }
+    },
+    "/v1/integrations/tasks/{taskId}/checks/disconnect": {
+      "post": {
+        "operationId": "TaskIntegrationsController_disconnectCheckFromTask_v1",
+        "parameters": [
+          {
+            "name": "taskId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ToggleCheckForTaskDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Disconnect checks from a task",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Disconnect checks from a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Disconnect checks from a task | Comp AI API",
+            "sidebarTitle": "Disconnect checks from a task",
+            "description": "Disconnect checks from a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
+            "og:title": "Disconnect checks from a task | Comp AI API",
+            "og:description": "Disconnect checks from a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "disconnect-check-from-task"
+        }
+      }
+    },
+    "/v1/integrations/tasks/{taskId}/checks/reconnect": {
+      "post": {
+        "operationId": "TaskIntegrationsController_reconnectCheckToTask_v1",
+        "parameters": [
+          {
+            "name": "taskId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ToggleCheckForTaskDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Reconnect checks to a task",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Reconnect checks to a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Reconnect checks to a task | Comp AI API",
+            "sidebarTitle": "Reconnect checks to a task",
+            "description": "Reconnect checks to a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
+            "og:title": "Reconnect checks to a task | Comp AI API",
+            "og:description": "Reconnect checks to a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "reconnect-check-to-task"
+        }
+      }
+    },
+    "/v1/integrations/tasks/{taskId}/runs": {
+      "get": {
+        "operationId": "TaskIntegrationsController_getTaskCheckRuns_v1",
+        "parameters": [
+          {
+            "name": "taskId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "List check runs for a task",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "List check runs for a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "List check runs for a task | Comp AI API",
+            "sidebarTitle": "List check runs for a task",
+            "description": "List check runs for a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
+            "og:title": "List check runs for a task | Comp AI API",
+            "og:description": "List check runs for a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "get-task-check-runs"
+        }
+      }
+    },
+    "/v1/integrations/sync/google-workspace/employees": {
+      "post": {
+        "operationId": "SyncController_syncGoogleWorkspaceEmployees_v1",
+        "parameters": [
+          {
+            "name": "connectionId",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Sync Google Workspace employees",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Sync Google Workspace employees in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Sync Google Workspace employees | Comp AI API",
+            "sidebarTitle": "Sync Google Workspace employees",
+            "description": "Sync Google Workspace employees in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
+            "og:title": "Sync Google Workspace employees | Comp AI API",
+            "og:description": "Sync Google Workspace employees in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "sync-google-workspace-employees"
+        }
+      }
+    },
+    "/v1/integrations/sync/google-workspace/status": {
+      "post": {
+        "operationId": "SyncController_getGoogleWorkspaceStatus_v1",
+        "parameters": [],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Get Google Workspace sync status",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Get Google Workspace sync status in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Get Google Workspace sync status | Comp AI API",
+            "sidebarTitle": "Get Google Workspace sync status",
+            "description": "Get Google Workspace sync status in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
+            "og:title": "Get Google Workspace sync status | Comp AI API",
+            "og:description": "Get Google Workspace sync status in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "get-google-workspace-status"
+        }
+      }
+    },
+    "/v1/integrations/sync/rippling/employees": {
+      "post": {
+        "operationId": "SyncController_syncRipplingEmployees_v1",
+        "parameters": [
+          {
+            "name": "connectionId",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Sync Rippling employees",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Sync Rippling employees in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Sync Rippling employees | Comp AI API",
+            "sidebarTitle": "Sync Rippling employees",
+            "description": "Sync Rippling employees in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
+            "og:title": "Sync Rippling employees | Comp AI API",
+            "og:description": "Sync Rippling employees in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "sync-rippling-employees"
+        }
+      }
+    },
+    "/v1/integrations/sync/rippling/status": {
+      "post": {
+        "operationId": "SyncController_getRipplingStatus_v1",
+        "parameters": [],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Get Rippling sync status",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Get Rippling sync status in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Get Rippling sync status | Comp AI API",
+            "sidebarTitle": "Get Rippling sync status",
+            "description": "Get Rippling sync status in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
+            "og:title": "Get Rippling sync status | Comp AI API",
+            "og:description": "Get Rippling sync status in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "get-rippling-status"
+        }
+      }
+    },
+    "/v1/integrations/sync/jumpcloud/employees": {
+      "post": {
+        "operationId": "SyncController_syncJumpCloudEmployees_v1",
+        "parameters": [
+          {
+            "name": "connectionId",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Sync JumpCloud employees",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Sync JumpCloud employees in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Sync JumpCloud employees | Comp AI API",
+            "sidebarTitle": "Sync JumpCloud employees",
+            "description": "Sync JumpCloud employees in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
+            "og:title": "Sync JumpCloud employees | Comp AI API",
+            "og:description": "Sync JumpCloud employees in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "sync-jump-cloud-employees"
+        }
+      }
+    },
+    "/v1/integrations/sync/jumpcloud/status": {
+      "post": {
+        "operationId": "SyncController_getJumpCloudStatus_v1",
+        "parameters": [],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Get JumpCloud sync status",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Get JumpCloud sync status in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Get JumpCloud sync status | Comp AI API",
+            "sidebarTitle": "Get JumpCloud sync status",
+            "description": "Get JumpCloud sync status in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
+            "og:title": "Get JumpCloud sync status | Comp AI API",
+            "og:description": "Get JumpCloud sync status in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "get-jump-cloud-status"
+        }
+      }
+    },
+    "/v1/integrations/sync/employee-sync-provider": {
+      "get": {
+        "operationId": "SyncController_getEmployeeSyncProvider_v1",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Get the currently configured employee sync provider",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Get the currently configured employee sync provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Get the currently configured employee sync | Comp AI API",
+            "sidebarTitle": "Get the currently configured employee sync provider",
+            "description": "Get the currently configured employee sync provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage.",
+            "og:title": "Get the currently configured employee sync | Comp AI API",
+            "og:description": "Get the currently configured employee sync provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "get-employee-sync-provider"
+        }
+      },
+      "post": {
+        "operationId": "SyncController_setEmployeeSyncProvider_v1",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetEmployeeSyncProviderDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Set the employee sync provider",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Set the employee sync provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Set the employee sync provider | Comp AI API",
+            "sidebarTitle": "Set the employee sync provider",
+            "description": "Set the employee sync provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
+            "og:title": "Set the employee sync provider | Comp AI API",
+            "og:description": "Set the employee sync provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "set-employee-sync-provider"
+        }
+      }
+    },
+    "/v1/integrations/sync/device-sync-provider": {
+      "get": {
+        "operationId": "SyncController_getDeviceSyncProvider_v1",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Get the currently configured device sync provider",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Get the currently configured device sync provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Get the currently configured device sync | Comp AI API",
+            "sidebarTitle": "Get the currently configured device sync provider",
+            "description": "Get the currently configured device sync provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage.",
+            "og:title": "Get the currently configured device sync | Comp AI API",
+            "og:description": "Get the currently configured device sync provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "get-device-sync-provider"
+        }
+      },
+      "post": {
+        "operationId": "SyncController_setDeviceSyncProvider_v1",
+        "parameters": [],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Set the device sync provider",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Set the device sync provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Set the device sync provider | Comp AI API",
+            "sidebarTitle": "Set the device sync provider",
+            "description": "Set the device sync provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
+            "og:title": "Set the device sync provider | Comp AI API",
+            "og:description": "Set the device sync provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "set-device-sync-provider"
+        }
+      }
+    },
+    "/v1/integrations/sync/available-providers": {
+      "get": {
+        "operationId": "SyncController_getAvailableSyncProviders_v1",
+        "parameters": [
+          {
+            "name": "syncType",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "List sync providers available to the org",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "List sync providers available to the org in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "List sync providers available to the org | Comp AI API",
+            "sidebarTitle": "List sync providers available to the org",
+            "description": "List sync providers available to the org in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
+            "og:title": "List sync providers available to the org | Comp AI API",
+            "og:description": "List sync providers available to the org in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "get-available-sync-providers"
+        }
+      }
+    },
+    "/v1/integrations/sync/dynamic/{providerSlug}/employees": {
+      "post": {
+        "operationId": "SyncController_syncDynamicProviderEmployees_v1",
+        "parameters": [
+          {
+            "name": "providerSlug",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "connectionId",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Sync employees for a dynamic provider",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Sync employees for a dynamic provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Sync employees for a dynamic provider | Comp AI API",
+            "sidebarTitle": "Sync employees for a dynamic provider",
+            "description": "Sync employees for a dynamic provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
+            "og:title": "Sync employees for a dynamic provider | Comp AI API",
+            "og:description": "Sync employees for a dynamic provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "sync-dynamic-provider-employees"
+        }
+      }
+    },
+    "/v1/integrations/sync/dynamic/{providerSlug}/devices": {
+      "post": {
+        "operationId": "SyncController_syncDynamicProviderDevices_v1",
+        "parameters": [
+          {
+            "name": "providerSlug",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "connectionId",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Sync devices for a dynamic provider",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Sync devices for a dynamic provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Sync devices for a dynamic provider | Comp AI API",
+            "sidebarTitle": "Sync devices for a dynamic provider",
+            "description": "Sync devices for a dynamic provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
+            "og:title": "Sync devices for a dynamic provider | Comp AI API",
+            "og:description": "Sync devices for a dynamic provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "sync-dynamic-provider-devices"
+        }
+      }
+    },
+    "/v1/integrations/sync/two-factor-source": {
+      "get": {
+        "operationId": "TwoFactorSourceController_getTwoFactorSource_v1",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Get the configured 2FA source provider",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Get the configured 2FA source provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Get the configured 2FA source provider | Comp AI API",
+            "sidebarTitle": "Get the configured 2FA source provider",
+            "description": "Get the configured 2FA source provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
+            "og:title": "Get the configured 2FA source provider | Comp AI API",
+            "og:description": "Get the configured 2FA source provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "get-two-factor-source"
+        }
+      },
+      "post": {
+        "operationId": "TwoFactorSourceController_setTwoFactorSource_v1",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetTwoFactorSourceDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Set the 2FA source provider",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Set the 2FA source provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Set the 2FA source provider | Comp AI API",
+            "sidebarTitle": "Set the 2FA source provider",
+            "description": "Set the 2FA source provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
+            "og:title": "Set the 2FA source provider | Comp AI API",
+            "og:description": "Set the 2FA source provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "set-two-factor-source"
+        }
+      }
+    },
+    "/v1/integrations/sync/available-2fa-sources": {
+      "get": {
+        "operationId": "TwoFactorSourceController_getAvailableTwoFactorSources_v1",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "List integrations that can supply per-user 2FA status",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "List integrations that can supply per-user 2FA status in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "List integrations that can supply per-user | Comp AI API",
+            "sidebarTitle": "List integrations that can supply per-user 2FA status",
+            "description": "List integrations that can supply per-user 2FA status in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees.",
+            "og:title": "List integrations that can supply per-user | Comp AI API",
+            "og:description": "List integrations that can supply per-user 2FA status in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "get-available-two-factor-sources"
+        }
+      }
+    },
+    "/v1/integrations/sync/two-factor-statuses": {
+      "get": {
+        "operationId": "TwoFactorSourceController_getTwoFactorStatuses_v1",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Per-user 2FA status from the configured source",
+        "tags": [
+          "Integrations"
+        ],
+        "description": "Per-user 2FA status from the configured source in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
+        "x-mint": {
+          "metadata": {
+            "title": "Per-user 2FA status from the configured source | Comp AI API",
+            "sidebarTitle": "Per-user 2FA status from the configured source",
+            "description": "Per-user 2FA status from the configured source in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage.",
+            "og:title": "Per-user 2FA status from the configured source | Comp AI API",
+            "og:description": "Per-user 2FA status from the configured source in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "get-two-factor-statuses"
+        }
+      }
+    },
+    "/v1/cloud-security/activity": {
+      "get": {
+        "operationId": "CloudSecurityController_getActivity_v1",
+        "parameters": [
+          {
+            "name": "connectionId",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "List recent cloud security activity",
+        "tags": [
+          "CloudSecurity"
+        ],
+        "description": "List recent cloud security activity in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture results to compliance work.",
+        "x-mint": {
+          "metadata": {
+            "title": "List recent cloud security activity | Comp AI API",
+            "sidebarTitle": "List recent cloud security activity",
+            "description": "List recent cloud security activity in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud.",
+            "og:title": "List recent cloud security activity | Comp AI API",
+            "og:description": "List recent cloud security activity in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "get-activity"
+        }
+      }
+    },
+    "/v1/cloud-security/providers": {
+      "get": {
+        "operationId": "CloudSecurityController_getProviders_v1",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "List supported cloud providers",
+        "tags": [
+          "CloudSecurity"
+        ],
+        "description": "List supported cloud providers in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture results to compliance work.",
+        "x-mint": {
+          "metadata": {
+            "title": "List supported cloud providers | Comp AI API",
+            "sidebarTitle": "List supported cloud providers",
+            "description": "List supported cloud providers in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture.",
+            "og:title": "List supported cloud providers | Comp AI API",
+            "og:description": "List supported cloud providers in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "get-providers"
+        }
+      }
+    },
+    "/v1/cloud-security/findings": {
+      "get": {
+        "operationId": "CloudSecurityController_getFindings_v1",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "List cloud security findings",
+        "tags": [
+          "CloudSecurity"
+        ],
+        "description": "List cloud security findings discovered by scans so teams can prioritize remediation before issues become audit findings.",
+        "x-mint": {
+          "metadata": {
+            "title": "List cloud security findings | Comp AI API",
+            "sidebarTitle": "List cloud security findings",
+            "description": "List cloud security findings discovered by scans so teams can prioritize remediation before issues become audit findings.",
+            "og:title": "List cloud security findings | Comp AI API",
+            "og:description": "List cloud security findings discovered by scans so teams can prioritize remediation before issues become audit findings."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "get-findings"
+        }
+      }
+    },
+    "/v1/cloud-security/findings/{findingId}/exception": {
+      "post": {
+        "description": "Accepts session, API key, or service token auth. For API key / service token callers without an explicit user attribution, the action is attributed to the org's owner and the audit log description records the calling key/service name.",
+        "operationId": "CloudSecurityController_markFindingAsException_v1",
+        "parameters": [
+          {
+            "name": "findingId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MarkExceptionDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "summary": "Mark a finding as an exception so it no longer appears in the active Scan Results list",
+        "tags": [
+          "CloudSecurity"
+        ],
+        "x-mint": {
+          "metadata": {
+            "title": "Mark a finding as an exception so it no | Comp AI API",
+            "sidebarTitle": "Mark a finding as an exception so it no longer appears in the active Scan Results list",
+            "description": "Accepts session, API key, or service token auth. For API key / service token callers without an explicit user attribution, the action is attributed to the.",
+            "og:title": "Mark a finding as an exception so it no | Comp AI API",
+            "og:description": "Accepts session, API key, or service token auth. For API key / service token callers without an explicit user attribution, the action is attributed to the."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "mark-finding-as-exception"
+        }
+      }
+    },
+    "/v1/cloud-security/connections/{connectionId}/scan-mode": {
+      "patch": {
+        "description": "Accepts session, API key, or service token auth. For API key / service token callers without an explicit user attribution, the action is attributed to the org's owner.",
+        "operationId": "CloudSecurityController_updateAwsScanMode_v1",
+        "parameters": [
+          {
+            "name": "connectionId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateAwsScanModeDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "Switch the AWS scan engine for a connection (Comp AI scanners ↔ Security Hub)",
+        "tags": [
+          "CloudSecurity"
+        ],
+        "x-mint": {
+          "metadata": {
+            "title": "Switch the AWS scan engine for a connection | Comp AI API",
+            "sidebarTitle": "Switch the AWS scan engine for a connection (Comp AI scanners ↔ Security Hub)",
+            "description": "Accepts session, API key, or service token auth. For API key / service token callers without an explicit user attribution, the action is attributed to the.",
+            "og:title": "Switch the AWS scan engine for a connection | Comp AI API",
+            "og:description": "Accepts session, API key, or service token auth. For API key / service token callers without an explicit user attribution, the action is attributed to the."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "update-aws-scan-mode"
+        }
+      }
+    },
+    "/v1/cloud-security/exceptions/{exceptionId}": {
+      "delete": {
+        "description": "Accepts session, API key, or service token auth. For API key / service token callers without an explicit user attribution, the action is attributed to the org's owner.",
+        "operationId": "CloudSecurityController_revokeException_v1",
+        "parameters": [
+          {
+            "name": "exceptionId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "Revoke an exception, reopening the finding",
+        "tags": [
+          "CloudSecurity"
+        ],
+        "x-mint": {
+          "metadata": {
+            "title": "Revoke an exception, reopening the finding | Comp AI API",
+            "sidebarTitle": "Revoke an exception, reopening the finding",
+            "description": "Accepts session, API key, or service token auth. For API key / service token callers without an explicit user attribution, the action is attributed to the.",
+            "og:title": "Revoke an exception, reopening the finding | Comp AI API",
+            "og:description": "Accepts session, API key, or service token auth. For API key / service token callers without an explicit user attribution, the action is attributed to the."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "revoke-exception"
+        }
+      }
+    },
+    "/v1/cloud-security/history": {
+      "get": {
+        "operationId": "CloudSecurityController_getHistory_v1",
+        "parameters": [
+          {
+            "name": "connectionId",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "List resolution, exception, and regression history for a connection",
+        "tags": [
+          "CloudSecurity"
+        ],
+        "description": "List resolution, exception, and regression history for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture results to compliance work.",
+        "x-mint": {
+          "metadata": {
+            "title": "List resolution, exception, and regression | Comp AI API",
+            "sidebarTitle": "List resolution, exception, and regression history for a connection",
+            "description": "List resolution, exception, and regression history for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services.",
+            "og:title": "List resolution, exception, and regression | Comp AI API",
+            "og:description": "List resolution, exception, and regression history for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "get-history"
+        }
+      }
+    },
+    "/v1/cloud-security/findings/{findingId}/check-definition": {
+      "get": {
+        "operationId": "CloudSecurityController_getCheckDefinition_v1",
+        "parameters": [
+          {
+            "name": "findingId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "Resolve the \"About this check\" description for a finding (AI-cached for AWS; provider-derived for GCP/Azure)",
+        "tags": [
+          "CloudSecurity"
+        ],
+        "description": "Resolve the \"About this check\" description for a finding (AI-cached for AWS; provider-derived for GCP/Azure) in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture.",
+        "x-mint": {
+          "metadata": {
+            "title": "Resolve the \"About this check\" description | Comp AI API",
+            "sidebarTitle": "Resolve the \"About this check\" description for a finding (AI-cached for AWS; provider-derived for GCP/Azure)",
+            "description": "Resolve the \"About this check\" description for a finding (AI-cached for AWS; provider-derived for GCP/Azure) in Comp AI. Run AWS, Azure, and GCP cloud.",
+            "og:title": "Resolve the \"About this check\" description | Comp AI API",
+            "og:description": "Resolve the \"About this check\" description for a finding (AI-cached for AWS; provider-derived for GCP/Azure) in Comp AI. Run AWS, Azure, and GCP cloud."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "get-check-definition"
+        }
+      }
+    },
+    "/v1/cloud-security/resolve-session/{connectionId}": {
+      "post": {
+        "operationId": "CloudSecurityController_resolveSession_v1",
+        "parameters": [
+          {
+            "name": "connectionId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "summary": "Resolve short-lived AWS credentials for a connection (internal only)",
+        "tags": [
+          "CloudSecurity"
+        ],
+        "description": "Resolve short-lived AWS credentials for a connection (internal only) in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture results to compliance work.",
+        "x-mint": {
+          "metadata": {
+            "title": "Resolve short-lived AWS credentials for a | Comp AI API",
+            "sidebarTitle": "Resolve short-lived AWS credentials for a connection (internal only)",
+            "description": "Resolve short-lived AWS credentials for a connection (internal only) in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services.",
+            "og:title": "Resolve short-lived AWS credentials for a | Comp AI API",
+            "og:description": "Resolve short-lived AWS credentials for a connection (internal only) in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "resolve-session"
+        }
+      }
+    },
+    "/v1/cloud-security/scan/{connectionId}": {
+      "post": {
+        "operationId": "CloudSecurityController_scan_v1",
+        "parameters": [
+          {
+            "name": "connectionId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "summary": "Run cloud security scan",
+        "tags": [
+          "CloudSecurity"
+        ],
+        "description": "Trigger a cloud security scan for a connected AWS, Azure, or GCP account and collect findings for compliance remediation.",
+        "x-mint": {
+          "metadata": {
+            "title": "Run cloud security scan | Comp AI API",
+            "sidebarTitle": "Run cloud security scan",
+            "description": "Trigger a cloud security scan for a connected AWS, Azure, or GCP account and collect findings for compliance remediation.",
+            "og:title": "Run cloud security scan | Comp AI API",
+            "og:description": "Trigger a cloud security scan for a connected AWS, Azure, or GCP account and collect findings for compliance remediation."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "scan"
+        }
+      }
+    },
+    "/v1/cloud-security/detect-services/{connectionId}": {
+      "post": {
+        "operationId": "CloudSecurityController_detectServices_v1",
+        "parameters": [
+          {
+            "name": "connectionId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "summary": "Detect available cloud services for a connection",
+        "tags": [
+          "CloudSecurity"
+        ],
+        "description": "Detect available cloud services for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture results to compliance work.",
+        "x-mint": {
+          "metadata": {
+            "title": "Detect available cloud services for a | Comp AI API",
+            "sidebarTitle": "Detect available cloud services for a connection",
+            "description": "Detect available cloud services for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings.",
+            "og:title": "Detect available cloud services for a | Comp AI API",
+            "og:description": "Detect available cloud services for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "detect-services"
+        }
+      }
+    },
+    "/v1/cloud-security/detect-gcp-org/{connectionId}": {
+      "post": {
+        "operationId": "CloudSecurityController_detectGcpOrg_v1",
+        "parameters": [
+          {
+            "name": "connectionId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "summary": "Detect the GCP organization for a connection",
+        "tags": [
+          "CloudSecurity"
+        ],
+        "description": "Detect the GCP organization for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture results to compliance work.",
+        "x-mint": {
+          "metadata": {
+            "title": "Detect the GCP organization for a connection | Comp AI API",
+            "sidebarTitle": "Detect the GCP organization for a connection",
+            "description": "Detect the GCP organization for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect.",
+            "og:title": "Detect the GCP organization for a connection | Comp AI API",
+            "og:description": "Detect the GCP organization for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "detect-gcp-org"
+        }
+      }
+    },
+    "/v1/cloud-security/select-gcp-projects/{connectionId}": {
+      "post": {
+        "operationId": "CloudSecurityController_selectGcpProjects_v1",
+        "parameters": [
+          {
+            "name": "connectionId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "summary": "Select GCP projects for a connection",
+        "tags": [
+          "CloudSecurity"
+        ],
+        "description": "Select GCP projects for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture results to compliance work.",
+        "x-mint": {
+          "metadata": {
+            "title": "Select GCP projects for a connection | Comp AI API",
+            "sidebarTitle": "Select GCP projects for a connection",
+            "description": "Select GCP projects for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud.",
+            "og:title": "Select GCP projects for a connection | Comp AI API",
+            "og:description": "Select GCP projects for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "select-gcp-projects"
+        }
+      }
+    },
+    "/v1/cloud-security/setup-gcp/{connectionId}": {
+      "post": {
+        "operationId": "CloudSecurityController_setupGcp_v1",
+        "parameters": [
+          {
+            "name": "connectionId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "summary": "Set up GCP for a connection",
+        "tags": [
+          "CloudSecurity"
+        ],
+        "description": "Set up GCP for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture results to compliance work.",
+        "x-mint": {
+          "metadata": {
+            "title": "Set up GCP for a connection | Comp AI API",
+            "sidebarTitle": "Set up GCP for a connection",
+            "description": "Set up GCP for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture.",
+            "og:title": "Set up GCP for a connection | Comp AI API",
+            "og:description": "Set up GCP for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "setup-gcp"
+        }
+      }
+    },
+    "/v1/cloud-security/setup-gcp/{connectionId}/resolve-step": {
+      "post": {
+        "operationId": "CloudSecurityController_resolveGcpSetupStep_v1",
+        "parameters": [
+          {
+            "name": "connectionId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "summary": "Resolve a GCP setup step",
+        "tags": [
+          "CloudSecurity"
+        ],
+        "description": "Resolve a GCP setup step in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture results to compliance work.",
+        "x-mint": {
+          "metadata": {
+            "title": "Resolve a GCP setup step | Comp AI API",
+            "sidebarTitle": "Resolve a GCP setup step",
+            "description": "Resolve a GCP setup step in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture.",
+            "og:title": "Resolve a GCP setup step | Comp AI API",
+            "og:description": "Resolve a GCP setup step in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "resolve-gcp-setup-step"
+        }
+      }
+    },
+    "/v1/cloud-security/setup-azure/{connectionId}": {
+      "post": {
+        "operationId": "CloudSecurityController_setupAzure_v1",
+        "parameters": [
+          {
+            "name": "connectionId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "summary": "Set up Azure for a connection",
+        "tags": [
+          "CloudSecurity"
+        ],
+        "description": "Set up Azure for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture results to compliance work.",
+        "x-mint": {
+          "metadata": {
+            "title": "Set up Azure for a connection | Comp AI API",
+            "sidebarTitle": "Set up Azure for a connection",
+            "description": "Set up Azure for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture.",
+            "og:title": "Set up Azure for a connection | Comp AI API",
+            "og:description": "Set up Azure for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "setup-azure"
+        }
+      }
+    },
+    "/v1/cloud-security/validate-azure/{connectionId}": {
+      "post": {
+        "operationId": "CloudSecurityController_validateAzure_v1",
+        "parameters": [
+          {
+            "name": "connectionId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "summary": "Validate Azure credentials for a connection",
+        "tags": [
+          "CloudSecurity"
+        ],
+        "description": "Validate Azure credentials for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture results to compliance work.",
+        "x-mint": {
+          "metadata": {
+            "title": "Validate Azure credentials for a connection | Comp AI API",
+            "sidebarTitle": "Validate Azure credentials for a connection",
+            "description": "Validate Azure credentials for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect.",
+            "og:title": "Validate Azure credentials for a connection | Comp AI API",
+            "og:description": "Validate Azure credentials for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "validate-azure"
+        }
+      }
+    },
+    "/v1/cloud-security/trigger/{connectionId}": {
+      "post": {
+        "operationId": "CloudSecurityController_triggerScan_v1",
+        "parameters": [
+          {
+            "name": "connectionId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "summary": "Trigger a cloud security run for a connection",
+        "tags": [
+          "CloudSecurity"
+        ],
+        "description": "Trigger a cloud security run for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture results to compliance work.",
+        "x-mint": {
+          "metadata": {
+            "title": "Trigger a cloud security run for a connection | Comp AI API",
+            "sidebarTitle": "Trigger a cloud security run for a connection",
+            "description": "Trigger a cloud security run for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings.",
+            "og:title": "Trigger a cloud security run for a connection | Comp AI API",
+            "og:description": "Trigger a cloud security run for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "trigger-scan"
+        }
+      }
+    },
+    "/v1/cloud-security/runs/{runId}": {
+      "get": {
+        "operationId": "CloudSecurityController_getRunStatus_v1",
+        "parameters": [
+          {
+            "name": "runId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "connectionId",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "Get a cloud security scan run by ID",
+        "tags": [
+          "CloudSecurity"
+        ],
+        "description": "Get a cloud security scan run by ID in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture results to compliance work.",
+        "x-mint": {
+          "metadata": {
+            "title": "Get a cloud security scan run by ID | Comp AI API",
+            "sidebarTitle": "Get a cloud security scan run by ID",
+            "description": "Get a cloud security scan run by ID in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud.",
+            "og:title": "Get a cloud security scan run by ID | Comp AI API",
+            "og:description": "Get a cloud security scan run by ID in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "get-run-status"
         }
       }
     },
@@ -13835,6 +16467,58 @@
         }
       }
     },
+    "/v1/trust-portal/settings/security-questionnaire": {
+      "put": {
+        "operationId": "TrustPortalController_updateSecurityQuestionnaire_v1",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "enabled"
+                ],
+                "properties": {
+                  "enabled": {
+                    "type": "boolean",
+                    "description": "When false, the Security Questionnaire is hidden from the public trust portal."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "Show or hide the Security Questionnaire on the public trust portal",
+        "tags": [
+          "Trust Portal"
+        ],
+        "description": "Show or hide the Security Questionnaire on the public trust portal in Comp AI. Configure the live Trust Center, custom domain, public overview, FAQs, compliance resources, documents, links, and vendor disclosures.",
+        "x-mint": {
+          "metadata": {
+            "title": "Show or hide the Security Questionnaire on | Comp AI API",
+            "sidebarTitle": "Show or hide the Security Questionnaire on the public trust portal",
+            "description": "Show or hide the Security Questionnaire on the public trust portal in Comp AI. Configure the live Trust Center, custom domain, public overview, FAQs.",
+            "og:title": "Show or hide the Security Questionnaire on | Comp AI API",
+            "og:description": "Show or hide the Security Questionnaire on the public trust portal in Comp AI. Configure the live Trust Center, custom domain, public overview, FAQs."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "update-security-questionnaire"
+        }
+      }
+    },
     "/v1/trust-portal/custom-frameworks": {
       "get": {
         "operationId": "TrustPortalController_listCustomFrameworks_v1",
@@ -14999,6 +17683,56 @@
         },
         "x-speakeasy-mcp": {
           "name": "get-public-overview"
+        }
+      }
+    },
+    "/v1/trust-access/{friendlyUrl}/security-questionnaire": {
+      "get": {
+        "description": "Whether the org offers the AI-assisted Security Questionnaire on its public trust portal. Defaults to enabled when the portal can't be resolved.",
+        "operationId": "TrustAccessController_getPublicSecurityQuestionnaire_v1",
+        "parameters": [
+          {
+            "name": "friendlyUrl",
+            "required": true,
+            "in": "path",
+            "description": "Trust Portal friendly URL or Organization ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Security Questionnaire visibility retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "summary": "Get Security Questionnaire visibility for a trust portal",
+        "tags": [
+          "Trust Access"
+        ],
+        "x-mint": {
+          "metadata": {
+            "title": "Get Security Questionnaire visibility for a | Comp AI API",
+            "sidebarTitle": "Get Security Questionnaire visibility for a trust portal",
+            "description": "Whether the org offers the AI-assisted Security Questionnaire on its public trust portal. Defaults to enabled when the portal can't be resolved.",
+            "og:title": "Get Security Questionnaire visibility for a | Comp AI API",
+            "og:description": "Whether the org offers the AI-assisted Security Questionnaire on its public trust portal. Defaults to enabled when the portal can't be resolved."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "get-public-security-questionnaire"
         }
       }
     },
@@ -18313,6 +21047,48 @@
         }
       }
     },
+    "/v1/isms/documents/{id}/versions": {
+      "get": {
+        "operationId": "IsmsController_getVersions_v1",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Published versions, newest first"
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "summary": "List an ISMS document's published version history",
+        "tags": [
+          "ISMS"
+        ],
+        "description": "List an ISMS document's published version history in Comp AI.",
+        "x-mint": {
+          "metadata": {
+            "title": "List an ISMS document's published version | Comp AI API",
+            "sidebarTitle": "List an ISMS document's published version history",
+            "description": "List an ISMS document's published version history in Comp AI.",
+            "og:title": "List an ISMS document's published version | Comp AI API",
+            "og:description": "List an ISMS document's published version history in Comp AI."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "get-versions"
+        }
+      }
+    },
     "/v1/isms/documents/{id}/export": {
       "post": {
         "operationId": "IsmsController_exportDocument_v1",
@@ -18455,6 +21231,79 @@
                       "met"
                     ]
                   },
+                  "responsibilities": {
+                    "type": "string"
+                  },
+                  "authorities": {
+                    "type": "string"
+                  },
+                  "authorityGrantedBy": {
+                    "type": "string"
+                  },
+                  "requiredCompetence": {
+                    "type": "string"
+                  },
+                  "auditRoute": {
+                    "type": "string",
+                    "enum": [
+                      "in_house",
+                      "external",
+                      "training_planned"
+                    ],
+                    "nullable": true
+                  },
+                  "auditRouteMemberId": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "auditFirmName": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "auditEvidenceRef": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "auditCourse": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "auditDueDate": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "roleId": {
+                    "type": "string"
+                  },
+                  "memberId": {
+                    "type": "string"
+                  },
+                  "basisOfCompetence": {
+                    "type": "string",
+                    "enum": [
+                      "education",
+                      "training",
+                      "experience",
+                      "combination"
+                    ],
+                    "nullable": true
+                  },
+                  "evidenceRetained": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "gap": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "remediationAction": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "remediationDueDate": {
+                    "type": "string",
+                    "nullable": true
+                  },
                   "position": {
                     "type": "integer",
                     "minimum": 0
@@ -18582,6 +21431,79 @@
                       "at_risk",
                       "met"
                     ]
+                  },
+                  "responsibilities": {
+                    "type": "string"
+                  },
+                  "authorities": {
+                    "type": "string"
+                  },
+                  "authorityGrantedBy": {
+                    "type": "string"
+                  },
+                  "requiredCompetence": {
+                    "type": "string"
+                  },
+                  "auditRoute": {
+                    "type": "string",
+                    "enum": [
+                      "in_house",
+                      "external",
+                      "training_planned"
+                    ],
+                    "nullable": true
+                  },
+                  "auditRouteMemberId": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "auditFirmName": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "auditEvidenceRef": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "auditCourse": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "auditDueDate": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "roleId": {
+                    "type": "string"
+                  },
+                  "memberId": {
+                    "type": "string"
+                  },
+                  "basisOfCompetence": {
+                    "type": "string",
+                    "enum": [
+                      "education",
+                      "training",
+                      "experience",
+                      "combination"
+                    ],
+                    "nullable": true
+                  },
+                  "evidenceRetained": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "gap": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "remediationAction": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "remediationDueDate": {
+                    "type": "string",
+                    "nullable": true
                   },
                   "position": {
                     "type": "integer",
@@ -18874,2434 +21796,6 @@
         },
         "x-speakeasy-mcp": {
           "name": "generate-all"
-        }
-      }
-    },
-    "/v1/integrations/connections/providers": {
-      "get": {
-        "operationId": "ConnectionsController_listProviders_v1",
-        "parameters": [
-          {
-            "name": "activeOnly",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "List integration providers",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "List available integration providers that can connect to the organization for automated evidence collection and compliance checks.",
-        "x-mint": {
-          "metadata": {
-            "title": "List integration providers | Comp AI API",
-            "sidebarTitle": "List integration providers",
-            "description": "List available integration providers that can connect to the organization for automated evidence collection and compliance checks.",
-            "og:title": "List integration providers | Comp AI API",
-            "og:description": "List available integration providers that can connect to the organization for automated evidence collection and compliance checks."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "list-providers"
-        }
-      }
-    },
-    "/v1/integrations/connections/providers/{slug}": {
-      "get": {
-        "operationId": "ConnectionsController_getProvider_v1",
-        "parameters": [
-          {
-            "name": "slug",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Get an integration provider by slug",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Get an integration provider by slug in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "Get an integration provider by slug | Comp AI API",
-            "sidebarTitle": "Get an integration provider by slug",
-            "description": "Get an integration provider by slug in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
-            "og:title": "Get an integration provider by slug | Comp AI API",
-            "og:description": "Get an integration provider by slug in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "get-provider"
-        }
-      }
-    },
-    "/v1/integrations/connections": {
-      "get": {
-        "operationId": "ConnectionsController_listConnections_v1",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "List integration connections",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "List integration connections in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "List integration connections | Comp AI API",
-            "sidebarTitle": "List integration connections",
-            "description": "List integration connections in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
-            "og:title": "List integration connections | Comp AI API",
-            "og:description": "List integration connections in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "list-connections"
-        }
-      },
-      "post": {
-        "operationId": "ConnectionsController_createConnection_v1",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateConnectionDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Create integration connection",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Create an integration connection so Comp AI can collect evidence, run checks, or sync data from a connected provider.",
-        "x-mint": {
-          "metadata": {
-            "title": "Create integration connection | Comp AI API",
-            "sidebarTitle": "Create integration connection",
-            "description": "Create an integration connection so Comp AI can collect evidence, run checks, or sync data from a connected provider.",
-            "og:title": "Create integration connection | Comp AI API",
-            "og:description": "Create an integration connection so Comp AI can collect evidence, run checks, or sync data from a connected provider."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "create-connection"
-        }
-      }
-    },
-    "/v1/integrations/connections/{id}": {
-      "get": {
-        "operationId": "ConnectionsController_getConnection_v1",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Get an integration connection by ID",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Get an integration connection by ID in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "Get an integration connection by ID | Comp AI API",
-            "sidebarTitle": "Get an integration connection by ID",
-            "description": "Get an integration connection by ID in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
-            "og:title": "Get an integration connection by ID | Comp AI API",
-            "og:description": "Get an integration connection by ID in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "get-connection"
-        }
-      },
-      "delete": {
-        "operationId": "ConnectionsController_deleteConnection_v1",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Delete an integration connection",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Delete an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "Delete an integration connection | Comp AI API",
-            "sidebarTitle": "Delete an integration connection",
-            "description": "Delete an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
-            "og:title": "Delete an integration connection | Comp AI API",
-            "og:description": "Delete an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "delete-connection"
-        }
-      },
-      "patch": {
-        "operationId": "ConnectionsController_updateConnection_v1",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateConnectionDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Update an integration connection",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Update an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "Update an integration connection | Comp AI API",
-            "sidebarTitle": "Update an integration connection",
-            "description": "Update an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
-            "og:title": "Update an integration connection | Comp AI API",
-            "og:description": "Update an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "update-connection"
-        }
-      }
-    },
-    "/v1/integrations/connections/{id}/test": {
-      "post": {
-        "operationId": "ConnectionsController_testConnection_v1",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Test an integration connection",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Test an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "Test an integration connection | Comp AI API",
-            "sidebarTitle": "Test an integration connection",
-            "description": "Test an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
-            "og:title": "Test an integration connection | Comp AI API",
-            "og:description": "Test an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "test-connection"
-        }
-      }
-    },
-    "/v1/integrations/connections/{id}/pause": {
-      "post": {
-        "operationId": "ConnectionsController_pauseConnection_v1",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Pause an integration connection",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Pause an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "Pause an integration connection | Comp AI API",
-            "sidebarTitle": "Pause an integration connection",
-            "description": "Pause an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
-            "og:title": "Pause an integration connection | Comp AI API",
-            "og:description": "Pause an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "pause-connection"
-        }
-      }
-    },
-    "/v1/integrations/connections/{id}/resume": {
-      "post": {
-        "operationId": "ConnectionsController_resumeConnection_v1",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Resume an integration connection",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Resume an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "Resume an integration connection | Comp AI API",
-            "sidebarTitle": "Resume an integration connection",
-            "description": "Resume an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
-            "og:title": "Resume an integration connection | Comp AI API",
-            "og:description": "Resume an integration connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "resume-connection"
-        }
-      }
-    },
-    "/v1/integrations/connections/{id}/disconnect": {
-      "post": {
-        "operationId": "ConnectionsController_disconnectConnection_v1",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Disconnect an integration",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Disconnect an integration in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "Disconnect an integration | Comp AI API",
-            "sidebarTitle": "Disconnect an integration",
-            "description": "Disconnect an integration in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
-            "og:title": "Disconnect an integration | Comp AI API",
-            "og:description": "Disconnect an integration in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "disconnect-connection"
-        }
-      }
-    },
-    "/v1/integrations/connections/{id}/services": {
-      "put": {
-        "operationId": "ConnectionsController_updateConnectionServices_v1",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateConnectionServicesDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Set services enabled on a connection",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Set services enabled on a connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "Set services enabled on a connection | Comp AI API",
-            "sidebarTitle": "Set services enabled on a connection",
-            "description": "Set services enabled on a connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
-            "og:title": "Set services enabled on a connection | Comp AI API",
-            "og:description": "Set services enabled on a connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "update-connection-services"
-        }
-      },
-      "get": {
-        "operationId": "ServicesController_getConnectionServices_v1",
-        "parameters": [
-          {
-            "name": "id",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "List services enabled on a connection",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "List services enabled on a connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "List services enabled on a connection | Comp AI API",
-            "sidebarTitle": "List services enabled on a connection",
-            "description": "List services enabled on a connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
-            "og:title": "List services enabled on a connection | Comp AI API",
-            "og:description": "List services enabled on a connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "get-connection-services"
-        }
-      }
-    },
-    "/v1/integrations/checks/providers/{providerSlug}": {
-      "get": {
-        "operationId": "ChecksController_listProviderChecks_v1",
-        "parameters": [
-          {
-            "name": "providerSlug",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "List check definitions for a provider",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "List check definitions for a provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "List check definitions for a provider | Comp AI API",
-            "sidebarTitle": "List check definitions for a provider",
-            "description": "List check definitions for a provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
-            "og:title": "List check definitions for a provider | Comp AI API",
-            "og:description": "List check definitions for a provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "list-provider-checks"
-        }
-      }
-    },
-    "/v1/integrations/checks/connections/{connectionId}": {
-      "get": {
-        "operationId": "ChecksController_listConnectionChecks_v1",
-        "parameters": [
-          {
-            "name": "connectionId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "List checks for a connection",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "List checks for a connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "List checks for a connection | Comp AI API",
-            "sidebarTitle": "List checks for a connection",
-            "description": "List checks for a connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
-            "og:title": "List checks for a connection | Comp AI API",
-            "og:description": "List checks for a connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "list-connection-checks"
-        }
-      }
-    },
-    "/v1/integrations/checks/connections/{connectionId}/run": {
-      "post": {
-        "operationId": "ChecksController_runConnectionChecks_v1",
-        "parameters": [
-          {
-            "name": "connectionId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RunChecksDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Run integration checks",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Run all compliance checks for an integration connection and capture results as automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "Run integration checks | Comp AI API",
-            "sidebarTitle": "Run integration checks",
-            "description": "Run all compliance checks for an integration connection and capture results as automated evidence.",
-            "og:title": "Run integration checks | Comp AI API",
-            "og:description": "Run all compliance checks for an integration connection and capture results as automated evidence."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "run-connection-checks"
-        }
-      }
-    },
-    "/v1/integrations/checks/connections/{connectionId}/run/{checkId}": {
-      "post": {
-        "operationId": "ChecksController_runSingleCheck_v1",
-        "parameters": [
-          {
-            "name": "connectionId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "checkId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Run a single check on a connection",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Run a single check on a connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "Run a single check on a connection | Comp AI API",
-            "sidebarTitle": "Run a single check on a connection",
-            "description": "Run a single check on a connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
-            "og:title": "Run a single check on a connection | Comp AI API",
-            "og:description": "Run a single check on a connection in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "run-single-check"
-        }
-      }
-    },
-    "/v1/integrations/variables/providers/{providerSlug}": {
-      "get": {
-        "operationId": "VariablesController_getProviderVariables_v1",
-        "parameters": [
-          {
-            "name": "providerSlug",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "List variable definitions for a provider",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "List variable definitions for a provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "List variable definitions for a provider | Comp AI API",
-            "sidebarTitle": "List variable definitions for a provider",
-            "description": "List variable definitions for a provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
-            "og:title": "List variable definitions for a provider | Comp AI API",
-            "og:description": "List variable definitions for a provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "get-provider-variables"
-        }
-      }
-    },
-    "/v1/integrations/variables/connections/{connectionId}": {
-      "get": {
-        "operationId": "VariablesController_getConnectionVariables_v1",
-        "parameters": [
-          {
-            "name": "connectionId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "List connection variables",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "List connection variables in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "List connection variables | Comp AI API",
-            "sidebarTitle": "List connection variables",
-            "description": "List connection variables in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
-            "og:title": "List connection variables | Comp AI API",
-            "og:description": "List connection variables in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "get-connection-variables"
-        }
-      },
-      "post": {
-        "operationId": "VariablesController_saveConnectionVariables_v1",
-        "parameters": [
-          {
-            "name": "connectionId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SaveVariablesDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Update connection variables",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Update connection variables in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "Update connection variables | Comp AI API",
-            "sidebarTitle": "Update connection variables",
-            "description": "Update connection variables in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
-            "og:title": "Update connection variables | Comp AI API",
-            "og:description": "Update connection variables in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "save-connection-variables"
-        }
-      }
-    },
-    "/v1/integrations/variables/connections/{connectionId}/options/{variableId}": {
-      "get": {
-        "operationId": "VariablesController_fetchVariableOptions_v1",
-        "parameters": [
-          {
-            "name": "connectionId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "variableId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Get options for a connection variable",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Get options for a connection variable in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "Get options for a connection variable | Comp AI API",
-            "sidebarTitle": "Get options for a connection variable",
-            "description": "Get options for a connection variable in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
-            "og:title": "Get options for a connection variable | Comp AI API",
-            "og:description": "Get options for a connection variable in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "fetch-variable-options"
-        }
-      }
-    },
-    "/v1/integrations/tasks/template/{templateId}/checks": {
-      "get": {
-        "operationId": "TaskIntegrationsController_getChecksForTaskTemplate_v1",
-        "parameters": [
-          {
-            "name": "templateId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "List checks for a task template",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "List checks for a task template in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "List checks for a task template | Comp AI API",
-            "sidebarTitle": "List checks for a task template",
-            "description": "List checks for a task template in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
-            "og:title": "List checks for a task template | Comp AI API",
-            "og:description": "List checks for a task template in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "get-checks-for-task-template"
-        }
-      }
-    },
-    "/v1/integrations/tasks/{taskId}/checks": {
-      "get": {
-        "operationId": "TaskIntegrationsController_getChecksForTask_v1",
-        "parameters": [
-          {
-            "name": "taskId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "List checks attached to a task",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "List checks attached to a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "List checks attached to a task | Comp AI API",
-            "sidebarTitle": "List checks attached to a task",
-            "description": "List checks attached to a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
-            "og:title": "List checks attached to a task | Comp AI API",
-            "og:description": "List checks attached to a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "get-checks-for-task"
-        }
-      }
-    },
-    "/v1/integrations/tasks/{taskId}/run-check": {
-      "post": {
-        "operationId": "TaskIntegrationsController_runCheckForTask_v1",
-        "parameters": [
-          {
-            "name": "taskId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RunCheckForTaskDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Run a check for a task",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Run a check for a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "Run a check for a task | Comp AI API",
-            "sidebarTitle": "Run a check for a task",
-            "description": "Run a check for a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
-            "og:title": "Run a check for a task | Comp AI API",
-            "og:description": "Run a check for a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "run-check-for-task"
-        }
-      }
-    },
-    "/v1/integrations/tasks/{taskId}/checks/disconnect": {
-      "post": {
-        "operationId": "TaskIntegrationsController_disconnectCheckFromTask_v1",
-        "parameters": [
-          {
-            "name": "taskId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ToggleCheckForTaskDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Disconnect checks from a task",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Disconnect checks from a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "Disconnect checks from a task | Comp AI API",
-            "sidebarTitle": "Disconnect checks from a task",
-            "description": "Disconnect checks from a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
-            "og:title": "Disconnect checks from a task | Comp AI API",
-            "og:description": "Disconnect checks from a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "disconnect-check-from-task"
-        }
-      }
-    },
-    "/v1/integrations/tasks/{taskId}/checks/reconnect": {
-      "post": {
-        "operationId": "TaskIntegrationsController_reconnectCheckToTask_v1",
-        "parameters": [
-          {
-            "name": "taskId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ToggleCheckForTaskDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Reconnect checks to a task",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Reconnect checks to a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "Reconnect checks to a task | Comp AI API",
-            "sidebarTitle": "Reconnect checks to a task",
-            "description": "Reconnect checks to a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
-            "og:title": "Reconnect checks to a task | Comp AI API",
-            "og:description": "Reconnect checks to a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "reconnect-check-to-task"
-        }
-      }
-    },
-    "/v1/integrations/tasks/{taskId}/runs": {
-      "get": {
-        "operationId": "TaskIntegrationsController_getTaskCheckRuns_v1",
-        "parameters": [
-          {
-            "name": "taskId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "List check runs for a task",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "List check runs for a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "List check runs for a task | Comp AI API",
-            "sidebarTitle": "List check runs for a task",
-            "description": "List check runs for a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
-            "og:title": "List check runs for a task | Comp AI API",
-            "og:description": "List check runs for a task in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "get-task-check-runs"
-        }
-      }
-    },
-    "/v1/integrations/sync/google-workspace/employees": {
-      "post": {
-        "operationId": "SyncController_syncGoogleWorkspaceEmployees_v1",
-        "parameters": [
-          {
-            "name": "connectionId",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Sync Google Workspace employees",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Sync Google Workspace employees in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "Sync Google Workspace employees | Comp AI API",
-            "sidebarTitle": "Sync Google Workspace employees",
-            "description": "Sync Google Workspace employees in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
-            "og:title": "Sync Google Workspace employees | Comp AI API",
-            "og:description": "Sync Google Workspace employees in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "sync-google-workspace-employees"
-        }
-      }
-    },
-    "/v1/integrations/sync/google-workspace/status": {
-      "post": {
-        "operationId": "SyncController_getGoogleWorkspaceStatus_v1",
-        "parameters": [],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Get Google Workspace sync status",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Get Google Workspace sync status in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "Get Google Workspace sync status | Comp AI API",
-            "sidebarTitle": "Get Google Workspace sync status",
-            "description": "Get Google Workspace sync status in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
-            "og:title": "Get Google Workspace sync status | Comp AI API",
-            "og:description": "Get Google Workspace sync status in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "get-google-workspace-status"
-        }
-      }
-    },
-    "/v1/integrations/sync/rippling/employees": {
-      "post": {
-        "operationId": "SyncController_syncRipplingEmployees_v1",
-        "parameters": [
-          {
-            "name": "connectionId",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Sync Rippling employees",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Sync Rippling employees in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "Sync Rippling employees | Comp AI API",
-            "sidebarTitle": "Sync Rippling employees",
-            "description": "Sync Rippling employees in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
-            "og:title": "Sync Rippling employees | Comp AI API",
-            "og:description": "Sync Rippling employees in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "sync-rippling-employees"
-        }
-      }
-    },
-    "/v1/integrations/sync/rippling/status": {
-      "post": {
-        "operationId": "SyncController_getRipplingStatus_v1",
-        "parameters": [],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Get Rippling sync status",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Get Rippling sync status in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "Get Rippling sync status | Comp AI API",
-            "sidebarTitle": "Get Rippling sync status",
-            "description": "Get Rippling sync status in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
-            "og:title": "Get Rippling sync status | Comp AI API",
-            "og:description": "Get Rippling sync status in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "get-rippling-status"
-        }
-      }
-    },
-    "/v1/integrations/sync/jumpcloud/employees": {
-      "post": {
-        "operationId": "SyncController_syncJumpCloudEmployees_v1",
-        "parameters": [
-          {
-            "name": "connectionId",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Sync JumpCloud employees",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Sync JumpCloud employees in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "Sync JumpCloud employees | Comp AI API",
-            "sidebarTitle": "Sync JumpCloud employees",
-            "description": "Sync JumpCloud employees in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
-            "og:title": "Sync JumpCloud employees | Comp AI API",
-            "og:description": "Sync JumpCloud employees in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "sync-jump-cloud-employees"
-        }
-      }
-    },
-    "/v1/integrations/sync/jumpcloud/status": {
-      "post": {
-        "operationId": "SyncController_getJumpCloudStatus_v1",
-        "parameters": [],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Get JumpCloud sync status",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Get JumpCloud sync status in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "Get JumpCloud sync status | Comp AI API",
-            "sidebarTitle": "Get JumpCloud sync status",
-            "description": "Get JumpCloud sync status in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
-            "og:title": "Get JumpCloud sync status | Comp AI API",
-            "og:description": "Get JumpCloud sync status in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "get-jump-cloud-status"
-        }
-      }
-    },
-    "/v1/integrations/sync/employee-sync-provider": {
-      "get": {
-        "operationId": "SyncController_getEmployeeSyncProvider_v1",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Get the currently configured employee sync provider",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Get the currently configured employee sync provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "Get the currently configured employee sync | Comp AI API",
-            "sidebarTitle": "Get the currently configured employee sync provider",
-            "description": "Get the currently configured employee sync provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage.",
-            "og:title": "Get the currently configured employee sync | Comp AI API",
-            "og:description": "Get the currently configured employee sync provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "get-employee-sync-provider"
-        }
-      },
-      "post": {
-        "operationId": "SyncController_setEmployeeSyncProvider_v1",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SetEmployeeSyncProviderDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Set the employee sync provider",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Set the employee sync provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "Set the employee sync provider | Comp AI API",
-            "sidebarTitle": "Set the employee sync provider",
-            "description": "Set the employee sync provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
-            "og:title": "Set the employee sync provider | Comp AI API",
-            "og:description": "Set the employee sync provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "set-employee-sync-provider"
-        }
-      }
-    },
-    "/v1/integrations/sync/device-sync-provider": {
-      "get": {
-        "operationId": "SyncController_getDeviceSyncProvider_v1",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Get the currently configured device sync provider",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Get the currently configured device sync provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "Get the currently configured device sync | Comp AI API",
-            "sidebarTitle": "Get the currently configured device sync provider",
-            "description": "Get the currently configured device sync provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage.",
-            "og:title": "Get the currently configured device sync | Comp AI API",
-            "og:description": "Get the currently configured device sync provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "get-device-sync-provider"
-        }
-      },
-      "post": {
-        "operationId": "SyncController_setDeviceSyncProvider_v1",
-        "parameters": [],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Set the device sync provider",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Set the device sync provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "Set the device sync provider | Comp AI API",
-            "sidebarTitle": "Set the device sync provider",
-            "description": "Set the device sync provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect.",
-            "og:title": "Set the device sync provider | Comp AI API",
-            "og:description": "Set the device sync provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "set-device-sync-provider"
-        }
-      }
-    },
-    "/v1/integrations/sync/available-providers": {
-      "get": {
-        "operationId": "SyncController_getAvailableSyncProviders_v1",
-        "parameters": [
-          {
-            "name": "syncType",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "List sync providers available to the org",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "List sync providers available to the org in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "List sync providers available to the org | Comp AI API",
-            "sidebarTitle": "List sync providers available to the org",
-            "description": "List sync providers available to the org in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
-            "og:title": "List sync providers available to the org | Comp AI API",
-            "og:description": "List sync providers available to the org in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "get-available-sync-providers"
-        }
-      }
-    },
-    "/v1/integrations/sync/dynamic/{providerSlug}/employees": {
-      "post": {
-        "operationId": "SyncController_syncDynamicProviderEmployees_v1",
-        "parameters": [
-          {
-            "name": "providerSlug",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "connectionId",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Sync employees for a dynamic provider",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Sync employees for a dynamic provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "Sync employees for a dynamic provider | Comp AI API",
-            "sidebarTitle": "Sync employees for a dynamic provider",
-            "description": "Sync employees for a dynamic provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
-            "og:title": "Sync employees for a dynamic provider | Comp AI API",
-            "og:description": "Sync employees for a dynamic provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "sync-dynamic-provider-employees"
-        }
-      }
-    },
-    "/v1/integrations/sync/dynamic/{providerSlug}/devices": {
-      "post": {
-        "operationId": "SyncController_syncDynamicProviderDevices_v1",
-        "parameters": [
-          {
-            "name": "providerSlug",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "connectionId",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "apikey": []
-          }
-        ],
-        "summary": "Sync devices for a dynamic provider",
-        "tags": [
-          "Integrations"
-        ],
-        "description": "Sync devices for a dynamic provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables, and collect automated evidence.",
-        "x-mint": {
-          "metadata": {
-            "title": "Sync devices for a dynamic provider | Comp AI API",
-            "sidebarTitle": "Sync devices for a dynamic provider",
-            "description": "Sync devices for a dynamic provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables.",
-            "og:title": "Sync devices for a dynamic provider | Comp AI API",
-            "og:description": "Sync devices for a dynamic provider in Comp AI. Connect vendor systems, configure OAuth apps, run compliance checks, sync employees, manage variables."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "sync-dynamic-provider-devices"
-        }
-      }
-    },
-    "/v1/cloud-security/activity": {
-      "get": {
-        "operationId": "CloudSecurityController_getActivity_v1",
-        "parameters": [
-          {
-            "name": "connectionId",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "summary": "List recent cloud security activity",
-        "tags": [
-          "CloudSecurity"
-        ],
-        "description": "List recent cloud security activity in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture results to compliance work.",
-        "x-mint": {
-          "metadata": {
-            "title": "List recent cloud security activity | Comp AI API",
-            "sidebarTitle": "List recent cloud security activity",
-            "description": "List recent cloud security activity in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud.",
-            "og:title": "List recent cloud security activity | Comp AI API",
-            "og:description": "List recent cloud security activity in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "get-activity"
-        }
-      }
-    },
-    "/v1/cloud-security/providers": {
-      "get": {
-        "operationId": "CloudSecurityController_getProviders_v1",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "summary": "List supported cloud providers",
-        "tags": [
-          "CloudSecurity"
-        ],
-        "description": "List supported cloud providers in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture results to compliance work.",
-        "x-mint": {
-          "metadata": {
-            "title": "List supported cloud providers | Comp AI API",
-            "sidebarTitle": "List supported cloud providers",
-            "description": "List supported cloud providers in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture.",
-            "og:title": "List supported cloud providers | Comp AI API",
-            "og:description": "List supported cloud providers in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "get-providers"
-        }
-      }
-    },
-    "/v1/cloud-security/findings": {
-      "get": {
-        "operationId": "CloudSecurityController_getFindings_v1",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "summary": "List cloud security findings",
-        "tags": [
-          "CloudSecurity"
-        ],
-        "description": "List cloud security findings discovered by scans so teams can prioritize remediation before issues become audit findings.",
-        "x-mint": {
-          "metadata": {
-            "title": "List cloud security findings | Comp AI API",
-            "sidebarTitle": "List cloud security findings",
-            "description": "List cloud security findings discovered by scans so teams can prioritize remediation before issues become audit findings.",
-            "og:title": "List cloud security findings | Comp AI API",
-            "og:description": "List cloud security findings discovered by scans so teams can prioritize remediation before issues become audit findings."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "get-findings"
-        }
-      }
-    },
-    "/v1/cloud-security/findings/{findingId}/exception": {
-      "post": {
-        "description": "Accepts session, API key, or service token auth. For API key / service token callers without an explicit user attribution, the action is attributed to the org's owner and the audit log description records the calling key/service name.",
-        "operationId": "CloudSecurityController_markFindingAsException_v1",
-        "parameters": [
-          {
-            "name": "findingId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MarkExceptionDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "summary": "Mark a finding as an exception so it no longer appears in the active Scan Results list",
-        "tags": [
-          "CloudSecurity"
-        ],
-        "x-mint": {
-          "metadata": {
-            "title": "Mark a finding as an exception so it no | Comp AI API",
-            "sidebarTitle": "Mark a finding as an exception so it no longer appears in the active Scan Results list",
-            "description": "Accepts session, API key, or service token auth. For API key / service token callers without an explicit user attribution, the action is attributed to the.",
-            "og:title": "Mark a finding as an exception so it no | Comp AI API",
-            "og:description": "Accepts session, API key, or service token auth. For API key / service token callers without an explicit user attribution, the action is attributed to the."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "mark-finding-as-exception"
-        }
-      }
-    },
-    "/v1/cloud-security/connections/{connectionId}/scan-mode": {
-      "patch": {
-        "description": "Accepts session, API key, or service token auth. For API key / service token callers without an explicit user attribution, the action is attributed to the org's owner.",
-        "operationId": "CloudSecurityController_updateAwsScanMode_v1",
-        "parameters": [
-          {
-            "name": "connectionId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateAwsScanModeDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "summary": "Switch the AWS scan engine for a connection (Comp AI scanners ↔ Security Hub)",
-        "tags": [
-          "CloudSecurity"
-        ],
-        "x-mint": {
-          "metadata": {
-            "title": "Switch the AWS scan engine for a connection | Comp AI API",
-            "sidebarTitle": "Switch the AWS scan engine for a connection (Comp AI scanners ↔ Security Hub)",
-            "description": "Accepts session, API key, or service token auth. For API key / service token callers without an explicit user attribution, the action is attributed to the.",
-            "og:title": "Switch the AWS scan engine for a connection | Comp AI API",
-            "og:description": "Accepts session, API key, or service token auth. For API key / service token callers without an explicit user attribution, the action is attributed to the."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "update-aws-scan-mode"
-        }
-      }
-    },
-    "/v1/cloud-security/exceptions/{exceptionId}": {
-      "delete": {
-        "description": "Accepts session, API key, or service token auth. For API key / service token callers without an explicit user attribution, the action is attributed to the org's owner.",
-        "operationId": "CloudSecurityController_revokeException_v1",
-        "parameters": [
-          {
-            "name": "exceptionId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "summary": "Revoke an exception, reopening the finding",
-        "tags": [
-          "CloudSecurity"
-        ],
-        "x-mint": {
-          "metadata": {
-            "title": "Revoke an exception, reopening the finding | Comp AI API",
-            "sidebarTitle": "Revoke an exception, reopening the finding",
-            "description": "Accepts session, API key, or service token auth. For API key / service token callers without an explicit user attribution, the action is attributed to the.",
-            "og:title": "Revoke an exception, reopening the finding | Comp AI API",
-            "og:description": "Accepts session, API key, or service token auth. For API key / service token callers without an explicit user attribution, the action is attributed to the."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "revoke-exception"
-        }
-      }
-    },
-    "/v1/cloud-security/history": {
-      "get": {
-        "operationId": "CloudSecurityController_getHistory_v1",
-        "parameters": [
-          {
-            "name": "connectionId",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "summary": "List resolution, exception, and regression history for a connection",
-        "tags": [
-          "CloudSecurity"
-        ],
-        "description": "List resolution, exception, and regression history for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture results to compliance work.",
-        "x-mint": {
-          "metadata": {
-            "title": "List resolution, exception, and regression | Comp AI API",
-            "sidebarTitle": "List resolution, exception, and regression history for a connection",
-            "description": "List resolution, exception, and regression history for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services.",
-            "og:title": "List resolution, exception, and regression | Comp AI API",
-            "og:description": "List resolution, exception, and regression history for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "get-history"
-        }
-      }
-    },
-    "/v1/cloud-security/findings/{findingId}/check-definition": {
-      "get": {
-        "operationId": "CloudSecurityController_getCheckDefinition_v1",
-        "parameters": [
-          {
-            "name": "findingId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "summary": "Resolve the \"About this check\" description for a finding (AI-cached for AWS; provider-derived for GCP/Azure)",
-        "tags": [
-          "CloudSecurity"
-        ],
-        "description": "Resolve the \"About this check\" description for a finding (AI-cached for AWS; provider-derived for GCP/Azure) in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture.",
-        "x-mint": {
-          "metadata": {
-            "title": "Resolve the \"About this check\" description | Comp AI API",
-            "sidebarTitle": "Resolve the \"About this check\" description for a finding (AI-cached for AWS; provider-derived for GCP/Azure)",
-            "description": "Resolve the \"About this check\" description for a finding (AI-cached for AWS; provider-derived for GCP/Azure) in Comp AI. Run AWS, Azure, and GCP cloud.",
-            "og:title": "Resolve the \"About this check\" description | Comp AI API",
-            "og:description": "Resolve the \"About this check\" description for a finding (AI-cached for AWS; provider-derived for GCP/Azure) in Comp AI. Run AWS, Azure, and GCP cloud."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "get-check-definition"
-        }
-      }
-    },
-    "/v1/cloud-security/resolve-session/{connectionId}": {
-      "post": {
-        "operationId": "CloudSecurityController_resolveSession_v1",
-        "parameters": [
-          {
-            "name": "connectionId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "summary": "Resolve short-lived AWS credentials for a connection (internal only)",
-        "tags": [
-          "CloudSecurity"
-        ],
-        "description": "Resolve short-lived AWS credentials for a connection (internal only) in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture results to compliance work.",
-        "x-mint": {
-          "metadata": {
-            "title": "Resolve short-lived AWS credentials for a | Comp AI API",
-            "sidebarTitle": "Resolve short-lived AWS credentials for a connection (internal only)",
-            "description": "Resolve short-lived AWS credentials for a connection (internal only) in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services.",
-            "og:title": "Resolve short-lived AWS credentials for a | Comp AI API",
-            "og:description": "Resolve short-lived AWS credentials for a connection (internal only) in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "resolve-session"
-        }
-      }
-    },
-    "/v1/cloud-security/scan/{connectionId}": {
-      "post": {
-        "operationId": "CloudSecurityController_scan_v1",
-        "parameters": [
-          {
-            "name": "connectionId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "summary": "Run cloud security scan",
-        "tags": [
-          "CloudSecurity"
-        ],
-        "description": "Trigger a cloud security scan for a connected AWS, Azure, or GCP account and collect findings for compliance remediation.",
-        "x-mint": {
-          "metadata": {
-            "title": "Run cloud security scan | Comp AI API",
-            "sidebarTitle": "Run cloud security scan",
-            "description": "Trigger a cloud security scan for a connected AWS, Azure, or GCP account and collect findings for compliance remediation.",
-            "og:title": "Run cloud security scan | Comp AI API",
-            "og:description": "Trigger a cloud security scan for a connected AWS, Azure, or GCP account and collect findings for compliance remediation."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "scan"
-        }
-      }
-    },
-    "/v1/cloud-security/detect-services/{connectionId}": {
-      "post": {
-        "operationId": "CloudSecurityController_detectServices_v1",
-        "parameters": [
-          {
-            "name": "connectionId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "summary": "Detect available cloud services for a connection",
-        "tags": [
-          "CloudSecurity"
-        ],
-        "description": "Detect available cloud services for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture results to compliance work.",
-        "x-mint": {
-          "metadata": {
-            "title": "Detect available cloud services for a | Comp AI API",
-            "sidebarTitle": "Detect available cloud services for a connection",
-            "description": "Detect available cloud services for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings.",
-            "og:title": "Detect available cloud services for a | Comp AI API",
-            "og:description": "Detect available cloud services for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "detect-services"
-        }
-      }
-    },
-    "/v1/cloud-security/detect-gcp-org/{connectionId}": {
-      "post": {
-        "operationId": "CloudSecurityController_detectGcpOrg_v1",
-        "parameters": [
-          {
-            "name": "connectionId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "summary": "Detect the GCP organization for a connection",
-        "tags": [
-          "CloudSecurity"
-        ],
-        "description": "Detect the GCP organization for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture results to compliance work.",
-        "x-mint": {
-          "metadata": {
-            "title": "Detect the GCP organization for a connection | Comp AI API",
-            "sidebarTitle": "Detect the GCP organization for a connection",
-            "description": "Detect the GCP organization for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect.",
-            "og:title": "Detect the GCP organization for a connection | Comp AI API",
-            "og:description": "Detect the GCP organization for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "detect-gcp-org"
-        }
-      }
-    },
-    "/v1/cloud-security/select-gcp-projects/{connectionId}": {
-      "post": {
-        "operationId": "CloudSecurityController_selectGcpProjects_v1",
-        "parameters": [
-          {
-            "name": "connectionId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "summary": "Select GCP projects for a connection",
-        "tags": [
-          "CloudSecurity"
-        ],
-        "description": "Select GCP projects for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture results to compliance work.",
-        "x-mint": {
-          "metadata": {
-            "title": "Select GCP projects for a connection | Comp AI API",
-            "sidebarTitle": "Select GCP projects for a connection",
-            "description": "Select GCP projects for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud.",
-            "og:title": "Select GCP projects for a connection | Comp AI API",
-            "og:description": "Select GCP projects for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "select-gcp-projects"
-        }
-      }
-    },
-    "/v1/cloud-security/setup-gcp/{connectionId}": {
-      "post": {
-        "operationId": "CloudSecurityController_setupGcp_v1",
-        "parameters": [
-          {
-            "name": "connectionId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "summary": "Set up GCP for a connection",
-        "tags": [
-          "CloudSecurity"
-        ],
-        "description": "Set up GCP for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture results to compliance work.",
-        "x-mint": {
-          "metadata": {
-            "title": "Set up GCP for a connection | Comp AI API",
-            "sidebarTitle": "Set up GCP for a connection",
-            "description": "Set up GCP for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture.",
-            "og:title": "Set up GCP for a connection | Comp AI API",
-            "og:description": "Set up GCP for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "setup-gcp"
-        }
-      }
-    },
-    "/v1/cloud-security/setup-gcp/{connectionId}/resolve-step": {
-      "post": {
-        "operationId": "CloudSecurityController_resolveGcpSetupStep_v1",
-        "parameters": [
-          {
-            "name": "connectionId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "summary": "Resolve a GCP setup step",
-        "tags": [
-          "CloudSecurity"
-        ],
-        "description": "Resolve a GCP setup step in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture results to compliance work.",
-        "x-mint": {
-          "metadata": {
-            "title": "Resolve a GCP setup step | Comp AI API",
-            "sidebarTitle": "Resolve a GCP setup step",
-            "description": "Resolve a GCP setup step in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture.",
-            "og:title": "Resolve a GCP setup step | Comp AI API",
-            "og:description": "Resolve a GCP setup step in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "resolve-gcp-setup-step"
-        }
-      }
-    },
-    "/v1/cloud-security/setup-azure/{connectionId}": {
-      "post": {
-        "operationId": "CloudSecurityController_setupAzure_v1",
-        "parameters": [
-          {
-            "name": "connectionId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "summary": "Set up Azure for a connection",
-        "tags": [
-          "CloudSecurity"
-        ],
-        "description": "Set up Azure for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture results to compliance work.",
-        "x-mint": {
-          "metadata": {
-            "title": "Set up Azure for a connection | Comp AI API",
-            "sidebarTitle": "Set up Azure for a connection",
-            "description": "Set up Azure for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture.",
-            "og:title": "Set up Azure for a connection | Comp AI API",
-            "og:description": "Set up Azure for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "setup-azure"
-        }
-      }
-    },
-    "/v1/cloud-security/validate-azure/{connectionId}": {
-      "post": {
-        "operationId": "CloudSecurityController_validateAzure_v1",
-        "parameters": [
-          {
-            "name": "connectionId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "summary": "Validate Azure credentials for a connection",
-        "tags": [
-          "CloudSecurity"
-        ],
-        "description": "Validate Azure credentials for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture results to compliance work.",
-        "x-mint": {
-          "metadata": {
-            "title": "Validate Azure credentials for a connection | Comp AI API",
-            "sidebarTitle": "Validate Azure credentials for a connection",
-            "description": "Validate Azure credentials for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect.",
-            "og:title": "Validate Azure credentials for a connection | Comp AI API",
-            "og:description": "Validate Azure credentials for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "validate-azure"
-        }
-      }
-    },
-    "/v1/cloud-security/trigger/{connectionId}": {
-      "post": {
-        "operationId": "CloudSecurityController_triggerScan_v1",
-        "parameters": [
-          {
-            "name": "connectionId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": ""
-          }
-        },
-        "summary": "Trigger a cloud security run for a connection",
-        "tags": [
-          "CloudSecurity"
-        ],
-        "description": "Trigger a cloud security run for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture results to compliance work.",
-        "x-mint": {
-          "metadata": {
-            "title": "Trigger a cloud security run for a connection | Comp AI API",
-            "sidebarTitle": "Trigger a cloud security run for a connection",
-            "description": "Trigger a cloud security run for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings.",
-            "og:title": "Trigger a cloud security run for a connection | Comp AI API",
-            "og:description": "Trigger a cloud security run for a connection in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "trigger-scan"
-        }
-      }
-    },
-    "/v1/cloud-security/runs/{runId}": {
-      "get": {
-        "operationId": "CloudSecurityController_getRunStatus_v1",
-        "parameters": [
-          {
-            "name": "runId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "connectionId",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "summary": "Get a cloud security scan run by ID",
-        "tags": [
-          "CloudSecurity"
-        ],
-        "description": "Get a cloud security scan run by ID in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud posture results to compliance work.",
-        "x-mint": {
-          "metadata": {
-            "title": "Get a cloud security scan run by ID | Comp AI API",
-            "sidebarTitle": "Get a cloud security scan run by ID",
-            "description": "Get a cloud security scan run by ID in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud.",
-            "og:title": "Get a cloud security scan run by ID | Comp AI API",
-            "og:description": "Get a cloud security scan run by ID in Comp AI. Run AWS, Azure, and GCP cloud security scans, detect enabled services, review findings, and connect cloud."
-          }
-        },
-        "x-speakeasy-mcp": {
-          "name": "get-run-status"
         }
       }
     },
@@ -23326,6 +23820,58 @@
         },
         "x-speakeasy-mcp": {
           "name": "create-custom"
+        }
+      }
+    },
+    "/v1/frameworks/{id}/custom": {
+      "patch": {
+        "description": "Update the name and/or description of an organization's custom framework. Only custom frameworks are editable; platform frameworks return 400.",
+        "operationId": "FrameworksController_updateCustom_v1",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCustomFrameworkDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Update a custom framework",
+        "tags": [
+          "Frameworks"
+        ],
+        "x-mint": {
+          "metadata": {
+            "title": "Update a custom framework | Comp AI API",
+            "sidebarTitle": "Update a custom framework",
+            "description": "Update the name and/or description of an organization's custom framework. Only custom frameworks are editable; platform frameworks return 400.",
+            "og:title": "Update a custom framework | Comp AI API",
+            "og:description": "Update the name and/or description of an organization's custom framework. Only custom frameworks are editable; platform frameworks return 400."
+          }
+        },
+        "x-speakeasy-mcp": {
+          "name": "update-custom"
         }
       }
     },
@@ -26381,6 +26927,240 @@
           "uploadUrl",
           "s3Key",
           "expiresIn"
+        ]
+      },
+      "CreateConnectionDto": {
+        "type": "object",
+        "properties": {
+          "organizationId": {
+            "type": "string",
+            "description": "Auto-resolved from your API key / session. You can omit this; it is ignored by the server."
+          },
+          "providerSlug": {
+            "type": "string",
+            "description": "Provider slug for the integration. Call list-providers first to see the available slugs (e.g. 'aws', 'gcp', 'azure', 'github').",
+            "example": "aws"
+          },
+          "credentials": {
+            "type": "object",
+            "description": "Provider-specific credential fields. Keys differ by provider — call get-provider-details for the exact shape. For AWS (Cloud Tests) the fields are: connectionName (display name), awsType ('aws-commercial' or 'aws-govcloud'), roleArn (auditor role), externalId (typically your org id), regions (string array), and optionally remediationRoleArn and awsScanMode ('comp_scanners' or 'security_hub'). Omit credentials for OAuth providers — use POST /v1/integrations/oauth/start instead.",
+            "additionalProperties": true,
+            "example": {
+              "connectionName": "Production AWS",
+              "awsType": "aws-commercial",
+              "roleArn": "arn:aws:iam::123456789012:role/CompAI-Auditor",
+              "externalId": "org_abc123",
+              "regions": [
+                "us-east-1",
+                "us-west-2"
+              ],
+              "remediationRoleArn": "arn:aws:iam::123456789012:role/CompAI-Remediator",
+              "awsScanMode": "comp_scanners"
+            }
+          }
+        },
+        "required": [
+          "providerSlug"
+        ]
+      },
+      "UpdateConnectionDto": {
+        "type": "object",
+        "properties": {
+          "organizationId": {
+            "type": "string",
+            "description": "Auto-resolved from your API key / session. You can omit this; it is ignored by the server."
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Connection metadata to merge into the existing record. Common AWS keys: connectionName, regions (string array), awsScanMode ('comp_scanners' or 'security_hub'). The server shallow-merges this with the existing metadata, so include only the keys you want to change.",
+            "additionalProperties": true,
+            "example": {
+              "connectionName": "Production AWS (renamed)",
+              "regions": [
+                "us-east-1",
+                "us-west-2"
+              ]
+            }
+          }
+        }
+      },
+      "UpdateConnectionServicesDto": {
+        "type": "object",
+        "properties": {
+          "organizationId": {
+            "type": "string",
+            "description": "Auto-resolved from your API key / session. You can omit this; it is ignored by the server."
+          },
+          "services": {
+            "type": "array",
+            "description": "Service IDs to enable on this connection. Any service IDs from the provider's manifest that are NOT in this list become disabled. Pass an empty array to disable all services.",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "s3",
+              "iam",
+              "cloudtrail"
+            ]
+          }
+        },
+        "required": [
+          "services"
+        ]
+      },
+      "RunChecksDto": {
+        "type": "object",
+        "properties": {
+          "organizationId": {
+            "type": "string",
+            "description": "Auto-resolved from your API key / session. You can omit this; it is ignored by the server."
+          },
+          "checkId": {
+            "type": "string",
+            "description": "Specific check ID to run. Omit to run ALL available checks for the connection (matches the provider manifest).",
+            "example": "aws-s3-bucket-public-access"
+          }
+        }
+      },
+      "SaveVariablesDto": {
+        "type": "object",
+        "properties": {
+          "organizationId": {
+            "type": "string",
+            "description": "Auto-resolved from your API key / session. You can omit this; it is ignored by the server."
+          },
+          "variables": {
+            "type": "object",
+            "description": "Map of variable id → value to persist for this connection. Values can be string, number, boolean, or string[] (the shape is provider-defined — call get-connection-variables to see what each connection accepts). Pass only the variables you want to set; existing ones not included are left untouched.",
+            "additionalProperties": true,
+            "example": {
+              "scan-interval-hours": 24,
+              "enabled-regions": [
+                "us-east-1",
+                "us-west-2"
+              ],
+              "strict-mode": true
+            }
+          }
+        },
+        "required": [
+          "variables"
+        ]
+      },
+      "RunCheckForTaskDto": {
+        "type": "object",
+        "properties": {
+          "organizationId": {
+            "type": "string",
+            "description": "Auto-resolved from your API key / session. You can omit this; it is ignored by the server."
+          },
+          "connectionId": {
+            "type": "string",
+            "description": "ID of the integration connection that owns the check (call list-connections to find it).",
+            "example": "conn_abc123"
+          },
+          "checkId": {
+            "type": "string",
+            "description": "ID of the integration check to run (from the provider manifest — call list-checks-for-task to find available ones).",
+            "example": "aws-s3-bucket-public-access"
+          }
+        },
+        "required": [
+          "connectionId",
+          "checkId"
+        ]
+      },
+      "ToggleCheckForTaskDto": {
+        "type": "object",
+        "properties": {
+          "organizationId": {
+            "type": "string",
+            "description": "Auto-resolved from your API key / session. You can omit this; it is ignored by the server."
+          },
+          "connectionId": {
+            "type": "string",
+            "description": "ID of the integration connection whose check is being disconnected from / reconnected to this task.",
+            "example": "conn_abc123"
+          },
+          "checkId": {
+            "type": "string",
+            "description": "ID of the integration check being toggled.",
+            "example": "aws-s3-bucket-public-access"
+          }
+        },
+        "required": [
+          "connectionId",
+          "checkId"
+        ]
+      },
+      "SetEmployeeSyncProviderDto": {
+        "type": "object",
+        "properties": {
+          "organizationId": {
+            "type": "string",
+            "description": "Auto-resolved from your API key / session. You can omit this; it is ignored by the server."
+          },
+          "provider": {
+            "type": "object",
+            "description": "Provider slug to use for employee sync (must have the \"sync\" capability in its manifest — call list-providers to see options). Pass null or omit the field to disable employee sync for this org.",
+            "example": "google-workspace",
+            "nullable": true
+          }
+        }
+      },
+      "SetTwoFactorSourceDto": {
+        "type": "object",
+        "properties": {
+          "organizationId": {
+            "type": "string",
+            "description": "Auto-resolved from your API key / session. You can omit this; it is ignored by the server."
+          },
+          "provider": {
+            "type": "object",
+            "description": "Provider slug whose 2FA check feeds the People-tab 2FA column (must be bound to the 2FA task — call available-2fa-sources for options). Pass null or omit to clear the source.",
+            "example": "google-workspace",
+            "nullable": true
+          }
+        }
+      },
+      "MarkExceptionDto": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "description": "Documentation for why this finding does not apply or is being accepted. Minimum 20 non-whitespace characters.",
+            "example": "Bucket hosts intentionally public marketing assets; writes restricted to the marketing IAM role."
+          },
+          "reviewedBy": {
+            "type": "string",
+            "description": "Free-text reviewer or approval reference.",
+            "example": "Approved by CISO 2026-Q1"
+          },
+          "expiresAt": {
+            "type": "string",
+            "description": "ISO date when this exception should auto-expire. Null/missing = never.",
+            "example": "2026-08-13"
+          }
+        },
+        "required": [
+          "reason"
+        ]
+      },
+      "UpdateAwsScanModeDto": {
+        "type": "object",
+        "properties": {
+          "mode": {
+            "type": "string",
+            "description": "Which scan engine to use for this AWS connection.",
+            "enum": [
+              "comp_scanners",
+              "security_hub"
+            ],
+            "example": "security_hub"
+          }
+        },
+        "required": [
+          "mode"
         ]
       },
       "CreateRiskDto": {
@@ -29461,6 +30241,10 @@
               "docx"
             ],
             "example": "pdf"
+          },
+          "versionId": {
+            "type": "string",
+            "description": "Published version to export. Omit to export the document's current published version (or the working draft if it has never been published); provide a version id to download exactly what was approved at that version."
           }
         },
         "required": [
@@ -29478,225 +30262,6 @@
         },
         "required": [
           "frameworkId"
-        ]
-      },
-      "CreateConnectionDto": {
-        "type": "object",
-        "properties": {
-          "organizationId": {
-            "type": "string",
-            "description": "Auto-resolved from your API key / session. You can omit this; it is ignored by the server."
-          },
-          "providerSlug": {
-            "type": "string",
-            "description": "Provider slug for the integration. Call list-providers first to see the available slugs (e.g. 'aws', 'gcp', 'azure', 'github').",
-            "example": "aws"
-          },
-          "credentials": {
-            "type": "object",
-            "description": "Provider-specific credential fields. Keys differ by provider — call get-provider-details for the exact shape. For AWS (Cloud Tests) the fields are: connectionName (display name), awsType ('aws-commercial' or 'aws-govcloud'), roleArn (auditor role), externalId (typically your org id), regions (string array), and optionally remediationRoleArn and awsScanMode ('comp_scanners' or 'security_hub'). Omit credentials for OAuth providers — use POST /v1/integrations/oauth/start instead.",
-            "additionalProperties": true,
-            "example": {
-              "connectionName": "Production AWS",
-              "awsType": "aws-commercial",
-              "roleArn": "arn:aws:iam::123456789012:role/CompAI-Auditor",
-              "externalId": "org_abc123",
-              "regions": [
-                "us-east-1",
-                "us-west-2"
-              ],
-              "remediationRoleArn": "arn:aws:iam::123456789012:role/CompAI-Remediator",
-              "awsScanMode": "comp_scanners"
-            }
-          }
-        },
-        "required": [
-          "providerSlug"
-        ]
-      },
-      "UpdateConnectionDto": {
-        "type": "object",
-        "properties": {
-          "organizationId": {
-            "type": "string",
-            "description": "Auto-resolved from your API key / session. You can omit this; it is ignored by the server."
-          },
-          "metadata": {
-            "type": "object",
-            "description": "Connection metadata to merge into the existing record. Common AWS keys: connectionName, regions (string array), awsScanMode ('comp_scanners' or 'security_hub'). The server shallow-merges this with the existing metadata, so include only the keys you want to change.",
-            "additionalProperties": true,
-            "example": {
-              "connectionName": "Production AWS (renamed)",
-              "regions": [
-                "us-east-1",
-                "us-west-2"
-              ]
-            }
-          }
-        }
-      },
-      "UpdateConnectionServicesDto": {
-        "type": "object",
-        "properties": {
-          "organizationId": {
-            "type": "string",
-            "description": "Auto-resolved from your API key / session. You can omit this; it is ignored by the server."
-          },
-          "services": {
-            "type": "array",
-            "description": "Service IDs to enable on this connection. Any service IDs from the provider's manifest that are NOT in this list become disabled. Pass an empty array to disable all services.",
-            "items": {
-              "type": "string"
-            },
-            "example": [
-              "s3",
-              "iam",
-              "cloudtrail"
-            ]
-          }
-        },
-        "required": [
-          "services"
-        ]
-      },
-      "RunChecksDto": {
-        "type": "object",
-        "properties": {
-          "organizationId": {
-            "type": "string",
-            "description": "Auto-resolved from your API key / session. You can omit this; it is ignored by the server."
-          },
-          "checkId": {
-            "type": "string",
-            "description": "Specific check ID to run. Omit to run ALL available checks for the connection (matches the provider manifest).",
-            "example": "aws-s3-bucket-public-access"
-          }
-        }
-      },
-      "SaveVariablesDto": {
-        "type": "object",
-        "properties": {
-          "organizationId": {
-            "type": "string",
-            "description": "Auto-resolved from your API key / session. You can omit this; it is ignored by the server."
-          },
-          "variables": {
-            "type": "object",
-            "description": "Map of variable id → value to persist for this connection. Values can be string, number, boolean, or string[] (the shape is provider-defined — call get-connection-variables to see what each connection accepts). Pass only the variables you want to set; existing ones not included are left untouched.",
-            "additionalProperties": true,
-            "example": {
-              "scan-interval-hours": 24,
-              "enabled-regions": [
-                "us-east-1",
-                "us-west-2"
-              ],
-              "strict-mode": true
-            }
-          }
-        },
-        "required": [
-          "variables"
-        ]
-      },
-      "RunCheckForTaskDto": {
-        "type": "object",
-        "properties": {
-          "organizationId": {
-            "type": "string",
-            "description": "Auto-resolved from your API key / session. You can omit this; it is ignored by the server."
-          },
-          "connectionId": {
-            "type": "string",
-            "description": "ID of the integration connection that owns the check (call list-connections to find it).",
-            "example": "conn_abc123"
-          },
-          "checkId": {
-            "type": "string",
-            "description": "ID of the integration check to run (from the provider manifest — call list-checks-for-task to find available ones).",
-            "example": "aws-s3-bucket-public-access"
-          }
-        },
-        "required": [
-          "connectionId",
-          "checkId"
-        ]
-      },
-      "ToggleCheckForTaskDto": {
-        "type": "object",
-        "properties": {
-          "organizationId": {
-            "type": "string",
-            "description": "Auto-resolved from your API key / session. You can omit this; it is ignored by the server."
-          },
-          "connectionId": {
-            "type": "string",
-            "description": "ID of the integration connection whose check is being disconnected from / reconnected to this task.",
-            "example": "conn_abc123"
-          },
-          "checkId": {
-            "type": "string",
-            "description": "ID of the integration check being toggled.",
-            "example": "aws-s3-bucket-public-access"
-          }
-        },
-        "required": [
-          "connectionId",
-          "checkId"
-        ]
-      },
-      "SetEmployeeSyncProviderDto": {
-        "type": "object",
-        "properties": {
-          "organizationId": {
-            "type": "string",
-            "description": "Auto-resolved from your API key / session. You can omit this; it is ignored by the server."
-          },
-          "provider": {
-            "type": "object",
-            "description": "Provider slug to use for employee sync (must have the \"sync\" capability in its manifest — call list-providers to see options). Pass null or omit the field to disable employee sync for this org.",
-            "example": "google-workspace",
-            "nullable": true
-          }
-        }
-      },
-      "MarkExceptionDto": {
-        "type": "object",
-        "properties": {
-          "reason": {
-            "type": "string",
-            "description": "Documentation for why this finding does not apply or is being accepted. Minimum 20 non-whitespace characters.",
-            "example": "Bucket hosts intentionally public marketing assets; writes restricted to the marketing IAM role."
-          },
-          "reviewedBy": {
-            "type": "string",
-            "description": "Free-text reviewer or approval reference.",
-            "example": "Approved by CISO 2026-Q1"
-          },
-          "expiresAt": {
-            "type": "string",
-            "description": "ISO date when this exception should auto-expire. Null/missing = never.",
-            "example": "2026-08-13"
-          }
-        },
-        "required": [
-          "reason"
-        ]
-      },
-      "UpdateAwsScanModeDto": {
-        "type": "object",
-        "properties": {
-          "mode": {
-            "type": "string",
-            "description": "Which scan engine to use for this AWS connection.",
-            "enum": [
-              "comp_scanners",
-              "security_hub"
-            ],
-            "example": "security_hub"
-          }
-        },
-        "required": [
-          "mode"
         ]
       },
       "TaskItemAssigneeDto": {
@@ -30152,6 +30717,20 @@
           "name",
           "description"
         ]
+      },
+      "UpdateCustomFrameworkDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Framework name",
+            "example": "Internal Controls"
+          },
+          "description": {
+            "type": "string",
+            "description": "Framework description"
+          }
+        }
       },
       "CreateCustomRequirementDto": {
         "type": "object",


### PR DESCRIPTION
## Why

The nightly Speakeasy `Generate` workflow has been a no-op since June 24 — not because the pipeline broke, but because its input froze. `packages/docs/openapi.json` was last regenerated on main on **June 19** (`3b409793d`), while 58 commits have touched controllers/DTOs since. Every nightly run since then logs `No changes detected` and exits without opening an SDK PR. The Gram sync (`gram-sync.yml`) is gated on the same file, so the hosted MCP is equally stale.

## What

- **Regenerates `packages/docs/openapi.json`** from current main via the deterministic generator (`GEN_OPENAPI=1 bunx jest src/gen-openapi.spec.ts`). 8 paths added, none removed:
  `/v1/frameworks/{id}/custom`, `/v1/integrations/sync/available-2fa-sources`, `/v1/integrations/sync/two-factor-source`, `/v1/integrations/sync/two-factor-statuses`, `/v1/isms/documents/{id}/versions`, `/v1/people/{id}/access`, `/v1/trust-access/{friendlyUrl}/security-questionnaire`, `/v1/trust-portal/settings/security-questionnaire`
- **Repairs the generator specs** (`gen-openapi.spec.ts`, `openapi-docs.spec.ts`), which failed to even load since `4f4c6f51a` (May 27) introduced the ESM-only `@inference/tracing` import into the AppModule graph, and later the pentest module started requiring `MACED_API_KEY` at construction. Adds the same style of ESM mocks the specs already use for better-auth, plus a dummy `mc_dev_` key.

The privacy guardrails in the generator (excluded paths, exposed tags, sensitive schemas) all pass on the regenerated document.

## After merge

- Tonight's scheduled `Generate` run (or a manual dispatch) will detect the spec change and open the usual `chore: 🐝 Update SDK` PR for `apps/mcp-server`.
- `gram-sync.yml` fires automatically on this merge and pushes the fresh spec to Gram.

## Known follow-ups (pre-existing, not introduced here)

Two `openapi-docs.spec.ts` quality tests still fail, hidden until now by the suite not loading:
1. ~20 ISMS endpoints lack OpenAPI summaries (they already shipped in the June 19 spec without summaries).
2. The curated SEO test for `GET /v1/policies` expects description copy that was since rewritten in the controller.

Both are content-quality items, worth a small follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Regenerated `packages/docs/openapi.json` to reflect current API and unblock the nightly Generate and Gram sync workflows. Fixed the OpenAPI generator tests so the spec builds reliably again.

- **Bug Fixes**
  - Mocked ESM-only `@inference/tracing` and `@inference/tracing/ai-sdk` in spec tests.
  - Set a dummy `MACED_API_KEY` in the test env to satisfy the pentest module.

- **New Features**
  - Public OpenAPI spec now includes 8 new endpoints.

<sup>Written for commit d62f973dc3e2e5cd4dc44b34322468694a61dfe7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

