### PR TITLE
docs: add --server-url configuration for self-hosted MCP deployments

### DIFF
--- a/packages/docs/mcp-server.mdx
+++ b/packages/docs/mcp-server.mdx
@@ -202,6 +202,44 @@ Save and reload Windsurf.
 
 That's it. The first time you start a chat in your AI client after install, the assistant will discover the Comp AI tools and start using them.
 
+## Self-hosted deployments
+
+If you're connecting to a self-hosted Comp AI instance instead of the hosted service, include the `--server-url` argument in every MCP server configuration.
+
+Example:
+
+```json
+{
+  "mcpServers": {
+    "comp-ai": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@trycompai/mcp-server",
+        "start",
+        "--apikey",
+        "comp_your_api_key_here",
+        "--server-url",
+        "https://your-comp-api.example.com"
+      ]
+    }
+  }
+}
+```
+
+This applies to:
+
+- Claude Desktop
+- Cursor
+- VS Code
+- Claude Code
+- Codex
+- Gemini
+- Windsurf
+- Any other MCP-compatible client
+
+Hosted users (`app.trycomp.ai`) can omit the `--server-url` argument.
+
 ## Verify it worked
 
 Open a fresh chat in your AI client and ask:

--- a/packages/docs/mcp-server.mdx
+++ b/packages/docs/mcp-server.mdx
@@ -56,6 +56,20 @@ The `npx -y @trycompai/mcp-server` command you'll see throughout is what handles
 
 No JSON editing required.
 
+<Warning>
+**Self-hosted deployments**
+
+The drag-and-drop installer currently configures the hosted Comp AI service.
+
+If you're connecting to a self-hosted Comp AI deployment, use the **Advanced — manual JSON config** below and include:
+
+```text
+--server-url https://your-comp-api.example.com
+```
+
+in the `args` array.
+</Warning>
+
 <Accordion title="Advanced — manual JSON config">
 If you prefer to manage `claude_desktop_config.json` yourself, open **Settings → Developer → Edit Config** and merge:
 
@@ -69,7 +83,9 @@ If you prefer to manage `claude_desktop_config.json` yourself, open **Settings �
         "@trycompai/mcp-server",
         "start",
         "--apikey",
-        "comp_your_api_key_here"
+        "comp_your_api_key_here",
+        "--server-url",
+        "https://your-comp-api.example.com"
       ]
     }
   }
@@ -100,7 +116,9 @@ Open **Cursor → Settings → Tools and Integrations → New MCP Server** and p
     "@trycompai/mcp-server",
     "start",
     "--apikey",
-    "comp_your_api_key_here"
+    "comp_your_api_key_here",
+    "--server-url",
+    "https://your-comp-api.example.com"
   ]
 }
 ```
@@ -129,7 +147,9 @@ Open the **Command Palette → MCP: Open User Configuration** and paste:
     "@trycompai/mcp-server",
     "start",
     "--apikey",
-    "comp_your_api_key_here"
+    "comp_your_api_key_here",
+    "--server-url",
+    "https://your-comp-api.example.com"
   ]
 }
 ```
@@ -142,7 +162,10 @@ Open the **Command Palette → MCP: Open User Configuration** and paste:
 Install with one command:
 
 ```bash
-claude mcp add CompAI -- npx -y @trycompai/mcp-server start --apikey comp_your_api_key_here
+claude mcp add CompAI -- \
+npx -y @trycompai/mcp-server start \
+--apikey comp_your_api_key_here \
+--server-url https://your-comp-api.example.com
 ```
 
 Claude Code registers the server immediately — Comp AI tools become available in your next session.
@@ -154,7 +177,10 @@ Claude Code registers the server immediately — Comp AI tools become available 
 Install with one command:
 
 ```bash
-codex mcp add comp-ai -- npx -y @trycompai/mcp-server start --apikey comp_your_api_key_here
+codex mcp add comp-ai -- \
+npx -y @trycompai/mcp-server start \
+--apikey comp_your_api_key_here \
+--server-url https://your-comp-api.example.com
 ```
 
 Codex registers the server immediately — Comp AI tools become available in your next session.
@@ -168,7 +194,10 @@ For ChatGPT desktop / web with MCP support, follow OpenAI's MCP integration docs
 Install with one command:
 
 ```bash
-gemini mcp add CompAI -- npx -y @trycompai/mcp-server start --apikey comp_your_api_key_here
+gemini mcp add CompAI -- \
+npx -y @trycompai/mcp-server start \
+--apikey comp_your_api_key_here \
+--server-url https://your-comp-api.example.com
 ```
 
 </Tab>
@@ -176,37 +205,6 @@ gemini mcp add CompAI -- npx -y @trycompai/mcp-server start --apikey comp_your_a
 <Tab title="Windsurf">
 
 Open **Windsurf → Settings → Cascade → Manage MCPs → View raw config** and paste:
-
-```json
-{
-  "mcpServers": {
-    "comp-ai": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@trycompai/mcp-server",
-        "start",
-        "--apikey",
-        "comp_your_api_key_here"
-      ]
-    }
-  }
-}
-```
-
-Save and reload Windsurf.
-
-</Tab>
-
-</Tabs>
-
-That's it. The first time you start a chat in your AI client after install, the assistant will discover the Comp AI tools and start using them.
-
-## Self-hosted deployments
-
-If you're connecting to a self-hosted Comp AI instance instead of the hosted service, include the `--server-url` argument in every MCP server configuration.
-
-Example:
 
 ```json
 {
@@ -227,18 +225,14 @@ Example:
 }
 ```
 
-This applies to:
+Save and reload Windsurf.
 
-- Claude Desktop
-- Cursor
-- VS Code
-- Claude Code
-- Codex
-- Gemini
-- Windsurf
-- Any other MCP-compatible client
+</Tab>
 
-Hosted users (`app.trycomp.ai`) can omit the `--server-url` argument.
+</Tabs>
+
+That's it. The first time you start a chat in your AI client after install, the assistant will discover the Comp AI tools and start using them.
+
 
 ## Verify it worked
 


### PR DESCRIPTION
## What does this PR do?

This PR adds documentation for configuring the `--server-url` argument when using the Comp AI MCP server with self-hosted deployments.

### Changes

- Added a **Self-hosted deployments** section to the MCP Server documentation.
- Added a JSON configuration example including the `--server-url` argument.
- Clarified that the configuration applies to all supported MCP clients.

### Why

The current documentation only shows the `--apikey` argument. Users running self-hosted Comp AI deployments also need to provide `--server-url`, which was not previously documented.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document how to set `--server-url` for self-hosted Comp MCP deployments. Added a self-hosted warning, clarified the drag‑and‑drop installer defaults to the hosted service, and updated all JSON/CLI examples across clients (Claude Desktop, Cursor, VS Code, Claude Code, Codex, Gemini, Windsurf) using `@trycompai/mcp-server` to include `--server-url`; hosted users can omit it.

<sup>Written for commit 5d799c463ea9a0268f697c46c35793818a811806. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

