### PR TITLE
fix(questionnaire): strip whole-sheet dataValidations before ExcelJS parse

### DIFF
--- a/apps/api/src/questionnaire/utils/content-extractor.spec.ts
+++ b/apps/api/src/questionnaire/utils/content-extractor.spec.ts
@@ -1,4 +1,5 @@
 import { extractContentFromFile } from './content-extractor';
+import AdmZip from 'adm-zip';
 import ExcelJS from 'exceljs';
 import { PDFDocument } from 'pdf-lib';
 import { generateText } from 'ai';
@@ -161,5 +162,44 @@ describe('content-extractor: extractContentFromFile', () => {
     await expect(
       extractContentFromFile(base64, 'application/octet-stream'),
     ).rejects.toThrow('Unsupported file type');
+  });
+
+  // Regression test for the 2026-07-16 api.trycomp.ai outage: HECVAT Full
+  // ships a whole-sheet dataValidation (~17 billion cells) that makes
+  // ExcelJS block the event loop for minutes. Without the sanitizing step
+  // in loadWorkbook this test does not fail — it hangs.
+  it('should extract content from an Excel file with a whole-sheet data validation', async () => {
+    const buffer = await createTestExcelBuffer([
+      {
+        name: 'Questions',
+        rows: [
+          ['Question', 'Response'],
+          ['Will your company sign a BAA?', 'Yes'],
+        ],
+      },
+    ]);
+
+    const zip = new AdmZip(buffer);
+    const entryName = 'xl/worksheets/sheet1.xml';
+    const xml = zip.readAsText(entryName);
+    const validation =
+      '<dataValidations count="1">' +
+      '<dataValidation allowBlank="1" showInputMessage="1" ' +
+      'prompt="Changes cannot be made in this sheet." ' +
+      'sqref="F18:F1048576 N1:XFD1048576 A3:A1048576"/>' +
+      '</dataValidations>';
+    zip.updateFile(
+      entryName,
+      Buffer.from(
+        xml.replace('</worksheet>', `${validation}</worksheet>`),
+        'utf8',
+      ),
+    );
+    const base64 = zip.toBuffer().toString('base64');
+
+    const result = await extractContentFromFile(base64, XLSX_MIME);
+
+    expect(result).toContain('Will your company sign a BAA?');
+    expect(result).toContain('Yes');
   });
 });

--- a/apps/api/src/questionnaire/utils/content-extractor.ts
+++ b/apps/api/src/questionnaire/utils/content-extractor.ts
@@ -5,6 +5,7 @@ import ExcelJS from 'exceljs';
 import AdmZip from 'adm-zip';
 import mammoth from 'mammoth';
 import { PDFDocument } from 'pdf-lib';
+import { stripXlsxDataValidations } from '@/utils/sanitize-xlsx';
 import { PARSING_MODEL, VISION_EXTRACTION_PROMPT } from './constants';
 import { parseQuestionsAndAnswers } from './question-parser';
 
@@ -12,10 +13,23 @@ import { parseQuestionsAndAnswers } from './question-parser';
  * Loads an Excel workbook from a buffer.
  */
 async function loadWorkbook(data: Uint8Array): Promise<ExcelJS.Workbook> {
-  const workbook = new ExcelJS.Workbook();
-  type LoadFn = (data: Uint8Array) => Promise<ExcelJS.Workbook>;
-  await (workbook.xlsx.load as unknown as LoadFn)(data);
-  return workbook;
+  const load = async (bytes: Uint8Array): Promise<ExcelJS.Workbook> => {
+    const workbook = new ExcelJS.Workbook();
+    type LoadFn = (data: Uint8Array) => Promise<ExcelJS.Workbook>;
+    await (workbook.xlsx.load as unknown as LoadFn)(bytes);
+    return workbook;
+  };
+
+  const sanitized = stripXlsxDataValidations(data);
+  if (sanitized === data) {
+    return load(data);
+  }
+  try {
+    return await load(sanitized);
+  } catch {
+    // If the rewritten archive is somehow unreadable, keep the old behavior.
+    return load(data);
+  }
 }
 
 export interface ContentExtractionLogger {

--- a/apps/api/src/questionnaire/utils/content-extractor.ts
+++ b/apps/api/src/questionnaire/utils/content-extractor.ts
@@ -5,32 +5,12 @@ import ExcelJS from 'exceljs';
 import AdmZip from 'adm-zip';
 import mammoth from 'mammoth';
 import { PDFDocument } from 'pdf-lib';
-import { stripXlsxDataValidations } from '@/utils/sanitize-xlsx';
+import {
+  assertXlsxDecompressionWithinLimit,
+  loadXlsxWorkbook,
+} from '@/utils/load-xlsx';
 import { PARSING_MODEL, VISION_EXTRACTION_PROMPT } from './constants';
 import { parseQuestionsAndAnswers } from './question-parser';
-
-/**
- * Loads an Excel workbook from a buffer.
- */
-async function loadWorkbook(data: Uint8Array): Promise<ExcelJS.Workbook> {
-  const load = async (bytes: Uint8Array): Promise<ExcelJS.Workbook> => {
-    const workbook = new ExcelJS.Workbook();
-    type LoadFn = (data: Uint8Array) => Promise<ExcelJS.Workbook>;
-    await (workbook.xlsx.load as unknown as LoadFn)(bytes);
-    return workbook;
-  };
-
-  const sanitized = stripXlsxDataValidations(data);
-  if (sanitized === data) {
-    return load(data);
-  }
-  try {
-    return await load(sanitized);
-  } catch {
-    // If the rewritten archive is somehow unreadable, keep the old behavior.
-    return load(data);
-  }
-}
 
 export interface ContentExtractionLogger {
   info: (message: string, meta?: Record<string, unknown>) => void;
@@ -632,7 +612,7 @@ function extractFromExcelXml(
  * are interpreted by the workbook parser instead of regex over raw XML.
  */
 async function extractFromExcelStandard(fileBuffer: Buffer): Promise<string> {
-  const workbook = await loadWorkbook(fileBuffer);
+  const workbook = await loadXlsxWorkbook(fileBuffer);
   const sheets: string[] = [];
 
   for (const worksheet of workbook.worksheets) {
@@ -685,6 +665,10 @@ async function extractFromExcel(
   const fileSizeMB = (fileBuffer.length / (1024 * 1024)).toFixed(2);
 
   logger.info('Processing Excel file', { fileType, fileSizeMB });
+
+  // Must run before extractExcelRawContent: its catch falls back to the
+  // AdmZip XML path, which would inflate an oversized archive anyway.
+  assertXlsxDecompressionWithinLimit(fileBuffer);
 
   const result = await extractExcelRawContent(fileBuffer, logger);
 

--- a/apps/api/src/trigger/vector-store/helpers/extract-content-from-file.ts
+++ b/apps/api/src/trigger/vector-store/helpers/extract-content-from-file.ts
@@ -1,35 +1,10 @@
-import { stripXlsxDataValidations } from '@/utils/sanitize-xlsx';
+import { loadXlsxWorkbook } from '@/utils/load-xlsx';
 import { logger } from '@/vector-store/logger';
 import { anthropic } from '@ai-sdk/anthropic';
 import { openai } from '@ai-sdk/openai';
 import { generateText } from 'ai';
 import ExcelJS from 'exceljs';
 import mammoth from 'mammoth';
-
-/**
- * Loads an Excel workbook from a Uint8Array/Buffer.
- * ExcelJS type declarations are incompatible with Node 22+ / TS 5.8+ Buffer types,
- * so we use a typed wrapper to avoid the mismatch.
- */
-async function loadWorkbook(data: Uint8Array): Promise<ExcelJS.Workbook> {
-  const load = async (bytes: Uint8Array): Promise<ExcelJS.Workbook> => {
-    const workbook = new ExcelJS.Workbook();
-    type LoadFn = (data: Uint8Array) => Promise<ExcelJS.Workbook>;
-    await (workbook.xlsx.load as unknown as LoadFn)(bytes);
-    return workbook;
-  };
-
-  const sanitized = stripXlsxDataValidations(data);
-  if (sanitized === data) {
-    return load(data);
-  }
-  try {
-    return await load(sanitized);
-  } catch {
-    // If the rewritten archive is somehow unreadable, keep the old behavior.
-    return load(data);
-  }
-}
 
 const htmlEntityMap = {
   '&nbsp;': ' ',
@@ -81,7 +56,7 @@ export async function extractContentFromFile(
         fileSizeMB,
       });
 
-      const workbook = await loadWorkbook(fileBuffer);
+      const workbook = await loadXlsxWorkbook(fileBuffer);
 
       // Process sheets sequentially
       const sheets: string[] = [];

--- a/apps/api/src/trigger/vector-store/helpers/extract-content-from-file.ts
+++ b/apps/api/src/trigger/vector-store/helpers/extract-content-from-file.ts
@@ -1,3 +1,4 @@
+import { stripXlsxDataValidations } from '@/utils/sanitize-xlsx';
 import { logger } from '@/vector-store/logger';
 import { anthropic } from '@ai-sdk/anthropic';
 import { openai } from '@ai-sdk/openai';
@@ -11,10 +12,23 @@ import mammoth from 'mammoth';
  * so we use a typed wrapper to avoid the mismatch.
  */
 async function loadWorkbook(data: Uint8Array): Promise<ExcelJS.Workbook> {
-  const workbook = new ExcelJS.Workbook();
-  type LoadFn = (data: Uint8Array) => Promise<ExcelJS.Workbook>;
-  await (workbook.xlsx.load as unknown as LoadFn)(data);
-  return workbook;
+  const load = async (bytes: Uint8Array): Promise<ExcelJS.Workbook> => {
+    const workbook = new ExcelJS.Workbook();
+    type LoadFn = (data: Uint8Array) => Promise<ExcelJS.Workbook>;
+    await (workbook.xlsx.load as unknown as LoadFn)(bytes);
+    return workbook;
+  };
+
+  const sanitized = stripXlsxDataValidations(data);
+  if (sanitized === data) {
+    return load(data);
+  }
+  try {
+    return await load(sanitized);
+  } catch {
+    // If the rewritten archive is somehow unreadable, keep the old behavior.
+    return load(data);
+  }
 }
 
 const htmlEntityMap = {

--- a/apps/api/src/utils/load-xlsx.spec.ts
+++ b/apps/api/src/utils/load-xlsx.spec.ts
@@ -1,0 +1,76 @@
+import AdmZip from 'adm-zip';
+import ExcelJS from 'exceljs';
+import {
+  assertXlsxDecompressionWithinLimit,
+  loadXlsxWorkbook,
+} from './load-xlsx';
+
+const FULL_SHEET_VALIDATION =
+  '<dataValidations count="1">' +
+  '<dataValidation allowBlank="1" showInputMessage="1" ' +
+  'prompt="Changes cannot be made in this sheet." ' +
+  'sqref="F18:F1048576 N1:XFD1048576 A3:A1048576"/>' +
+  '</dataValidations>';
+
+async function buildWorkbook(): Promise<Buffer> {
+  const workbook = new ExcelJS.Workbook();
+  const sheet = workbook.addWorksheet('Questions');
+  sheet.getCell('A1').value = 'Will your company sign a BAA?';
+  sheet.getCell('B1').value = 'Yes';
+  const data = await workbook.xlsx.writeBuffer();
+  return Buffer.from(data as ArrayBuffer);
+}
+
+function injectValidation(xlsx: Buffer, block: string): Buffer {
+  const zip = new AdmZip(xlsx);
+  const entryName = 'xl/worksheets/sheet1.xml';
+  const xml = zip.readAsText(entryName);
+  zip.updateFile(
+    entryName,
+    Buffer.from(xml.replace('</worksheet>', `${block}</worksheet>`), 'utf8'),
+  );
+  return zip.toBuffer();
+}
+
+describe('loadXlsxWorkbook', () => {
+  it('loads a workbook poisoned with a whole-sheet data validation', async () => {
+    const poisoned = injectValidation(
+      await buildWorkbook(),
+      FULL_SHEET_VALIDATION,
+    );
+
+    const workbook = await loadXlsxWorkbook(poisoned);
+    const sheet = workbook.getWorksheet('Questions');
+
+    expect(sheet?.getCell('A1').value).toBe('Will your company sign a BAA?');
+    expect(sheet?.getCell('B1').value).toBe('Yes');
+  });
+
+  it('rejects buffers that are not xlsx archives', async () => {
+    await expect(
+      loadXlsxWorkbook(Buffer.from('not an xlsx file')),
+    ).rejects.toThrow();
+  });
+});
+
+describe('assertXlsxDecompressionWithinLimit', () => {
+  it('accepts a normal workbook under the default limit', async () => {
+    const clean = await buildWorkbook();
+
+    expect(() => assertXlsxDecompressionWithinLimit(clean)).not.toThrow();
+  });
+
+  it('rejects archives whose declared uncompressed size exceeds the limit', async () => {
+    const clean = await buildWorkbook();
+
+    expect(() => assertXlsxDecompressionWithinLimit(clean, 10)).toThrow(
+      /safety limit/,
+    );
+  });
+
+  it('ignores buffers that are not zip archives', () => {
+    expect(() =>
+      assertXlsxDecompressionWithinLimit(Buffer.from('not a zip')),
+    ).not.toThrow();
+  });
+});

--- a/apps/api/src/utils/load-xlsx.ts
+++ b/apps/api/src/utils/load-xlsx.ts
@@ -1,0 +1,63 @@
+import AdmZip from 'adm-zip';
+import ExcelJS from 'exceljs';
+import { stripXlsxDataValidations } from './sanitize-xlsx';
+
+// Generous for questionnaires (HECVAT Full inflates to ~6 MB) while still
+// rejecting zip bombs that expand to multiple GB.
+export const MAX_XLSX_UNCOMPRESSED_BYTES = 512 * 1024 * 1024;
+
+/**
+ * Rejects xlsx archives whose declared uncompressed size exceeds the limit,
+ * using only the zip central directory — nothing is inflated. Call this
+ * before any code path that decompresses worksheet XML (ExcelJS or AdmZip),
+ * so a zip bomb is refused before it can exhaust memory.
+ */
+export function assertXlsxDecompressionWithinLimit(
+  data: Uint8Array,
+  limitBytes: number = MAX_XLSX_UNCOMPRESSED_BYTES,
+): void {
+  let entries: AdmZip.IZipEntry[];
+  try {
+    const buffer = Buffer.isBuffer(data) ? data : Buffer.from(data);
+    entries = new AdmZip(buffer).getEntries();
+  } catch {
+    // Not a readable archive — let the workbook loader report its own error.
+    return;
+  }
+
+  let totalBytes = 0;
+  for (const entry of entries) {
+    totalBytes += entry.header.size;
+  }
+
+  if (totalBytes > limitBytes) {
+    const totalMB = Math.round(totalBytes / (1024 * 1024));
+    const limitMB = Math.round(limitBytes / (1024 * 1024));
+    throw new Error(
+      `Excel file expands to ${totalMB} MB uncompressed, exceeding the ${limitMB} MB safety limit.`,
+    );
+  }
+}
+
+/**
+ * The only supported way to open an xlsx with ExcelJS in this codebase:
+ * enforces the decompression limit and strips whole-sheet dataValidations
+ * (see stripXlsxDataValidations) before parsing. There is deliberately no
+ * fallback to the original bytes — if the sanitized archive fails to load,
+ * re-parsing the unsanitized one could reintroduce the event-loop hang the
+ * sanitizer exists to prevent (2026-07-16 outage).
+ */
+export async function loadXlsxWorkbook(
+  data: Uint8Array,
+): Promise<ExcelJS.Workbook> {
+  assertXlsxDecompressionWithinLimit(data);
+
+  const workbook = new ExcelJS.Workbook();
+  // ExcelJS type declarations are incompatible with Node 22+ / TS 5.8+
+  // Buffer types, so we use a typed wrapper to avoid the mismatch.
+  type LoadFn = (data: Uint8Array) => Promise<ExcelJS.Workbook>;
+  await (workbook.xlsx.load as unknown as LoadFn)(
+    stripXlsxDataValidations(data),
+  );
+  return workbook;
+}

--- a/apps/api/src/utils/sanitize-xlsx.spec.ts
+++ b/apps/api/src/utils/sanitize-xlsx.spec.ts
@@ -67,10 +67,15 @@ describe('stripXlsxDataValidations', () => {
     expect(stripXlsxDataValidations(clean)).toBe(clean);
   });
 
-  it('returns the input unchanged when the buffer is not a zip archive', () => {
+  it('fails closed when the buffer is not a readable archive', () => {
+    // An archive AdmZip cannot read might still parse in ExcelJS's more
+    // lenient unzipper, validations included — so it must be rejected,
+    // never passed through unsanitized.
     const garbage = Buffer.from('not an xlsx file');
 
-    expect(stripXlsxDataValidations(garbage)).toBe(garbage);
+    expect(() => stripXlsxDataValidations(garbage)).toThrow(
+      /Unable to sanitize/,
+    );
   });
 
   it('keeps the workbook loadable with all cell text intact', async () => {

--- a/apps/api/src/utils/sanitize-xlsx.spec.ts
+++ b/apps/api/src/utils/sanitize-xlsx.spec.ts
@@ -1,0 +1,92 @@
+import AdmZip from 'adm-zip';
+import ExcelJS from 'exceljs';
+import { stripXlsxDataValidations } from './sanitize-xlsx';
+
+// A whole-sheet validation range like the one the HECVAT Full template ships
+// (~17 billion cells). Loading it un-stripped would block the event loop for
+// minutes, so passing tests must go through the sanitized path.
+const FULL_SHEET_VALIDATION =
+  '<dataValidations count="1">' +
+  '<dataValidation allowBlank="1" showInputMessage="1" showErrorMessage="1" ' +
+  'prompt="Changes cannot be made in this sheet." ' +
+  'sqref="F18:F1048576 N1:XFD1048576 A3:A1048576"/>' +
+  '</dataValidations>';
+
+async function buildWorkbook(): Promise<Buffer> {
+  const workbook = new ExcelJS.Workbook();
+  const sheet = workbook.addWorksheet('Questions');
+  sheet.getCell('A1').value = 'Will your company sign a BAA?';
+  sheet.getCell('B1').value = 'Yes';
+  const data = await workbook.xlsx.writeBuffer();
+  return Buffer.from(data as ArrayBuffer);
+}
+
+function injectValidation(xlsx: Buffer, block: string): Buffer {
+  const zip = new AdmZip(xlsx);
+  const entryName = 'xl/worksheets/sheet1.xml';
+  const xml = zip.readAsText(entryName);
+  zip.updateFile(
+    entryName,
+    Buffer.from(xml.replace('</worksheet>', `${block}</worksheet>`), 'utf8'),
+  );
+  return zip.toBuffer();
+}
+
+function readSheetXml(xlsx: Uint8Array): string {
+  const zip = new AdmZip(Buffer.from(xlsx));
+  return zip.readAsText('xl/worksheets/sheet1.xml');
+}
+
+describe('stripXlsxDataValidations', () => {
+  it('removes dataValidations blocks from worksheet xml', async () => {
+    const poisoned = injectValidation(
+      await buildWorkbook(),
+      FULL_SHEET_VALIDATION,
+    );
+
+    const sanitized = stripXlsxDataValidations(poisoned);
+
+    expect(readSheetXml(poisoned)).toContain('<dataValidations');
+    expect(readSheetXml(sanitized)).not.toContain('<dataValidations');
+  });
+
+  it('removes self-closing dataValidations elements', async () => {
+    const poisoned = injectValidation(
+      await buildWorkbook(),
+      '<dataValidations count="0"/>',
+    );
+
+    const sanitized = stripXlsxDataValidations(poisoned);
+
+    expect(readSheetXml(sanitized)).not.toContain('<dataValidations');
+  });
+
+  it('returns the input unchanged when there is nothing to strip', async () => {
+    const clean = await buildWorkbook();
+
+    expect(stripXlsxDataValidations(clean)).toBe(clean);
+  });
+
+  it('returns the input unchanged when the buffer is not a zip archive', () => {
+    const garbage = Buffer.from('not an xlsx file');
+
+    expect(stripXlsxDataValidations(garbage)).toBe(garbage);
+  });
+
+  it('keeps the workbook loadable with all cell text intact', async () => {
+    const poisoned = injectValidation(
+      await buildWorkbook(),
+      FULL_SHEET_VALIDATION,
+    );
+
+    const sanitized = stripXlsxDataValidations(poisoned);
+
+    const workbook = new ExcelJS.Workbook();
+    type LoadFn = (data: Uint8Array) => Promise<ExcelJS.Workbook>;
+    await (workbook.xlsx.load as unknown as LoadFn)(sanitized);
+    const sheet = workbook.getWorksheet('Questions');
+
+    expect(sheet?.getCell('A1').value).toBe('Will your company sign a BAA?');
+    expect(sheet?.getCell('B1').value).toBe('Yes');
+  });
+});

--- a/apps/api/src/utils/sanitize-xlsx.ts
+++ b/apps/api/src/utils/sanitize-xlsx.ts
@@ -19,8 +19,12 @@ const DATA_VALIDATIONS_BLOCK_RE =
  * Validations only hold dropdown rules and prompts, never cell text, so
  * removing them cannot change extracted content.
  *
- * Best-effort: returns the original bytes untouched when there is nothing
- * to strip or when the archive cannot be rewritten.
+ * Returns the original bytes untouched only when the archive was read
+ * successfully and contained nothing to strip. Fails closed otherwise:
+ * if the archive cannot be inspected or rewritten, it throws rather than
+ * letting potentially unsanitized bytes reach ExcelJS — an archive that
+ * AdmZip cannot read might still be accepted by ExcelJS's more lenient
+ * unzipper, validations included.
  */
 export function stripXlsxDataValidations(data: Uint8Array): Uint8Array {
   try {
@@ -46,7 +50,11 @@ export function stripXlsxDataValidations(data: Uint8Array): Uint8Array {
     }
 
     return changed ? zip.toBuffer() : data;
-  } catch {
-    return data;
+  } catch (error) {
+    throw new Error(
+      `Unable to sanitize the Excel archive: ${
+        error instanceof Error ? error.message : 'unknown error'
+      }. The file may be corrupt — re-save it in Excel and upload it again.`,
+    );
   }
 }

--- a/apps/api/src/utils/sanitize-xlsx.ts
+++ b/apps/api/src/utils/sanitize-xlsx.ts
@@ -1,0 +1,52 @@
+import AdmZip from 'adm-zip';
+
+const WORKSHEET_ENTRY_RE = /^xl\/worksheets\/[^/]+\.xml$/;
+
+// Matches a whole <dataValidations>...</dataValidations> block or a
+// self-closing <dataValidations/>. Validations cannot nest, so the
+// non-greedy body match is safe.
+const DATA_VALIDATIONS_BLOCK_RE =
+  /<dataValidations(?:\s[^>]*)?\/>|<dataValidations(?:\s[^>]*)?>[\s\S]*?<\/dataValidations>/g;
+
+/**
+ * Removes <dataValidations> blocks from every worksheet inside an xlsx
+ * archive before the workbook is handed to ExcelJS.
+ *
+ * ExcelJS registers each validation on every individual cell of its sqref
+ * range, so a template with a whole-sheet range — e.g. HECVAT Full ships
+ * "N1:XFD1048576" ≈ 17 billion cells — blocks the event loop until the
+ * process is killed (incident 2026-07-16, api.trycomp.ai outage).
+ * Validations only hold dropdown rules and prompts, never cell text, so
+ * removing them cannot change extracted content.
+ *
+ * Best-effort: returns the original bytes untouched when there is nothing
+ * to strip or when the archive cannot be rewritten.
+ */
+export function stripXlsxDataValidations(data: Uint8Array): Uint8Array {
+  try {
+    const buffer = Buffer.isBuffer(data) ? data : Buffer.from(data);
+    const zip = new AdmZip(buffer);
+    let changed = false;
+
+    for (const entry of zip.getEntries()) {
+      if (!WORKSHEET_ENTRY_RE.test(entry.entryName)) {
+        continue;
+      }
+
+      const xml = entry.getData().toString('utf8');
+      if (!xml.includes('<dataValidations')) {
+        continue;
+      }
+
+      const cleaned = xml.replace(DATA_VALIDATIONS_BLOCK_RE, '');
+      if (cleaned !== xml) {
+        zip.updateFile(entry.entryName, Buffer.from(cleaned, 'utf8'));
+        changed = true;
+      }
+    }
+
+    return changed ? zip.toBuffer() : data;
+  } catch {
+    return data;
+  }
+}


### PR DESCRIPTION
## Why

api.trycomp.ai went down 2026-07-16 05:39–05:45 UTC (Better Stack alert). Root cause: a customer uploaded `HECVAT_Full.xlsx` to the questionnaire auto-answer export endpoint. The stock HECVAT Full template ships a `<dataValidation>` covering `N1:XFD1048576` + several full-column ranges — **~17.2 billion cells**. ExcelJS registers validations cell-by-cell (`data-validations-xform.js`), so `workbook.xlsx.load()` hard-blocks the Node event loop. ALB health checks (`/v1/health`, 5s timeout) timed out, ECS killed the task, the customer retried, and the replacement died too — three containers were serially killed (05:27, 05:38, 06:02 UTC); the 05:38 overlap took both targets out and caused the visible outage.

The parse never succeeded — the customer never got their export.

## What

- New `stripXlsxDataValidations` (`apps/api/src/utils/sanitize-xlsx.ts`): removes `<dataValidations>` blocks from every worksheet XML inside the xlsx zip before the workbook reaches ExcelJS. Validations hold only dropdown rules and prompts — never cell text — so extraction output is unchanged.
- Wired into `loadWorkbook` in both Excel parse sites: `questionnaire/utils/content-extractor.ts` and `trigger/vector-store/helpers/extract-content-from-file.ts`.
- Safety: best-effort — if there is nothing to strip the original bytes pass through untouched (same reference); if the rewritten archive somehow fails to load, we retry with the original bytes, so worst case equals current behavior. The existing XML fallback path is also still in place.
- ExcelJS ignores `x14` (extLst) validations entirely, so only the standard block needs stripping.

## Verification

- Ran the customer's actual file from S3 through the patched extractor: **hang (killed after 3+ min) → 0.33s, 601,303 chars extracted across all 15 sheets.**
- 28 tests pass across 3 suites, including a new regression test that loads a workbook poisoned with the HECVAT-style full-sheet validation through `extractContentFromFile` (without the fix this test hangs, by design).
- `tsc --noEmit`: only the 23 pre-existing errors already present on main; none in touched files.

## Out of scope (follow-up)

Moving the 4 in-process export parse call sites (`parse/upload`, `parse/upload/token`, JSON export variants) onto the existing Trigger.dev questionnaire tasks, plus a per-file size cap and zip decompression guard — planned as a separate PR since it changes the endpoint contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip Excel data validations from uploaded `.xlsx` files and add a decompression safety check before `ExcelJS` parsing to prevent hangs and zip-bomb crashes. A shared loader keeps questionnaire and vector-store exports fast and stable without changing extracted text.

- **Bug Fixes**
  - Shared loader `loadXlsxWorkbook` uses `stripXlsxDataValidations` and is called by both questionnaire and vector-store paths.
  - Zip-bomb guard `assertXlsxDecompressionWithinLimit` (512 MB uncompressed) runs before any inflation, including ahead of the XML fallback path.
  - Fail-closed: sanitizer throws if it cannot rewrite the archive; no retry with original bytes; questionnaire falls back to the XML extractor so unsanitized bytes never reach `ExcelJS`.
  - Tests added for validation stripping, loader, decompression limit, and a HECVAT regression; customer file now completes in ~0.33s instead of hanging.

<sup>Written for commit d7a3f2dfc191db009274950b4bd3d7cd6ce1f33a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

