### PR TITLE
fix(people): restore role selection in invite dialog

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/people/all/components/MultiRoleCombobox.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/MultiRoleCombobox.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { MultiRoleCombobox } from './MultiRoleCombobox';
+
+// jsdom doesn't implement these APIs that Radix Popover / cmdk rely on.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+  Element.prototype.hasPointerCapture = vi.fn(() => false);
+  Element.prototype.releasePointerCapture = vi.fn();
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+});
+
+const ALLOWED = ['admin', 'auditor', 'employee', 'contractor'];
+
+async function openAndGetRoleItem(name: string) {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole('combobox'));
+  const item = (await screen.findByText(name)).closest('[cmdk-item]');
+  if (!(item instanceof HTMLElement)) {
+    throw new Error(`Role item "${name}" not found`);
+  }
+  return { user, item };
+}
+
+describe('MultiRoleCombobox selection', () => {
+  it('does not cancel pointerdown on a role item (regression: role not selectable)', async () => {
+    // The role items previously had `onPointerDown={(e) => e.preventDefault()}`.
+    // Cancelling pointerdown suppresses the browser's native pointer->click
+    // sequence that drives cmdk's `onSelect`, so clicking a role did nothing.
+    // jsdom fires a synthetic click that bypasses the pointer sequence, so we
+    // assert the underlying DOM contract directly: the item must let the
+    // pointerdown default action proceed.
+    render(
+      <MultiRoleCombobox
+        selectedRoles={[]}
+        onSelectedRolesChange={vi.fn()}
+        allowedRoles={ALLOWED}
+        placeholder="Select a role"
+      />,
+    );
+
+    const { item } = await openAndGetRoleItem('Admin');
+    const pointerDown = new PointerEvent('pointerdown', { bubbles: true, cancelable: true });
+    item.dispatchEvent(pointerDown);
+
+    expect(pointerDown.defaultPrevented).toBe(false);
+  });
+
+  it('adds a role to the selection when clicked', async () => {
+    const handleChange = vi.fn();
+    render(
+      <MultiRoleCombobox
+        selectedRoles={[]}
+        onSelectedRolesChange={handleChange}
+        allowedRoles={ALLOWED}
+        placeholder="Select a role"
+      />,
+    );
+
+    const { user, item } = await openAndGetRoleItem('Admin');
+    await user.click(item);
+
+    expect(handleChange).toHaveBeenCalledWith(['admin']);
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/MultiRoleComboboxContent.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/MultiRoleComboboxContent.tsx
@@ -89,8 +89,6 @@ export function MultiRoleComboboxContent({
               <CommandItem
                 key={role.value}
                 value={getRoleDisplayLabel(role.value)} // Use translated label for search/value
-                onPointerDown={(e) => e.preventDefault()}
-                onClick={(e) => e.stopPropagation()}
                 onSelect={() => {
                   handleSelect(role.value);
                   onCloseDialog();
@@ -140,8 +138,6 @@ export function MultiRoleComboboxContent({
                   <CommandItem
                     key={customRole.id}
                     value={customRole.name}
-                    onPointerDown={(e) => e.preventDefault()}
-                    onClick={(e) => e.stopPropagation()}
                     onSelect={() => {
                       handleSelect(roleValue);
                       onCloseDialog();


### PR DESCRIPTION
## Problem

When adding a user manually in the People tab, the role selector is non-functional. Users cannot select roles by clicking or keyboard. The dropdown renders and highlights items on hover, but selection never fires and the popover never closes. CSV import works fine as a workaround since it bypasses this component.

## Root cause

MultiRoleCombobox uses a cmdk Command inside a Radix Popover that portals outside the modal Dialog. This creates two issues:

1. The portalled popover sits outside the Dialog's FocusScope, so the CommandInput loses focus
2. cmdk requires CommandInput focus to fire onSelect (via dispatched cmdk-item-select events or keyboard Enter)
3. MultiRoleComboboxContent adds onPointerDown preventDefault on every item, blocking pointer selection

Result: pointer and keyboard selection both fail while hover highlighting still works (from the untouched onPointerMove).

## Fix

Removed the interfering onPointerDown/onClick handlers from the role items in MultiRoleComboboxContent. This allows cmdk's native selection to work inside the modal Dialog context.

This is a UI-only change to the People combobox. No auth, RBAC, schema, or org-scoping logic touched.

## Explicitly NOT touched

- Dialog modal behavior or FocusScope
- Popover portal positioning
- cmdk Command setup
- Role assignment logic
- CSV import flow

## Verification

✅ Manual role selection works by click in the invite dialog
✅ Manual role selection works by keyboard in the invite dialog
✅ Popover closes after selection
✅ Selected roles show checkmarks
✅ CSV import still works
✅ Tested in multiple browsers

Fixes CS-748

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores role selection in the People invite dialog by letting `cmdk` item selection fire normally. Users can now select roles via mouse or keyboard and the popover closes; fixes CS-748.

- **Bug Fixes**
  - Removed `onPointerDown` and `onClick` handlers on combobox items that blocked `onSelect`.
  - Added tests to verify pointerdown isn’t canceled and clicking a role updates `onSelectedRolesChange`.

<sup>Written for commit 9329dfa8b564e9fcee8c830d9a0cd1218dbf26a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

