### PR TITLE
fix(people): keep role picker clickable in the invite dialog (CS-748)

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/people/all/components/MultiRoleCombobox.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/MultiRoleCombobox.test.tsx
@@ -16,55 +16,73 @@ beforeAll(() => {
 });
 
 const ALLOWED = ['admin', 'auditor', 'employee', 'contractor'];
+const CUSTOM_ROLES = [
+  { id: 'orole_1', name: 'Security Reviewer', permissions: { control: ['read'] } },
+];
 
-async function openAndGetRoleItem(name: string) {
-  const user = userEvent.setup();
-  await user.click(screen.getByRole('combobox'));
-  const item = (await screen.findByText(name)).closest('[cmdk-item]');
-  if (!(item instanceof HTMLElement)) {
-    throw new Error(`Role item "${name}" not found`);
-  }
-  return { user, item };
-}
-
-describe('MultiRoleCombobox selection', () => {
-  it('does not cancel pointerdown on a role item (regression: role not selectable)', async () => {
-    // The role items previously had `onPointerDown={(e) => e.preventDefault()}`.
-    // Cancelling pointerdown suppresses the browser's native pointer->click
-    // sequence that drives cmdk's `onSelect`, so clicking a role did nothing.
-    // jsdom fires a synthetic click that bypasses the pointer sequence, so we
-    // assert the underlying DOM contract directly: the item must let the
-    // pointerdown default action proceed.
+describe('MultiRoleCombobox (CS-748)', () => {
+  it('forces pointer-events on the popover content so roles stay clickable inside a modal dialog', async () => {
+    // This combobox is used inside the modal "Add User" Radix Dialog, which
+    // locks `body { pointer-events: none }`. A Radix dismissable-layer version
+    // skew (react-dialog -> 1.1.15 vs react-popover -> 1.1.11) puts the two in
+    // separate module-level layer contexts, so the portaled popover never
+    // re-enables pointer events and its role items inherit `none` — unclickable
+    // and unhoverable. The fix forces pointer-events on the content. jsdom can't
+    // hit-test, so we assert the fix is present here; the end-to-end click
+    // behavior inside the modal is verified in a real browser.
+    const user = userEvent.setup();
     render(
       <MultiRoleCombobox
         selectedRoles={[]}
         onSelectedRolesChange={vi.fn()}
         allowedRoles={ALLOWED}
+        customRoles={CUSTOM_ROLES}
         placeholder="Select a role"
       />,
     );
 
-    const { item } = await openAndGetRoleItem('Admin');
-    const pointerDown = new PointerEvent('pointerdown', { bubbles: true, cancelable: true });
-    item.dispatchEvent(pointerDown);
+    await user.click(screen.getByRole('combobox'));
 
-    expect(pointerDown.defaultPrevented).toBe(false);
+    const content = document.querySelector('[data-slot="popover-content"]');
+    expect(content).not.toBeNull();
+    expect(content).toHaveStyle({ pointerEvents: 'auto' });
   });
 
-  it('adds a role to the selection when clicked', async () => {
+  it('selects a built-in role when clicked', async () => {
     const handleChange = vi.fn();
+    const user = userEvent.setup();
     render(
       <MultiRoleCombobox
         selectedRoles={[]}
         onSelectedRolesChange={handleChange}
         allowedRoles={ALLOWED}
+        customRoles={CUSTOM_ROLES}
         placeholder="Select a role"
       />,
     );
 
-    const { user, item } = await openAndGetRoleItem('Admin');
-    await user.click(item);
+    await user.click(screen.getByRole('combobox'));
+    await user.click(await screen.findByText('Admin'));
 
     expect(handleChange).toHaveBeenCalledWith(['admin']);
+  });
+
+  it('selects a custom role when clicked (the customer-reported path)', async () => {
+    const handleChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <MultiRoleCombobox
+        selectedRoles={[]}
+        onSelectedRolesChange={handleChange}
+        allowedRoles={ALLOWED}
+        customRoles={CUSTOM_ROLES}
+        placeholder="Select a role"
+      />,
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    await user.click(await screen.findByText('Security Reviewer'));
+
+    expect(handleChange).toHaveBeenCalledWith(['Security Reviewer']);
   });
 });

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/MultiRoleCombobox.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/MultiRoleCombobox.tsx
@@ -169,7 +169,22 @@ export function MultiRoleCombobox({
           />
         </div>
       </PopoverTrigger>
-      <PopoverContent className="w-[280px] p-0" align="start">
+      {/*
+        This Popover is portaled to <body> while rendered inside a modal Radix
+        Dialog (the invite "Add User" dialog). The Dialog locks
+        `body { pointer-events: none }`, and a Radix version skew
+        (react-dialog -> react-dismissable-layer@1.1.15 vs
+        react-popover -> react-dismissable-layer@1.1.11) means the two live in
+        separate module-level layer contexts, so the popover never re-enables
+        pointer events on itself and its items inherit `none` — making every
+        role unclickable/unhoverable. Forcing pointer-events here restores
+        interactivity for the whole popover subtree. See CS-748.
+      */}
+      <PopoverContent
+        className="w-[280px] p-0"
+        align="start"
+        style={{ pointerEvents: 'auto' }}
+      >
         <MultiRoleComboboxContent
           searchTerm={searchTerm}
           setSearchTerm={setSearchTerm}


### PR DESCRIPTION
## Problem

In the People tab → **Add User** dialog, the role picker opens and lists all roles, but **no role can be selected — by mouse or keyboard**. Hovering doesn't even highlight a row. CSV import assigns roles fine, which is why that was the only workaround.

The previous attempt (#3428) removed two handlers from the role items but **did not fix it** — those handlers were effectively dead code (cmdk overrides item `onClick`, and `preventDefault` on `pointerdown` doesn't cancel `click`), and its tests rendered the combobox in isolation so they passed without reproducing the real environment.

## Root cause (verified)

The picker (`MultiRoleCombobox`) is a Radix **Popover** portaled to `<body>`, rendered inside the modal Radix **Dialog**. A modal Dialog sets `body { pointer-events: none }` and relies on Radix's `react-dismissable-layer` re-enabling pointer events on layers above it — but that coordination only works when every Radix package shares **one** `react-dismissable-layer` module instance (its layer registry is module-level state).

Here there are **two** copies:

| package | resolves dismissable-layer |
|---|---|
| `@radix-ui/react-dialog@1.1.19` | `1.1.15` (hoisted) |
| `@radix-ui/react-popover@1.1.15` | `1.1.11` (nested, exact pin) |

So the Dialog locks `body` in one context, the Popover checks the *other* (empty) context, decides no modal is active, and never sets `pointer-events: auto` on itself → the popover content and every role item **inherit `pointer-events: none`** → unclickable and unhoverable.

I reproduced this in a real browser (Playwright) using the actual installed Radix packages:

| | `pointer-events` on item | click selects? |
|---|---|---|
| before | `none` (inherited from locked `body`) | ❌ click passes through to a lower element |
| after | `auto` | ✅ selects |

## Fix

Force `pointer-events: auto` on the popover content, so the whole popover subtree stays interactive even while `body` is locked. One-line, scoped, no dependency changes. Covers both built-in and custom roles (same popover).

## Verification

- ✅ Real-browser repro (above): confirms the block and that the fix restores selection.
- ✅ Replaced the previous isolated tests with ones covering the **built-in** and **custom-role** selection paths, plus a guard that the popover content keeps `pointer-events: auto`.
- ✅ `tsc` clean for the changed files (pre-existing unrelated errors remain on `main`).

## Alternative (optional follow-up)

The true root cause is the dependency skew. A `bun` override forcing a single `@radix-ui/react-dismissable-layer` version would fix **every** Popover/Dropdown/Select-in-Dialog at once — but it touches the whole Radix tree and needs broader regression testing, so I kept this PR scoped to unblock the customer. Happy to do the dedupe separately if you'd prefer the root fix.

Fixes CS-748


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores role selection in People → Add User by making the role picker clickable again (CS-748). The popover now forces `pointer-events: auto` to work around a Radix layer-context version skew that left items unclickable.

- **Bug Fixes**
  - Force pointer events on popover content in `MultiRoleCombobox` so items stay interactive inside `@radix-ui/react-dialog`.
  - Update tests to cover selecting built-in and custom roles; assert popover content keeps `pointer-events: auto`.

<sup>Written for commit 0f24c95ee0b20c5403ca7bcc8c46beba1d13bad8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

