### PR TITLE
fix(people): make role selector popover modal inside invite dialog

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/people/all/components/MultiRoleCombobox.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/MultiRoleCombobox.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { MultiRoleCombobox } from './MultiRoleCombobox';
@@ -49,6 +49,36 @@ describe('MultiRoleCombobox selection', () => {
     item.dispatchEvent(pointerDown);
 
     expect(pointerDown.defaultPrevented).toBe(false);
+  });
+
+  it('opens the role list as a modal layer so the parent Dialog cannot swallow selections (regression: CS-748)', async () => {
+    // This combobox always renders inside a modal Radix Dialog (invite + edit
+    // roles). A non-modal Popover portals its content outside that Dialog, so the
+    // Dialog's focus/dismiss layer governs the role items and cmdk's onSelect
+    // (driven by the item's native click / a focus-dependent Enter) never fires —
+    // clicking a role does nothing. jsdom's synthetic click bypasses that
+    // pointer/focus path and can't reproduce the failure, so we assert the DOM
+    // contract the fix depends on: the Popover must open as a *modal* dismissable
+    // layer, which disables outside pointer events (body `pointer-events: none`)
+    // and traps focus, taking governance of the items back from the Dialog.
+    render(
+      <MultiRoleCombobox
+        selectedRoles={[]}
+        onSelectedRolesChange={vi.fn()}
+        allowedRoles={ALLOWED}
+        placeholder="Select a role"
+      />,
+    );
+
+    expect(document.body.style.pointerEvents).toBe('');
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('combobox'));
+    await screen.findByText('Admin');
+
+    await waitFor(() => {
+      expect(document.body.style.pointerEvents).toBe('none');
+    });
   });
 
   it('adds a role to the selection when clicked', async () => {

--- a/apps/app/src/app/(app)/[orgId]/people/all/components/MultiRoleCombobox.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/all/components/MultiRoleCombobox.tsx
@@ -154,7 +154,12 @@ export function MultiRoleCombobox({
   });
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    // `modal` is required: this combobox always renders inside a modal Radix
+    // Dialog (invite + edit-roles). A non-modal Popover portals its content
+    // outside that Dialog, leaving the Dialog's focus/dismiss layer in charge of
+    // the role items, so cmdk's onSelect (driven by the item's native click / a
+    // focus-dependent Enter) never fires and roles can't be selected (CS-748).
+    <Popover open={open} onOpenChange={setOpen} modal>
       <PopoverTrigger asChild>
         <div>
           <MultiRoleComboboxTrigger


### PR DESCRIPTION
## Problem

Role selector in the manual user invite flow is not clickable. Dropdown opens and shows all four built-in roles, cursor highlights each row, but clicking a role does nothing. Trigger stays on "Select role(s)", no checkmark appears, popover stays open. CSV import works fine since it bypasses this component.

## Root cause

MultiRoleCombobox is a Radix Popover wrapping cmdk Command, rendered inside InviteMembersModal (a modal Dialog). The Dialog traps focus and prevents pointer interactions from reaching the popover content. The portaled popover sits outside the Dialog's dismissable-layer tree, so item clicks never fire cmdk onSelect. PR #3428 removed preventDefault from onPointerDown on CommandItems but that alone is insufficient - the focus trap still blocks interaction.

## Fix

Make the MultiRoleCombobox Popover modal and ensure its content renders within the Dialog's event/focus context. This lets clicks on role items properly bubble to cmdk onSelect handlers.

## Explicitly NOT touched

- Auth or RBAC logic
- Role schema or database
- Org scoping or role assignment logic
- CSV import path

## Verification

✅ Role selector opens when adding user manually
✅ Can click individual roles by mouse
✅ Can select roles by keyboard
✅ Selection closes popover and shows checkmark
✅ Multiple roles selectable
✅ Dialog submits with selected roles
✅ CSV import still works

Fixes CS-748

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the unselectable role picker in manual user invites by making the role selector popover modal inside the invite dialog, so clicks and keyboard selection register. Addresses Linear CS-748 and restores role assignment in the People tab.

- **Bug Fixes**
  - Set the Radix `Popover` in `MultiRoleCombobox` to `modal` to keep interactions within the Dialog’s focus/dismiss layer.
  - Added a regression test to assert modal layer behavior and prevent future focus-trap issues.

<sup>Written for commit ed2d9f56959ce568b3281fb313ce894c77c1508e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

