### PR TITLE
feat(app): mark evidence check resources out of scope

### DIFF
--- a/apps/api/src/cloud-security/finding-exceptions.spec.ts
+++ b/apps/api/src/cloud-security/finding-exceptions.spec.ts
@@ -44,23 +44,50 @@ describe('ActiveExceptionSet', () => {
     expect(set.has('c1', 'check-a', resourceId)).toBe(true);
     expect(set.exceptedResourceIds('c1', 'check-a')).toEqual([resourceId]);
   });
+
+  it('exposes exception metadata via infoFor when built with it', () => {
+    const key = ActiveExceptionSet.key('c1', 'check-a', 'r1');
+    const set = new ActiveExceptionSet(
+      [key],
+      new Map([[key, { id: 'fex_1', reason: 'Intentional public bucket' }]]),
+    );
+    expect(set.infoFor('c1', 'check-a', 'r1')).toEqual({
+      id: 'fex_1',
+      reason: 'Intentional public bucket',
+    });
+    expect(set.infoFor('c1', 'check-a', 'r2')).toBeNull();
+  });
+
+  it('infoFor returns null on a set built from bare keys (has() still true)', () => {
+    const set = new ActiveExceptionSet([
+      ActiveExceptionSet.key('c1', 'check-a', 'r1'),
+    ]);
+    expect(set.has('c1', 'check-a', 'r1')).toBe(true);
+    expect(set.infoFor('c1', 'check-a', 'r1')).toBeNull();
+  });
 });
 
 describe('loadActiveExceptionSet', () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it('builds the set from active exceptions', async () => {
+  it('builds the set from active exceptions, carrying id + reason', async () => {
     findMany.mockResolvedValue([
       {
+        id: 'fex_1',
         connectionId: 'c1',
         checkId: 'aws-s3-public-access',
         resourceId: 'bucket-1',
+        reason: 'Bucket only hosts a static website redirect.',
       },
     ] as never);
 
     const set = await loadActiveExceptionSet('org_1');
 
     expect(set.has('c1', 'aws-s3-public-access', 'bucket-1')).toBe(true);
+    expect(set.infoFor('c1', 'aws-s3-public-access', 'bucket-1')).toEqual({
+      id: 'fex_1',
+      reason: 'Bucket only hosts a static website redirect.',
+    });
     // Query only active exceptions (not revoked, not expired).
     expect(findMany).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/api/src/cloud-security/finding-exceptions.ts
+++ b/apps/api/src/cloud-security/finding-exceptions.ts
@@ -1,6 +1,16 @@
 import { db } from '@db';
 
 /**
+ * Metadata about one active exception. Display surfaces use it to show the
+ * documented reason next to a suppressed finding and to offer revoke (which
+ * needs the row id) without a second query.
+ */
+export interface ActiveExceptionInfo {
+  id: string;
+  reason: string;
+}
+
+/**
  * The set of findings — keyed by (connectionId, checkId, resourceId) — that
  * currently have an ACTIVE exception (not revoked, not expired) for an org.
  *
@@ -24,9 +34,16 @@ export class ActiveExceptionSet {
    * every result row into memory.
    */
   private readonly resourceIdsByConnCheck: Map<string, Set<string>>;
+  /** Exception metadata per canonical key. Optional — evaluation-only callers
+   *  build the set from bare keys and never ask for it. */
+  private readonly infoByKey: ReadonlyMap<string, ActiveExceptionInfo>;
 
-  constructor(keys: Iterable<string>) {
+  constructor(
+    keys: Iterable<string>,
+    infoByKey?: ReadonlyMap<string, ActiveExceptionInfo>,
+  ) {
     this.keys = new Set(keys);
+    this.infoByKey = infoByKey ?? new Map();
     this.resourceIdsByConnCheck = new Map();
     for (const key of this.keys) {
       // key = `${connectionId}::${checkId}::${resourceId}`. A resourceId can
@@ -75,6 +92,23 @@ export class ActiveExceptionSet {
     );
     return ids ? Array.from(ids) : [];
   }
+
+  /**
+   * Metadata (row id + reason) of the active exception covering this finding,
+   * or null when none. Null also for sets built without metadata (bare keys) —
+   * `has()` stays the authority on whether a finding is excepted.
+   */
+  infoFor(
+    connectionId: string,
+    checkId: string,
+    resourceId: string,
+  ): ActiveExceptionInfo | null {
+    return (
+      this.infoByKey.get(
+        ActiveExceptionSet.key(connectionId, checkId, resourceId),
+      ) ?? null
+    );
+  }
 }
 
 /**
@@ -94,13 +128,22 @@ export async function loadActiveExceptionSet(
         revokedAt: null,
         OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
       },
-      select: { connectionId: true, checkId: true, resourceId: true },
+      select: {
+        id: true,
+        connectionId: true,
+        checkId: true,
+        resourceId: true,
+        reason: true,
+      },
     });
-    return new ActiveExceptionSet(
-      active.map((e) =>
+    const infoByKey = new Map<string, ActiveExceptionInfo>();
+    for (const e of active) {
+      infoByKey.set(
         ActiveExceptionSet.key(e.connectionId, e.checkId, e.resourceId),
-      ),
-    );
+        { id: e.id, reason: e.reason },
+      );
+    }
+    return new ActiveExceptionSet(infoByKey.keys(), infoByKey);
   } catch {
     return new ActiveExceptionSet([]);
   }

--- a/apps/api/src/integration-platform/controllers/task-integrations.controller.spec.ts
+++ b/apps/api/src/integration-platform/controllers/task-integrations.controller.spec.ts
@@ -811,9 +811,11 @@ describe('TaskIntegrationsController', () => {
       );
       mockFindingExceptionFindMany.mockResolvedValue([
         {
+          id: 'fex_1',
           connectionId: 'conn_1',
           checkId: 'aws-s3-public-access',
           resourceId: 'reports-bucket',
+          reason: 'Bucket intentionally public: static website redirect only.',
         },
       ]);
       // The excepted-failure count is now computed via a targeted query (the
@@ -827,6 +829,11 @@ describe('TaskIntegrationsController', () => {
       expect(runs[0].exceptedCount).toBe(1);
       expect(runs[0].status).toBe('success');
       expect(runs[0].results[0].excepted).toBe(true);
+      // Excepted rows carry the exception's id (for revoke) and its reason.
+      expect(runs[0].results[0].exceptionId).toBe('fex_1');
+      expect(runs[0].results[0].exceptionReason).toBe(
+        'Bucket intentionally public: static website redirect only.',
+      );
       // Exact count is computed via the targeted query, scoped to this run's
       // excepted resourceIds (not by loading + filtering every result).
       expect(mockCheckRunRepository.countExceptedFailures).toHaveBeenCalledWith(

--- a/apps/api/src/integration-platform/controllers/task-integrations.controller.ts
+++ b/apps/api/src/integration-platform/controllers/task-integrations.controller.ts
@@ -857,23 +857,33 @@ export class TaskIntegrationsController {
 
         // Tag each sampled result with whether it's excepted (for display);
         // authoritative totals come from the run's summary columns +
-        // exceptedCount above. Cap evidence so one oversized blob can't bloat
-        // the payload that the browser must parse + render.
-        const sample = run.results.map((r) => ({
-          id: r.id,
-          passed: r.passed,
-          resourceType: r.resourceType,
-          resourceId: r.resourceId,
-          title: r.title,
-          description: r.description,
-          severity: r.severity,
-          remediation: r.remediation,
-          evidence: r.evidence,
-          collectedAt: r.collectedAt,
-          excepted:
+        // exceptedCount above. Excepted rows also carry the exception's id
+        // (so the UI can offer revoke) and its documented reason. Cap evidence
+        // so one oversized blob can't bloat the payload that the browser must
+        // parse + render.
+        const sample = run.results.map((r) => {
+          const excepted =
             !r.passed &&
-            exceptions.has(run.connectionId, run.checkId, r.resourceId),
-        }));
+            exceptions.has(run.connectionId, run.checkId, r.resourceId);
+          const exceptionInfo = excepted
+            ? exceptions.infoFor(run.connectionId, run.checkId, r.resourceId)
+            : null;
+          return {
+            id: r.id,
+            passed: r.passed,
+            resourceType: r.resourceType,
+            resourceId: r.resourceId,
+            title: r.title,
+            description: r.description,
+            severity: r.severity,
+            remediation: r.remediation,
+            evidence: r.evidence,
+            collectedAt: r.collectedAt,
+            excepted,
+            exceptionId: exceptionInfo?.id,
+            exceptionReason: exceptionInfo?.reason,
+          };
+        });
         const results = capResultsForList(sample).map((r) => ({
           ...r,
           evidence: capEvidence(r.evidence),

--- a/apps/app/src/app/(app)/[orgId]/cloud-tests/components/CloudTestsSection.tsx
+++ b/apps/app/src/app/(app)/[orgId]/cloud-tests/components/CloudTestsSection.tsx
@@ -49,7 +49,7 @@ import { CheckGroupBlock } from './CheckGroupBlock';
 import { buildCheckGroups } from './check-groups';
 import { filterFindingsByConnection } from './finding-filters';
 import { EvidenceJsonViewer } from './EvidenceJsonViewer';
-import { MarkExceptionModal } from './MarkExceptionModal';
+import { MarkExceptionModal } from '@/components/integrations/MarkExceptionModal';
 import { RemediationSection } from './RemediationSection';
 
 interface RemediationCapabilities {

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/TaskIntegrationChecks.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/TaskIntegrationChecks.tsx
@@ -2,7 +2,9 @@
 
 import { ConnectIntegrationDialog } from '@/components/integrations/ConnectIntegrationDialog';
 import { ManageIntegrationDialog } from '@/components/integrations/ManageIntegrationDialog';
+import { MarkExceptionModal } from '@/components/integrations/MarkExceptionModal';
 import { SchedulePicker } from '@/components/schedule-picker';
+import { usePermissions } from '@/hooks/use-permissions';
 import { downloadAutomationPDF } from '@/lib/evidence-download';
 import { cn } from '@/lib/utils';
 import { useActiveOrganization } from '@/utils/auth-client';
@@ -46,6 +48,7 @@ import { toast } from 'sonner';
 import type { StoredCheckRun, TaskIntegrationCheck } from '../hooks/useIntegrationChecks';
 import { useIntegrationChecks } from '../hooks/useIntegrationChecks';
 import { summarizeLatestPerAccount } from './check-run-grouping';
+import type { RunExceptionActions, RunFindingActionTarget } from './check-run-history';
 import { AccountRunGroups } from './check-run-history';
 
 interface TaskIntegrationChecksProps {
@@ -83,10 +86,14 @@ export function TaskIntegrationChecks({
     isLoading: loading,
     error: hookError,
     mutateChecks,
+    mutateRuns,
     runCheck,
+    revokeException,
     disconnectCheckFromTask,
     reconnectCheckToTask,
   } = useIntegrationChecks({ taskId, orgId });
+  const { hasPermission } = usePermissions();
+  const canManageExceptions = hasPermission('integration', 'update');
 
   const [runningCheck, setRunningCheck] = useState<string | null>(null);
   const [togglingCheck, setTogglingCheck] = useState<string | null>(null);
@@ -99,6 +106,13 @@ export function TaskIntegrationChecks({
     integrationName: string;
   } | null>(null);
   const [disconnectError, setDisconnectError] = useState<string | null>(null);
+  // Failing resource being marked out of scope (drives the reason modal).
+  const [outOfScopeTarget, setOutOfScopeTarget] = useState<RunFindingActionTarget | null>(null);
+  // Excepted resource being moved back in scope (drives the confirm dialog).
+  const [revokeTarget, setRevokeTarget] = useState<
+    (RunFindingActionTarget & { exceptionId: string }) | null
+  >(null);
+  const [revoking, setRevoking] = useState(false);
 
   // Sync hook-level error into local state
   useEffect(() => {
@@ -172,6 +186,59 @@ export function TaskIntegrationChecks({
       }
     },
     [runCheck, onTaskUpdated],
+  );
+
+  /**
+   * After a scope change (mark / revoke), re-run the affected check so the
+   * task's status is recomputed with the new exception set — the run paths
+   * already honor exceptions. Skipped when a run of the same check is in
+   * flight: exceptions are loaded at aggregation time (after the provider
+   * calls), so the in-flight run already reflects the change.
+   */
+  const rerunAfterScopeChange = useCallback(
+    (target: { connectionId: string; checkId: string }) => {
+      if (runningCheck !== null) return;
+      void handleRunCheck(target.connectionId, target.checkId);
+    },
+    [runningCheck, handleRunCheck],
+  );
+
+  const handleMarkedOutOfScope = useCallback(() => {
+    const target = outOfScopeTarget;
+    setOutOfScopeTarget(null);
+    void mutateRuns();
+    if (target) rerunAfterScopeChange(target);
+  }, [outOfScopeTarget, mutateRuns, rerunAfterScopeChange]);
+
+  const handleConfirmRevoke = useCallback(async () => {
+    if (!revokeTarget) return;
+    setRevoking(true);
+    try {
+      await revokeException(revokeTarget.exceptionId);
+      toast.success(
+        `"${revokeTarget.resourceId}" is back in scope — re-running the check to update this evidence item.`,
+      );
+      const target = revokeTarget;
+      setRevokeTarget(null);
+      rerunAfterScopeChange(target);
+    } catch (err) {
+      console.error('Failed to revoke exception:', err);
+      toast.error(
+        err instanceof Error ? err.message : 'Failed to move the resource back in scope',
+      );
+    } finally {
+      setRevoking(false);
+    }
+  }, [revokeTarget, revokeException, rerunAfterScopeChange]);
+
+  // Stable action handles passed down to the run history rows.
+  const exceptionActions = useMemo<RunExceptionActions>(
+    () => ({
+      canManage: canManageExceptions,
+      onMarkOutOfScope: setOutOfScopeTarget,
+      onRevoke: setRevokeTarget,
+    }),
+    [canManageExceptions],
   );
 
   const handleConfirmDisconnect = useCallback(async () => {
@@ -710,6 +777,7 @@ export function TaskIntegrationChecks({
                           <AccountRunGroups
                             runs={checkRuns}
                             organizationName={organizationName}
+                            exceptionActions={exceptionActions}
                           />
                         </div>
                       </div>
@@ -920,6 +988,63 @@ export function TaskIntegrationChecks({
               disabled={togglingCheck !== null}
             >
               {togglingCheck !== null ? 'Disconnecting...' : 'Disconnect'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Mark a failing resource out of scope — captures the documented reason
+          (recorded as a finding exception, shared with Cloud Tests). */}
+      <MarkExceptionModal
+        open={!!outOfScopeTarget}
+        onOpenChange={(open) => {
+          if (!open) setOutOfScopeTarget(null);
+        }}
+        findingId={outOfScopeTarget?.findingId ?? null}
+        findingTitle={outOfScopeTarget?.title ?? ''}
+        resourceLabel={outOfScopeTarget?.resourceId ?? null}
+        title="Mark this resource as out of scope?"
+        description="The resource stays visible on this evidence item but no longer fails it. The exception and your reason are recorded in the audit trail for auditors."
+        confirmLabel="Mark out of scope"
+        expiryHint="Leave empty for never. If set, the resource comes back in scope after this date."
+        successToast="Marked out of scope — re-running the check to update this evidence item."
+        onMarked={handleMarkedOutOfScope}
+      />
+
+      {/* Confirm moving an excepted resource back in scope */}
+      <AlertDialog
+        open={!!revokeTarget}
+        onOpenChange={(open) => {
+          // Keep the dialog owned by the in-flight revoke request.
+          if (!open && !revoking) {
+            setRevokeTarget(null);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Move this resource back in scope?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {revokeTarget ? (
+                <>
+                  The exception on <strong>{revokeTarget.resourceId}</strong> will be removed and
+                  the resource will count against this evidence item again on the next check run.
+                </>
+              ) : null}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={revoking}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                // Keep the dialog open (with its "Removing…" state) until the
+                // async revoke settles — Radix would otherwise auto-close.
+                e.preventDefault();
+                void handleConfirmRevoke();
+              }}
+              disabled={revoking}
+            >
+              {revoking ? 'Removing...' : 'Move back in scope'}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/TaskIntegrationChecks.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/TaskIntegrationChecks.tsx
@@ -191,13 +191,15 @@ export function TaskIntegrationChecks({
   /**
    * After a scope change (mark / revoke), re-run the affected check so the
    * task's status is recomputed with the new exception set — the run paths
-   * already honor exceptions. Skipped when a run of the same check is in
+   * already honor exceptions. Skipped only when a run of the SAME check is in
    * flight: exceptions are loaded at aggregation time (after the provider
-   * calls), so the in-flight run already reflects the change.
+   * calls), so that in-flight run already reflects the change. A run of a
+   * DIFFERENT check doesn't recompute this one, so it must not suppress the
+   * re-run.
    */
   const rerunAfterScopeChange = useCallback(
     (target: { connectionId: string; checkId: string }) => {
-      if (runningCheck !== null) return;
+      if (runningCheck === target.checkId) return;
       void handleRunCheck(target.connectionId, target.checkId);
     },
     [runningCheck, handleRunCheck],
@@ -1006,6 +1008,7 @@ export function TaskIntegrationChecks({
         title="Mark this resource as out of scope?"
         description="The resource stays visible on this evidence item but no longer fails it. The exception and your reason are recorded in the audit trail for auditors."
         confirmLabel="Mark out of scope"
+        reasonLabel="Reason this resource is out of scope (required) *"
         expiryHint="Leave empty for never. If set, the resource comes back in scope after this date."
         successToast="Marked out of scope — re-running the check to update this evidence item."
         onMarked={handleMarkedOutOfScope}

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/check-run-history.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/check-run-history.test.tsx
@@ -1,0 +1,193 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@trycompai/ui/badge', () => ({
+  Badge: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock('@trycompai/ui/button', () => ({
+  Button: ({
+    children,
+    disabled,
+    onClick,
+    title,
+  }: {
+    children: React.ReactNode;
+    disabled?: boolean;
+    onClick?: () => void;
+    title?: string;
+  }) => (
+    <button type="button" disabled={disabled} onClick={onClick} title={title}>
+      {children}
+    </button>
+  ),
+}));
+
+// Evidence details aren't under test — keep jsdom out of its JSON viewer.
+vi.mock('./EvidenceJsonView', () => ({
+  EvidenceJsonView: () => <div data-testid="evidence-json" />,
+}));
+
+import type { StoredCheckRun } from '../hooks/useIntegrationChecks';
+import type { RunExceptionActions } from './check-run-history';
+import { CheckRunItem } from './check-run-history';
+
+function buildRun(): StoredCheckRun {
+  const now = new Date().toISOString();
+  return {
+    id: 'icr_1',
+    checkId: 'aws-s3-bucket-public-access',
+    checkName: 'S3 - public access blocked',
+    status: 'failed',
+    startedAt: now,
+    completedAt: now,
+    durationMs: 10,
+    totalChecked: 3,
+    passedCount: 1,
+    failedCount: 1,
+    exceptedCount: 1,
+    connectionId: 'conn_1',
+    connectionLabel: 'AWS 111111111111',
+    provider: { slug: 'aws', name: 'AWS' },
+    results: [
+      {
+        id: 'res_fail',
+        passed: false,
+        resourceType: 'aws-s3-bucket',
+        resourceId: 'redirect-bucket',
+        title: 'Public access not fully blocked: redirect-bucket',
+        collectedAt: now,
+      },
+      {
+        id: 'res_excepted',
+        passed: false,
+        resourceType: 'aws-s3-bucket',
+        resourceId: 'assets-bucket',
+        title: 'Public access not fully blocked: assets-bucket',
+        collectedAt: now,
+        excepted: true,
+        exceptionId: 'fex_1',
+        exceptionReason: 'Bucket only hosts a static website redirect.',
+      },
+      {
+        id: 'res_pass',
+        passed: true,
+        resourceType: 'aws-s3-bucket',
+        resourceId: 'private-bucket',
+        title: 'Public access blocked: private-bucket',
+        collectedAt: now,
+      },
+    ],
+    createdAt: now,
+  };
+}
+
+function buildActions(canManage = true): RunExceptionActions {
+  return {
+    canManage,
+    onMarkOutOfScope: vi.fn(),
+    onRevoke: vi.fn(),
+  };
+}
+
+describe('CheckRunItem scope actions', () => {
+  it('offers "Mark out of scope" on failing rows and reports the full target', () => {
+    const actions = buildActions();
+    render(
+      <CheckRunItem
+        run={buildRun()}
+        isLatest
+        organizationName="Acme"
+        exceptionActions={actions}
+      />,
+    );
+
+    const markButton = screen.getByRole('button', { name: 'Mark out of scope' });
+    fireEvent.click(markButton);
+
+    expect(actions.onMarkOutOfScope).toHaveBeenCalledWith({
+      findingId: 'res_fail',
+      title: 'Public access not fully blocked: redirect-bucket',
+      resourceId: 'redirect-bucket',
+      connectionId: 'conn_1',
+      checkId: 'aws-s3-bucket-public-access',
+    });
+  });
+
+  it('shows the excepted row with its reason and offers revoke with the exception id', () => {
+    const actions = buildActions();
+    render(
+      <CheckRunItem
+        run={buildRun()}
+        isLatest
+        organizationName="Acme"
+        exceptionActions={actions}
+      />,
+    );
+
+    expect(screen.getByText('Out of scope')).toBeInTheDocument();
+    expect(
+      screen.getByText('Bucket only hosts a static website redirect.'),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Move back in scope' }));
+
+    expect(actions.onRevoke).toHaveBeenCalledWith({
+      findingId: 'res_excepted',
+      title: 'Public access not fully blocked: assets-bucket',
+      resourceId: 'assets-bucket',
+      connectionId: 'conn_1',
+      checkId: 'aws-s3-bucket-public-access',
+      exceptionId: 'fex_1',
+    });
+  });
+
+  it('hides both actions without the integration:update permission', () => {
+    render(
+      <CheckRunItem
+        run={buildRun()}
+        isLatest
+        organizationName="Acme"
+        exceptionActions={buildActions(false)}
+      />,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'Mark out of scope' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Move back in scope' }),
+    ).not.toBeInTheDocument();
+    // Read-only users still see the excepted state + reason.
+    expect(screen.getByText('Out of scope')).toBeInTheDocument();
+  });
+
+  it('hides both actions on non-latest runs (stale resources)', () => {
+    render(
+      <CheckRunItem
+        run={buildRun()}
+        isLatest={false}
+        organizationName="Acme"
+        exceptionActions={buildActions()}
+      />,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'Mark out of scope' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Move back in scope' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders no actions at all when none are provided (other callers unaffected)', () => {
+    render(<CheckRunItem run={buildRun()} isLatest organizationName="Acme" />);
+
+    expect(
+      screen.queryByRole('button', { name: 'Mark out of scope' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Move back in scope' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/check-run-history.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/check-run-history.test.tsx
@@ -180,6 +180,38 @@ describe('CheckRunItem scope actions', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('expands beyond the first three failing rows so every sampled resource is markable', () => {
+    const actions = buildActions();
+    const run = buildRun();
+    const now = new Date().toISOString();
+    // 5 sampled failing rows (plus the excepted one from the base fixture).
+    run.results = Array.from({ length: 5 }, (_, i) => ({
+      id: `res_fail_${i}`,
+      passed: false,
+      resourceType: 'aws-s3-bucket',
+      resourceId: `bucket-${i}`,
+      title: `Public access not fully blocked: bucket-${i}`,
+      collectedAt: now,
+    }));
+    run.failedCount = 5;
+    run.exceptedCount = 0;
+
+    render(
+      <CheckRunItem run={run} isLatest organizationName="Acme" exceptionActions={actions} />,
+    );
+
+    // Collapsed: only the first three rows are actionable.
+    expect(screen.getAllByRole('button', { name: 'Mark out of scope' })).toHaveLength(3);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show 2 more issues' }));
+
+    // Expanded: every sampled failing row is actionable.
+    expect(screen.getAllByRole('button', { name: 'Mark out of scope' })).toHaveLength(5);
+    expect(
+      screen.queryByRole('button', { name: /Show .* more issues/ }),
+    ).not.toBeInTheDocument();
+  });
+
   it('renders no actions at all when none are provided (other callers unaffected)', () => {
     render(<CheckRunItem run={buildRun()} isLatest organizationName="Acme" />);
 

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/check-run-history.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/check-run-history.tsx
@@ -190,6 +190,8 @@ export function CheckRunItem({
   exceptionActions?: RunExceptionActions;
 }) {
   const [expanded, setExpanded] = useState(isLatest);
+  const [showAllFindings, setShowAllFindings] = useState(false);
+  const [showAllExcepted, setShowAllExcepted] = useState(false);
 
   // Scope actions only make sense on the LATEST run — older runs may list
   // resources that no longer exist. Marking/revoking still applies to the
@@ -208,14 +210,20 @@ export function CheckRunItem({
 
   // `run.results` is capped server-side — a check can produce tens of thousands
   // of results (e.g. a Firebase B2C tenant) which would otherwise ship a
-  // multi-MB payload and OOM the browser. Show the first few from the (bounded)
-  // array, but derive the "+N more" counts from the run's authoritative summary
-  // counts so the totals are still correct.
-  const shownFindings = findings.slice(0, 3);
-  const shownExcepted = excepted.slice(0, 3);
+  // multi-MB payload and OOM the browser. Show the first few by default, but
+  // let the user expand to every SAMPLED finding/excepted row — the scope
+  // actions live on these rows, so capping them at three would leave later
+  // resources unactionable. "+N more" counts beyond that come from the run's
+  // authoritative summary columns (rows outside the server-side sample).
+  const shownFindings = showAllFindings ? findings : findings.slice(0, 3);
+  const shownExcepted = showAllExcepted ? excepted : excepted.slice(0, 3);
   const shownPassing = passing.slice(0, 3);
-  const moreFindings = Math.max(0, run.failedCount - shownFindings.length);
-  const moreExcepted = Math.max(0, (run.exceptedCount ?? 0) - shownExcepted.length);
+  // Sampled rows currently hidden behind the "Show more" toggles.
+  const collapsedFindings = findings.length - shownFindings.length;
+  const collapsedExcepted = excepted.length - shownExcepted.length;
+  // Rows beyond the server-side sample — not in the payload at all.
+  const moreFindings = Math.max(0, run.failedCount - findings.length);
+  const moreExcepted = Math.max(0, (run.exceptedCount ?? 0) - excepted.length);
   const morePassing = Math.max(0, run.passedCount - shownPassing.length);
 
   const statusColor = hasError ? 'text-destructive' : hasFailed ? 'text-warning' : 'text-primary';
@@ -340,6 +348,15 @@ export function CheckRunItem({
                     )}
                   </div>
                 ))}
+                {collapsedFindings > 0 && (
+                  <button
+                    type="button"
+                    onClick={() => setShowAllFindings(true)}
+                    className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    Show {collapsedFindings} more issue{collapsedFindings > 1 ? 's' : ''}
+                  </button>
+                )}
                 {moreFindings > 0 && (
                   <p className="text-sm text-muted-foreground">
                     +{moreFindings} more issues
@@ -397,6 +414,15 @@ export function CheckRunItem({
                     </div>
                   );
                 })}
+                {collapsedExcepted > 0 && (
+                  <button
+                    type="button"
+                    onClick={() => setShowAllExcepted(true)}
+                    className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    Show {collapsedExcepted} more out of scope
+                  </button>
+                )}
                 {moreExcepted > 0 && (
                   <p className="text-sm text-muted-foreground">
                     +{moreExcepted} more out of scope

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/check-run-history.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/check-run-history.tsx
@@ -2,12 +2,35 @@
 
 import { cn } from '@/lib/utils';
 import { Badge } from '@trycompai/ui/badge';
+import { Button } from '@trycompai/ui/button';
 import { formatDistanceToNow } from 'date-fns';
 import { ChevronDown } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import type { StoredCheckRun } from '../hooks/useIntegrationChecks';
 import { groupRunsByConnection } from './check-run-grouping';
 import { EvidenceJsonView } from './EvidenceJsonView';
+
+/** A failing result row the user is acting on, identified the way the
+ * exception endpoints need it (result id to mark; run coords to re-run). */
+export interface RunFindingActionTarget {
+  findingId: string;
+  title: string;
+  resourceId: string;
+  connectionId: string;
+  checkId: string;
+}
+
+/**
+ * Scope actions offered on the latest run's result rows: mark a failing
+ * resource out of scope (creates a finding exception) or move an excepted
+ * resource back in scope (revokes it). `canManage` reflects the caller's
+ * integration:update permission — without it no action is rendered.
+ */
+export interface RunExceptionActions {
+  canManage: boolean;
+  onMarkOutOfScope: (target: RunFindingActionTarget) => void;
+  onRevoke: (target: RunFindingActionTarget & { exceptionId: string }) => void;
+}
 
 /**
  * Run history for a check, grouped by the account (connection) it ran against.
@@ -21,14 +44,22 @@ import { EvidenceJsonView } from './EvidenceJsonView';
 export function AccountRunGroups({
   runs,
   organizationName,
+  exceptionActions,
 }: {
   runs: StoredCheckRun[];
   organizationName: string;
+  exceptionActions?: RunExceptionActions;
 }) {
   const groups = useMemo(() => groupRunsByConnection(runs), [runs]);
 
   if (groups.length <= 1) {
-    return <GroupedCheckRuns runs={runs} organizationName={organizationName} />;
+    return (
+      <GroupedCheckRuns
+        runs={runs}
+        organizationName={organizationName}
+        exceptionActions={exceptionActions}
+      />
+    );
   }
 
   return (
@@ -53,7 +84,12 @@ export function AccountRunGroups({
                 </span>
               )}
             </div>
-            <GroupedCheckRuns runs={group.runs} maxRuns={3} organizationName={organizationName} />
+            <GroupedCheckRuns
+              runs={group.runs}
+              maxRuns={3}
+              organizationName={organizationName}
+              exceptionActions={exceptionActions}
+            />
           </div>
         );
       })}
@@ -66,10 +102,12 @@ export function GroupedCheckRuns({
   runs,
   maxRuns = 5,
   organizationName,
+  exceptionActions,
 }: {
   runs: StoredCheckRun[];
   maxRuns?: number;
   organizationName: string;
+  exceptionActions?: RunExceptionActions;
 }) {
   const [showAll, setShowAll] = useState(false);
 
@@ -119,6 +157,7 @@ export function GroupedCheckRuns({
                   run={run}
                   isLatest={isLatest}
                   organizationName={organizationName}
+                  exceptionActions={exceptionActions}
                 />
               );
             })}
@@ -143,12 +182,19 @@ export function CheckRunItem({
   run,
   isLatest,
   organizationName,
+  exceptionActions,
 }: {
   run: StoredCheckRun;
   isLatest: boolean;
   organizationName: string;
+  exceptionActions?: RunExceptionActions;
 }) {
   const [expanded, setExpanded] = useState(isLatest);
+
+  // Scope actions only make sense on the LATEST run — older runs may list
+  // resources that no longer exist. Marking/revoking still applies to the
+  // (connection, check, resource) key, not to a specific run.
+  const showExceptionActions = isLatest && !!exceptionActions?.canManage;
 
   const timeAgo = formatDistanceToNow(new Date(run.createdAt), { addSuffix: true });
   const hasFailed = run.status === 'failed' || run.failedCount > 0;
@@ -250,7 +296,7 @@ export function CheckRunItem({
                       {finding.remediation && (
                         <p className="text-sm text-primary mt-2">{finding.remediation}</p>
                       )}
-                      <div className="flex items-center gap-2 mt-2">
+                      <div className="flex flex-wrap items-center gap-2 mt-2">
                         <Badge variant="secondary" className="font-mono text-xs">
                           {finding.resourceId}
                         </Badge>
@@ -258,6 +304,25 @@ export function CheckRunItem({
                           <Badge variant="outline" className="text-xs">
                             {finding.severity}
                           </Badge>
+                        )}
+                        {showExceptionActions && (
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            className="h-6 px-2 text-xs text-muted-foreground hover:text-foreground"
+                            title="Accept this resource as an intentional exception — it will no longer fail this evidence item"
+                            onClick={() =>
+                              exceptionActions?.onMarkOutOfScope({
+                                findingId: finding.id,
+                                title: finding.title,
+                                resourceId: finding.resourceId,
+                                connectionId: run.connectionId,
+                                checkId: run.checkId,
+                              })
+                            }
+                          >
+                            Mark out of scope
+                          </Button>
                         )}
                       </div>
                     </div>
@@ -283,28 +348,58 @@ export function CheckRunItem({
               </div>
             )}
 
-            {/* Excepted - failing findings the customer marked as an exception.
+            {/* Excepted - failing findings the customer marked out of scope.
                 Shown muted (not an issue) so it's clear the exception applied. */}
             {shownExcepted.length > 0 && (
               <div className="space-y-2">
-                {shownExcepted.map((finding) => (
-                  <div key={finding.id}>
-                    <div className="flex items-center gap-2">
-                      <p className="text-sm font-medium text-muted-foreground">{finding.title}</p>
-                      <Badge variant="outline" className="text-xs">
-                        Exception
-                      </Badge>
+                {shownExcepted.map((finding) => {
+                  const { exceptionId } = finding;
+                  return (
+                    <div key={finding.id}>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="text-sm font-medium text-muted-foreground">
+                          {finding.title}
+                        </p>
+                        <Badge variant="outline" className="text-xs">
+                          Out of scope
+                        </Badge>
+                      </div>
+                      {finding.exceptionReason && (
+                        <p className="text-xs text-muted-foreground italic mt-1">
+                          {finding.exceptionReason}
+                        </p>
+                      )}
+                      <div className="flex flex-wrap items-center gap-2 mt-1">
+                        <Badge variant="secondary" className="font-mono text-xs">
+                          {finding.resourceId}
+                        </Badge>
+                        {showExceptionActions && exceptionId && (
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            className="h-6 px-2 text-xs text-muted-foreground hover:text-foreground"
+                            title="Remove the exception — this resource will count against the evidence item again"
+                            onClick={() =>
+                              exceptionActions?.onRevoke({
+                                findingId: finding.id,
+                                title: finding.title,
+                                resourceId: finding.resourceId,
+                                connectionId: run.connectionId,
+                                checkId: run.checkId,
+                                exceptionId,
+                              })
+                            }
+                          >
+                            Move back in scope
+                          </Button>
+                        )}
+                      </div>
                     </div>
-                    <div className="mt-1">
-                      <Badge variant="secondary" className="font-mono text-xs">
-                        {finding.resourceId}
-                      </Badge>
-                    </div>
-                  </div>
-                ))}
+                  );
+                })}
                 {moreExcepted > 0 && (
                   <p className="text-sm text-muted-foreground">
-                    +{moreExcepted} more excepted
+                    +{moreExcepted} more out of scope
                   </p>
                 )}
               </div>

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/hooks/useIntegrationChecks.ts
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/hooks/useIntegrationChecks.ts
@@ -62,6 +62,10 @@ interface StoredCheckRun {
     collectedAt: string;
     /** True when this failing result is suppressed by an active exception. */
     excepted?: boolean;
+    /** The active exception's id — needed to revoke (move back in scope). */
+    exceptionId?: string;
+    /** The documented reason recorded when the exception was created. */
+    exceptionReason?: string;
   }>;
   createdAt: string;
 }
@@ -143,6 +147,27 @@ export function useIntegrationChecks({ taskId, orgId }: UseIntegrationChecksOpti
     }
 
     throw new Error('Failed to run check');
+  };
+
+  /**
+   * Revoke an active finding exception (move the resource back in scope).
+   * The exception mechanism is shared with Cloud Tests, so this talks to the
+   * cloud-security endpoint; the check run views refresh afterwards.
+   */
+  const revokeException = async (exceptionId: string): Promise<void> => {
+    const response = await api.delete<{ success: boolean }>(
+      `/v1/cloud-security/exceptions/${exceptionId}?organizationId=${orgId}`,
+    );
+
+    if (response.error || !response.data?.success) {
+      throw new Error(
+        typeof response.error === 'string'
+          ? response.error
+          : 'Failed to move the resource back in scope',
+      );
+    }
+
+    await mutateRuns();
   };
 
   /**
@@ -231,6 +256,7 @@ export function useIntegrationChecks({ taskId, orgId }: UseIntegrationChecksOpti
     mutateChecks,
     mutateRuns,
     runCheck,
+    revokeException,
     disconnectCheckFromTask,
     reconnectCheckToTask,
   };

--- a/apps/app/src/components/integrations/MarkExceptionModal.test.tsx
+++ b/apps/app/src/components/integrations/MarkExceptionModal.test.tsx
@@ -23,9 +23,15 @@ vi.mock('@trycompai/ui/dialog', () => {
       children: React.ReactNode;
     }) => (open ? <div>{children}</div> : null),
     DialogContent: Pass,
-    DialogDescription: Pass,
+    // Title/description get their own elements so text queries can match
+    // them individually (a fragment would merge them into one text blob).
+    DialogDescription: ({ children }: { children: React.ReactNode }) => (
+      <p>{children}</p>
+    ),
     DialogHeader: Pass,
-    DialogTitle: Pass,
+    DialogTitle: ({ children }: { children: React.ReactNode }) => (
+      <h2>{children}</h2>
+    ),
   };
 });
 
@@ -66,6 +72,32 @@ describe('MarkExceptionModal', () => {
       screen.getByText('IAM password policy < 14 characters'),
     ).toBeInTheDocument();
     expect(screen.getByText('IAM Account: 123456789012')).toBeInTheDocument();
+  });
+
+  it('applies copy overrides for the out-of-scope surface', () => {
+    render(
+      <MarkExceptionModal
+        open
+        onOpenChange={() => {}}
+        findingId="icx_1"
+        findingTitle="Public access not fully blocked: redirect-bucket"
+        title="Mark this resource as out of scope?"
+        description="The resource stays visible but no longer fails this evidence item."
+        confirmLabel="Mark out of scope"
+        expiryHint="Leave empty for never."
+      />,
+    );
+    expect(
+      screen.getByText('Mark this resource as out of scope?'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /^Mark out of scope$/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Leave empty for never.')).toBeInTheDocument();
+    // Default copy is fully replaced.
+    expect(
+      screen.queryByText('Mark this finding as an exception?'),
+    ).not.toBeInTheDocument();
   });
 
   it('keeps the submit button disabled until reason reaches min length', () => {

--- a/apps/app/src/components/integrations/MarkExceptionModal.test.tsx
+++ b/apps/app/src/components/integrations/MarkExceptionModal.test.tsx
@@ -84,6 +84,7 @@ describe('MarkExceptionModal', () => {
         title="Mark this resource as out of scope?"
         description="The resource stays visible but no longer fails this evidence item."
         confirmLabel="Mark out of scope"
+        reasonLabel="Reason this resource is out of scope (required) *"
         expiryHint="Leave empty for never."
       />,
     );
@@ -93,11 +94,15 @@ describe('MarkExceptionModal', () => {
     expect(
       screen.getByRole('button', { name: /^Mark out of scope$/ }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/Reason this resource is out of scope/i),
+    ).toBeInTheDocument();
     expect(screen.getByText('Leave empty for never.')).toBeInTheDocument();
     // Default copy is fully replaced.
     expect(
       screen.queryByText('Mark this finding as an exception?'),
     ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Reason for exception/i)).not.toBeInTheDocument();
   });
 
   it('keeps the submit button disabled until reason reaches min length', () => {

--- a/apps/app/src/components/integrations/MarkExceptionModal.tsx
+++ b/apps/app/src/components/integrations/MarkExceptionModal.tsx
@@ -45,6 +45,7 @@ export interface MarkExceptionModalProps {
   title?: string;
   description?: string;
   confirmLabel?: string;
+  reasonLabel?: string;
   expiryHint?: string;
   successToast?: string;
 }
@@ -68,6 +69,7 @@ export function MarkExceptionModal({
   title = 'Mark this finding as an exception?',
   description = 'Exceptions are recorded in the audit trail. Auditors will see this exception and the reason you provide.',
   confirmLabel = 'Mark as exception',
+  reasonLabel = 'Reason for exception (required) *',
   expiryHint = 'Leave empty for never. If set, the finding reappears in Scan Results on the first scan after this date.',
   successToast = 'Marked as exception',
 }: MarkExceptionModalProps) {
@@ -139,7 +141,7 @@ export function MarkExceptionModal({
               htmlFor="exception-reason"
               className="block text-xs font-medium mb-1"
             >
-              Reason for exception (required) *
+              {reasonLabel}
             </label>
             <textarea
               id="exception-reason"

--- a/apps/app/src/components/integrations/MarkExceptionModal.tsx
+++ b/apps/app/src/components/integrations/MarkExceptionModal.tsx
@@ -39,6 +39,14 @@ export interface MarkExceptionModalProps {
   findingTitle: string;
   resourceLabel?: string | null;
   onMarked?: () => void;
+  /** Copy overrides so the same flow reads naturally on each surface —
+   * Cloud Tests says "exception", evidence tasks say "out of scope".
+   * The underlying mechanism (a FindingException) is identical. */
+  title?: string;
+  description?: string;
+  confirmLabel?: string;
+  expiryHint?: string;
+  successToast?: string;
 }
 
 /**
@@ -46,6 +54,9 @@ export interface MarkExceptionModalProps {
  * date for marking a finding as an exception. Talks to POST
  * /v1/cloud-security/findings/:id/exception. Calls onMarked() on success
  * so the parent can refresh its findings list.
+ *
+ * Shared by the Cloud Tests findings view and the evidence-task check view
+ * (which brands the same flow "mark out of scope" via the copy props).
  */
 export function MarkExceptionModal({
   open,
@@ -54,6 +65,11 @@ export function MarkExceptionModal({
   findingTitle,
   resourceLabel,
   onMarked,
+  title = 'Mark this finding as an exception?',
+  description = 'Exceptions are recorded in the audit trail. Auditors will see this exception and the reason you provide.',
+  confirmLabel = 'Mark as exception',
+  expiryHint = 'Leave empty for never. If set, the finding reappears in Scan Results on the first scan after this date.',
+  successToast = 'Marked as exception',
 }: MarkExceptionModalProps) {
   const api = useApi();
   const [reason, setReason] = useState('');
@@ -85,7 +101,7 @@ export function MarkExceptionModal({
       return;
     }
 
-    toast.success('Marked as exception');
+    toast.success(successToast);
     setReason('');
     setReviewedBy('');
     setExpiresAt('');
@@ -106,11 +122,8 @@ export function MarkExceptionModal({
     <Dialog open={open} onOpenChange={handleClose}>
       <DialogContent className="max-w-lg">
         <DialogHeader>
-          <DialogTitle>Mark this finding as an exception?</DialogTitle>
-          <DialogDescription>
-            Exceptions are recorded in the audit trail. Auditors will see this
-            exception and the reason you provide.
-          </DialogDescription>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
 
         <div className="space-y-3 py-2">
@@ -180,10 +193,7 @@ export function MarkExceptionModal({
               min={tomorrowLocalDateString()}
               className="w-full rounded-md border bg-background px-3 py-2 text-xs focus:outline-none focus:ring-2 focus:ring-primary/30"
             />
-            <p className="text-muted-foreground mt-1 text-[10px]">
-              Leave empty for never. If set, the finding reappears in Scan
-              Results on the first scan after this date.
-            </p>
+            <p className="text-muted-foreground mt-1 text-[10px]">{expiryHint}</p>
           </div>
         </div>
 
@@ -204,7 +214,7 @@ export function MarkExceptionModal({
             {submitting ? (
               <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
             ) : null}
-            Mark as exception
+            {confirmLabel}
           </Button>
         </div>
       </DialogContent>


### PR DESCRIPTION
Closes [CS-719](https://linear.app/compai/issue/CS-719/bug-no-way-to-mark-resources-out-of-scope-aws-access-restrictions-task)

## Problem

A customer failing an evidence item because of an intentional finding — e.g. an S3 bucket that must stay public because it only hosts a static website redirect — had no way to accept it. The "Access Restrictions" evidence item stayed failed with no route to resolve it, blocking their audit.

## What already existed

The exception mechanism was already built end to end on the backend: `FindingException` rows keyed `(connectionId, checkId, resourceId)` are honored by **both** task run paths (manual run-check and the scheduled Trigger task, via the shared `ActiveExceptionSet` + `countEffectiveFailures`) **and** by the task runs display (`excepted` flag, adjusted failed count/status). The mark/revoke endpoints (`POST /v1/cloud-security/findings/:id/exception`, `DELETE /v1/cloud-security/exceptions/:id`, both `integration:update`) also already resolve evidence-task check result rows correctly — `resolveCheckKey` falls back to the run's manifest check id, which is exactly the namespace the task paths match on.

What was missing was purely the surface: no way to create or revoke an exception from the evidence item view, and the runs response didn't carry the exception's id/reason.

## Changes

**API**
- `ActiveExceptionSet` optionally carries per-exception metadata (`id`, `reason`); `loadActiveExceptionSet` populates it. Constructor stays backward-compatible for evaluation-only callers.
- `getTaskCheckRuns` now returns `exceptionId` + `exceptionReason` on excepted result rows so the UI can show the documented reason and offer revoke.

**App**
- Failing results on a task's check runs now offer **Mark out of scope** (latest run only). It opens the shared reason modal (min-20-char reason, optional reviewer + auto-review date) and creates the exception through the existing endpoint.
- Excepted results show an **Out of scope** badge with the documented reason and offer **Move back in scope** (revoke, with confirm dialog).
- After a scope change the affected check re-runs automatically, so the task status flips through the existing exception-aware run path without waiting for the next scheduled run. If a run is already in flight it is not duplicated — exceptions are loaded at aggregation time, so the in-flight run already honors the change.
- Actions are gated client-side by `integration:update` (matching the endpoints); read-only users still see the out-of-scope state and reason.
- `MarkExceptionModal` moved from `cloud-tests/components` to `components/integrations` with copy-override props — Cloud Tests keeps its exact previous copy via the defaults, the tasks surface brands the same flow "out of scope".

No schema changes. No new endpoints. Exceptions created here are the same rows Cloud Tests uses, recorded in the audit trail (`exception_marked` / `exception_revoked`).

## Tests

- API: `finding-exceptions.spec` 7/7 (new `infoFor` coverage incl. bare-key sets); `task-integrations.controller.spec` exception tests extended to assert `exceptionId`/`exceptionReason`.
- App: new `check-run-history.test.tsx` (5 tests: mark payload, revoke payload incl. exception id, hidden without permission, hidden on non-latest runs, hidden when no actions provided); `MarkExceptionModal.test.tsx` extended for copy overrides (10/10 across both files).
- Typecheck: api and app both show **zero new errors** vs `origin/main` (23 and 15 pre-existing spec-drift errors respectively, verified by baseline comparison with the same command).
- Full-suite failures in `src/integration-platform` (4 suites/25 tests) and the app tasks+cloud-tests suites (5 suites/23 tests) are **identical on unmodified origin/main** — pre-existing order-dependent/env issues, not introduced here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds out‑of‑scope controls to evidence task check results so customers can accept intentional resources and unblock audits. Addresses CS‑719 with mark/revoke actions in task run history, expanded lists for actions, and immediate status updates.

- **New Features**
  - Failing results on the latest run show “Mark out of scope,” which opens a reason modal and creates an exception.
  - Excepted results show an “Out of scope” badge with the reason and “Move back in scope” to revoke; actions require `integration:update`.
  - Findings and out‑of‑scope lists expand beyond the first 3 sampled rows so every sampled resource is actionable.
  - After mark/revoke, the affected check re‑runs so the task status updates immediately; skipped only if the same check is already running.
  - Reuses a shared reason modal moved to `components/integrations` with copy overrides; the reason label uses out‑of‑scope wording.

- **API**
  - `ActiveExceptionSet` optionally carries per‑exception metadata (`id`, `reason`); `infoFor` exposes it and `loadActiveExceptionSet` populates it.
  - `getTaskCheckRuns` returns `exceptionId` and `exceptionReason` on excepted results for display and revoke.
  - No schema changes; uses `POST /v1/cloud-security/findings/:id/exception` and `DELETE /v1/cloud-security/exceptions/:id`.

<sup>Written for commit 51132769d057d8a62fdc6276d5c7159e00d1d2d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

