### PR TITLE
docs: document self-hosted MCP server configuration

### DIFF
--- a/packages/docs/mcp-server.mdx
+++ b/packages/docs/mcp-server.mdx
@@ -56,6 +56,12 @@ The `npx -y @trycompai/mcp-server` command you'll see throughout is what handles
 
 No JSON editing required.
 
+<Warning>
+The drag-and-drop installer is configured for the hosted Comp AI service.
+
+If you're using a self-hosted deployment, use the manual JSON configuration and include the `--server-url` argument.
+</Warning>
+
 <Accordion title="Advanced — manual JSON config">
 If you prefer to manage `claude_desktop_config.json` yourself, open **Settings → Developer → Edit Config** and merge:
 
@@ -89,6 +95,12 @@ Fully quit and reopen Claude Desktop.
 
 Click the button above, confirm in Cursor, then paste your Comp AI API key when prompted.
 
+<Warning>
+The one-click installer is configured for the hosted Comp AI service.
+
+If you're using a self-hosted deployment, use the Advanced — manual JSON config below and include the `--server-url` argument.
+</Warning>
+
 <Accordion title="Advanced — manual JSON config">
 Open **Cursor → Settings → Tools and Integrations → New MCP Server** and paste:
 
@@ -117,6 +129,12 @@ Save and reload Cursor.
 [![Install in VS Code](https://img.shields.io/badge/VS_Code-VS_Code?style=flat-square&label=Install%20CompAi%20MCP&color=0098FF)](vscode://ms-vscode.vscode-mcp/install?name=CompAi&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyJAdHJ5Y29tcGFpL21jcC1zZXJ2ZXIiLCJzdGFydCIsIi0tYXBpa2V5IiwiIl19)
 
 Click the button above, confirm in VS Code, then paste your Comp AI API key when prompted.
+
+<Warning>
+The one-click installer is configured for the hosted Comp AI service.
+
+If you're using a self-hosted deployment, use the Advanced — manual JSON config below and include the `--server-url` argument.
+</Warning>
 
 <Accordion title="Advanced — manual JSON config">
 Open the **Command Palette → MCP: Open User Configuration** and paste:
@@ -196,6 +214,139 @@ Open **Windsurf → Settings → Cascade → Manage MCPs → View raw config** a
 
 Save and reload Windsurf.
 
+</Tab>
+
+</Tabs>
+
+## Self-hosted deployments
+
+If you're connecting to a self-hosted Comp AI deployment instead of the hosted Comp AI service, you must include the `--server-url` argument in your MCP server configuration.
+
+Hosted Comp AI users do not need to specify `--server-url`.
+
+Choose your AI client below and update its configuration by adding the `--server-url` argument.
+
+<Tabs>
+
+<Tab title="Claude Desktop">
+
+Update the manual JSON configuration by adding the `--server-url` argument.
+
+```json
+{
+  "mcpServers": {
+    "comp-ai": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@trycompai/mcp-server",
+        "start",
+        "--apikey",
+        "comp_your_api_key_here",
+        "--server-url",
+        "https://your-self-hosted-comp-api.example.com"
+      ]
+    }
+  }
+}
+```
+</Tab>
+
+<Tab title="Cursor">
+
+Update the manual JSON configuration by adding the `--server-url` argument.
+
+```json
+{
+  "command": "npx",
+  "args": [
+    "-y",
+    "@trycompai/mcp-server",
+    "start",
+    "--apikey",
+    "comp_your_api_key_here",
+    "--server-url",
+    "https://your-self-hosted-comp-api.example.com"
+  ]
+}
+```
+</Tab>
+
+<Tab title="VS Code">
+
+Update your MCP configuration by adding the `--server-url` argument.
+
+```json
+{
+  "command": "npx",
+  "args": [
+    "-y",
+    "@trycompai/mcp-server",
+    "start",
+    "--apikey",
+    "comp_your_api_key_here",
+    "--server-url",
+    "https://your-self-hosted-comp-api.example.com"
+  ]
+}
+```
+</Tab>
+
+<Tab title="Claude Code (CLI)">
+
+Append the `--server-url` argument to your existing installation command.
+
+```bash
+claude mcp add CompAI -- npx -y @trycompai/mcp-server start \
+  --apikey comp_your_api_key_here \
+  --server-url https://your-self-hosted-comp-api.example.com
+```
+</Tab>
+
+<Tab title="Codex CLI">
+
+Append the `--server-url` argument to your existing installation command.
+
+```bash
+codex mcp add comp-ai -- npx -y @trycompai/mcp-server start \
+  --apikey comp_your_api_key_here \
+  --server-url https://your-self-hosted-comp-api.example.com
+```
+</Tab>
+
+<Tab title="Gemini CLI">
+
+Append the `--server-url` argument to your existing installation command.
+
+```bash
+gemini mcp add CompAI -- npx -y @trycompai/mcp-server start \
+  --apikey comp_your_api_key_here \
+  --server-url https://your-self-hosted-comp-api.example.com
+```
+</Tab>
+
+<Tab title="Windsurf">
+
+Update your MCP configuration by adding the `--server-url` argument.
+
+```json
+{
+  "mcpServers": {
+    "comp-ai": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@trycompai/mcp-server",
+        "start",
+        "--apikey",
+        "comp_your_api_key_here",
+        "--server-url",
+        "https://your-self-hosted-comp-api.example.com"
+      ]
+    }
+  }
+}
+```
 </Tab>
 
 </Tabs>


### PR DESCRIPTION
## Summary

- Added documentation for self-hosted deployments using `--server-url`
- Kept existing hosted installation examples unchanged
- Added warnings for one-click installers that are configured for the hosted service
- Included a self-hosted JSON configuration example

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds docs for self‑hosted MCP server configuration using `--server-url`, with per‑client JSON/CLI examples. Hosted users don’t need `--server-url`.

- **New Features**
  - New “Self‑hosted deployments” section with tabbed examples for Claude Desktop, Cursor, VS Code, Claude Code, Codex, Gemini, and Windsurf.
  - Warnings added next to hosted‑only one‑click/drag‑and‑drop installers directing self‑hosted users to manual JSON config.

<sup>Written for commit bea10bbe579c1e915e2138353c4f57e7d46f2f9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

