### PR TITLE
fix(github-integration): distinguish ghas disabled from permission denied in oauth flow

### DIFF
--- a/packages/integration-platform/src/manifests/github/checks/__tests__/code-scanning.test.ts
+++ b/packages/integration-platform/src/manifests/github/checks/__tests__/code-scanning.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'bun:test';
+import type { CheckContext } from '../../../../types';
+import type { GitHubRepo } from '../../types';
+import { codeScanningCheck } from '../code-scanning';
+
+interface RepoConfig {
+  private: boolean;
+  /**
+   * `advanced_security.status`. `undefined` means GitHub omitted the
+   * `security_and_analysis` block entirely — which is what happens over an OAuth
+   * connection whose user lacks repo-admin visibility.
+   */
+  ghas?: 'enabled' | 'disabled';
+  /** Whether the code-scanning default-setup API 403s (permission/GHAS gate). */
+  defaultSetup403?: boolean;
+}
+
+const makeRepo = (fullName: string, config: RepoConfig): GitHubRepo => {
+  const [owner, name] = fullName.split('/');
+  const repo: GitHubRepo = {
+    id: 1,
+    name: name!,
+    full_name: fullName,
+    html_url: `https://github.com/${fullName}`,
+    private: config.private,
+    default_branch: 'main',
+    owner: { login: owner!, type: 'Organization' },
+  };
+  if (config.ghas) {
+    repo.security_and_analysis = { advanced_security: { status: config.ghas } };
+  }
+  return repo;
+};
+
+interface RunResult {
+  passed: Array<{ resourceId: string; title: string }>;
+  failed: Array<{ resourceId: string; title: string }>;
+}
+
+async function runCheck(repos: Record<string, RepoConfig>): Promise<RunResult> {
+  const passed: RunResult['passed'] = [];
+  const failed: RunResult['failed'] = [];
+
+  const ctx = {
+    accessToken: 'tok',
+    credentials: {},
+    variables: { target_repos: Object.keys(repos) },
+    connectionId: 'conn_1',
+    organizationId: 'org_1',
+    metadata: {},
+    log: () => {},
+    warn: () => {},
+    pass: (result) => {
+      passed.push({ resourceId: result.resourceId ?? '', title: result.title });
+    },
+    fail: (result) => {
+      failed.push({ resourceId: result.resourceId ?? '', title: result.title });
+    },
+    fetch: (async <T>(path: string): Promise<T> => {
+      // /repos/<owner>/<repo>
+      const repoMatch = path.match(/^\/repos\/([^/]+\/[^/]+)$/);
+      if (repoMatch) {
+        const fullName = repoMatch[1]!;
+        const config = repos[fullName];
+        if (!config) throw new Error(`404 ${path}`);
+        return makeRepo(fullName, config) as unknown as T;
+      }
+
+      // /repos/<owner>/<repo>/code-scanning/default-setup
+      const setupMatch = path.match(/^\/repos\/([^/]+\/[^/]+)\/code-scanning\/default-setup$/);
+      if (setupMatch) {
+        const config = repos[setupMatch[1]!]!;
+        // GitHub 403s this endpoint for private repos when the token lacks the
+        // repo-admin visibility the code-scanning API requires (and, separately,
+        // when GHAS is off). Both surface identically to us.
+        if (config.defaultSetup403) throw new Error(`403 Forbidden: ${path}`);
+        return { state: 'not-configured' } as unknown as T;
+      }
+
+      // /repos/<owner>/<repo>/git/trees/<branch>?recursive=1 — no workflow files
+      // (default-setup repos carry no CodeQL .yml).
+      if (/^\/repos\/[^/]+\/[^/]+\/git\/trees\/.+/.test(path)) {
+        return { sha: 'x', url: '', truncated: false, tree: [] } as unknown as T;
+      }
+
+      throw new Error(`Unexpected fetch: ${path}`);
+    }) as CheckContext['fetch'],
+    fetchAllPages: (async () => []) as CheckContext['fetchAllPages'],
+    fetchWithCursor: (async () => []) as CheckContext['fetchWithCursor'],
+    fetchWithLinkHeader: (async () => []) as CheckContext['fetchWithLinkHeader'],
+    graphql: (async () => ({})) as CheckContext['graphql'],
+    getState: (async () => null) as CheckContext['getState'],
+    setState: (async () => {}) as CheckContext['setState'],
+  } as CheckContext;
+
+  await codeScanningCheck.run(ctx);
+  return { passed, failed };
+}
+
+describe('codeScanningCheck GHAS visibility (regression: CS-756)', () => {
+  it('does NOT report GHAS required when GHAS status is unknown (OAuth non-admin: 403 + private + no security_and_analysis block)', async () => {
+    // Saltbox repro: OAuth token without repo-admin visibility on a private repo
+    // that actually HAS GHAS + CodeQL default setup enabled. GitHub omits the
+    // `security_and_analysis` block AND 403s the code-scanning API. We cannot
+    // confirm GHAS is off, so we must not falsely claim it is.
+    const { passed, failed } = await runCheck({
+      'saltbox/s1-app-monitor': { private: true, defaultSetup403: true }, // ghas block omitted
+    });
+
+    expect(passed).toHaveLength(0);
+    expect(failed).toHaveLength(1);
+    // Before the fix this was:
+    //   "Code scanning requires GitHub Advanced Security for s1-app-monitor"
+    expect(failed[0]!.title).toBe('Cannot access code scanning configuration for s1-app-monitor');
+    expect(failed[0]!.title).not.toContain('requires GitHub Advanced Security');
+  });
+
+  it('still reports GHAS required when GHAS is positively disabled on a private repo', async () => {
+    const { failed } = await runCheck({
+      'acme/no-ghas': { private: true, ghas: 'disabled', defaultSetup403: true },
+    });
+
+    expect(failed).toHaveLength(1);
+    expect(failed[0]!.title).toBe('Code scanning requires GitHub Advanced Security for no-ghas');
+  });
+
+  it('reports permission-denied (not GHAS required) when GHAS is enabled but the API still 403s', async () => {
+    const { failed } = await runCheck({
+      'acme/ghas-on': { private: true, ghas: 'enabled', defaultSetup403: true },
+    });
+
+    expect(failed).toHaveLength(1);
+    expect(failed[0]!.title).toBe('Cannot access code scanning configuration for ghas-on');
+  });
+});

--- a/packages/integration-platform/src/manifests/github/checks/code-scanning.ts
+++ b/packages/integration-platform/src/manifests/github/checks/code-scanning.ts
@@ -46,6 +46,14 @@ type CodeScanningStatus =
   | { status: 'permission-denied'; isPrivate: boolean }
   | { status: 'ghas-required' };
 
+/**
+ * Whether GitHub Advanced Security is enabled for a repo. `unknown` covers the
+ * case where GitHub omits the repo's `security_and_analysis` block because the
+ * token lacks repo-admin visibility (common over OAuth connections) — we must
+ * NOT treat that as `disabled`.
+ */
+type GhasStatus = 'enabled' | 'disabled' | 'unknown';
+
 const decodeFile = (file: GitHubFileResponse): string => {
   if (!file?.content) return '';
   if (file.encoding === 'base64') {
@@ -149,12 +157,12 @@ export const codeScanningCheck: IntegrationCheck = {
       repoName,
       tree,
       isPrivate,
-      isGhasEnabled,
+      ghasStatus,
     }: {
       repoName: string;
       tree: GitHubTreeEntry[];
       isPrivate: boolean;
-      isGhasEnabled: boolean;
+      ghasStatus: GhasStatus;
     }): Promise<CodeScanningStatus> => {
       let apiGot403 = false;
 
@@ -178,7 +186,7 @@ export const codeScanningCheck: IntegrationCheck = {
           // workflow file contents only requires contents:read. A 403 here does
           // not mean we can't check for code scanning workflows.
           ctx.log(
-            `Code scanning API returned 403 for ${repoName} (private: ${isPrivate}, ghas: ${isGhasEnabled}). Falling back to workflow file scanning.`,
+            `Code scanning API returned 403 for ${repoName} (private: ${isPrivate}, ghas: ${ghasStatus}). Falling back to workflow file scanning.`,
           );
           apiGot403 = true;
         } else {
@@ -200,10 +208,14 @@ export const codeScanningCheck: IntegrationCheck = {
       }
 
       if (apiGot403) {
-        if (isPrivate) {
-          if (isGhasEnabled) {
-            return { status: 'permission-denied', isPrivate };
-          }
+        // A 403 from the code-scanning API on a private repo can mean either GHAS
+        // is off (CodeQL genuinely can't be configured) OR the token lacks the
+        // repo-admin visibility the API requires. Only claim "GHAS required" when
+        // we can positively confirm GHAS is disabled. Over an OAuth connection
+        // without repo admin, GitHub omits the repo's `security_and_analysis`
+        // block, so ghasStatus is 'unknown' — treat that (and 'enabled') as
+        // permission-denied rather than falsely reporting GHAS is not enabled.
+        if (isPrivate && ghasStatus === 'disabled') {
           return { status: 'ghas-required' };
         }
         return { status: 'permission-denied', isPrivate };
@@ -217,13 +229,17 @@ export const codeScanningCheck: IntegrationCheck = {
       if (!repo) continue;
 
       const tree = await fetchRepoTree(repo.full_name, repo.default_branch);
-      const isGhasEnabled = repo.security_and_analysis?.advanced_security?.status === 'enabled';
+      // `security_and_analysis` is only returned to repo admins, so over an OAuth
+      // connection without admin visibility this is undefined — 'unknown', NOT
+      // 'disabled'. Conflating the two is what made us falsely report GHAS off.
+      const ghasStatus: GhasStatus =
+        repo.security_and_analysis?.advanced_security?.status ?? 'unknown';
 
       const codeScanningStatus = await getCodeScanningStatus({
         repoName: repo.full_name,
         tree,
         isPrivate: repo.private,
-        isGhasEnabled,
+        ghasStatus,
       });
 
       switch (codeScanningStatus.status) {


### PR DESCRIPTION
## Problem
The CodeQL integration incorrectly reports that GitHub Advanced Security (GHAS) is not enabled when using OAuth, even though GHAS is actually active on the repository. This forces customers to manually upload evidence as a workaround and causes confusion about automation support.

## Root cause
The `isGhasEnabled` check in code-scanning.ts conflates two distinct failure modes. It returns false both when `advanced_security.status` is explicitly 'disabled' AND when the `security_and_analysis` block is absent from the API response. Over OAuth, GitHub only returns this block to repository admins due to permission constraints. The check treats a missing block (permission denied) the same as an explicitly disabled status (feature not enabled), returning the 'ghas-required' error in both cases.

## Fix
Updated the logic to distinguish between the two scenarios. When `security_and_analysis` is absent, we now return 'permission-denied' instead of 'ghas-required'. This accurately reflects that we lack permission to read the setting rather than claiming GHAS is disabled. The check still returns 'ghas-required' only when status is positively 'disabled'.

No changes to auth, RBAC, API schemas, or GitHub App integration paths. Behavior for genuinely-disabled repos and the GitHub App connection remains unchanged.

## Explicitly NOT touched
- OAuth token validation or scoping
- GitHub App integration or permissions
- Repository admin checks or RBAC logic
- API schema or response structure

## Verification
✅ Code path for explicitly disabled GHAS still returns 'ghas-required'
✅ Code path for missing security_and_analysis block now returns 'permission-denied'
✅ GitHub App path unaffected (receives full security_and_analysis block)
✅ No schema changes required

Fixes CS-756

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false “GHAS not enabled” errors in the OAuth CodeQL check by distinguishing permission issues from GHAS being disabled. Addresses CS-756 and prevents unnecessary manual evidence uploads for private repos.

- **Bug Fixes**
  - Updated `packages/integration-platform/src/manifests/github/checks/code-scanning.ts` to treat a missing `security_and_analysis` block as 'unknown' and return 'permission-denied' on 403 for private repos unless GHAS is explicitly 'disabled'.
  - Only return 'ghas-required' when `advanced_security.status === 'disabled'`; GitHub App behavior is unchanged.
  - Added regression tests in `packages/integration-platform/src/manifests/github/checks/__tests__/code-scanning.test.ts` for OAuth non-admin, GHAS disabled, and GHAS enabled scenarios.

<sup>Written for commit ec42f969ce659735645f4667a775a09883be14ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

