### PR TITLE
fix(app): keep task automation "Last ran" fresh when recent runs are held

### DIFF
--- a/apps/api/src/integration-platform/controllers/task-integrations.controller.spec.ts
+++ b/apps/api/src/integration-platform/controllers/task-integrations.controller.spec.ts
@@ -220,6 +220,7 @@ describe('TaskIntegrationsController', () => {
     complete: jest.fn(),
     addResults: jest.fn(),
     findLatestPerConnectionAndCheckByTask: jest.fn(),
+    findLastAttemptPerConnectionAndCheckByTask: jest.fn(),
     countExceptedFailures: jest.fn(),
   };
   const mockCredentialVaultService = { getDecryptedCredentials: jest.fn() };
@@ -290,6 +291,10 @@ describe('TaskIntegrationsController', () => {
     // Default: nothing excepted (no count query needed). Exception tests
     // override this to the exact excepted-failure count for the run.
     mockCheckRunRepository.countExceptedFailures.mockResolvedValue(0);
+    // Default: no last-attempt rows (tests that care set their own).
+    mockCheckRunRepository.findLastAttemptPerConnectionAndCheckByTask.mockResolvedValue(
+      [],
+    );
     mockCredentialVaultService.getDecryptedCredentials.mockResolvedValue(
       VALID_CREDS,
     );
@@ -889,6 +894,30 @@ describe('TaskIntegrationsController', () => {
       expect(
         mockCheckRunRepository.findLatestPerConnectionAndCheckByTask,
       ).not.toHaveBeenCalled();
+    });
+
+    it('returns lastAttempts (incl. held runs) so "Last ran" stays truthful (CS-753)', async () => {
+      // The visible runs list can be days older than the newest attempt when
+      // recent runs were held (they're excluded from `runs`). The endpoint
+      // must surface WHEN each (connection, check) last ran — timestamps only.
+      mockCheckRunRepository.findLatestPerConnectionAndCheckByTask.mockResolvedValue(
+        [],
+      );
+      const attempt = {
+        connectionId: 'conn_1',
+        checkId: 'entra_id_mfa',
+        lastAttemptAt: new Date('2026-07-16T06:00:00Z'),
+      };
+      mockCheckRunRepository.findLastAttemptPerConnectionAndCheckByTask.mockResolvedValue(
+        [attempt],
+      );
+
+      const response = await controller.getTaskCheckRuns('task_1', 'org_1');
+
+      expect(response.lastAttempts).toEqual([attempt]);
+      expect(
+        mockCheckRunRepository.findLastAttemptPerConnectionAndCheckByTask,
+      ).toHaveBeenCalledWith('task_1');
     });
 
     it('bounds a run with a huge result set + logs so the payload stays small (CS-588)', async () => {

--- a/apps/api/src/integration-platform/controllers/task-integrations.controller.ts
+++ b/apps/api/src/integration-platform/controllers/task-integrations.controller.ts
@@ -925,6 +925,15 @@ export class TaskIntegrationsController {
       }),
     );
 
-    return { runs: mappedRuns };
+    // WHEN each (connection, check) last ran, INCLUDING runs held as
+    // 'inconclusive' (which are excluded from `runs`). Timestamps only — held
+    // outcomes stay hidden. Without this the UI's "Last ran" froze at the last
+    // visible run while the daily schedule kept running (CS-753).
+    const lastAttempts =
+      await this.checkRunRepository.findLastAttemptPerConnectionAndCheckByTask(
+        taskId,
+      );
+
+    return { runs: mappedRuns, lastAttempts };
   }
 }

--- a/apps/api/src/integration-platform/repositories/check-run.repository.spec.ts
+++ b/apps/api/src/integration-platform/repositories/check-run.repository.spec.ts
@@ -266,6 +266,55 @@ describe('CheckRunRepository.findLatestPerConnectionAndCheckByTask', () => {
   });
 });
 
+describe('CheckRunRepository.findLastAttemptPerConnectionAndCheckByTask', () => {
+  const repo = new CheckRunRepository();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns each group’s latest attempt timestamp, INCLUDING held runs (CS-753)', async () => {
+    mockGroupBy.mockResolvedValue([
+      {
+        connectionId: 'A',
+        checkId: 'entra_id_mfa',
+        _max: { createdAt: new Date('2026-07-16T06:00:00Z') },
+      },
+    ]);
+
+    const attempts =
+      await repo.findLastAttemptPerConnectionAndCheckByTask('task_1');
+
+    expect(attempts).toEqual([
+      {
+        connectionId: 'A',
+        checkId: 'entra_id_mfa',
+        lastAttemptAt: new Date('2026-07-16T06:00:00Z'),
+      },
+    ]);
+    // The whole point: NO status filter — a run held as 'inconclusive' still
+    // counts as an attempt. Disconnected connections stay excluded.
+    const where = mockGroupBy.mock.calls[0][0].where;
+    expect(where.status).toBeUndefined();
+    expect(where.connection).toEqual({ status: { not: 'disconnected' } });
+    expect(where.taskId).toBe('task_1');
+  });
+
+  it('drops groups without a timestamp and returns [] for a task with no runs', async () => {
+    mockGroupBy.mockResolvedValue([
+      { connectionId: 'A', checkId: 'c', _max: { createdAt: null } },
+    ]);
+    expect(
+      await repo.findLastAttemptPerConnectionAndCheckByTask('task_1'),
+    ).toEqual([]);
+
+    mockGroupBy.mockResolvedValue([]);
+    expect(
+      await repo.findLastAttemptPerConnectionAndCheckByTask('task_1'),
+    ).toEqual([]);
+  });
+});
+
 describe('CheckRunRepository.countExceptedFailures', () => {
   const repo = new CheckRunRepository();
 

--- a/apps/api/src/integration-platform/repositories/check-run.repository.ts
+++ b/apps/api/src/integration-platform/repositories/check-run.repository.ts
@@ -267,6 +267,39 @@ export class CheckRunRepository {
   }
 
   /**
+   * WHEN each (connection, check) last ran for a task — INCLUDING runs held as
+   * `inconclusive`. Timestamps only: no status, no counts, no results, so held
+   * outcomes stay hidden.
+   *
+   * `findLatestPerConnectionAndCheckByTask` above excludes held runs, which is
+   * right for RESULTS — but using that list for the "Last ran" label froze the
+   * label at the last visible run while a scheduled check kept running (and
+   * being held) every day. Customers read that as "the schedule stopped"
+   * (CS-753). This gives the UI the true last-attempt time per group.
+   */
+  async findLastAttemptPerConnectionAndCheckByTask(taskId: string) {
+    const groups = await db.integrationCheckRun.groupBy({
+      by: ['connectionId', 'checkId'],
+      where: {
+        taskId,
+        connection: { status: { not: 'disconnected' } },
+      },
+      _max: { createdAt: true },
+    });
+    return groups.flatMap((g) =>
+      g._max.createdAt
+        ? [
+            {
+              connectionId: g.connectionId,
+              checkId: g.checkId,
+              lastAttemptAt: g._max.createdAt,
+            },
+          ]
+        : [],
+    );
+  }
+
+  /**
    * Count a run's FAILING results whose resourceId is under an active exception.
    * Lets the task UI compute the effective (non-excepted) failure count exactly
    * WITHOUT loading every result row — only the bounded display sample is

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/TaskIntegrationChecks.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/TaskIntegrationChecks.tsx
@@ -83,6 +83,7 @@ export function TaskIntegrationChecks({
   const {
     checks,
     runs: storedRuns,
+    lastAttempts,
     isLoading: loading,
     error: hookError,
     mutateChecks,
@@ -530,8 +531,13 @@ export function TaskIntegrationChecks({
                 const checkRuns = runsByCheck[check.checkId] || [];
                 // A check runs once per connected account; summarize the latest
                 // run of EACH account so the header reflects all of them, not
-                // just the most recently run one.
-                const summary = summarizeLatestPerAccount(checkRuns);
+                // just the most recently run one. `lastAttempts` keeps "Last
+                // ran" truthful when newer runs exist but are held server-side
+                // (they never appear in `checkRuns`).
+                const summary = summarizeLatestPerAccount(
+                  checkRuns,
+                  lastAttempts.filter((a) => a.checkId === check.checkId),
+                );
                 const isRunning = runningCheck === check.checkId;
                 const isExpanded = expandedCheck === check.checkId;
                 const needsConfig = check.needsConfiguration;

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/check-run-grouping.test.ts
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/check-run-grouping.test.ts
@@ -90,4 +90,48 @@ describe('summarizeLatestPerAccount', () => {
       hasSucceeded: false,
     });
   });
+
+  // CS-753: a check whose recent runs are all held server-side (hidden from
+  // the runs list) still RAN — "Last ran" must advance to the newest attempt,
+  // while counts/status keep reflecting the latest visible run.
+  it('advances lastRunAt to a newer held attempt without touching counts/status', () => {
+    const runs = [
+      makeRun({
+        id: 'a1',
+        connectionId: 'A',
+        status: 'failed',
+        passedCount: 34,
+        failedCount: 10,
+        createdAt: '2026-07-13T10:00:00Z',
+      }),
+    ];
+    const summary = summarizeLatestPerAccount(runs, [
+      { connectionId: 'A', checkId: 'aws-s3-encryption', lastAttemptAt: '2026-07-16T06:00:00Z' },
+    ]);
+    expect(summary.lastRunAt).toBe('2026-07-16T06:00:00Z');
+    // Results shown are still the latest VISIBLE run's.
+    expect(summary.passed).toBe(34);
+    expect(summary.failed).toBe(10);
+    expect(summary.hasFailed).toBe(true);
+  });
+
+  it('ignores attempts older than the latest visible run', () => {
+    const runs = [
+      makeRun({ id: 'a1', connectionId: 'A', createdAt: '2026-07-16T06:00:00Z' }),
+    ];
+    const summary = summarizeLatestPerAccount(runs, [
+      { connectionId: 'A', checkId: 'aws-s3-encryption', lastAttemptAt: '2026-07-13T06:00:00Z' },
+    ]);
+    expect(summary.lastRunAt).toBe('2026-07-16T06:00:00Z');
+  });
+
+  it('keeps "Not run yet" (null) when a check has only ever been held', () => {
+    // Held-only checks have no visible runs; their outcomes stay hidden by
+    // design, so the attempt timestamp alone must not fabricate a summary.
+    const summary = summarizeLatestPerAccount([], [
+      { connectionId: 'A', checkId: 'aws-s3-encryption', lastAttemptAt: '2026-07-16T06:00:00Z' },
+    ]);
+    expect(summary.lastRunAt).toBeNull();
+    expect(summary.accountCount).toBe(0);
+  });
 });

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/check-run-grouping.ts
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/check-run-grouping.ts
@@ -1,4 +1,7 @@
-import type { StoredCheckRun } from '../hooks/useIntegrationChecks';
+import type {
+  CheckRunAttempt,
+  StoredCheckRun,
+} from '../hooks/useIntegrationChecks';
 
 export interface AccountRunGroup {
   connectionId: string;
@@ -46,9 +49,18 @@ export interface RunsSummary {
 /**
  * Aggregate the latest run per account for the card header — so a multi-account
  * check shows totals across all accounts, not just the most recently run one.
+ *
+ * `lastAttempts` (optional, already filtered to this check) carries WHEN each
+ * account last ran INCLUDING runs the server held back from `runs`. A check
+ * whose recent runs are all held still ran — without this, "Last ran" froze at
+ * the older visible run and customers read it as "the schedule stopped"
+ * (CS-753). Counts/status always come from visible runs only, and a check with
+ * no visible run at all keeps `lastRunAt: null` ("Not run yet") — held
+ * outcomes stay hidden; only the timestamp advances.
  */
 export function summarizeLatestPerAccount(
   runs: StoredCheckRun[],
+  lastAttempts: CheckRunAttempt[] = [],
 ): RunsSummary {
   const groups = groupRunsByConnection(runs);
   let passed = 0;
@@ -69,6 +81,17 @@ export function summarizeLatestPerAccount(
     const at = latest.completedAt || latest.createdAt;
     if (at && (!lastRunAt || new Date(at) > new Date(lastRunAt))) {
       lastRunAt = at;
+    }
+  }
+
+  if (lastRunAt) {
+    for (const attempt of lastAttempts) {
+      if (
+        attempt.lastAttemptAt &&
+        new Date(attempt.lastAttemptAt) > new Date(lastRunAt)
+      ) {
+        lastRunAt = attempt.lastAttemptAt;
+      }
     }
   }
 

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/hooks/useIntegrationChecks.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/hooks/useIntegrationChecks.test.tsx
@@ -94,6 +94,38 @@ describe('useIntegrationChecks', () => {
     expect(result.current.checks[1]!.isDisabledForTask).toBe(true);
   });
 
+  it('exposes lastAttempts from the runs endpoint, defaulting to [] when absent (CS-753)', async () => {
+    const attempt = {
+      connectionId: 'icn_1',
+      checkId: 'branch_protection',
+      lastAttemptAt: '2026-07-16T06:00:00.000Z',
+    };
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes('/checks')) {
+        return Promise.resolve(
+          createJsonResponse({
+            checks: [makeCheck()],
+            task: { id: TASK_ID, title: 'Test', templateId: 'tpl_1' },
+          }),
+        );
+      }
+      if (url.includes('/runs')) {
+        return Promise.resolve(
+          createJsonResponse({ runs: [], lastAttempts: [attempt] }),
+        );
+      }
+      return Promise.resolve(createJsonResponse({}));
+    });
+
+    const { result } = renderHook(
+      () => useIntegrationChecks({ taskId: TASK_ID, orgId: ORG_ID }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.lastAttempts).toEqual([attempt]);
+  });
+
   it('disconnectCheckFromTask POSTs to the disconnect endpoint and updates the cache', async () => {
     mockInitialLoad([makeCheck({ checkId: 'branch_protection' })]);
 

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/hooks/useIntegrationChecks.ts
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/hooks/useIntegrationChecks.ts
@@ -70,7 +70,17 @@ interface StoredCheckRun {
   createdAt: string;
 }
 
-export type { StoredCheckRun, TaskIntegrationCheck };
+/**
+ * When a (connection, check) last ran — INCLUDING runs held server-side (which
+ * never appear in `runs`). Timestamp only; held outcomes stay hidden.
+ */
+interface CheckRunAttempt {
+  connectionId: string;
+  checkId: string;
+  lastAttemptAt: string;
+}
+
+export type { CheckRunAttempt, StoredCheckRun, TaskIntegrationCheck };
 
 export const integrationChecksKey = (taskId: string, orgId: string) =>
   ['/v1/integrations/tasks/checks', taskId, orgId] as const;
@@ -105,23 +115,29 @@ export function useIntegrationChecks({ taskId, orgId }: UseIntegrationChecksOpti
   );
 
   const {
-    data: runs,
+    data: runsData,
     error: runsError,
     isLoading: runsLoading,
     mutate: mutateRuns,
   } = useSWR(
     integrationRunsKey(taskId, orgId),
     async () => {
-      const response = await api.get<{ runs: StoredCheckRun[] }>(
-        `/v1/integrations/tasks/${taskId}/runs?organizationId=${orgId}`,
-      );
+      const response = await api.get<{
+        runs: StoredCheckRun[];
+        lastAttempts?: CheckRunAttempt[];
+      }>(`/v1/integrations/tasks/${taskId}/runs?organizationId=${orgId}`);
       if (response.error) throw new Error(response.error);
-      return response.data?.runs ?? [];
+      return {
+        runs: response.data?.runs ?? [],
+        lastAttempts: response.data?.lastAttempts ?? [],
+      };
     },
     {
       revalidateOnFocus: false,
     },
   );
+  const runs = runsData?.runs;
+  const lastAttempts = runsData?.lastAttempts;
 
   const runCheck = async (
     connectionId: string,
@@ -251,6 +267,7 @@ export function useIntegrationChecks({ taskId, orgId }: UseIntegrationChecksOpti
   return {
     checks: Array.isArray(checks) ? checks : [],
     runs: Array.isArray(runs) ? runs : [],
+    lastAttempts: Array.isArray(lastAttempts) ? lastAttempts : [],
     isLoading: checksLoading || runsLoading,
     error: checksError?.message || runsError?.message || null,
     mutateChecks,


### PR DESCRIPTION
## Problem

CS-753: a customer's Microsoft Entra ID automation showed "Last ran 3 days ago" (and looked like the daily schedule had stopped) while Google Workspace in the same automation group stayed fresh. The schedule was in fact fine — prod run history shows the Entra checks executed every day at ~6 AM UTC, each completing in seconds.

## Root cause

The task Automations card derives "Last ran" from the run list returned by `GET /v1/integrations/tasks/:taskId/runs`, and that list intentionally excludes runs recorded as `inconclusive` (held; their results must not be shown). For a dynamic integration, runs with findings are held every day — so the newest *visible* run can be days old while the check keeps running daily. "Last ran" then freezes at the last visible run and reads as a dead schedule. Static integrations (e.g. Google Workspace) record failures as `failed` (visible), which is why they looked healthy in comparison.

## Fix

Surface **when** each (connection, check) last ran without revealing held outcomes:

- **API** — `CheckRunRepository.findLastAttemptPerConnectionAndCheckByTask`: one `groupBy` over the task's runs with **no status filter** (disconnected connections still excluded), returning `{ connectionId, checkId, lastAttemptAt }` only. The `/runs` endpoint returns it as `lastAttempts` alongside the unchanged `runs`.
- **App** — `summarizeLatestPerAccount` advances `lastRunAt` to the newest attempt **only when the check already has visible history**. Counts, status dot, and the run history list still come exclusively from visible runs, and a check that has only ever been held keeps showing "Not run yet" (that hiding is by design).

## Explicitly NOT changed

- Held-run semantics (`decideRunStatus`, dynamic holds) and the self-heal flow — untouched.
- Visible run results/status — `lastAttempts` carries timestamps only.
- The additive response field is backward-compatible; the endpoint has no declared response schema, so `packages/docs/openapi.json` is unchanged.

## Verification

- New unit tests at every layer: repository query shape (no status filter, disconnected excluded, null-timestamp groups dropped), controller passthrough, hook exposure (incl. legacy response without `lastAttempts`), and summary logic (advance / ignore-older / held-only stays "Not run yet").
- `check-run-grouping` 7/7 and `useIntegrationChecks` 5/5 pass (vitest); repository and controller specs pass except failures already present on `main` baseline (verified by running the HEAD versions: 2 stale `findLatestResultsByConnectionAndCheck` tests, 3 stale `runCheckForTask` tests — unrelated to this change).
- Typecheck: no errors in the touched files (repo-wide typecheck has pre-existing errors on `main` in unrelated spec files).
- Not exercised against production; the UI behavior change is covered by the unit tests above.

Follow-ups tracked separately: why held runs went unprocessed by the reveal pipeline for 3 days, and whether a failure already revealed as real should keep being re-held on subsequent scheduled runs.

Fixes CS-753


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the Automations "Last ran" accurate when recent runs are held, so schedules don’t look stalled. Adds `lastAttempts` to the runs API and updates the UI to use it without revealing held outcomes. Fixes CS-753.

- **Bug Fixes**
  - API: `/v1/integrations/tasks/:taskId/runs` now returns `lastAttempts` (per connection/check last run timestamp, including held runs) via `findLastAttemptPerConnectionAndCheckByTask`.
  - App: `useIntegrationChecks` exposes `lastAttempts`; `summarizeLatestPerAccount` advances "Last ran" only if the check has visible history. Counts and status still come from visible runs; held-only checks stay "Not run yet".
  - Tests: Added repository, controller, hook, and UI summary tests for timestamp advancement, ignoring older attempts, and held-only cases.

<sup>Written for commit 990f025e895434607c632b0251ab0f9cc2a7aa1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

