### PR TITLE
fix(auth): redirect microsoft sso callback errors to portal instead of api docs

### DIFF
--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -62,6 +62,7 @@
         "dev": "next dev --turbopack -p 3002",
         "lint": "eslint . && prettier --check .",
         "prebuild": "bun run db:generate",
-        "start": "next start"
+        "start": "next start",
+        "test": "vitest run"
     }
 }

--- a/apps/portal/src/app/components/google-sign-in.tsx
+++ b/apps/portal/src/app/components/google-sign-in.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { authClient } from '@/app/lib/auth-client';
+import { buildSignInCallbackUrls } from '@/app/lib/auth-callback';
 import { Button } from '@trycompai/ui/button';
 import { Icons } from '@trycompai/ui/icons';
 import { Spinner } from '@trycompai/design-system';
@@ -18,26 +19,18 @@ export function GoogleSignIn({
   const handleSignIn = async () => {
     setLoading(true);
 
-    // Build the callback URL with search params
-    const baseURL = window.location.origin;
-    const isDeviceAuth = searchParams?.get('device_auth') === 'true';
-    const path = isDeviceAuth
-      ? '/auth/device-callback'
-      : inviteCode
-        ? `/invite/${inviteCode}`
-        : '/';
-    const redirectTo = new URL(path, baseURL);
-
-    // Append all search params if they exist
-    if (searchParams) {
-      searchParams.forEach((value, key) => {
-        redirectTo.searchParams.append(key, value);
-      });
-    }
+    const { callbackURL, errorCallbackURL } = buildSignInCallbackUrls({
+      origin: window.location.origin,
+      inviteCode,
+      searchParams,
+    });
 
     await authClient.signIn.social({
       provider: 'google',
-      callbackURL: redirectTo.toString(),
+      callbackURL,
+      // Without this, an OAuth callback error redirects to the API root
+      // (Swagger docs) instead of back to the portal. See CS-760.
+      errorCallbackURL,
     });
   };
 

--- a/apps/portal/src/app/components/microsoft-sign-in.tsx
+++ b/apps/portal/src/app/components/microsoft-sign-in.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { authClient } from '@/app/lib/auth-client';
+import { buildSignInCallbackUrls } from '@/app/lib/auth-callback';
 import { Button } from '@trycompai/ui/button';
 import { Icons } from '@trycompai/ui/icons';
 import { Spinner } from '@trycompai/design-system';
@@ -20,26 +21,18 @@ export function MicrosoftSignIn({
     setLoading(true);
 
     try {
-      // Build the callback URL with search params
-      const baseURL = window.location.origin;
-      const isDeviceAuth = searchParams?.get('device_auth') === 'true';
-      const path = isDeviceAuth
-        ? '/auth/device-callback'
-        : inviteCode
-          ? `/invite/${inviteCode}`
-          : '/';
-      const redirectTo = new URL(path, baseURL);
-
-      // Append all search params if they exist
-      if (searchParams) {
-        searchParams.forEach((value, key) => {
-          redirectTo.searchParams.append(key, value);
-        });
-      }
+      const { callbackURL, errorCallbackURL } = buildSignInCallbackUrls({
+        origin: window.location.origin,
+        inviteCode,
+        searchParams,
+      });
 
       await authClient.signIn.social({
         provider: 'microsoft',
-        callbackURL: redirectTo.toString(),
+        callbackURL,
+        // Without this, an OAuth callback error redirects to the API root
+        // (Swagger docs) instead of back to the portal. See CS-760.
+        errorCallbackURL,
       });
     } catch (error) {
       setLoading(false);

--- a/apps/portal/src/app/lib/auth-callback.test.ts
+++ b/apps/portal/src/app/lib/auth-callback.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { buildSignInCallbackUrls } from './auth-callback';
+
+const PORTAL_ORIGIN = 'https://portal.trycomp.ai';
+const API_ORIGIN = 'https://api.trycomp.ai';
+
+describe('buildSignInCallbackUrls', () => {
+  // CS-760: a new Microsoft/Entra user accepts a portal invite; the OAuth
+  // callback errors and better-auth redirects to the errorCallbackURL. If that
+  // URL is missing, better-auth defaults to the API baseURL and the user lands
+  // on the Swagger docs. The error URL MUST be rooted at the portal, not the API.
+  it('returns an errorCallbackURL rooted at the portal, not the API', () => {
+    const { errorCallbackURL } = buildSignInCallbackUrls({
+      origin: PORTAL_ORIGIN,
+      inviteCode: 'invite_test123',
+    });
+
+    const url = new URL(errorCallbackURL);
+    expect(url.origin).toBe(PORTAL_ORIGIN);
+    expect(url.origin).not.toBe(API_ORIGIN);
+    expect(url.pathname).toBe('/auth');
+  });
+
+  it('sends the success path to the invite page when an invite code is present', () => {
+    const { callbackURL, errorCallbackURL } = buildSignInCallbackUrls({
+      origin: PORTAL_ORIGIN,
+      inviteCode: 'org_abc123',
+    });
+
+    expect(callbackURL).toBe(`${PORTAL_ORIGIN}/invite/org_abc123`);
+    // Success goes to the invite; error still returns to the portal sign-in.
+    expect(errorCallbackURL).toBe(`${PORTAL_ORIGIN}/auth`);
+  });
+
+  it('routes device-auth sign-ins to the device callback and preserves params on both URLs', () => {
+    const searchParams = new URLSearchParams({
+      device_auth: 'true',
+      callback_port: '54321',
+      state: 'xyz',
+    });
+
+    const { callbackURL, errorCallbackURL } = buildSignInCallbackUrls({
+      origin: PORTAL_ORIGIN,
+      searchParams,
+    });
+
+    const success = new URL(callbackURL);
+    expect(success.pathname).toBe('/auth/device-callback');
+    expect(success.searchParams.get('callback_port')).toBe('54321');
+    expect(success.searchParams.get('state')).toBe('xyz');
+
+    const error = new URL(errorCallbackURL);
+    expect(error.origin).toBe(PORTAL_ORIGIN);
+    expect(error.pathname).toBe('/auth');
+    expect(error.searchParams.get('callback_port')).toBe('54321');
+  });
+
+  it('defaults the success path to root when there is no invite or device auth', () => {
+    const { callbackURL, errorCallbackURL } = buildSignInCallbackUrls({
+      origin: PORTAL_ORIGIN,
+    });
+
+    expect(callbackURL).toBe(`${PORTAL_ORIGIN}/`);
+    expect(errorCallbackURL).toBe(`${PORTAL_ORIGIN}/auth`);
+  });
+});

--- a/apps/portal/src/app/lib/auth-callback.ts
+++ b/apps/portal/src/app/lib/auth-callback.ts
@@ -1,0 +1,49 @@
+export interface SignInCallbackUrls {
+  /** Where better-auth sends the user after a successful OAuth sign-in. */
+  callbackURL: string;
+  /** Where better-auth sends the user when the OAuth callback errors. */
+  errorCallbackURL: string;
+}
+
+/**
+ * Build the success + error callback URLs for a portal OAuth (Google/Microsoft)
+ * sign-in.
+ *
+ * Both URLs are absolute and rooted at the PORTAL origin. Passing an
+ * `errorCallbackURL` is essential: without it, better-auth falls back to a
+ * default error URL rooted at the API's baseURL (api.trycomp.ai) when the OAuth
+ * callback errors, which lands the user on the Swagger API docs page instead of
+ * the portal (see redirectOnError/parseState in better-auth and CS-760). This is
+ * most visible for brand-new Microsoft/Entra work accounts, whose ID token can
+ * miss claims and trip the error path. Sending the error path back to the
+ * portal's /auth page lets the user retry or fall back to the magic-link login.
+ */
+export function buildSignInCallbackUrls({
+  origin,
+  inviteCode,
+  searchParams,
+}: {
+  origin: string;
+  inviteCode?: string;
+  searchParams?: URLSearchParams;
+}): SignInCallbackUrls {
+  const isDeviceAuth = searchParams?.get('device_auth') === 'true';
+  const successPath = isDeviceAuth
+    ? '/auth/device-callback'
+    : inviteCode
+      ? `/invite/${inviteCode}`
+      : '/';
+
+  return {
+    callbackURL: withSearchParams(new URL(successPath, origin), searchParams).toString(),
+    // On error, return the user to the portal sign-in page (never the API).
+    errorCallbackURL: withSearchParams(new URL('/auth', origin), searchParams).toString(),
+  };
+}
+
+function withSearchParams(url: URL, searchParams?: URLSearchParams): URL {
+  searchParams?.forEach((value, key) => {
+    url.searchParams.append(key, value);
+  });
+  return url;
+}

--- a/apps/portal/vitest.config.ts
+++ b/apps/portal/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    exclude: ['node_modules', 'dist', '.next'],
+  },
+});


### PR DESCRIPTION
## Problem
When a new user completes Microsoft SSO during portal onboarding, they are redirected to the Swagger API docs page instead of the portal. This blocks new user signup flow.

## Root cause
The portal initiates Microsoft OAuth via `authClient.signIn.social({callbackURL})` without specifying an `errorCallbackURL`. On the server side, better-auth has no `onAPIError.errorURL` configured. When the OAuth callback encounters any error, better-auth's fallback redirect logic routes to the baseURL (api.trycomp.ai), which has a root redirect to /api/docs, landing the user on Swagger docs.

A June fix addressed one specific cause (email_not_found via upn fallback) but did not fix the error redirect target itself, leaving the issue live for any other callback error.

## Fix
Add `errorCallbackURL` to the portal's Microsoft SSO sign-in call, pointing to the portal origin. This ensures callback errors redirect back to the portal UI instead of the API docs page. No changes to auth logic, RBAC, or server config.

## Explicitly NOT touched
No modifications to better-auth server configuration or global error handling. Auth flow logic and RBAC remain unchanged.

## Verification
Added regression test asserting that portal sign-in specifies a portal-origin errorCallbackURL. Targeted unit tests pass locally ✅

Fixes CS-760

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirect OAuth callback errors back to the portal instead of `api.trycomp.ai` Swagger docs by passing an explicit `errorCallbackURL` for Microsoft (and Google) SSO. Fixes CS-760 and unblocks new user onboarding.

- **Bug Fixes**
  - Added `errorCallbackURL` to `authClient.signIn.social` and ensured success/error URLs are rooted at `portal.trycomp.ai`.
  - Preserves invite and device-auth search params in both success and error redirects.

- **Refactors**
  - Introduced `buildSignInCallbackUrls` used by Microsoft and Google buttons; added `vitest` tests covering invite/device-auth and error paths.

<sup>Written for commit 7920baec27f21571030553bc43b6b63cc779701a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

