### PR TITLE
fix(integrations): report code scanning off vs missing permission correctly

### DIFF
--- a/packages/integration-platform/src/manifests/github/checks/__tests__/code-scanning.test.ts
+++ b/packages/integration-platform/src/manifests/github/checks/__tests__/code-scanning.test.ts
@@ -3,16 +3,33 @@ import type { CheckContext } from '../../../../types';
 import type { GitHubRepo } from '../../types';
 import { codeScanningCheck } from '../code-scanning';
 
+// GitHub's real 403 bodies for the code-scanning API.
+const FEATURE_OFF_BODY =
+  '{"message":"Code Security must be enabled for this repository to use code scanning.","status":"403"}';
+const NOT_ACCESSIBLE_BODY = '{"message":"Resource not accessible by integration","status":"403"}';
+
+type SecurityStatus = 'enabled' | 'disabled';
+
 interface RepoConfig {
   private: boolean;
   /**
-   * `advanced_security.status`. `undefined` means GitHub omitted the
-   * `security_and_analysis` block entirely — which is what happens over an OAuth
-   * connection whose user lacks repo-admin visibility.
+   * `advanced_security.status` (the legacy field, still sent by GitHub Enterprise
+   * Server / older payloads). `undefined` means GitHub omitted the whole
+   * `security_and_analysis` block — what happens over a connection without
+   * repo-admin visibility.
    */
-  ghas?: 'enabled' | 'disabled';
-  /** Whether the code-scanning default-setup API 403s (permission/GHAS gate). */
-  defaultSetup403?: boolean;
+  ghas?: SecurityStatus;
+  /**
+   * `code_security.status` — GitHub's 2026 Code Security GA renamed the
+   * code-scanning entitlement to this. Newer payloads carry it instead of `ghas`.
+   */
+  codeSecurity?: SecurityStatus;
+  /** When set, the code-scanning default-setup API 403s with this body. */
+  defaultSetup403Body?: string;
+  /** default-setup returns `state: 'configured'` (code scanning is on). */
+  defaultSetupConfigured?: boolean;
+  /** Workflow files present in the repo tree: path → file content. */
+  workflowFiles?: Record<string, string>;
 }
 
 const makeRepo = (fullName: string, config: RepoConfig): GitHubRepo => {
@@ -26,15 +43,30 @@ const makeRepo = (fullName: string, config: RepoConfig): GitHubRepo => {
     default_branch: 'main',
     owner: { login: owner!, type: 'Organization' },
   };
-  if (config.ghas) {
-    repo.security_and_analysis = { advanced_security: { status: config.ghas } };
+  if (config.ghas || config.codeSecurity) {
+    repo.security_and_analysis = {
+      ...(config.codeSecurity ? { code_security: { status: config.codeSecurity } } : {}),
+      ...(config.ghas ? { advanced_security: { status: config.ghas } } : {}),
+    };
   }
   return repo;
 };
 
+// Mirrors how ctx.fetch surfaces an HTTP error: the response body is appended to
+// the message, so the check can read GitHub's own explanation from `String(error)`.
+const httpError = (status: number, body: string): Error =>
+  new Error(`HTTP ${status}: Forbidden - ${body}`);
+
+interface FailResult {
+  resourceId: string;
+  title: string;
+  description: string;
+  remediation?: string;
+}
+
 interface RunResult {
   passed: Array<{ resourceId: string; title: string }>;
-  failed: Array<{ resourceId: string; title: string }>;
+  failed: FailResult[];
 }
 
 async function runCheck(repos: Record<string, RepoConfig>): Promise<RunResult> {
@@ -50,11 +82,17 @@ async function runCheck(repos: Record<string, RepoConfig>): Promise<RunResult> {
     metadata: {},
     log: () => {},
     warn: () => {},
+    error: () => {},
     pass: (result) => {
       passed.push({ resourceId: result.resourceId ?? '', title: result.title });
     },
     fail: (result) => {
-      failed.push({ resourceId: result.resourceId ?? '', title: result.title });
+      failed.push({
+        resourceId: result.resourceId ?? '',
+        title: result.title,
+        description: result.description,
+        remediation: result.remediation,
+      });
     },
     fetch: (async <T>(path: string): Promise<T> => {
       // /repos/<owner>/<repo>
@@ -62,7 +100,7 @@ async function runCheck(repos: Record<string, RepoConfig>): Promise<RunResult> {
       if (repoMatch) {
         const fullName = repoMatch[1]!;
         const config = repos[fullName];
-        if (!config) throw new Error(`404 ${path}`);
+        if (!config) throw httpError(404, 'repo');
         return makeRepo(fullName, config) as unknown as T;
       }
 
@@ -70,17 +108,30 @@ async function runCheck(repos: Record<string, RepoConfig>): Promise<RunResult> {
       const setupMatch = path.match(/^\/repos\/([^/]+\/[^/]+)\/code-scanning\/default-setup$/);
       if (setupMatch) {
         const config = repos[setupMatch[1]!]!;
-        // GitHub 403s this endpoint for private repos when the token lacks the
-        // repo-admin visibility the code-scanning API requires (and, separately,
-        // when GHAS is off). Both surface identically to us.
-        if (config.defaultSetup403) throw new Error(`403 Forbidden: ${path}`);
+        if (config.defaultSetup403Body) throw httpError(403, config.defaultSetup403Body);
+        if (config.defaultSetupConfigured) {
+          return { state: 'configured', languages: ['javascript'] } as unknown as T;
+        }
         return { state: 'not-configured' } as unknown as T;
       }
 
-      // /repos/<owner>/<repo>/git/trees/<branch>?recursive=1 — no workflow files
-      // (default-setup repos carry no CodeQL .yml).
-      if (/^\/repos\/[^/]+\/[^/]+\/git\/trees\/.+/.test(path)) {
-        return { sha: 'x', url: '', truncated: false, tree: [] } as unknown as T;
+      // /repos/<owner>/<repo>/git/trees/<branch>?recursive=1
+      const treeMatch = path.match(/^\/repos\/([^/]+\/[^/]+)\/git\/trees\/.+/);
+      if (treeMatch) {
+        const config = repos[treeMatch[1]!]!;
+        const tree = Object.keys(config.workflowFiles ?? {}).map((p) => ({
+          path: p,
+          type: 'blob' as const,
+        }));
+        return { sha: 'x', url: '', truncated: false, tree } as unknown as T;
+      }
+
+      // /repos/<owner>/<repo>/contents/<path>
+      const contentsMatch = path.match(/^\/repos\/([^/]+\/[^/]+)\/contents\/(.+)$/);
+      if (contentsMatch) {
+        const content = repos[contentsMatch[1]!]?.workflowFiles?.[contentsMatch[2]!];
+        if (content == null) throw httpError(404, 'contents');
+        return { path: contentsMatch[2]!, encoding: 'utf-8', content } as unknown as T;
       }
 
       throw new Error(`Unexpected fetch: ${path}`);
@@ -98,38 +149,114 @@ async function runCheck(repos: Record<string, RepoConfig>): Promise<RunResult> {
 }
 
 describe('codeScanningCheck GHAS visibility (regression: CS-756)', () => {
-  it('does NOT report GHAS required when GHAS status is unknown (OAuth non-admin: 403 + private + no security_and_analysis block)', async () => {
-    // Saltbox repro: OAuth token without repo-admin visibility on a private repo
-    // that actually HAS GHAS + CodeQL default setup enabled. GitHub omits the
-    // `security_and_analysis` block AND 403s the code-scanning API. We cannot
-    // confirm GHAS is off, so we must not falsely claim it is.
+  it('does NOT report GHAS required when the feature is visible-but-unknown and the API 403s for permission (OAuth non-admin)', async () => {
+    // OAuth token without repo-admin visibility on a private repo that actually
+    // HAS code scanning enabled. GitHub omits the `security_and_analysis` block
+    // AND 403s the code-scanning API with a permission ("not accessible") body —
+    // NOT a "must be enabled" body. We cannot confirm the feature is off, so we
+    // must not falsely claim it is.
     const { passed, failed } = await runCheck({
-      'saltbox/s1-app-monitor': { private: true, defaultSetup403: true }, // ghas block omitted
+      'saltbox/s1-app-monitor': { private: true, defaultSetup403Body: NOT_ACCESSIBLE_BODY },
     });
 
     expect(passed).toHaveLength(0);
     expect(failed).toHaveLength(1);
-    // Before the fix this was:
-    //   "Code scanning requires GitHub Advanced Security for s1-app-monitor"
     expect(failed[0]!.title).toBe('Cannot access code scanning configuration for s1-app-monitor');
-    expect(failed[0]!.title).not.toContain('requires GitHub Advanced Security');
+    expect(failed[0]!.title).not.toContain('requires GitHub');
   });
 
-  it('still reports GHAS required when GHAS is positively disabled on a private repo', async () => {
+  it('still reports Code Security required when it is positively disabled on a private repo', async () => {
     const { failed } = await runCheck({
-      'acme/no-ghas': { private: true, ghas: 'disabled', defaultSetup403: true },
+      'acme/no-ghas': { private: true, ghas: 'disabled', defaultSetup403Body: NOT_ACCESSIBLE_BODY },
     });
 
     expect(failed).toHaveLength(1);
-    expect(failed[0]!.title).toBe('Code scanning requires GitHub Advanced Security for no-ghas');
+    expect(failed[0]!.title).toBe('Code scanning requires GitHub Code Security for no-ghas');
   });
 
-  it('reports permission-denied (not GHAS required) when GHAS is enabled but the API still 403s', async () => {
+  it('reports permission-denied (not Code Security required) when GHAS is enabled but the API still 403s for permission', async () => {
     const { failed } = await runCheck({
-      'acme/ghas-on': { private: true, ghas: 'enabled', defaultSetup403: true },
+      'acme/ghas-on': { private: true, ghas: 'enabled', defaultSetup403Body: NOT_ACCESSIBLE_BODY },
     });
 
     expect(failed).toHaveLength(1);
     expect(failed[0]!.title).toBe('Cannot access code scanning configuration for ghas-on');
+  });
+});
+
+describe('codeScanningCheck feature-off vs permission (regression: CS-762)', () => {
+  it('private repo with Code Security disabled (new code_security field) → "requires Code Security", NOT a permission error', async () => {
+    // The exact CS-762 case: GitHub's 2026 payload carries `code_security`
+    // (not `advanced_security`) and the 403 body says the feature must be enabled.
+    const { passed, failed } = await runCheck({
+      'acme/webapp': {
+        private: true,
+        codeSecurity: 'disabled',
+        defaultSetup403Body: FEATURE_OFF_BODY,
+      },
+    });
+
+    expect(passed).toEqual([]);
+    expect(failed).toHaveLength(1);
+    const finding = failed[0]!;
+    expect(finding.title).toBe('Code scanning requires GitHub Code Security for webapp');
+    // Must NOT surface the misleading permission message or the wrong remediation.
+    expect(finding.description).not.toContain('does not have permission');
+    expect(finding.remediation).not.toContain('Code scanning alerts: Read');
+  });
+
+  it('403 "must be enabled" body wins even when security_and_analysis is omitted (unknown)', async () => {
+    const { failed } = await runCheck({
+      'acme/api': { private: true, defaultSetup403Body: FEATURE_OFF_BODY },
+    });
+
+    expect(failed.map((f) => f.title)).toEqual([
+      'Code scanning requires GitHub Code Security for api',
+    ]);
+  });
+
+  it('public repo with a "must be enabled" 403 → not-configured (never a permission error)', async () => {
+    const { failed } = await runCheck({
+      'acme/public': { private: false, defaultSetup403Body: FEATURE_OFF_BODY },
+    });
+
+    expect(failed.map((f) => f.title)).toEqual(['Code scanning not enabled for public']);
+  });
+
+  it('genuine "Resource not accessible" 403 → permission-denied with an accurate remediation', async () => {
+    const { failed } = await runCheck({
+      'acme/secret': { private: true, defaultSetup403Body: NOT_ACCESSIBLE_BODY },
+    });
+
+    expect(failed).toHaveLength(1);
+    const finding = failed[0]!;
+    expect(finding.title).toBe('Cannot access code scanning configuration for secret');
+    expect(finding.description).toContain('Administration: read');
+    expect(finding.remediation).not.toContain('Code scanning alerts: Read');
+  });
+
+  it('default setup configured → pass', async () => {
+    const { passed, failed } = await runCheck({
+      'acme/scanned': { private: true, codeSecurity: 'enabled', defaultSetupConfigured: true },
+    });
+
+    expect(failed).toEqual([]);
+    expect(passed.map((p) => p.title)).toEqual(['CodeQL scanning configured for scanned']);
+  });
+
+  it('third-party SAST workflow satisfies the check even when the API 403s', async () => {
+    const { passed, failed } = await runCheck({
+      'acme/sast': {
+        private: true,
+        defaultSetup403Body: FEATURE_OFF_BODY,
+        workflowFiles: {
+          '.github/workflows/security.yml':
+            'jobs:\n  scan:\n    steps:\n      - uses: github/codeql-action/upload-sarif@v3',
+        },
+      },
+    });
+
+    expect(failed).toEqual([]);
+    expect(passed.map((p) => p.title)).toEqual(['CodeQL scanning configured for sast']);
   });
 });

--- a/packages/integration-platform/src/manifests/github/checks/code-scanning.ts
+++ b/packages/integration-platform/src/manifests/github/checks/code-scanning.ts
@@ -47,10 +47,11 @@ type CodeScanningStatus =
   | { status: 'ghas-required' };
 
 /**
- * Whether GitHub Advanced Security is enabled for a repo. `unknown` covers the
- * case where GitHub omits the repo's `security_and_analysis` block because the
- * token lacks repo-admin visibility (common over OAuth connections) — we must
- * NOT treat that as `disabled`.
+ * Whether the repo's code-scanning entitlement (GitHub Code Security, formerly
+ * Advanced Security) is enabled. `unknown` covers the case where GitHub omits the
+ * repo's `security_and_analysis` block because the token lacks repo-admin
+ * visibility (common over OAuth connections) — we must NOT treat that as
+ * `disabled`.
  */
 type GhasStatus = 'enabled' | 'disabled' | 'unknown';
 
@@ -165,6 +166,13 @@ export const codeScanningCheck: IntegrationCheck = {
       ghasStatus: GhasStatus;
     }): Promise<CodeScanningStatus> => {
       let apiGot403 = false;
+      // GitHub returns 403 for two very different reasons, and only one is our
+      // fault. When the code-scanning feature is simply not turned on for the
+      // repo, the 403 body says "…must be enabled…" (Code Security / Advanced
+      // Security). When our token genuinely lacks access it says "Resource not
+      // accessible by integration". This flag records the former so we don't
+      // report a repo-configuration gap as a missing integration permission.
+      let featureDisabled = false;
 
       // First, try the default setup API
       try {
@@ -182,11 +190,18 @@ export const codeScanningCheck: IntegrationCheck = {
         const errorStr = String(error);
 
         if (errorStr.includes('403') || errorStr.includes('Forbidden')) {
-          // The code-scanning API requires GHAS for private repos, but reading
-          // workflow file contents only requires contents:read. A 403 here does
-          // not mean we can't check for code scanning workflows.
+          // The code-scanning API requires Code Security for private repos, but
+          // reading workflow file contents only requires contents:read. A 403
+          // here does not mean we can't check for code scanning workflows.
+          //
+          // `ctx.fetch` puts GitHub's response body in the error message, so we
+          // can read GitHub's own explanation. "…must be enabled…" means the
+          // feature is off on the repo, not that we lack permission.
+          if (/must be enabled|advanced security|code security/i.test(errorStr)) {
+            featureDisabled = true;
+          }
           ctx.log(
-            `Code scanning API returned 403 for ${repoName} (private: ${isPrivate}, ghas: ${ghasStatus}). Falling back to workflow file scanning.`,
+            `Code scanning API returned 403 for ${repoName} (private: ${isPrivate}, ghas: ${ghasStatus}, featureDisabled: ${featureDisabled}). Falling back to workflow file scanning.`,
           );
           apiGot403 = true;
         } else {
@@ -208,13 +223,19 @@ export const codeScanningCheck: IntegrationCheck = {
       }
 
       if (apiGot403) {
-        // A 403 from the code-scanning API on a private repo can mean either GHAS
-        // is off (CodeQL genuinely can't be configured) OR the token lacks the
-        // repo-admin visibility the API requires. Only claim "GHAS required" when
-        // we can positively confirm GHAS is disabled. Over an OAuth connection
-        // without repo admin, GitHub omits the repo's `security_and_analysis`
-        // block, so ghasStatus is 'unknown' — treat that (and 'enabled') as
-        // permission-denied rather than falsely reporting GHAS is not enabled.
+        // Prefer GitHub's own explanation. If it told us the feature must be
+        // enabled, this is a repo-configuration gap, not a permission problem:
+        // a private repo needs GitHub Code Security (paid), while a public repo
+        // just has not set code scanning up.
+        if (featureDisabled) {
+          return isPrivate ? { status: 'ghas-required' } : { status: 'not-configured' };
+        }
+        // No feature-off signal in the body. Fall back to the repo's
+        // `security_and_analysis` block: only claim "Code Security required" when
+        // we can positively confirm it is disabled. Over a connection without
+        // repo-admin visibility GitHub omits that block, so ghasStatus is
+        // 'unknown' — treat that (and 'enabled') as permission-denied rather than
+        // falsely reporting the feature is off.
         if (isPrivate && ghasStatus === 'disabled') {
           return { status: 'ghas-required' };
         }
@@ -229,11 +250,17 @@ export const codeScanningCheck: IntegrationCheck = {
       if (!repo) continue;
 
       const tree = await fetchRepoTree(repo.full_name, repo.default_branch);
-      // `security_and_analysis` is only returned to repo admins, so over an OAuth
-      // connection without admin visibility this is undefined — 'unknown', NOT
-      // 'disabled'. Conflating the two is what made us falsely report GHAS off.
+      // Read the code-scanning entitlement. GitHub's 2026 Code Security GA renamed
+      // this from `advanced_security` to `code_security`; check the new key first
+      // and fall back to the old one for GitHub Enterprise Server / older payloads.
+      // `security_and_analysis` is only returned to repo admins, so over a
+      // connection without admin visibility the whole block is undefined —
+      // 'unknown', NOT 'disabled'. Conflating the two is what made us falsely
+      // report the feature off (or, after the OAuth fix, falsely report a
+      // permission problem).
+      const sa = repo.security_and_analysis;
       const ghasStatus: GhasStatus =
-        repo.security_and_analysis?.advanced_security?.status ?? 'unknown';
+        sa?.code_security?.status ?? sa?.advanced_security?.status ?? 'unknown';
 
       const codeScanningStatus = await getCodeScanningStatus({
         repoName: repo.full_name,
@@ -271,14 +298,14 @@ export const codeScanningCheck: IntegrationCheck = {
 
         case 'ghas-required':
           ctx.fail({
-            title: `Code scanning requires GitHub Advanced Security for ${repo.name}`,
+            title: `Code scanning requires GitHub Code Security for ${repo.name}`,
             description:
-              'This is a private repository. GitHub Advanced Security (GHAS) must be enabled before CodeQL can be configured. GHAS is a paid feature for private repositories.',
+              'This private repository has no code scanning configured. GitHub CodeQL requires GitHub Code Security (formerly GitHub Advanced Security), a paid feature for private repositories. A third-party SAST tool (Semgrep, Snyk, Trivy, etc.) that uploads SARIF results also satisfies this check.',
             resourceType: 'repository',
             resourceId: repo.full_name,
             severity: 'medium',
             remediation:
-              'Enable GitHub Advanced Security in the repository settings (Settings → Code security and analysis → GitHub Advanced Security), then enable CodeQL.',
+              'Enable GitHub Code Security for this repository (Settings → Code security → GitHub Advanced Security / Code Security) and turn on CodeQL default setup, or add a workflow under .github/workflows that runs a SAST tool and uploads SARIF (github/codeql-action/upload-sarif).',
             evidence: {
               [repo.full_name]: {
                 code_scanning: {
@@ -294,12 +321,12 @@ export const codeScanningCheck: IntegrationCheck = {
           ctx.fail({
             title: `Cannot access code scanning configuration for ${repo.name}`,
             description:
-              'The GitHub integration does not have permission to read code scanning configuration. This may be due to missing permissions or organization policies.',
+              "GitHub returned 403 when reading this repository's code scanning configuration. GitHub requires admin (Administration: read) access to the repository to read this setting, and the connected account or GitHub App installation does not currently have it for this repo.",
             resourceType: 'repository',
             resourceId: repo.full_name,
             severity: 'medium',
             remediation:
-              'Ensure the GitHub App has "Code scanning alerts: Read" permission. If this is an organization repository, check that organization policies allow access.',
+              'Reconnect with an account that has admin access to this repository, or grant the GitHub App installation admin (Administration: read) access to it. If this is an organization repository, also confirm organization policies allow the app to access it.',
             evidence: {
               [repo.full_name]: {
                 code_scanning: {

--- a/packages/integration-platform/src/manifests/github/types.ts
+++ b/packages/integration-platform/src/manifests/github/types.ts
@@ -17,6 +17,11 @@ export interface GitHubRepo {
   default_branch: string;
   owner: { login: string; type?: 'User' | 'Organization' };
   security_and_analysis?: {
+    // GitHub's 2026 "Code Security" GA renamed the code-scanning entitlement from
+    // `advanced_security` to `code_security`. Newer API responses only carry
+    // `code_security`; `advanced_security` is kept for GitHub Enterprise Server
+    // and older responses.
+    code_security?: { status: 'enabled' | 'disabled' };
     advanced_security?: { status: 'enabled' | 'disabled' };
     dependabot_security_updates?: { status: 'enabled' | 'disabled' };
     secret_scanning?: { status: 'enabled' | 'disabled' };


### PR DESCRIPTION
## Problem

A customer's GitHub App code scanning check fails with **"The GitHub integration does not have permission to read code scanning configuration"** and recommends adding **"Code scanning alerts: Read"**. That suggested fix is **wrong** — verified live against the affected connection.

## What's actually happening

- The affected repo is **private** with GitHub **Code Security disabled**.
- All code-scanning endpoints return `403 "Code Security must be enabled for this repository to use code scanning."` — a **feature-not-enabled** error, not a permission error.
- The App **already has** every permission it needs (`administration=read`, confirmed via `/user/installations`). The check calls `/code-scanning/default-setup` (needs **Administration: read**), *not* the alerts endpoint — so `security_events` / "Code scanning alerts" would do nothing; that endpoint 403s with the same "must be enabled" body.

## Root cause

GitHub's 2026 **Code Security GA renamed `security_and_analysis.advanced_security` → `code_security`**. The check still read `advanced_security`, so its GHAS-status was **always `unknown`**. Combined with the earlier OAuth visibility fix, every private repo whose code-scanning API 403'd was misclassified as **`permission-denied`**, surfacing the misleading message + wrong remediation.

## Fix

- **Use GitHub's 403 body as the authoritative signal.** `"…must be enabled…"` → feature off (private → *needs Code Security*; public → *not configured*); `"Resource not accessible by integration"` → genuine permission gap. Robust to further field renames and cleanly separates the two 403 causes.
- **Read the new `code_security` field** (with `advanced_security` fallback for GitHub Enterprise Server).
- **Correct the `permission-denied` remediation** — the real requirement for `default-setup` is Administration/repo-admin access, not "Code scanning alerts: Read".
- Refresh `ghas-required` wording to current "GitHub Code Security" branding and mention the third-party SAST alternative.

Shared by the `github` and `github-app` integrations — both benefit.

## Verification

- Verified live against the affected connection (read-only, nothing persisted): the new logic returns `ghas-required` → *"Code scanning requires GitHub Code Security for …"*.
- Unit tests: 9 cases covering the feature-off vs permission split; the earlier visible-but-unknown → permission regression still holds. `bun test` (28 github checks) + `tsc --noEmit` green.

## No GitHub App change needed

The App's permissions are already correct. This is purely a check-classification bug. Note: for a private repo with Code Security genuinely disabled, the check still (correctly) **fails** with an accurate message — enable Code Security or add a SAST workflow — it does not auto-pass.

## Note

`code-scanning.ts` was already over the 300-line guideline (338 → 365). Left the structure intact to keep this a focused bugfix; splitting the check into modules is a reasonable follow-up.
