### PR TITLE
fix(deps): bump adm-zip to 0.6.0 (Dependabot #88/#89)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -89,7 +89,7 @@
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.34.2",
         "@upstash/vector": "^1.2.2",
-        "adm-zip": "^0.5.16",
+        "adm-zip": "^0.6.0",
         "ai": "^6.0.175",
         "archiver": "^7.0.1",
         "axios": "^1.16.0",

--- a/bun.lock
+++ b/bun.lock
@@ -153,7 +153,7 @@
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.34.2",
         "@upstash/vector": "^1.2.2",
-        "adm-zip": "^0.5.16",
+        "adm-zip": "^0.6.0",
         "ai": "^6.0.175",
         "archiver": "^7.0.1",
         "axios": "^1.16.0",
@@ -3170,7 +3170,7 @@
 
     "acorn-walk": ["acorn-walk@8.3.5", "", { "dependencies": { "acorn": "^8.11.0" } }, "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw=="],
 
-    "adm-zip": ["adm-zip@0.5.18", "", {}, "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng=="],
+    "adm-zip": ["adm-zip@0.6.0", "", {}, "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg=="],
 
     "agent-base": ["agent-base@9.0.0", "", {}, "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA=="],
 


### PR DESCRIPTION
## What & why

Fixes Dependabot alerts **#88** and **#89** — `adm-zip < 0.6.0` allows a crafted ZIP to trigger a ~4 GB memory allocation (DoS, High).

**This is genuinely reachable** (not a false positive): `apps/api/src/questionnaire/utils/content-extractor.ts` runs `new AdmZip(fileBuffer)` directly on **user-uploaded questionnaire files** (xlsx/docx are ZIP containers). So a crafted upload could OOM the API.

## Change

- `apps/api/package.json`: `adm-zip ^0.5.16 → ^0.6.0`
- `bun.lock`: updated → resolves **adm-zip@0.6.0** (patched)

Our usage (`new AdmZip`, `getEntry`, `getData`, `addFile`, `toBuffer`) is unchanged in 0.6.0 (engines: node >=14). API typecheck is clean for the adm-zip consumers (`content-extractor.ts`, `questionnaire.service.ts`).

## Supersedes Dependabot PR #3451

#3451 bumped `apps/api/package.json` but **left `bun.lock` out of sync**, which would break `bun install --frozen-lockfile` in CI. This PR updates both. #3451 can be closed.

## Related (not in this PR)

The other 4 Dependabot alerts (brace-expansion #90/#91, tmp #58/#59) were **dev-only transitive deps** of the Speakeasy-generated `@trycompai/mcp-server` (`dev=true` in its lockfile, not shipped to consumers, not in the runtime server). Dismissed as "not used in path" with documented rationale.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `adm-zip` to 0.6.0 to patch a DoS that can allocate ~4 GB from crafted ZIPs, reachable via user-uploaded xlsx/docx questionnaire files. Updates `apps/api/package.json` and `bun.lock`; usage is unchanged; resolves Dependabot #88/#89 and supersedes #3451.

<sup>Written for commit 927b2e8b5dccbb4d4d5f6f68c71fcc93fc5074ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

