### PR TITLE
fix(eset): update setup instructions to reflect current console ui path

### DIFF
--- a/integrations-catalog/__tests__/eset-protect-setup-instructions.test.ts
+++ b/integrations-catalog/__tests__/eset-protect-setup-instructions.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Regression test for CS-764.
+ *
+ * The published ESET Protect setup instructions referenced "More > Users > API
+ * Users", a path that no longer exists in the ESET PROTECT console. More
+ * importantly, the only option that path now exposes ("New Mapped Account")
+ * creates a console login with NO API ("Integrations") access, so every check
+ * was denied. API access has to be granted to a user in ESET PROTECT Hub (or
+ * ESET Business Account) by enabling the "Integrations" toggle. These
+ * assertions pin the customer-facing instructions to that current flow.
+ */
+describe('ESET Protect catalog setup instructions (CS-764)', () => {
+  const catalog = JSON.parse(
+    readFileSync(join(import.meta.dir, '..', 'integrations', 'eset-protect.json'), 'utf8'),
+  ) as { authConfig: { config: { setupInstructions: string } } };
+  const setupInstructions = catalog.authConfig.config.setupInstructions;
+
+  it('does not reference the outdated "More > Users" console path', () => {
+    expect(setupInstructions).not.toContain('More > Users');
+  });
+
+  it('directs users to ESET PROTECT Hub / ESET Business Account for the API user', () => {
+    expect(setupInstructions).toContain('ESET PROTECT Hub');
+    expect(setupInstructions).toContain('ESET Business Account');
+  });
+
+  it('tells users to enable the "Integrations" API-access toggle', () => {
+    expect(setupInstructions).toContain('Integrations');
+  });
+
+  it('warns that the "New Mapped Account" console option does not grant API access', () => {
+    expect(setupInstructions).toContain('New Mapped Account');
+  });
+});

--- a/integrations-catalog/integrations/eset-protect.json
+++ b/integrations-catalog/integrations/eset-protect.json
@@ -8,7 +8,7 @@
   "authConfig": {
     "type": "custom",
     "config": {
-      "setupInstructions": "1. Log in to ESET Protect Cloud console\n2. Go to More > Users > API Users\n3. Create a new API user with Device Management read permissions\n4. Note your region from the console URL (eu, de, us, jpn, or ca)\n5. Enter the API username, password, and region prefix",
+      "setupInstructions": "1. Create the API user in ESET PROTECT Hub (or ESET Business Account if your company has not migrated to Hub). Do NOT use the \"New Mapped Account\" option in the ESET PROTECT web console — that only creates a console login and does not grant API access.\n2. In Hub/EBA, open Users, edit that user, and enable the \"Integrations\" toggle under Permissions / Access Rights. A Superuser must do this, and it cannot be enabled on their own account.\n3. Have that user sign in once so API access is activated.\n4. Note your region from the console URL (eu, de, us, jpn, or ca).\n5. Enter the API username, password, and region prefix below, then reconnect.",
       "credentialFields": [
         {
           "label": "API Username",


### PR DESCRIPTION
## Problem

A customer reported being unable to complete ESET Protect Cloud integration setup. Our documentation pointed them to More > Users > API Users to create an API user, but that path no longer exists in the current ESET console.

## Root cause

ESET Protect Cloud UI has changed. The documented path More > Users no longer contains API user creation. The current console shows More > Access Rights > Users instead, and the only account creation option available there is "New Mapped Account", which grants console login only and does not provide the API/Integrations access required for our integration.

API users must now be created in ESET PROTECT Hub or ESET Business Account (for unmigrated orgs), not in the us02.protect.eset.com console. The Integrations permission toggle must be explicitly enabled by a superuser on the created account.

## Fix

Updated the in-app ESET setup guide to direct users to create API users in ESET PROTECT Hub/Business Account instead of the console, and clarified that the Integrations permission must be enabled by a superuser before connecting.

## Explicitly NOT touched

No changes to API client code, connector logic, or permission validation. This is a documentation-only fix.

## Verification

Updated setup guide text matches current ESET Protect Cloud UI and aligns with ESET's support guidance. Unit tests for setup flow validation pass locally ✅.

Fixes CS-764

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes outdated ESET Protect setup instructions so users create an API user in ESET PROTECT Hub/EBA with “Integrations” enabled, not via the console’s “New Mapped Account” (addresses CS-764). This unblocks customers from completing the integration.

- **Bug Fixes**
  - Updated `integrations-catalog/integrations/eset-protect.json` to direct users to ESET PROTECT Hub/EBA, require the “Integrations” toggle, include a one-time sign-in step, and remove the “More > Users” path.
  - Added `integrations-catalog/__tests__/eset-protect-setup-instructions.test.ts` to assert the new guidance (mentions Hub/EBA, “Integrations” toggle, warns against “New Mapped Account”) and prevent regressions.

<sup>Written for commit 27c84ea8876939749a37f206ce8d9a60fb5ba958. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

