### PR TITLE
feat(offboarding): mark checklist steps as exceptions with a reason

### DIFF
--- a/apps/api/src/offboarding-checklist/dto/mark-checklist-exception.dto.spec.ts
+++ b/apps/api/src/offboarding-checklist/dto/mark-checklist-exception.dto.spec.ts
@@ -1,0 +1,22 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { MarkChecklistExceptionDto } from './mark-checklist-exception.dto';
+
+describe('MarkChecklistExceptionDto', () => {
+  it('accepts a non-empty reason', async () => {
+    const dto = plainToInstance(MarkChecklistExceptionDto, {
+      reason: 'No company device was ever issued',
+    });
+    expect(await validate(dto)).toHaveLength(0);
+  });
+
+  it('rejects a missing reason', async () => {
+    const dto = plainToInstance(MarkChecklistExceptionDto, {});
+    expect((await validate(dto)).length).toBeGreaterThan(0);
+  });
+
+  it('rejects a whitespace-only reason', async () => {
+    const dto = plainToInstance(MarkChecklistExceptionDto, { reason: '   ' });
+    expect((await validate(dto)).length).toBeGreaterThan(0);
+  });
+});

--- a/apps/api/src/offboarding-checklist/dto/mark-checklist-exception.dto.ts
+++ b/apps/api/src/offboarding-checklist/dto/mark-checklist-exception.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, Matches } from 'class-validator';
+
+export class MarkChecklistExceptionDto {
+  @ApiProperty({
+    description:
+      'Why this offboarding step is being marked as an exception (could not or need not be done). Required and non-empty.',
+    example: 'This person was never issued a company device.',
+  })
+  @IsString()
+  @IsNotEmpty()
+  // Reject whitespace-only reasons — an exception must be justified.
+  @Matches(/\S/, { message: 'reason must not be empty' })
+  reason!: string;
+}

--- a/apps/api/src/offboarding-checklist/offboarding-checklist.controller.spec.ts
+++ b/apps/api/src/offboarding-checklist/offboarding-checklist.controller.spec.ts
@@ -1,0 +1,79 @@
+import { BadRequestException } from '@nestjs/common';
+
+// The controller imports `db` from `@db` at module load; stub it so the test
+// doesn't spin up a real Prisma client (markException delegates to the service).
+jest.mock('@db', () => ({ db: {} }));
+
+// The guard imports pull in @trycompai/auth → better-auth (ESM), which jest
+// can't transform. We call controller methods directly (guards never run), so
+// stub the guard modules to cut that import chain.
+jest.mock('../auth/hybrid-auth.guard', () => ({ HybridAuthGuard: class {} }));
+jest.mock('../auth/permission.guard', () => ({ PermissionGuard: class {} }));
+
+import { OffboardingChecklistController } from './offboarding-checklist.controller';
+import type { AuthContext as AuthContextType } from '../auth/types';
+
+describe('OffboardingChecklistController', () => {
+  const service = { markException: jest.fn() };
+  const exportService = {};
+  let controller: OffboardingChecklistController;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    controller = new OffboardingChecklistController(
+      service as never,
+      exportService as never,
+    );
+  });
+
+  const sessionContext: AuthContextType = {
+    authType: 'session',
+    userId: 'usr_1',
+    userEmail: 'user@example.com',
+    organizationId: 'org_1',
+    memberId: 'mem_1',
+    isApiKey: false,
+    isPlatformAdmin: false,
+    userRoles: null,
+  };
+
+  describe('markException', () => {
+    it('delegates to the service with the acting user and reason', async () => {
+      service.markException.mockResolvedValue({ id: 'occ_1' });
+
+      const result = await controller.markException(
+        'org_1',
+        sessionContext,
+        'mem_1',
+        'oct_1',
+        { reason: 'No company device was ever issued' },
+      );
+
+      expect(service.markException).toHaveBeenCalledWith({
+        organizationId: 'org_1',
+        memberId: 'mem_1',
+        templateItemId: 'oct_1',
+        completedById: 'usr_1',
+        reason: 'No company device was ever issued',
+      });
+      expect(result).toEqual({ id: 'occ_1' });
+    });
+
+    it('rejects when there is no user context', async () => {
+      const apiKeyContext: AuthContextType = {
+        authType: 'api-key',
+        organizationId: 'org_1',
+        isApiKey: true,
+        isPlatformAdmin: false,
+        userRoles: null,
+      };
+
+      await expect(
+        controller.markException('org_1', apiKeyContext, 'mem_1', 'oct_1', {
+          reason: 'No device',
+        }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(service.markException).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/offboarding-checklist/offboarding-checklist.controller.ts
+++ b/apps/api/src/offboarding-checklist/offboarding-checklist.controller.ts
@@ -24,6 +24,7 @@ import { OffboardingExportService } from './offboarding-export.service';
 import { CreateTemplateItemDto } from './dto/create-template-item.dto';
 import { UpdateTemplateItemDto } from './dto/update-template-item.dto';
 import { CompleteChecklistItemDto } from './dto/complete-checklist-item.dto';
+import { MarkChecklistExceptionDto } from './dto/mark-checklist-exception.dto';
 
 @ApiTags('Offboarding Checklist')
 @Controller({ path: 'offboarding-checklist', version: '1' })
@@ -240,6 +241,29 @@ export class OffboardingChecklistController {
       organizationId,
       memberId,
       templateItemId,
+    });
+  }
+
+  @Post('member/:memberId/item/:templateItemId/exception')
+  @RequirePermission('member', 'update')
+  @ApiOperation({
+    summary: 'Mark an offboarding checklist item as an exception',
+    description:
+      "Resolves an offboarding checklist item as an exception — the step could not or need not be done for this member — with a required reason, instead of completing it with evidence. The reason is recorded in the audit log and the offboarding evidence export.",
+  })
+  async markException(
+    @OrganizationId() organizationId: string,
+    @AuthContext() authContext: AuthContextType,
+    @Param('memberId') memberId: string,
+    @Param('templateItemId') templateItemId: string,
+    @Body() dto: MarkChecklistExceptionDto,
+  ) {
+    return this.offboardingChecklistService.markException({
+      organizationId,
+      memberId,
+      templateItemId,
+      completedById: this.requireUserId(authContext),
+      reason: dto.reason,
     });
   }
 

--- a/apps/api/src/offboarding-checklist/offboarding-checklist.service.spec.ts
+++ b/apps/api/src/offboarding-checklist/offboarding-checklist.service.spec.ts
@@ -167,9 +167,45 @@ describe('OffboardingChecklistService', () => {
       expect(result.totalItems).toBe(2);
       expect(result.completedItems).toBe(1);
       expect(result.items[0].completed).toBe(true);
+      expect(result.items[0].isException).toBe(false);
       expect(result.items[0].evidence).toHaveLength(1);
       expect(result.items[1].completed).toBe(false);
       expect(result.items[1].evidence).toHaveLength(0);
+    });
+
+    it('surfaces exception state and reason on the item', async () => {
+      mockDb.offboardingChecklistTemplate.count.mockResolvedValue(1);
+      mockDb.offboardingChecklistTemplate.findMany.mockResolvedValue([
+        {
+          id: 'oct_1',
+          organizationId: 'org_1',
+          title: 'Retrieve company devices',
+          isEnabled: true,
+          sortOrder: 1,
+        },
+      ]);
+      mockDb.offboardingChecklistCompletion.findMany.mockResolvedValue([
+        {
+          id: 'occ_1',
+          templateItemId: 'oct_1',
+          memberId: 'mem_1',
+          completedById: 'usr_1',
+          completedBy: { id: 'usr_1', name: 'Test User' },
+          isException: true,
+          exceptionReason: 'No company device was ever issued',
+        },
+      ]);
+      mockDb.attachment.findMany.mockResolvedValue([]);
+
+      const result = await service.getMemberChecklist('org_1', 'mem_1');
+
+      // An exception counts as resolved (completed) but is flagged distinctly.
+      expect(result.items[0].completed).toBe(true);
+      expect(result.completedItems).toBe(1);
+      expect(result.items[0].isException).toBe(true);
+      expect(result.items[0].exceptionReason).toBe(
+        'No company device was ever issued',
+      );
     });
   });
 
@@ -284,6 +320,126 @@ describe('OffboardingChecklistService', () => {
         },
         'usr_1',
       );
+    });
+  });
+
+  describe('markException', () => {
+    it('creates an exception completion with the reason and no evidence', async () => {
+      mockDb.offboardingChecklistCompletion.findFirst.mockResolvedValue(null);
+      // evidenceRequired is true to prove the exception path bypasses it.
+      mockDb.offboardingChecklistTemplate.findFirst.mockResolvedValue({
+        id: 'oct_1',
+        organizationId: 'org_1',
+        isEnabled: true,
+        isAccessRevocation: false,
+        evidenceRequired: true,
+      });
+      mockDb.offboardingChecklistCompletion.create.mockResolvedValue({
+        id: 'occ_1',
+        isException: true,
+        exceptionReason: 'No company device was ever issued',
+      });
+
+      const result = await service.markException({
+        organizationId: 'org_1',
+        memberId: 'mem_1',
+        templateItemId: 'oct_1',
+        completedById: 'usr_1',
+        reason: 'No company device was ever issued',
+      });
+
+      expect(result.id).toBe('occ_1');
+      expect(
+        mockDb.offboardingChecklistCompletion.create,
+      ).toHaveBeenCalledWith({
+        data: {
+          organizationId: 'org_1',
+          memberId: 'mem_1',
+          templateItemId: 'oct_1',
+          completedById: 'usr_1',
+          isException: true,
+          exceptionReason: 'No company device was ever issued',
+        },
+      });
+      expect(mockAttachmentsService.uploadAttachment).not.toHaveBeenCalled();
+    });
+
+    it('trims the reason before saving', async () => {
+      mockDb.offboardingChecklistCompletion.findFirst.mockResolvedValue(null);
+      mockDb.offboardingChecklistTemplate.findFirst.mockResolvedValue({
+        id: 'oct_1',
+        organizationId: 'org_1',
+        isEnabled: true,
+        isAccessRevocation: false,
+      });
+      mockDb.offboardingChecklistCompletion.create.mockResolvedValue({ id: 'occ_1' });
+
+      await service.markException({
+        organizationId: 'org_1',
+        memberId: 'mem_1',
+        templateItemId: 'oct_1',
+        completedById: 'usr_1',
+        reason: '  No device issued  ',
+      });
+
+      expect(
+        mockDb.offboardingChecklistCompletion.create,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ exceptionReason: 'No device issued' }),
+        }),
+      );
+    });
+
+    it('throws if the step is already resolved', async () => {
+      mockDb.offboardingChecklistCompletion.findFirst.mockResolvedValue({
+        id: 'occ_1',
+      });
+
+      await expect(
+        service.markException({
+          organizationId: 'org_1',
+          memberId: 'mem_1',
+          templateItemId: 'oct_1',
+          completedById: 'usr_1',
+          reason: 'No device issued',
+        }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('throws if the template item is not found', async () => {
+      mockDb.offboardingChecklistCompletion.findFirst.mockResolvedValue(null);
+      mockDb.offboardingChecklistTemplate.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.markException({
+          organizationId: 'org_1',
+          memberId: 'mem_1',
+          templateItemId: 'oct_invalid',
+          completedById: 'usr_1',
+          reason: 'No device issued',
+        }),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('throws when the step is the access-revocation step', async () => {
+      mockDb.offboardingChecklistCompletion.findFirst.mockResolvedValue(null);
+      mockDb.offboardingChecklistTemplate.findFirst.mockResolvedValue({
+        id: 'oct_ar',
+        organizationId: 'org_1',
+        isEnabled: true,
+        isAccessRevocation: true,
+      });
+
+      await expect(
+        service.markException({
+          organizationId: 'org_1',
+          memberId: 'mem_1',
+          templateItemId: 'oct_ar',
+          completedById: 'usr_1',
+          reason: 'Handled elsewhere',
+        }),
+      ).rejects.toBeInstanceOf(BadRequestException);
     });
   });
 

--- a/apps/api/src/offboarding-checklist/offboarding-checklist.service.ts
+++ b/apps/api/src/offboarding-checklist/offboarding-checklist.service.ts
@@ -172,6 +172,8 @@ export class OffboardingChecklistService {
           ...template,
           templateItemId: template.id,
           completed: !!completion,
+          isException: completion?.isException ?? false,
+          exceptionReason: completion?.exceptionReason ?? null,
           completion: completion ?? null,
           evidence,
         };
@@ -260,6 +262,58 @@ export class OffboardingChecklistService {
     }
 
     return completion;
+  }
+
+  async markException({
+    organizationId,
+    memberId,
+    templateItemId,
+    completedById,
+    reason,
+  }: {
+    organizationId: string;
+    memberId: string;
+    templateItemId: string;
+    completedById: string;
+    reason: string;
+  }) {
+    const existing = await db.offboardingChecklistCompletion.findFirst({
+      where: { organizationId, memberId, templateItemId },
+    });
+
+    if (existing) {
+      throw new BadRequestException('Item is already resolved');
+    }
+
+    const template = await db.offboardingChecklistTemplate.findFirst({
+      where: { id: templateItemId, organizationId, isEnabled: true },
+    });
+
+    if (!template) {
+      throw new NotFoundException('Template item not found');
+    }
+
+    // The access-revocation step is driven by the per-vendor revocation flow,
+    // so it can't be blanket-excepted here.
+    if (template.isAccessRevocation) {
+      throw new BadRequestException(
+        'The access revocation step cannot be marked as an exception',
+      );
+    }
+
+    // An exception resolves the step without evidence (that's the point — the
+    // step could not or need not be done), so the evidenceRequired check that
+    // completeItem enforces is intentionally skipped.
+    return db.offboardingChecklistCompletion.create({
+      data: {
+        organizationId,
+        memberId,
+        templateItemId,
+        completedById,
+        isException: true,
+        exceptionReason: reason.trim(),
+      },
+    });
   }
 
   async uncompleteItem({

--- a/apps/api/src/offboarding-checklist/offboarding-export-summary.spec.ts
+++ b/apps/api/src/offboarding-checklist/offboarding-export-summary.spec.ts
@@ -1,0 +1,57 @@
+// The export service imports `db` from `@db` at module load; stub it so this
+// pure-function test doesn't spin up a real Prisma client.
+jest.mock('@db', () => ({
+  db: {},
+  AttachmentEntityType: { offboarding_checklist: 'offboarding_checklist' },
+}));
+
+import { buildSummaryCsv } from './offboarding-export.service';
+
+type Items = Parameters<typeof buildSummaryCsv>[0];
+
+describe('buildSummaryCsv', () => {
+  it('flags excepted items with an Exception status and includes the reason', () => {
+    const csv = buildSummaryCsv([
+      {
+        title: 'Retrieve company devices',
+        completed: true,
+        isException: true,
+        exceptionReason: 'No company device was ever issued',
+        completion: null,
+        evidence: [],
+      },
+    ] as unknown as Items);
+
+    const [header, row] = csv.split('\n');
+    expect(header).toContain('Exception Reason');
+    expect(row).toContain('Exception');
+    expect(row).toContain('No company device was ever issued');
+  });
+
+  it('uses Complete / Pending and a blank reason for non-exception items', () => {
+    const csv = buildSummaryCsv([
+      {
+        title: 'Done thing',
+        completed: true,
+        isException: false,
+        exceptionReason: null,
+        completion: null,
+        evidence: [],
+      },
+      {
+        title: 'Pending thing',
+        completed: false,
+        isException: false,
+        exceptionReason: null,
+        completion: null,
+        evidence: [],
+      },
+    ] as unknown as Items);
+
+    const lines = csv.split('\n');
+    expect(lines[1]).toContain('"Done thing",Complete');
+    expect(lines[2]).toContain('"Pending thing",Pending');
+    // A completed/pending row ends with an empty reason field.
+    expect(lines[1].endsWith('""')).toBe(true);
+  });
+});

--- a/apps/api/src/offboarding-checklist/offboarding-export.service.ts
+++ b/apps/api/src/offboarding-checklist/offboarding-export.service.ts
@@ -71,18 +71,7 @@ export class OffboardingExportService {
     items: ChecklistItems,
     prefix = '',
   ) {
-    const rows = [
-      'Item,Status,Completed By,Completed Date,Evidence Count',
-      ...items.map((item) => {
-        const status = item.completed ? 'Complete' : 'Pending';
-        const completedBy = item.completion?.completedBy?.name ?? '';
-        const completedDate = item.completion?.completedAt
-          ? new Date(item.completion.completedAt).toISOString().split('T')[0]
-          : '';
-        return `"${escapeCsvField(item.title)}",${status},"${escapeCsvField(completedBy)}",${completedDate},${item.evidence.length}`;
-      }),
-    ];
-    archive.append(rows.join('\n'), { name: `${prefix}summary.csv` });
+    archive.append(buildSummaryCsv(items), { name: `${prefix}summary.csv` });
   }
 
   private appendVendorRevocationsCsv(
@@ -221,6 +210,33 @@ export class OffboardingExportService {
       return null;
     }
   }
+}
+
+/**
+ * Builds the offboarding summary CSV. Excepted steps are reported with an
+ * `Exception` status and their justification in the `Exception Reason` column —
+ * that reason is the audit artifact for a step that was legitimately skipped.
+ */
+export function buildSummaryCsv(items: ChecklistItems): string {
+  const rows = [
+    'Item,Status,Completed By,Completed Date,Evidence Count,Exception Reason',
+    ...items.map((item) => {
+      const status = summaryStatus(item);
+      const completedBy = item.completion?.completedBy?.name ?? '';
+      const completedDate = item.completion?.completedAt
+        ? new Date(item.completion.completedAt).toISOString().split('T')[0]
+        : '';
+      const reason = item.exceptionReason ?? '';
+      return `"${escapeCsvField(item.title)}",${status},"${escapeCsvField(completedBy)}",${completedDate},${item.evidence.length},"${escapeCsvField(reason)}"`;
+    }),
+  ];
+  return rows.join('\n');
+}
+
+function summaryStatus(item: ChecklistItems[number]): string {
+  if (item.isException) return 'Exception';
+  if (item.completed) return 'Complete';
+  return 'Pending';
 }
 
 function sanitizeFileName(name: string): string {

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/ExceptionReasonForm.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/ExceptionReasonForm.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@trycompai/design-system', () => ({
+  Textarea: (props: Record<string, unknown>) => <textarea {...props} />,
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+  HStack: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Stack: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+import { ExceptionReasonForm } from './ExceptionReasonForm';
+
+describe('ExceptionReasonForm', () => {
+  it('disables Save until a non-empty reason is entered', () => {
+    render(<ExceptionReasonForm onSubmit={vi.fn()} onCancel={vi.fn()} />);
+
+    const save = screen.getByRole('button', { name: /save exception/i });
+    expect(save).toBeDisabled();
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: '   ' },
+    });
+    expect(save).toBeDisabled(); // whitespace only
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'No company device issued' },
+    });
+    expect(save).toBeEnabled();
+  });
+
+  it('submits the trimmed reason', () => {
+    const onSubmit = vi.fn();
+    render(<ExceptionReasonForm onSubmit={onSubmit} onCancel={vi.fn()} />);
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: '  No company device issued  ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /save exception/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith('No company device issued');
+  });
+
+  it('calls onCancel when Cancel is clicked', () => {
+    const onCancel = vi.fn();
+    render(<ExceptionReasonForm onSubmit={vi.fn()} onCancel={onCancel} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onCancel).toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/ExceptionReasonForm.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/ExceptionReasonForm.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { Button, HStack, Stack, Textarea } from '@trycompai/design-system';
+import { useState } from 'react';
+
+interface ExceptionReasonFormProps {
+  onSubmit: (reason: string) => void | Promise<void>;
+  onCancel: () => void;
+  isSubmitting?: boolean;
+}
+
+/**
+ * Inline form for marking an offboarding step as an exception: a required
+ * free-text reason plus Save / Cancel. Save stays disabled until the reason has
+ * non-whitespace content, and submits the trimmed value.
+ */
+export function ExceptionReasonForm({
+  onSubmit,
+  onCancel,
+  isSubmitting = false,
+}: ExceptionReasonFormProps) {
+  const [reason, setReason] = useState('');
+  const trimmed = reason.trim();
+
+  return (
+    <Stack gap="2">
+      <Textarea
+        value={reason}
+        onChange={(e) => setReason(e.target.value)}
+        placeholder="Why is this step being marked as an exception? (e.g. this person was never issued a company device)"
+        rows={2}
+        disabled={isSubmitting}
+        aria-label="Exception reason"
+      />
+      <HStack gap="2">
+        <Button
+          size="sm"
+          onClick={() => onSubmit(trimmed)}
+          disabled={!trimmed || isSubmitting}
+          loading={isSubmitting}
+        >
+          Save exception
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onCancel}
+          disabled={isSubmitting}
+        >
+          Cancel
+        </Button>
+      </HStack>
+    </Stack>
+  );
+}

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/OffboardingChecklist.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/OffboardingChecklist.tsx
@@ -23,6 +23,7 @@ export function OffboardingChecklist({
     isLoading,
     completeItem,
     uncompleteItem,
+    markException,
     uploadEvidence,
     getDownloadUrl,
     refreshChecklist,
@@ -52,6 +53,24 @@ export function OffboardingChecklist({
       }
     },
     [uncompleteItem],
+  );
+
+  const handleMarkException = useCallback(
+    async ({
+      templateItemId,
+      reason,
+    }: {
+      templateItemId: string;
+      reason: string;
+    }) => {
+      try {
+        await markException({ templateItemId, reason });
+        toast.success('Item marked as exception');
+      } catch {
+        toast.error('Failed to mark item as exception');
+      }
+    },
+    [markException],
   );
 
   const handleUploadEvidence = useCallback(
@@ -149,6 +168,7 @@ export function OffboardingChecklist({
               canEdit={canEdit}
               onComplete={handleComplete}
               onUncomplete={handleUncomplete}
+              onMarkException={handleMarkException}
               onUploadEvidence={handleUploadEvidence}
               onDownload={handleDownload}
               onChecklistRefresh={() => refreshChecklist()}

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/OffboardingChecklistItem.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/OffboardingChecklistItem.test.tsx
@@ -1,0 +1,128 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ChecklistItem } from '@/hooks/use-offboarding-checklist';
+
+vi.mock('@trycompai/design-system', () => ({
+  Collapsible: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  CollapsibleTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  CollapsibleContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+  HStack: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Stack: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Text: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  Badge: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  Textarea: (props: Record<string, unknown>) => <textarea {...props} />,
+}));
+
+vi.mock('@trycompai/design-system/icons', () => ({
+  ChevronDown: () => <span>chevron</span>,
+  Checkmark: () => <span>check</span>,
+  DocumentDownload: () => <span>download</span>,
+  Upload: () => <span>upload</span>,
+}));
+
+vi.mock('@/hooks/use-access-revocations', () => ({
+  useAccessRevocations: () => ({ revocations: null }),
+}));
+
+vi.mock('./AccessRevocationList', () => ({
+  AccessRevocationList: () => <div>access-revocation-list</div>,
+}));
+
+import { OffboardingChecklistItem } from './OffboardingChecklistItem';
+
+function makeItem(overrides: Partial<ChecklistItem> = {}): ChecklistItem {
+  return {
+    templateItemId: 'oct_1',
+    title: 'Retrieve company devices',
+    description: 'Collect all company-owned hardware.',
+    evidenceRequired: false,
+    isAccessRevocation: false,
+    sortOrder: 1,
+    completed: false,
+    isException: false,
+    exceptionReason: null,
+    completedAt: null,
+    completedBy: null,
+    completionId: null,
+    notes: null,
+    evidence: [],
+    ...overrides,
+  };
+}
+
+const noop = vi.fn().mockResolvedValue(undefined);
+
+function renderItem(item: ChecklistItem, handlers: Record<string, unknown> = {}) {
+  return render(
+    <OffboardingChecklistItem
+      item={item}
+      memberId="mem_1"
+      canEdit
+      onComplete={noop}
+      onUncomplete={noop}
+      onMarkException={noop}
+      onUploadEvidence={noop}
+      onDownload={noop}
+      {...handlers}
+    />,
+  );
+}
+
+describe('OffboardingChecklistItem — exceptions', () => {
+  it('marks an unresolved step as an exception with a typed reason', async () => {
+    const onMarkException = vi.fn().mockResolvedValue(undefined);
+    renderItem(makeItem(), { onMarkException });
+
+    fireEvent.click(screen.getByRole('button', { name: /mark as exception/i }));
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'This person was never issued a company device' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /save exception/i }));
+
+    await waitFor(() =>
+      expect(onMarkException).toHaveBeenCalledWith({
+        templateItemId: 'oct_1',
+        reason: 'This person was never issued a company device',
+      }),
+    );
+  });
+
+  it('shows the reason and a remove action for an excepted step', async () => {
+    const onUncomplete = vi.fn().mockResolvedValue(undefined);
+    renderItem(
+      makeItem({
+        completed: true,
+        isException: true,
+        exceptionReason: 'No company device was ever issued',
+      }),
+      { onUncomplete },
+    );
+
+    expect(
+      screen.getByText('No company device was ever issued'),
+    ).toBeInTheDocument();
+    // The "Mark complete" affordance must NOT be offered for an exception.
+    expect(
+      screen.queryByRole('button', { name: /mark complete/i }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /remove exception/i }));
+    await waitFor(() => expect(onUncomplete).toHaveBeenCalledWith('oct_1'));
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/OffboardingChecklistItem.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/OffboardingChecklistItem.tsx
@@ -1,25 +1,20 @@
 'use client';
 
 import type { ChecklistItem } from '@/hooks/use-offboarding-checklist';
-import { useAccessRevocations } from '@/hooks/use-access-revocations';
 import {
-  Badge,
-  Button,
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
-  HStack,
-  Stack,
-  Text,
 } from '@trycompai/design-system';
-import {
-  Checkmark,
-  ChevronDown,
-  DocumentDownload,
-  Upload,
-} from '@trycompai/design-system/icons';
+import { ChevronDown } from '@trycompai/design-system/icons';
 import { useRef, useState } from 'react';
 import { AccessRevocationList } from './AccessRevocationList';
+import {
+  ChecklistStatusCircle,
+  ItemBadges,
+  ItemProgress,
+} from './offboarding-item-indicators';
+import { EvidenceContent, SimpleContent } from './offboarding-item-content';
 
 interface OffboardingChecklistItemProps {
   item: ChecklistItem;
@@ -27,131 +22,13 @@ interface OffboardingChecklistItemProps {
   canEdit: boolean;
   onComplete: (args: { templateItemId: string; file?: File }) => Promise<void>;
   onUncomplete: (templateItemId: string) => Promise<void>;
+  onMarkException: (args: {
+    templateItemId: string;
+    reason: string;
+  }) => Promise<void>;
   onUploadEvidence: (templateItemId: string, file: File) => Promise<void>;
   onDownload: (attachmentId: string) => Promise<void>;
   onChecklistRefresh?: () => void;
-}
-
-function StatusCircle({ done, total }: { done: number; total: number }) {
-  const allDone = done === total && total > 0;
-  const partial = done > 0 && !allDone;
-
-  if (allDone) {
-    return (
-      <div className="flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground">
-        <Checkmark size={11} />
-      </div>
-    );
-  }
-  if (partial) {
-    return (
-      <div className="flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full border-[1.5px] border-primary">
-        <div className="h-2 w-2 rounded-full bg-primary" />
-      </div>
-    );
-  }
-  return (
-    <div
-      className="h-[18px] w-[18px] shrink-0 rounded-full border-[1.5px]"
-      style={{ borderColor: 'oklch(0.85 0 0)' }}
-    />
-  );
-}
-
-function ChecklistStatusCircle({
-  item,
-  memberId,
-}: {
-  item: ChecklistItem;
-  memberId: string;
-}) {
-  if (item.isAccessRevocation) {
-    return <AccessRevocationStatusCircle memberId={memberId} />;
-  }
-  const done = item.completed ? 1 : 0;
-  return <StatusCircle done={done} total={1} />;
-}
-
-function AccessRevocationStatusCircle({ memberId }: { memberId: string }) {
-  const { revocations } = useAccessRevocations(memberId);
-  if (!revocations) return <StatusCircle done={0} total={0} />;
-  return (
-    <StatusCircle
-      done={revocations.revokedCount}
-      total={revocations.totalVendors}
-    />
-  );
-}
-
-function ItemBadges({
-  item,
-}: {
-  item: ChecklistItem;
-}) {
-  return (
-    <>
-      {item.isAccessRevocation && (
-        <div>
-          <Badge variant="accent">Critical</Badge>
-        </div>
-      )}
-      {item.evidenceRequired && (
-        <div>
-          <Badge variant="outline">Evidence</Badge>
-        </div>
-      )}
-    </>
-  );
-}
-
-function ItemProgress({
-  item,
-  memberId,
-}: {
-  item: ChecklistItem;
-  memberId: string;
-}) {
-  if (item.isAccessRevocation) {
-    return <AccessRevocationProgress memberId={memberId} />;
-  }
-  const done = item.completed ? 1 : 0;
-  const total = 1;
-  const pct = done / total;
-  return (
-    <div className="flex items-center gap-2">
-      <span className="min-w-[56px] text-right font-mono text-xs tabular-nums text-muted-foreground">
-        {done}/{total}
-      </span>
-      <div className="h-1 w-[60px] overflow-hidden rounded-full bg-muted">
-        <div
-          className="h-full bg-primary transition-all"
-          style={{ width: `${pct * 100}%` }}
-        />
-      </div>
-    </div>
-  );
-}
-
-function AccessRevocationProgress({ memberId }: { memberId: string }) {
-  const { revocations } = useAccessRevocations(memberId);
-  if (!revocations) return null;
-  const pct =
-    revocations.totalVendors > 0
-      ? revocations.revokedCount / revocations.totalVendors
-      : 0;
-  return (
-    <div className="flex items-center gap-2">
-      <span className="min-w-[56px] text-right font-mono text-xs tabular-nums text-muted-foreground">
-        {revocations.revokedCount}/{revocations.totalVendors}
-      </span>
-      <div className="h-1 w-[60px] overflow-hidden rounded-full bg-muted">
-        <div
-          className="h-full bg-primary transition-all"
-          style={{ width: `${pct * 100}%` }}
-        />
-      </div>
-    </div>
-  );
 }
 
 export function OffboardingChecklistItem({
@@ -160,6 +37,7 @@ export function OffboardingChecklistItem({
   canEdit,
   onComplete,
   onUncomplete,
+  onMarkException,
   onUploadEvidence,
   onDownload,
   onChecklistRefresh,
@@ -183,6 +61,16 @@ export function OffboardingChecklistItem({
     setIsProcessing(true);
     try {
       await onUncomplete(item.templateItemId);
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const handleMarkException = async (reason: string) => {
+    if (isProcessing) return;
+    setIsProcessing(true);
+    try {
+      await onMarkException({ templateItemId: item.templateItemId, reason });
     } finally {
       setIsProcessing(false);
     }
@@ -221,10 +109,13 @@ export function OffboardingChecklistItem({
   };
 
   const isExpandable =
-    item.isAccessRevocation || item.evidenceRequired || canEdit;
+    item.isAccessRevocation || item.evidenceRequired || item.isException || canEdit;
 
   return (
-    <Collapsible open={isExpandable ? isOpen : false} onOpenChange={isExpandable ? setIsOpen : undefined}>
+    <Collapsible
+      open={isExpandable ? isOpen : false}
+      onOpenChange={isExpandable ? setIsOpen : undefined}
+    >
       <div className="overflow-hidden rounded-lg border bg-background">
         <CollapsibleTrigger className="flex w-full items-center gap-2 px-3.5 py-3 text-left transition-colors hover:bg-muted/50">
           <ChecklistStatusCircle item={item} memberId={memberId} />
@@ -269,6 +160,7 @@ export function OffboardingChecklistItem({
                   onFileSelect={handleFileSelect}
                   onDownload={onDownload}
                   onUncomplete={handleUncomplete}
+                  onMarkException={handleMarkException}
                 />
               ) : (
                 <SimpleContent
@@ -277,6 +169,7 @@ export function OffboardingChecklistItem({
                   isProcessing={isProcessing}
                   onComplete={handleComplete}
                   onUncomplete={handleUncomplete}
+                  onMarkException={handleMarkException}
                 />
               )}
             </div>
@@ -284,130 +177,5 @@ export function OffboardingChecklistItem({
         </CollapsibleContent>
       </div>
     </Collapsible>
-  );
-}
-
-function SimpleContent({
-  item,
-  canEdit,
-  isProcessing,
-  onComplete,
-  onUncomplete,
-}: {
-  item: ChecklistItem;
-  canEdit: boolean;
-  isProcessing: boolean;
-  onComplete: () => void;
-  onUncomplete: () => void;
-}) {
-  if (!canEdit) return null;
-
-  return (
-    <div>
-      {item.completed ? (
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={onUncomplete}
-          disabled={isProcessing}
-          loading={isProcessing}
-        >
-          Undo
-        </Button>
-      ) : (
-        <Button
-          size="sm"
-          onClick={onComplete}
-          disabled={isProcessing}
-          loading={isProcessing}
-        >
-          Mark complete
-        </Button>
-      )}
-    </div>
-  );
-}
-
-function EvidenceContent({
-  item,
-  canEdit,
-  isProcessing,
-  dropzoneInputRef,
-  onFileDrop,
-  onFileSelect,
-  onDownload,
-  onUncomplete,
-}: {
-  item: ChecklistItem;
-  canEdit: boolean;
-  isProcessing: boolean;
-  dropzoneInputRef: React.RefObject<HTMLInputElement | null>;
-  onFileDrop: (e: React.DragEvent<HTMLDivElement>) => void;
-  onFileSelect: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  onDownload: (attachmentId: string) => void;
-  onUncomplete: () => void;
-}) {
-  return (
-    <Stack gap="3">
-      {item.evidence.length > 0 && (
-        <Stack gap="1">
-          {item.evidence.map((file) => (
-            <HStack key={file.id} gap="2" align="center">
-              <Text size="sm" variant="muted">
-                {file.name}
-              </Text>
-              <div>
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  onClick={() => onDownload(file.id)}
-                >
-                  <DocumentDownload size={14} />
-                </Button>
-              </div>
-            </HStack>
-          ))}
-        </Stack>
-      )}
-
-      {canEdit && (
-        <div
-          onDrop={onFileDrop}
-          onDragOver={(e) => e.preventDefault()}
-          onClick={() => !isProcessing && dropzoneInputRef.current?.click()}
-          className={`flex cursor-pointer flex-col items-center gap-2 rounded-md border-2 border-dashed border-muted-foreground/25 px-4 py-6 text-center transition hover:border-muted-foreground/50 hover:bg-muted/25${isProcessing ? ' pointer-events-none opacity-50' : ''}`}
-        >
-          <Upload size={20} className="text-muted-foreground" />
-          <div>
-            <Text size="sm" variant="muted">
-              {item.completed
-                ? 'Drop files here or click to add more evidence'
-                : 'Drop files here or click to upload proof and mark as complete'}
-            </Text>
-          </div>
-          <input
-            ref={dropzoneInputRef}
-            type="file"
-            className="hidden"
-            onChange={onFileSelect}
-            accept=".pdf,.doc,.docx,.png,.jpg,.jpeg,.csv,.xlsx"
-          />
-        </div>
-      )}
-
-      {item.completed && canEdit && (
-        <div>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={onUncomplete}
-            disabled={isProcessing}
-            loading={isProcessing}
-          >
-            Undo completion
-          </Button>
-        </div>
-      )}
-    </Stack>
   );
 }

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/offboarding-item-content.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/offboarding-item-content.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import type { ChecklistItem } from '@/hooks/use-offboarding-checklist';
+import { Button, HStack, Stack, Text } from '@trycompai/design-system';
+import { DocumentDownload, Upload } from '@trycompai/design-system/icons';
+import { useState } from 'react';
+import { ExceptionReasonForm } from './ExceptionReasonForm';
+
+/** Shown once a step has been resolved as an exception: the reason + a way to undo. */
+function ExceptionResolvedView({
+  reason,
+  canEdit,
+  isProcessing,
+  onRemove,
+}: {
+  reason: string | null;
+  canEdit: boolean;
+  isProcessing: boolean;
+  onRemove: () => void;
+}) {
+  return (
+    <Stack gap="2">
+      <Stack gap="1">
+        <Text size="xs" variant="muted">
+          Marked as exception
+        </Text>
+        {reason && <Text size="sm">{reason}</Text>}
+      </Stack>
+      {canEdit && (
+        <div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onRemove}
+            disabled={isProcessing}
+            loading={isProcessing}
+          >
+            Remove exception
+          </Button>
+        </div>
+      )}
+    </Stack>
+  );
+}
+
+export function SimpleContent({
+  item,
+  canEdit,
+  isProcessing,
+  onComplete,
+  onUncomplete,
+  onMarkException,
+}: {
+  item: ChecklistItem;
+  canEdit: boolean;
+  isProcessing: boolean;
+  onComplete: () => void;
+  onUncomplete: () => void;
+  onMarkException: (reason: string) => Promise<void>;
+}) {
+  const [showExceptionForm, setShowExceptionForm] = useState(false);
+
+  if (item.isException) {
+    return (
+      <ExceptionResolvedView
+        reason={item.exceptionReason}
+        canEdit={canEdit}
+        isProcessing={isProcessing}
+        onRemove={onUncomplete}
+      />
+    );
+  }
+
+  if (!canEdit) return null;
+
+  if (item.completed) {
+    return (
+      <div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onUncomplete}
+          disabled={isProcessing}
+          loading={isProcessing}
+        >
+          Undo
+        </Button>
+      </div>
+    );
+  }
+
+  if (showExceptionForm) {
+    return (
+      <ExceptionReasonForm
+        onSubmit={async (reason) => {
+          await onMarkException(reason);
+          setShowExceptionForm(false);
+        }}
+        onCancel={() => setShowExceptionForm(false)}
+        isSubmitting={isProcessing}
+      />
+    );
+  }
+
+  return (
+    <HStack gap="2">
+      <Button
+        size="sm"
+        onClick={onComplete}
+        disabled={isProcessing}
+        loading={isProcessing}
+      >
+        Mark complete
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => setShowExceptionForm(true)}
+        disabled={isProcessing}
+      >
+        Mark as exception
+      </Button>
+    </HStack>
+  );
+}
+
+export function EvidenceContent({
+  item,
+  canEdit,
+  isProcessing,
+  dropzoneInputRef,
+  onFileDrop,
+  onFileSelect,
+  onDownload,
+  onUncomplete,
+  onMarkException,
+}: {
+  item: ChecklistItem;
+  canEdit: boolean;
+  isProcessing: boolean;
+  dropzoneInputRef: React.RefObject<HTMLInputElement | null>;
+  onFileDrop: (e: React.DragEvent<HTMLDivElement>) => void;
+  onFileSelect: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onDownload: (attachmentId: string) => void;
+  onUncomplete: () => void;
+  onMarkException: (reason: string) => Promise<void>;
+}) {
+  const [showExceptionForm, setShowExceptionForm] = useState(false);
+
+  if (item.isException) {
+    return (
+      <ExceptionResolvedView
+        reason={item.exceptionReason}
+        canEdit={canEdit}
+        isProcessing={isProcessing}
+        onRemove={onUncomplete}
+      />
+    );
+  }
+
+  return (
+    <Stack gap="3">
+      {item.evidence.length > 0 && (
+        <Stack gap="1">
+          {item.evidence.map((file) => (
+            <HStack key={file.id} gap="2" align="center">
+              <Text size="sm" variant="muted">
+                {file.name}
+              </Text>
+              <div>
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  onClick={() => onDownload(file.id)}
+                >
+                  <DocumentDownload size={14} />
+                </Button>
+              </div>
+            </HStack>
+          ))}
+        </Stack>
+      )}
+
+      {canEdit && (
+        <div
+          onDrop={onFileDrop}
+          onDragOver={(e) => e.preventDefault()}
+          onClick={() => !isProcessing && dropzoneInputRef.current?.click()}
+          className={`flex cursor-pointer flex-col items-center gap-2 rounded-md border-2 border-dashed border-muted-foreground/25 px-4 py-6 text-center transition hover:border-muted-foreground/50 hover:bg-muted/25${isProcessing ? ' pointer-events-none opacity-50' : ''}`}
+        >
+          <Upload size={20} className="text-muted-foreground" />
+          <div>
+            <Text size="sm" variant="muted">
+              {item.completed
+                ? 'Drop files here or click to add more evidence'
+                : 'Drop files here or click to upload proof and mark as complete'}
+            </Text>
+          </div>
+          <input
+            ref={dropzoneInputRef}
+            type="file"
+            className="hidden"
+            onChange={onFileSelect}
+            accept=".pdf,.doc,.docx,.png,.jpg,.jpeg,.csv,.xlsx"
+          />
+        </div>
+      )}
+
+      {item.completed && canEdit && (
+        <div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onUncomplete}
+            disabled={isProcessing}
+            loading={isProcessing}
+          >
+            Undo completion
+          </Button>
+        </div>
+      )}
+
+      {!item.completed &&
+        canEdit &&
+        (showExceptionForm ? (
+          <ExceptionReasonForm
+            onSubmit={async (reason) => {
+              await onMarkException(reason);
+              setShowExceptionForm(false);
+            }}
+            onCancel={() => setShowExceptionForm(false)}
+            isSubmitting={isProcessing}
+          />
+        ) : (
+          <div>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowExceptionForm(true)}
+              disabled={isProcessing}
+            >
+              Can&apos;t complete this? Mark as exception
+            </Button>
+          </div>
+        ))}
+    </Stack>
+  );
+}

--- a/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/offboarding-item-indicators.tsx
+++ b/apps/app/src/app/(app)/[orgId]/people/[employeeId]/components/offboarding-item-indicators.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import type { ChecklistItem } from '@/hooks/use-offboarding-checklist';
+import { useAccessRevocations } from '@/hooks/use-access-revocations';
+import { Badge } from '@trycompai/design-system';
+import { Checkmark } from '@trycompai/design-system/icons';
+
+export function StatusCircle({ done, total }: { done: number; total: number }) {
+  const allDone = done === total && total > 0;
+  const partial = done > 0 && !allDone;
+
+  if (allDone) {
+    return (
+      <div className="flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground">
+        <Checkmark size={11} />
+      </div>
+    );
+  }
+  if (partial) {
+    return (
+      <div className="flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full border-[1.5px] border-primary">
+        <div className="h-2 w-2 rounded-full bg-primary" />
+      </div>
+    );
+  }
+  return (
+    <div
+      className="h-[18px] w-[18px] shrink-0 rounded-full border-[1.5px]"
+      style={{ borderColor: 'oklch(0.85 0 0)' }}
+    />
+  );
+}
+
+/** Amber dash — the step is resolved as an exception, not actually completed. */
+export function ExceptionStatusCircle() {
+  return (
+    <div className="flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full bg-amber-500 text-white">
+      <div className="h-[2px] w-2 rounded-full bg-white" />
+    </div>
+  );
+}
+
+export function ChecklistStatusCircle({
+  item,
+  memberId,
+}: {
+  item: ChecklistItem;
+  memberId: string;
+}) {
+  if (item.isAccessRevocation) {
+    return <AccessRevocationStatusCircle memberId={memberId} />;
+  }
+  if (item.isException) {
+    return <ExceptionStatusCircle />;
+  }
+  const done = item.completed ? 1 : 0;
+  return <StatusCircle done={done} total={1} />;
+}
+
+function AccessRevocationStatusCircle({ memberId }: { memberId: string }) {
+  const { revocations } = useAccessRevocations(memberId);
+  if (!revocations) return <StatusCircle done={0} total={0} />;
+  return (
+    <StatusCircle
+      done={revocations.revokedCount}
+      total={revocations.totalVendors}
+    />
+  );
+}
+
+export function ItemBadges({ item }: { item: ChecklistItem }) {
+  return (
+    <>
+      {item.isAccessRevocation && (
+        <div>
+          <Badge variant="accent">Critical</Badge>
+        </div>
+      )}
+      {item.evidenceRequired && (
+        <div>
+          <Badge variant="outline">Evidence</Badge>
+        </div>
+      )}
+      {item.isException && (
+        <div>
+          <Badge variant="secondary">Exception</Badge>
+        </div>
+      )}
+    </>
+  );
+}
+
+export function ItemProgress({
+  item,
+  memberId,
+}: {
+  item: ChecklistItem;
+  memberId: string;
+}) {
+  if (item.isAccessRevocation) {
+    return <AccessRevocationProgress memberId={memberId} />;
+  }
+  if (item.isException) {
+    return (
+      <span className="text-xs font-medium text-amber-600">Exception</span>
+    );
+  }
+  return <ProgressBar done={item.completed ? 1 : 0} total={1} />;
+}
+
+function ProgressBar({ done, total }: { done: number; total: number }) {
+  const pct = total > 0 ? done / total : 0;
+  return (
+    <div className="flex items-center gap-2">
+      <span className="min-w-[56px] text-right font-mono text-xs tabular-nums text-muted-foreground">
+        {done}/{total}
+      </span>
+      <div className="h-1 w-[60px] overflow-hidden rounded-full bg-muted">
+        <div
+          className="h-full bg-primary transition-all"
+          style={{ width: `${pct * 100}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function AccessRevocationProgress({ memberId }: { memberId: string }) {
+  const { revocations } = useAccessRevocations(memberId);
+  if (!revocations) return null;
+  return (
+    <ProgressBar
+      done={revocations.revokedCount}
+      total={revocations.totalVendors}
+    />
+  );
+}

--- a/apps/app/src/hooks/use-offboarding-checklist.ts
+++ b/apps/app/src/hooks/use-offboarding-checklist.ts
@@ -27,6 +27,8 @@ export interface ChecklistItem {
   isAccessRevocation: boolean;
   sortOrder: number;
   completed: boolean;
+  isException: boolean;
+  exceptionReason: string | null;
   completedAt: string | null;
   completedBy: CompletedBy | null;
   completionId: string | null;
@@ -91,6 +93,24 @@ export function useOffboardingChecklist(memberId: string) {
     [api, memberId, mutate],
   );
 
+  const markException = useCallback(
+    async ({
+      templateItemId,
+      reason,
+    }: {
+      templateItemId: string;
+      reason: string;
+    }) => {
+      const response = await api.post(
+        `/v1/offboarding-checklist/member/${memberId}/item/${templateItemId}/exception`,
+        { reason },
+      );
+      if (response.error) throw new Error(response.error);
+      await mutate();
+    },
+    [api, memberId, mutate],
+  );
+
   const uploadEvidence = useCallback(
     async (templateItemId: string, file: File) => {
       const base64 = await fileToBase64(file);
@@ -125,6 +145,7 @@ export function useOffboardingChecklist(memberId: string) {
     error,
     completeItem,
     uncompleteItem,
+    markException,
     uploadEvidence,
     getDownloadUrl,
     refreshChecklist: mutate,

--- a/packages/db/prisma/migrations/20260722195055_add_offboarding_checklist_exception/migration.sql
+++ b/packages/db/prisma/migrations/20260722195055_add_offboarding_checklist_exception/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "OffboardingChecklistCompletion" ADD COLUMN     "exceptionReason" TEXT,
+ADD COLUMN     "isException" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/db/prisma/schema/offboarding-checklist.prisma
+++ b/packages/db/prisma/schema/offboarding-checklist.prisma
@@ -19,13 +19,17 @@ model OffboardingChecklistTemplate {
 }
 
 model OffboardingChecklistCompletion {
-  id             String   @id @default(dbgenerated("generate_prefixed_cuid('occ'::text)"))
-  organizationId String
-  memberId       String
-  templateItemId String?
-  completedById  String?
-  completedAt    DateTime @default(now())
-  notes          String?
+  id              String   @id @default(dbgenerated("generate_prefixed_cuid('occ'::text)"))
+  organizationId  String
+  memberId        String
+  templateItemId  String?
+  completedById   String?
+  completedAt     DateTime @default(now())
+  notes           String?
+  // When true, the step was resolved as an exception (could not / need not be
+  // done) rather than actually completed. `exceptionReason` explains why.
+  isException     Boolean  @default(false)
+  exceptionReason String?
 
   organization Organization                  @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   member       Member                        @relation(fields: [memberId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
## What & why

Some offboarding checklist steps can't be fulfilled for a given person — e.g. **Retrieve company devices** when they were never issued one. Today a step has one resolution (complete, sometimes with evidence), so an unfulfillable step stays permanently incomplete, shows as "remaining", and the offboarding never looks done. There's also no record of *why* it was skipped.

This adds an **exception** resolution: mark a step as an exception with a required free-text reason. It resolves the step (clears "remaining", counts toward progress, stops blocking completion) but is visually and semantically distinct from a real completion, and the reason is preserved for the audit log and evidence export.

## Design note

An offboarding step has no per-member row until it's resolved — the `OffboardingChecklistCompletion` row **is** the resolution (`@@unique(memberId, templateItemId)`). "Completed" and "exception" are mutually-exclusive ways to resolve the same step, so this reuses that row with an `isException` discriminator rather than a separate table (unlike `FindingException`, which suppresses an independently-existing finding). No expiry/revoke lifecycle — "remove exception" is just deleting the row (existing uncomplete flow).

## Backend

- `OffboardingChecklistCompletion` gains `isException` + `exceptionReason` (additive migration, no backfill).
- `POST /v1/offboarding-checklist/member/:memberId/item/:templateItemId/exception` (`member:update`, auto-audited — the interceptor folds `reason` into the record). `markException` **skips** the evidence requirement and rejects the access-revocation step. `getMemberChecklist` surfaces the fields; an exception counts as resolved.
- Evidence-export summary CSV now reports an `Exception` status and the reason in a new `Exception Reason` column — the audit artifact for a legitimately skipped step.

## Frontend

- "Mark as exception" action with an inline required-reason form (Save disabled until non-empty), an **Exception** badge, a distinct amber status indicator, the reason shown in the expanded row, and a **Remove exception** action.
- Split the oversized `OffboardingChecklistItem.tsx` (413 → 181 lines) into focused indicator/content modules to stay under the 300-line limit.

## Testing (TDD)

- **API:** `markException` (creates the exception row, bypasses evidence, rejects if already resolved / on the access-revocation step), controller delegation + no-user guard, DTO validation, and `buildSummaryCsv` (Exception status + reason column).
- **App:** `ExceptionReasonForm` (required-reason gating, trimmed submit) and `OffboardingChecklistItem` (mark → form → hook call; excepted view shows reason + Remove).
- Typecheck clean on all changed files; no `@trycompai/ui` / `lucide-react` imports.

## ⚠️ Migration

Adds a Prisma migration (`add_offboarding_checklist_exception`) — run `prisma migrate` on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an exception resolution for offboarding checklist steps with a required reason. This lets you mark unfulfillable steps as handled without evidence, counts toward progress, and is clearly shown as an exception in the UI and export.

- **New Features**
  - API: `POST /v1/offboarding-checklist/member/:memberId/item/:templateItemId/exception` records `isException` and `exceptionReason`, skips evidence, and rejects the access‑revocation step.
  - Checklist: exceptions are treated as resolved; UI shows an Exception badge, amber status, the reason, and a “Remove exception” action.
  - Export: summary CSV adds an Exception status and an “Exception Reason” column.
  - Frontend: inline “Mark as exception” reason form (required, trimmed); refactored `OffboardingChecklistItem` into focused indicator/content modules.

- **Migration**
  - Run `prisma migrate` to add `isException` and `exceptionReason` to `OffboardingChecklistCompletion`.

<sup>Written for commit d820421b405fd94ef54c4cb761669e7f1b1c81c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

