### PR TITLE
fix(app): stop left-nav rail tooltips flickering on hover (CS-773)

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/components/AppShellWrapper.tsx
+++ b/apps/app/src/app/(app)/[orgId]/components/AppShellWrapper.tsx
@@ -27,7 +27,6 @@ import {
   AppShellNavbar,
   AppShellRail,
   AppShellAIChatTrigger,
-  AppShellRailItem,
   AppShellSidebar,
   AppShellSidebarHeader,
   AppShellUserMenu,
@@ -54,6 +53,7 @@ import { TrustSidebar } from '../trust/components/TrustSidebar';
 import { getAppShellSearchGroups } from './app-shell-search-groups';
 import { AppSidebar } from './AppSidebar';
 import { ConditionalOnboardingTracker } from './ConditionalOnboardingTracker';
+import { ShellRailNavItem } from './ShellRailNavItem';
 
 interface AppShellWrapperProps {
   children: React.ReactNode;
@@ -340,30 +340,5 @@ function AppShellWrapperContent({
         </AppShellBody>
       </AppShell>
     </TooltipProvider>
-  );
-}
-
-function ShellRailNavItem({
-  href,
-  isActive,
-  icon,
-  label,
-}: {
-  href: string;
-  isActive: boolean;
-  icon: React.ReactNode;
-  label: string;
-}) {
-  const railItemId = `app-shell-rail-${label.toLowerCase()}`;
-
-  return (
-    <Link href={href}>
-      <AppShellRailItem
-        isActive={isActive}
-        icon={icon}
-        id={railItemId}
-        label={label}
-      />
-    </Link>
   );
 }

--- a/apps/app/src/app/(app)/[orgId]/components/ShellRailNavItem.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/components/ShellRailNavItem.test.tsx
@@ -1,0 +1,62 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+// next/link needs an App Router context that jsdom doesn't provide; render a plain anchor.
+vi.mock('next/link', () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+import {
+  AppShell,
+  AppShellBody,
+  AppShellRail,
+} from '@trycompai/design-system';
+import { ShellRailNavItem } from './ShellRailNavItem';
+
+const Icon = () => <svg data-testid="icon" />;
+
+// Regression for CS-773: the far-left product rail tooltips flashed open then vanished
+// (~0.1s) on hover. Root cause: ShellRailNavItem passed a label-derived `id` to
+// AppShellRailItem, and AppShellRail re-renders the same rail items into the always-mounted
+// mobile drawer. That produced two DOM elements sharing one `id`, which the design system
+// forwards to the Base UI tooltip trigger — the duplicate trigger id collides in Base UI's
+// floating tree and closes the active tooltip. The fix is to not set a hard-coded id.
+describe('ShellRailNavItem (CS-773 tooltip flicker)', () => {
+  it('does not set a hard-coded, label-derived id on the rail item', () => {
+    render(<ShellRailNavItem href="/org/overview" isActive icon={<Icon />} label="Compliance" />);
+
+    const button = document.querySelector('[data-slot="app-shell-rail-item"]');
+    expect(button).not.toBeNull();
+    // The old bug set id="app-shell-rail-compliance". Any hard-coded id here is duplicated
+    // into the mobile drawer copy and breaks the tooltip, so it must be absent.
+    expect(button?.getAttribute('id')).not.toBe('app-shell-rail-compliance');
+  });
+
+  it('renders the rail with unique element ids across the desktop rail and mobile drawer', () => {
+    // AppShellRail mirrors its children into the always-mounted mobile drawer, so each logical
+    // item renders twice. With the fix, the design system generates a unique id per instance;
+    // with the bug, the two copies would share the same hard-coded id.
+    render(
+      <AppShell>
+        <AppShellBody>
+          <AppShellRail>
+            <ShellRailNavItem href="/org/overview" isActive icon={<Icon />} label="Compliance" />
+            <ShellRailNavItem href="/org/trust" isActive={false} icon={<Icon />} label="Trust" />
+            <ShellRailNavItem href="/org/security" isActive={false} icon={<Icon />} label="Security" />
+          </AppShellRail>
+        </AppShellBody>
+      </AppShell>,
+    );
+
+    const ids = Array.from(document.querySelectorAll('[data-slot="app-shell-rail-item"]'))
+      .map((el) => el.getAttribute('id'))
+      .filter((id): id is string => Boolean(id));
+
+    // There must be no duplicate ids among rail item buttons.
+    expect(new Set(ids).size).toBe(ids.length);
+    // Sanity: the duplicate render means each of the 3 items appears twice.
+    expect(document.querySelectorAll('[data-slot="app-shell-rail-item"]').length).toBe(6);
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/components/ShellRailNavItem.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/components/ShellRailNavItem.test.tsx
@@ -8,11 +8,7 @@ vi.mock('next/link', () => ({
   ),
 }));
 
-import {
-  AppShell,
-  AppShellBody,
-  AppShellRail,
-} from '@trycompai/design-system';
+import { AppShell, AppShellBody, AppShellRail } from '@trycompai/design-system';
 import { ShellRailNavItem } from './ShellRailNavItem';
 
 const Icon = () => <svg data-testid="icon" />;
@@ -44,7 +40,12 @@ describe('ShellRailNavItem (CS-773 tooltip flicker)', () => {
           <AppShellRail>
             <ShellRailNavItem href="/org/overview" isActive icon={<Icon />} label="Compliance" />
             <ShellRailNavItem href="/org/trust" isActive={false} icon={<Icon />} label="Trust" />
-            <ShellRailNavItem href="/org/security" isActive={false} icon={<Icon />} label="Security" />
+            <ShellRailNavItem
+              href="/org/security"
+              isActive={false}
+              icon={<Icon />}
+              label="Security"
+            />
           </AppShellRail>
         </AppShellBody>
       </AppShell>,

--- a/apps/app/src/app/(app)/[orgId]/components/ShellRailNavItem.tsx
+++ b/apps/app/src/app/(app)/[orgId]/components/ShellRailNavItem.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { AppShellRailItem } from '@trycompai/design-system';
+import Link from 'next/link';
+
+interface ShellRailNavItemProps {
+  href: string;
+  isActive: boolean;
+  icon: React.ReactNode;
+  label: string;
+}
+
+/**
+ * A single icon in the far-left product rail (Compliance, Trust, Security, Settings, Admin).
+ *
+ * CS-773: Do NOT pass an explicit `id` to `AppShellRailItem`. `AppShellRail` re-renders these
+ * same rail items into the always-mounted mobile drawer, so any hard-coded `id` becomes a
+ * duplicate DOM id. The design system uses that `id` as the Base UI tooltip trigger's id, and
+ * two triggers sharing one id collide in Base UI's floating tree — the active (desktop) trigger
+ * is treated as unmounted and the tooltip auto-closes ~0.1s after opening (the "tooltip glitching
+ * on hover" bug). Leaving the id unset lets the design system generate a unique id per instance.
+ */
+export function ShellRailNavItem({ href, isActive, icon, label }: ShellRailNavItemProps) {
+  return (
+    <Link href={href}>
+      <AppShellRailItem isActive={isActive} icon={icon} label={label} />
+    </Link>
+  );
+}


### PR DESCRIPTION
## Problem (CS-773)

Hovering the far-left product rail icons (Compliance, Trust, Security, Settings, Admin) showed each tooltip for ~0.1s, then it vanished while the cursor was still over the icon.

## Root cause

`ShellRailNavItem` passed a label-derived `id` (`app-shell-rail-<label>`) to the design system's `AppShellRailItem`.

`AppShellRail` re-renders the same rail items into the **always-mounted mobile drawer** (via `setRailContent`), so each `id` lands on **two** DOM elements. The design system forwards that `id` to the Base UI tooltip trigger, so both copies register the **same deterministic trigger id** and collide in Base UI's floating tree. When the desktop tooltip opens, Base UI's `closeOnActiveTriggerUnmount` logic treats the active trigger as unmounted and closes the tooltip one microtask later — the flash.

Notably, this is **not** caused by the `<Link>`/`<a>` nesting (a common first guess): a bare tooltip trigger inside an anchor stays open fine. The trigger is the duplicate `id`.

## Fix

Don't set an explicit `id` on the rail items. The `id` was **unused** anywhere in `comp` or `comp-private` (only referenced at its own definition site). Without it, the design system generates a unique id per instance, so the two copies no longer collide.

- Extracted `ShellRailNavItem` into its own file so it can be unit-tested.
- Added a regression test asserting rail items carry no hard-coded / duplicate ids (fails with the old `id`, passes with the fix).

## How it was verified

- Reproduced the flash with the **real design system components** in a headless browser: duplicate `id` → flash 5/5; no `id` → stable 5/5.
- Confirmed the exact Base UI close path (`closeOnActiveTriggerUnmount`) via temporary runtime instrumentation (reverted).
- `ShellRailNavItem.test.tsx`: 2/2 passing; verified it fails when the `id` is reintroduced.
- ESLint clean; no new TypeScript errors in the changed files (the repo's pre-existing red is in unrelated test fixtures).

## Follow-up (design system, out of scope here)

`AppShellRailItem` forwarding a consumer `id` straight to the Base UI tooltip trigger — combined with `AppShellRail` duplicating rail content into the mobile drawer — means any consumer that sets an `id` hits this bug. Worth hardening upstream (e.g., don't use a consumer `id` as the trigger id, or don't remount identical triggers in the drawer).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tooltip flicker in the left nav rail (CS-773). Removes hard-coded ids from rail items so the desktop rail and mobile drawer no longer collide, keeping tooltips open on hover.

- **Bug Fixes**
  - Extracted `ShellRailNavItem`; stopped passing `id` to `AppShellRailItem` from `@trycompai/design-system`.
  - Added regression tests to prevent hard-coded/duplicate rail-item ids and to verify unique ids across rail and mobile drawer (prettier-format only).

<sup>Written for commit f177919b43133c6da39fbb8dfb56e3345bf265c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

