### PR TITLE
fix(app): use the GA gemini-3.1-flash-lite slug

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/automation/[automationId]/components/workflow/workflow-visualizer-simple.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/automation/[automationId]/components/workflow/workflow-visualizer-simple.tsx
@@ -229,7 +229,7 @@ Please fix the automation script to resolve this error.`;
       { text: errorMessage },
       {
         body: {
-          modelId: 'google/gemini-3.1-flash-lite-preview',
+          modelId: 'google/gemini-3.1-flash-lite',
           reasoningEffort: 'high',
           orgId,
           taskId,

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/automation/[automationId]/hooks/use-chat-handlers.ts
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/automation/[automationId]/hooks/use-chat-handlers.ts
@@ -74,7 +74,7 @@ export function useChatHandlers({
         { text },
         {
           body: {
-            modelId: 'google/gemini-3.1-flash-lite-preview',
+            modelId: 'google/gemini-3.1-flash-lite',
             reasoningEffort: 'high',
             orgId,
             taskId,
@@ -96,7 +96,7 @@ export function useChatHandlers({
         },
         {
           body: {
-            modelId: 'google/gemini-3.1-flash-lite-preview',
+            modelId: 'google/gemini-3.1-flash-lite',
             reasoningEffort: 'high',
             orgId,
             taskId,
@@ -120,7 +120,7 @@ export function useChatHandlers({
         },
         {
           body: {
-            modelId: 'google/gemini-3.1-flash-lite-preview',
+            modelId: 'google/gemini-3.1-flash-lite',
             reasoningEffort: 'high',
             orgId,
             taskId,

--- a/apps/app/src/lib/rerank-suggestions.spec.ts
+++ b/apps/app/src/lib/rerank-suggestions.spec.ts
@@ -80,6 +80,22 @@ describe('rerankSuggestions', () => {
     expect(byId.tsk_c).toBe(0);
   });
 
+  // Regression: the reranker was pinned to `google/gemini-3.1-flash-lite-preview`. The
+  // gateway retires `-preview` aliases on GA, so every call 404'd — and because both
+  // callers in run-linkage.ts catch and fall back to cosine, nothing surfaced the failure.
+  it('requests a GA model slug, never a -preview alias', async () => {
+    generateObjectMock.mockResolvedValueOnce({ object: { scores: [] } });
+
+    await rerankSuggestions({
+      source: { kind: 'risk', title: 't', description: 'd' },
+      candidates: [{ id: 'tsk_a', title: 'A', description: 'a', cosineScore: 0.5 }],
+    });
+
+    const { model } = generateObjectMock.mock.calls[0][0];
+    expect(model.modelId).toBe('google/gemini-3.1-flash-lite');
+    expect(model.modelId).not.toMatch(/-preview$/);
+  });
+
   it('assigns 0 to candidates the LLM omits', async () => {
     generateObjectMock.mockResolvedValueOnce({
       object: { scores: [{ id: 'tsk_a', score: 8 }] },

--- a/apps/app/src/lib/rerank-suggestions.ts
+++ b/apps/app/src/lib/rerank-suggestions.ts
@@ -43,7 +43,12 @@ const gateway = createGatewayProvider({
   baseURL: process.env.AI_GATEWAY_BASE_URL,
 });
 
-const RERANK_MODEL = 'google/gemini-3.1-flash-lite-preview' as const;
+/**
+ * GA slug. Never pin a `-preview` alias here: the gateway retires it once the model
+ * goes GA, and every rerank call then 404s. Both callers in `run-linkage.ts` swallow that
+ * into a cosine-only fallback, so the failure is silent — suggestion quality just degrades.
+ */
+const RERANK_MODEL = 'google/gemini-3.1-flash-lite' as const;
 
 const SYSTEM_PROMPT = `You are a GRC analyst evaluating which compliance tasks would meaningfully reduce a specific risk or vendor exposure.
 


### PR DESCRIPTION
Companion to trycompai/comp-private#329, which carries the customer-facing fix.

## Background

`google/gemini-3.1-flash-lite-preview` no longer exists — the AI Gateway retires `-preview` aliases when a model goes GA. Verified against the live catalog:

```
$ curl -s https://ai-gateway.vercel.sh/v1/models | grep gemini-3.1-flash-lite
google/gemini-3.1-flash-lite          ← exists (GA)
google/gemini-3.1-flash-lite-image
google/gemini-3.1-flash-lite-preview  ← GONE
```

Two paths in this repo referenced it.

## 1. Auto-link reranking — a real, silent regression

`apps/app/src/lib/rerank-suggestions.ts` calls the gateway **directly** for risk/vendor → task auto-link suggestions. Both callers in `run-linkage.ts` (`rerankAndBuildScoreMap`, `rerankForAutonomousPersist`) catch the failure and fall back to raw cosine similarity.

So nothing errored and nothing was logged to the user — auto-link suggestions have just been running at pre-reranker precision, which is the exact problem this module was added to solve (cosine scores collapse into a 0.61–0.64 band for short compliance prose, so on-target tasks and keyword coincidences rank identically).

Added a regression test asserting the requested slug is GA and not a `-preview` alias. Confirmed it fails against the old value:

```
× requests a GA model slug, never a -preview alias
  → expected 'google/gemini-3.1-flash-lite-preview' to be 'google/gemini-3.1-flash-lite'
```

## 2. Automation chat `modelId` — inert, updated for consistency

`use-chat-handlers.ts` (×3) and `workflow-visualizer-simple.tsx` (×1) send `modelId` in the request body, but the enterprise-api chat route hardcodes its own model and ignores the field. Updating them changes no behavior; it just stops the two repos disagreeing about which model is in use.

## Verification

```
$ cd apps/app && npx vitest run src/lib/rerank-suggestions.spec.ts src/lib/embedding/run-linkage.spec.ts
 Test Files  2 passed (2)
      Tests  26 passed (26)
```

`tsc --noEmit` clean on all changed files; `eslint` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch all references to the GA model `google/gemini-3.1-flash-lite` to fix silent reranking failures caused by the retired `-preview` alias. Also align inert chat `modelId` fields to the same GA slug for consistency.

- **Bug Fixes**
  - Replace reranker model with `google/gemini-3.1-flash-lite` to stop 404s and restore auto-link suggestion quality.
  - Add a regression test that asserts a GA slug is used (no `-preview`), and update chat `modelId` fields to the GA slug (no behavior change).

<sup>Written for commit ec646ed7b1b016de785eefee724e51f4c9690a07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

