### PR TITLE
fix(api): don't let scheduled browser runs overwrite not_relevant tasks

### DIFF
--- a/apps/api/src/trigger/browser-automation/run-browser-automation.spec.ts
+++ b/apps/api/src/trigger/browser-automation/run-browser-automation.spec.ts
@@ -2,7 +2,7 @@ jest.mock('@db', () => ({
   db: {
     browserAutomation: { findUnique: jest.fn(), update: jest.fn() },
     browserAutomationRun: { create: jest.fn() },
-    task: { findUnique: jest.fn(), update: jest.fn() },
+    task: { findUnique: jest.fn(), update: jest.fn(), updateMany: jest.fn() },
     organization: { findUnique: jest.fn() },
     member: { findMany: jest.fn() },
   },

--- a/apps/api/src/trigger/browser-automation/run-browser-automation.spec.ts
+++ b/apps/api/src/trigger/browser-automation/run-browser-automation.spec.ts
@@ -22,11 +22,31 @@ jest.mock('@trycompai/email', () => ({
   isUserUnsubscribed: jest.fn().mockResolvedValue(false),
 }));
 
+// Control what the actual browser run returns so we can drive the task-status
+// transitions in the worker body.
+const mockRunBrowserAutomation = jest.fn();
+jest.mock('../../browserbase/browserbase.service', () => ({
+  BrowserbaseService: jest.fn().mockImplementation(() => ({
+    runBrowserAutomation: mockRunBrowserAutomation,
+  })),
+}));
+
+import { db } from '@db';
 import {
   isTaskStatusProtectedFromAutomation,
+  runBrowserAutomation,
   shouldMarkTaskDoneAfterBrowserRun,
   shouldMarkTaskFailedAfterBrowserRun,
 } from './run-browser-automation';
+
+type WorkerTask = {
+  run: (payload: {
+    automationId: string;
+    automationName: string;
+    organizationId: string;
+    taskId: string;
+  }) => Promise<{ statusChangedToFailed: boolean }>;
+};
 
 describe('shouldMarkTaskDoneAfterBrowserRun', () => {
   it('allows screenshot-only automations to complete tasks', () => {
@@ -87,5 +107,91 @@ describe('isTaskStatusProtectedFromAutomation', () => {
     for (const status of ['todo', 'in_progress', 'in_review', 'done', 'failed']) {
       expect(isTaskStatusProtectedFromAutomation(status)).toBe(false);
     }
+  });
+});
+
+describe('runBrowserAutomation worker — task-status transitions are atomic + guarded', () => {
+  const worker = runBrowserAutomation as unknown as WorkerTask;
+  const payload = {
+    automationId: 'bau_1',
+    automationName: 'GitHub MFA',
+    organizationId: 'org_1',
+    taskId: 'tsk_1',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (db.browserAutomation.findUnique as jest.Mock).mockResolvedValue({
+      id: 'bau_1',
+      isEnabled: true,
+      evaluationCriteria: 'MFA is enforced',
+    });
+    // findUnique serves both the title lookup and the frequency lookup.
+    (db.task.findUnique as jest.Mock).mockResolvedValue({
+      title: 'Enforce MFA',
+      frequency: 'monthly',
+    });
+    (db.task.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+    (db.browserAutomation.update as jest.Mock).mockResolvedValue({});
+  });
+
+  it('flips a passing run to done via an updateMany that excludes not_relevant', async () => {
+    mockRunBrowserAutomation.mockResolvedValue({
+      success: true,
+      runId: 'bar_1',
+      screenshotUrl: 'https://s3/shot.jpg',
+      evaluationStatus: 'pass',
+    });
+
+    await worker.run(payload);
+
+    expect(db.task.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: 'tsk_1',
+          status: { notIn: expect.arrayContaining(['done', 'not_relevant']) },
+        },
+        data: expect.objectContaining({ status: 'done' }),
+      }),
+    );
+    // The task is never updated by primary key alone (which would ignore the guard).
+    expect(db.task.update).not.toHaveBeenCalled();
+  });
+
+  it('flips a regressed run to failed via an updateMany that excludes not_relevant', async () => {
+    mockRunBrowserAutomation.mockResolvedValue({
+      success: false,
+      runId: 'bar_1',
+      evaluationStatus: 'fail',
+    });
+
+    const result = await worker.run(payload);
+
+    expect(db.task.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: 'tsk_1',
+          status: { notIn: expect.arrayContaining(['failed', 'not_relevant']) },
+        },
+        data: { status: 'failed' },
+      }),
+    );
+    expect(result.statusChangedToFailed).toBe(true);
+    expect(db.task.update).not.toHaveBeenCalled();
+  });
+
+  it('treats a zero-count update as no transition (protected/already-failed task)', async () => {
+    mockRunBrowserAutomation.mockResolvedValue({
+      success: false,
+      runId: 'bar_1',
+      evaluationStatus: 'fail',
+    });
+    // The atomic guard matched nothing — e.g. the task was concurrently marked
+    // not_relevant, or was already failed.
+    (db.task.updateMany as jest.Mock).mockResolvedValue({ count: 0 });
+
+    const result = await worker.run(payload);
+
+    expect(result.statusChangedToFailed).toBe(false);
   });
 });

--- a/apps/api/src/trigger/browser-automation/run-browser-automation.spec.ts
+++ b/apps/api/src/trigger/browser-automation/run-browser-automation.spec.ts
@@ -23,6 +23,7 @@ jest.mock('@trycompai/email', () => ({
 }));
 
 import {
+  isTaskStatusProtectedFromAutomation,
   shouldMarkTaskDoneAfterBrowserRun,
   shouldMarkTaskFailedAfterBrowserRun,
 } from './run-browser-automation';
@@ -73,5 +74,18 @@ describe('shouldMarkTaskFailedAfterBrowserRun', () => {
 
   it('does not fail the task on a passing verdict', () => {
     expect(shouldMarkTaskFailedAfterBrowserRun({ evaluationStatus: 'pass' })).toBe(false);
+  });
+});
+
+describe('isTaskStatusProtectedFromAutomation', () => {
+  it('protects a deliberate human not_relevant decision', () => {
+    // A scheduled run must never overwrite this (it has a human justification).
+    expect(isTaskStatusProtectedFromAutomation('not_relevant')).toBe(true);
+  });
+
+  it('does not protect the normal automatable statuses', () => {
+    for (const status of ['todo', 'in_progress', 'in_review', 'done', 'failed']) {
+      expect(isTaskStatusProtectedFromAutomation(status)).toBe(false);
+    }
   });
 });

--- a/apps/api/src/trigger/browser-automation/run-browser-automation.ts
+++ b/apps/api/src/trigger/browser-automation/run-browser-automation.ts
@@ -38,6 +38,17 @@ export function shouldMarkTaskFailedAfterBrowserRun(input: {
 }
 
 /**
+ * Task statuses a scheduled run must NOT overwrite — a deliberate human decision.
+ * `not_relevant` is set by a person (with a justification) to exclude the task
+ * from compliance; an automation flipping it to done/failed would silently
+ * destroy that decision. Mirrors the codebase norm (cloud-security skips
+ * `not_relevant` "user intent"). Exported for unit testing.
+ */
+export function isTaskStatusProtectedFromAutomation(status: string): boolean {
+  return status === 'not_relevant';
+}
+
+/**
  * Worker task that runs a single browser automation.
  *
  * Triggered by the per-org runner (run-org-browser-automations), which waits on
@@ -123,7 +134,11 @@ export const runBrowserAutomation = task({
           select: { status: true, frequency: true },
         });
 
-        if (currentTask && currentTask.status !== 'done') {
+        if (
+          currentTask &&
+          currentTask.status !== 'done' &&
+          !isTaskStatusProtectedFromAutomation(currentTask.status)
+        ) {
           let reviewDate: Date | undefined;
           if (currentTask.frequency) {
             reviewDate = new Date();
@@ -177,10 +192,14 @@ export const runBrowserAutomation = task({
         const oldStatus = taskBeforeUpdate?.status ?? 'todo';
 
         // Transition only: don't re-flip / re-report a task that's already
-        // failed. The per-org runner (run-org-browser-automations) collects
-        // these transitions and sends one bundled failure email — covering both
-        // `needs_reauth` and control-regressed (`evaluation fail`) cases.
-        if (oldStatus !== 'failed') {
+        // failed. Also never overwrite a deliberate human decision like
+        // `not_relevant`. The per-org runner (run-org-browser-automations)
+        // collects these transitions and sends one bundled failure email —
+        // covering both `needs_reauth` and control-regressed (`evaluation fail`).
+        if (
+          oldStatus !== 'failed' &&
+          !isTaskStatusProtectedFromAutomation(oldStatus)
+        ) {
           await db.task.update({
             where: { id: taskId },
             data: { status: 'failed' },

--- a/apps/api/src/trigger/browser-automation/run-browser-automation.ts
+++ b/apps/api/src/trigger/browser-automation/run-browser-automation.ts
@@ -38,14 +38,19 @@ export function shouldMarkTaskFailedAfterBrowserRun(input: {
 }
 
 /**
- * Task statuses a scheduled run must NOT overwrite — a deliberate human decision.
- * `not_relevant` is set by a person (with a justification) to exclude the task
- * from compliance; an automation flipping it to done/failed would silently
- * destroy that decision. Mirrors the codebase norm (cloud-security skips
- * `not_relevant` "user intent"). Exported for unit testing.
+ * Task statuses a scheduled run must NEVER overwrite — deliberate human
+ * decisions. `not_relevant` is set by a person (with a justification) to exclude
+ * the task from compliance; an automation flipping it to done/failed would
+ * silently destroy that decision. Mirrors the codebase norm (cloud-security
+ * skips `not_relevant` as "user intent"). Single source of truth for both the
+ * exported guard and the atomic status-update WHERE clauses below.
  */
+export const AUTOMATION_PROTECTED_TASK_STATUSES = ['not_relevant'] as const;
+
 export function isTaskStatusProtectedFromAutomation(status: string): boolean {
-  return status === 'not_relevant';
+  return (AUTOMATION_PROTECTED_TASK_STATUSES as readonly string[]).includes(
+    status,
+  );
 }
 
 /**
@@ -131,40 +136,36 @@ export const runBrowserAutomation = task({
       ) {
         const currentTask = await db.task.findUnique({
           where: { id: taskId },
-          select: { status: true, frequency: true },
+          select: { frequency: true },
         });
 
-        if (
-          currentTask &&
-          currentTask.status !== 'done' &&
-          !isTaskStatusProtectedFromAutomation(currentTask.status)
-        ) {
-          let reviewDate: Date | undefined;
-          if (currentTask.frequency) {
-            reviewDate = new Date();
-            switch (currentTask.frequency) {
-              case 'monthly':
-                reviewDate.setMonth(reviewDate.getMonth() + 1);
-                break;
-              case 'quarterly':
-                reviewDate.setMonth(reviewDate.getMonth() + 3);
-                break;
-              case 'yearly':
-                reviewDate.setFullYear(reviewDate.getFullYear() + 1);
-                break;
-            }
+        let reviewDate: Date | undefined;
+        if (currentTask?.frequency) {
+          reviewDate = new Date();
+          switch (currentTask.frequency) {
+            case 'monthly':
+              reviewDate.setMonth(reviewDate.getMonth() + 1);
+              break;
+            case 'quarterly':
+              reviewDate.setMonth(reviewDate.getMonth() + 3);
+              break;
+            case 'yearly':
+              reviewDate.setFullYear(reviewDate.getFullYear() + 1);
+              break;
           }
-
-          await db.task.update({
-            where: { id: taskId },
-            data: {
-              status: 'done',
-              ...(reviewDate ? { reviewDate } : {}),
-            },
-          });
-
-          logger.info(`Task ${taskId} marked as done`);
         }
+
+        // Atomic: flip to done only if it isn't already done and isn't a
+        // protected human status — the guard is in the WHERE, so a concurrent
+        // `not_relevant` action can't be clobbered between a read and the write.
+        const doneUpdate = await db.task.updateMany({
+          where: {
+            id: taskId,
+            status: { notIn: ['done', ...AUTOMATION_PROTECTED_TASK_STATUSES] },
+          },
+          data: { status: 'done', ...(reviewDate ? { reviewDate } : {}) },
+        });
+        if (doneUpdate.count > 0) logger.info(`Task ${taskId} marked as done`);
       }
     } else {
       logger.error(`Automation ${automationId} failed`, {
@@ -185,25 +186,19 @@ export const runBrowserAutomation = task({
           needsReauth: result.needsReauth,
         })
       ) {
-        const taskBeforeUpdate = await db.task.findUnique({
-          where: { id: taskId },
-          select: { status: true },
+        // Atomic transition: flip to failed only if it isn't already failed and
+        // isn't a protected human status (e.g. `not_relevant`). The guard lives
+        // in the WHERE so a concurrent human action can't be overwritten between
+        // a read and the write; count > 0 means THIS run caused the transition
+        // (which drives the per-org bundled failure email).
+        const failedUpdate = await db.task.updateMany({
+          where: {
+            id: taskId,
+            status: { notIn: ['failed', ...AUTOMATION_PROTECTED_TASK_STATUSES] },
+          },
+          data: { status: 'failed' },
         });
-        const oldStatus = taskBeforeUpdate?.status ?? 'todo';
-
-        // Transition only: don't re-flip / re-report a task that's already
-        // failed. Also never overwrite a deliberate human decision like
-        // `not_relevant`. The per-org runner (run-org-browser-automations)
-        // collects these transitions and sends one bundled failure email —
-        // covering both `needs_reauth` and control-regressed (`evaluation fail`).
-        if (
-          oldStatus !== 'failed' &&
-          !isTaskStatusProtectedFromAutomation(oldStatus)
-        ) {
-          await db.task.update({
-            where: { id: taskId },
-            data: { status: 'failed' },
-          });
+        if (failedUpdate.count > 0) {
           statusChangedToFailed = true;
         } else {
           logger.info(


### PR DESCRIPTION
## What & why

I reviewed the automated-review (cubic) findings on the stage→prod deploy PR (#3506) — 40 findings. **One is genuinely harmful to users, and it's fixed here.** The rest are already-fixed or documented-deferred (details below).

### The issue (P1) — fixed
A scheduled browser automation flipped **any** non-`done`/non-`failed` task to `done` or `failed` — **including tasks a person deliberately marked `not_relevant`** (which carries a human justification). That silently **overwrote the compliance decision** and orphaned its justification.

### The fix
Guard both the done and failed transitions so an automated run **never overwrites a `not_relevant` task** — matching the existing codebase norm (cloud-security already *"skips not_relevant (user intent)"*). Added a small exported helper `isTaskStatusProtectedFromAutomation` + unit tests.

Scope: `apps/api/src/trigger/browser-automation/run-browser-automation.ts` (+ spec). 8 tests pass, typecheck clean.

## The other 39 findings — why they're not here
- **Already fixed** on the feature branch. The deploy diff re-includes the original code, so cubic re-surfaces issues that are already addressed: the API-error `.error` checks, `task:*` vs `integration:*` permission gating, empty-state connect gating, evidence best-effort capture, session cleanup on callback throw, `markVerified` freshness, the roll-up `pass` verdict, the MFA-instruction cache, etc.
- **Documented-deferred edges** (recorded, none prod-blocking): orphaned 1Password item on credential re-save (H-2), session cleanup on a mid-connect unmount, the sibling-automation task-status race, 1Password resolve-error classification, and the DNS-blind `IsSafeUrl` (mitigated — the browser runs in Browserbase's isolated egress, not our network).
- **Low / not-an-issue:** the `vendor-logo` route is a favicon proxy to a **fixed** upstream host (not an open SSRF); the remainder are accessibility / test-coverage nits.

Only the `not_relevant` overwrite would actively harm a user's data — hence a focused PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scheduled browser runs no longer overwrite tasks marked `not_relevant`; human decisions and justifications are preserved. Done/failed transitions are now guarded atomically and only apply when the task isn’t already `done`/`failed`.

- **Bug Fixes**
  - Use atomic `updateMany` with a WHERE that excludes `done`, `failed`, and protected statuses (`isTaskStatusProtectedFromAutomation`) to prevent race conditions; derive `statusChangedToFailed` from affected row count.
  - Add unit tests for `isTaskStatusProtectedFromAutomation` and worker-level tests that assert the atomic `updateMany` filters and zero-count handling; compute `reviewDate` from `frequency` without pre-checking current status.

<sup>Written for commit 2ea3283766640f377a51af3390908cbfec9a8912. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

