### PR TITLE
fix(audit): stop plaintext secrets leaking into the audit log

### DIFF
--- a/apps/api/src/admin-organizations/admin-audit-log.interceptor.spec.ts
+++ b/apps/api/src/admin-organizations/admin-audit-log.interceptor.spec.ts
@@ -54,6 +54,8 @@ jest.mock('@db', () => ({
 jest.mock('../audit/audit-log.constants', () => ({
   MUTATION_METHODS: new Set(['POST', 'PATCH', 'PUT', 'DELETE']),
   SENSITIVE_KEYS: new Set(['password', 'token']),
+  SENSITIVE_KEY_PATTERN:
+    /secret|password|passphrase|credential|token|api[_-]?key|private[_-]?key|totp|access[_-]?key/i,
 }));
 
 function buildContext(overrides: {
@@ -255,6 +257,28 @@ describe('AdminAuditLogInterceptor', () => {
           const changes = callData.data.changes;
           expect(changes.status).toBeDefined();
           expect(changes.password).toBeUndefined();
+          done();
+        }, 50);
+      },
+    });
+  });
+
+  it('sanitizes credential-shaped keys the exact list misses (clientSecret)', (done) => {
+    mockPolicyFind.mockResolvedValue({ name: 'Test' });
+
+    const ctx = buildContext({
+      method: 'PATCH',
+      url: '/v1/admin/organizations/org_1/policies/pol_1',
+      params: { orgId: 'org_1' },
+      body: { status: 'published', clientSecret: 'leak_me' },
+    });
+
+    interceptor.intercept(ctx, nextHandler).subscribe({
+      complete: () => {
+        setTimeout(() => {
+          const changes = mockCreate.mock.calls[0][0].data.data.changes;
+          expect(changes.status).toBeDefined();
+          expect(changes.clientSecret).toBeUndefined();
           done();
         }, 50);
       },

--- a/apps/api/src/admin-organizations/admin-audit-log.interceptor.ts
+++ b/apps/api/src/admin-organizations/admin-audit-log.interceptor.ts
@@ -8,7 +8,11 @@ import {
 import { AuditLogEntityType, db, Prisma } from '@db';
 import { Reflector } from '@nestjs/core';
 import { Observable, tap } from 'rxjs';
-import { MUTATION_METHODS, SENSITIVE_KEYS } from '../audit/audit-log.constants';
+import {
+  MUTATION_METHODS,
+  SENSITIVE_KEYS,
+  SENSITIVE_KEY_PATTERN,
+} from '../audit/audit-log.constants';
 import { SKIP_ADMIN_AUDIT_LOG_KEY } from './skip-admin-audit-log.decorator';
 
 const SEGMENT_TO_RESOURCE: Record<
@@ -261,7 +265,15 @@ export class AdminAuditLogInterceptor implements NestInterceptor {
     const changes: Changes = {};
 
     for (const [key, value] of Object.entries(body)) {
-      if (value === undefined || SENSITIVE_KEYS.has(key)) continue;
+      // Skip exact-match sensitive keys AND credential-shaped names the exact
+      // list misses (clientSecret, secretAccessKey, …) — shared with the global
+      // interceptor so both audit paths redact consistently.
+      if (
+        value === undefined ||
+        SENSITIVE_KEYS.has(key) ||
+        SENSITIVE_KEY_PATTERN.test(key)
+      )
+        continue;
       changes[key] = { previous: null, current: value };
     }
 

--- a/apps/api/src/audit/audit-log.constants.ts
+++ b/apps/api/src/audit/audit-log.constants.ts
@@ -24,6 +24,24 @@ export const SENSITIVE_KEYS = new Set([
   'totpCode',
 ]);
 
+/**
+ * Fallback pattern for credential-ish field names the exact-match set misses
+ * (e.g. `clientSecret`, `secretAccessKey`, `aws_secret_access_key`). Matched
+ * case-insensitively against key names anywhere in the audited body, so new
+ * credential fields are redacted without having to enumerate every name.
+ */
+export const SENSITIVE_KEY_PATTERN =
+  /secret|password|passphrase|credential|token|api[_-]?key|private[_-]?key|totp|access[_-]?key/i;
+
+/**
+ * Resources whose request body must never be diffed into the audit log at all —
+ * the field carrying the secret is generically named (e.g. the secret manager's
+ * `value`) so key-based redaction can't catch it, and reading audit logs needs
+ * only `app:read`. For these we log the action (Created/Updated/Deleted) with no
+ * payload, keeping plaintext out of a store that bypasses `secret:read`.
+ */
+export const REDACT_BODY_RESOURCES = new Set(['secret']);
+
 export const RESOURCE_TO_ENTITY_TYPE: Record<
   string,
   AuditLogEntityType | null

--- a/apps/api/src/audit/audit-log.interceptor.spec.ts
+++ b/apps/api/src/audit/audit-log.interceptor.spec.ts
@@ -443,6 +443,45 @@ describe('AuditLogInterceptor', () => {
     });
   });
 
+  it('logs the action but never the payload for the secret resource', (done) => {
+    // Reading audit logs needs only app:read; the secret manager's plaintext
+    // `value` must not be diffed into the log where an auditor (no secret:read)
+    // could read it.
+    jest.spyOn(reflector, 'getAllAndOverride').mockImplementation((key) => {
+      if (key === PERMISSIONS_KEY) {
+        return [{ resource: 'secret', actions: ['create'] }];
+      }
+      if (key === SKIP_AUDIT_LOG_KEY) return false;
+      return undefined;
+    });
+
+    const context = createMockExecutionContext({
+      method: 'POST',
+      url: '/v1/secrets',
+      params: {},
+      body: { name: 'STRIPE_KEY', value: 'sk_live_super_secret' },
+    });
+    const handler = createMockCallHandler({ id: 'sec_1' });
+
+    interceptor.intercept(context, handler).subscribe({
+      next: () => {
+        setTimeout(() => {
+          expect(mockCreate).toHaveBeenCalled();
+          // The action is recorded...
+          expect(mockCreate).toHaveBeenCalledWith(
+            expect.objectContaining({
+              data: expect.objectContaining({ description: 'Created secret' }),
+            }),
+          );
+          // ...but the plaintext value never appears anywhere in the row.
+          const persisted = JSON.stringify(mockCreate.mock.calls[0][0]);
+          expect(persisted).not.toContain('sk_live_super_secret');
+          done();
+        }, 50);
+      },
+    });
+  });
+
   it('should skip requests without userId', (done) => {
     jest.spyOn(reflector, 'getAllAndOverride').mockImplementation((key) => {
       if (key === PERMISSIONS_KEY) {

--- a/apps/api/src/audit/audit-log.interceptor.ts
+++ b/apps/api/src/audit/audit-log.interceptor.ts
@@ -15,6 +15,7 @@ import { AUDIT_READ_KEY, SKIP_AUDIT_LOG_KEY } from './skip-audit-log.decorator';
 import {
   MEMBER_REF_FIELDS,
   MUTATION_METHODS,
+  REDACT_BODY_RESOURCES,
   RESOURCE_TO_ENTITY_TYPE,
 } from './audit-log.constants';
 import {
@@ -268,6 +269,12 @@ export class AuditLogInterceptor implements NestInterceptor {
               } else if (relationMappingResult) {
                 changes = relationMappingResult.changes;
                 descriptionOverride ??= relationMappingResult.description;
+              } else if (REDACT_BODY_RESOURCES.has(resource)) {
+                // Credential resources (e.g. the secret manager) carry their
+                // secret in a generically-named field. Diffing the body would
+                // land plaintext in a store readable with only app:read, which
+                // bypasses <resource>:read. Record the action, not the payload.
+                changes = null;
               } else {
                 changes = requestBody
                   ? buildChanges(requestBody, previousValues, memberNames)

--- a/apps/api/src/audit/audit-log.utils.spec.ts
+++ b/apps/api/src/audit/audit-log.utils.spec.ts
@@ -1,0 +1,66 @@
+// buildChanges → constants pull Prisma enums at module load; stub @db so the
+// pure redaction logic can be tested without a real client.
+jest.mock('@db', () => ({
+  db: {},
+  AuditLogEntityType: new Proxy({}, { get: (_t, p) => p }),
+  CommentEntityType: new Proxy({}, { get: (_t, p) => p }),
+}));
+
+import { buildChanges } from './audit-log.utils';
+
+describe('buildChanges — redaction', () => {
+  it('redacts the existing exact-match sensitive keys', () => {
+    const changes = buildChanges(
+      { password: 'p', apiKey: 'k', name: 'ok' },
+      null,
+      {},
+    );
+    expect(changes?.password.current).toBe('[REDACTED]');
+    expect(changes?.apiKey.current).toBe('[REDACTED]');
+    expect(changes?.name.current).toBe('ok');
+  });
+
+  it('redacts credential-named keys the exact list misses (clientSecret, secretAccessKey)', () => {
+    const changes = buildChanges(
+      {
+        clientSecret: 'abc',
+        secretAccessKey: 'xyz',
+        aws_secret_access_key: 'q',
+        name: 'ok',
+      },
+      null,
+      {},
+    );
+    expect(changes?.clientSecret.current).toBe('[REDACTED]');
+    expect(changes?.secretAccessKey.current).toBe('[REDACTED]');
+    expect(changes?.aws_secret_access_key.current).toBe('[REDACTED]');
+    expect(changes?.name.current).toBe('ok');
+  });
+
+  it('summarizes object elements inside arrays so secrets in generic fields cannot leak', () => {
+    // e.g. browserbase `extraFields: [{ label, value }]` — `value` is a secret
+    // under a non-credential key; the whole element is hidden as [Object].
+    const changes = buildChanges(
+      { extraFields: [{ label: 'workspace', value: 'sekret' }] },
+      null,
+      {},
+    );
+    expect(changes?.extraFields.current).toEqual(['[Object]']);
+  });
+
+  it('keeps primitive array elements (ids, scopes, tags) visible', () => {
+    const changes = buildChanges({ scopes: ['read', 'write'] }, null, {});
+    expect(changes?.scopes.current).toEqual(['read', 'write']);
+  });
+
+  it('keeps summarizing nested plain objects as [Object]', () => {
+    const changes = buildChanges({ config: { a: 1, token: 't' } }, null, {});
+    expect(changes?.config.current).toBe('[Object]');
+  });
+
+  it('leaves ordinary values untouched', () => {
+    const changes = buildChanges({ status: 'active', count: 3 }, null, {});
+    expect(changes?.status.current).toBe('active');
+    expect(changes?.count.current).toBe(3);
+  });
+});

--- a/apps/api/src/audit/audit-log.utils.ts
+++ b/apps/api/src/audit/audit-log.utils.ts
@@ -4,6 +4,7 @@ import {
   COMMENT_ENTITY_TYPE_MAP,
   MEMBER_REF_FIELDS,
   SENSITIVE_KEYS,
+  SENSITIVE_KEY_PATTERN,
 } from './audit-log.constants';
 
 export type AuditContextOverride = {
@@ -328,12 +329,27 @@ export function buildDescription(
   }
 }
 
+function isSensitiveKey(key: string): boolean {
+  return SENSITIVE_KEYS.has(key) || SENSITIVE_KEY_PATTERN.test(key);
+}
+
 function sanitizeValue(key: string, value: unknown): unknown {
-  if (SENSITIVE_KEYS.has(key)) return '[REDACTED]';
+  if (isSensitiveKey(key)) return '[REDACTED]';
   if (value instanceof Date) return value.toISOString();
-  if (value && typeof value === 'object' && !Array.isArray(value))
-    return '[Object]';
+  // Arrays are logged rather than summarized, so a secret in a generically-named
+  // field inside an array element (e.g. `extraFields: [{ label, value }]`) would
+  // otherwise land in the log verbatim. Keep primitive elements (ids, scopes,
+  // tags) but summarize object/array elements as '[Object]' — the same way a
+  // nested object is hidden below.
+  if (Array.isArray(value)) return value.map(summarizeArrayItem);
+  if (value && typeof value === 'object') return '[Object]';
   return value;
+}
+
+function summarizeArrayItem(item: unknown): unknown {
+  if (item instanceof Date) return item.toISOString();
+  if (item && typeof item === 'object') return '[Object]';
+  return item;
 }
 
 export function buildChanges(

--- a/apps/api/src/email/email.controller.ts
+++ b/apps/api/src/email/email.controller.ts
@@ -10,6 +10,7 @@ import { tasks } from '@trigger.dev/sdk';
 import { HybridAuthGuard } from '../auth/hybrid-auth.guard';
 import { PermissionGuard } from '../auth/permission.guard';
 import { RequirePermission } from '../auth/require-permission.decorator';
+import { SkipAuditLog } from '../audit/skip-audit-log.decorator';
 import { SendEmailDto } from './dto/send-email.dto';
 import { SendBatchEmailDto } from './dto/send-batch-email.dto';
 import type { sendEmailTask } from '../trigger/email/send-email';
@@ -24,6 +25,9 @@ export class EmailController {
   @Post('send')
   @HttpCode(200)
   @RequirePermission('email', 'send')
+  // The body carries rendered `html` (magic-links / OTP) and full attachment
+  // bytes — never worth diffing into the audit log, and readable with app:read.
+  @SkipAuditLog()
   @ApiOperation({
     summary: 'Send an email via the centralized Trigger task (internal)',
   })
@@ -46,6 +50,7 @@ export class EmailController {
   @Post('send-batch')
   @HttpCode(200)
   @RequirePermission('email', 'send')
+  @SkipAuditLog()
   @ApiOperation({
     summary: 'Send a batch of emails via the centralized Trigger task (internal)',
   })


### PR DESCRIPTION
## Summary (security)

Audit rows are readable with `app:read` (which the **auditor** role has), but the `AuditLogInterceptor` diffed request bodies into `AuditLog.data` using only **exact-match, top-level key** redaction. Credentials therefore landed in cleartext in a store readable by roles that are denied the resource's own read permission.

**Confirmed, traced leak:** `POST` / `PUT /v1/secrets` stored the plaintext `value` (the key `value` isn't in the denylist) → any **auditor** (deliberately denied `secret:read` — see the comment at `permissions.ts:50-53`) could read org secrets via `GET /v1/audit-logs`. Intra-tenant, but auditor is often an external third party, and the plaintext also sits in DB/backups/log pipelines. High severity.

I also swept every audited mutation endpoint for the same class of issue and fixed them all.

## Fix — defense in depth

1. **Per-resource body skip** — `REDACT_BODY_RESOURCES = {'secret'}`: log the action (`Created/Updated/Deleted secret`) but never diff the body. This is the only thing that catches a secret in a generically-named field like `value`.
2. **Regex key matching** — `sanitizeValue` now redacts keys matching `/secret|password|passphrase|credential|token|api[_-]?key|private[_-]?key|totp|access[_-]?key/i`, so `clientSecret`, `secretAccessKey`, `accessKeyId`, … are caught (they weren't before).
3. **Array summarization** — object elements inside arrays are now summarized as `[Object]` (nested objects already were), closing secrets that ride in generic array fields — e.g. browserbase `extraFields[].value` (site login creds) and email `attachments[].content`. Primitive array elements (ids, scopes, tags) stay visible.
4. **`@SkipAuditLog`** on the internal mailer (`/v1/internal/email/send*`) — `html`/attachments carry OTP/magic-links and have little audit value.

## Sweep result (all other credential endpoints)

Already **covered** by the above: cloud-security `validate-aws` (`accessKeyId`/`secretAccessKey` → regex), integration `connections`/`variables`/`credentials` (nested object → `[Object]`), oauth-apps `clientSecret` (regex), browserbase `totpSeed`. API-key creation returns the key in the *response* (bodies only are logged) — not affected. Platform admin credential save uses a separate interceptor that never logs bodies.

Residual (identifier, not secret): browserbase `username` / oauth `clientId` remain visible — login identities, not credentials.

## Tests
- `audit-log.utils.spec` (new): regex redaction, array-object summarization, nested-object hiding, primitives preserved.
- `audit-log.interceptor.spec`: a `secret` mutation logs the action but the plaintext never appears in the row.
- Audit suite 68/68, typecheck clean.

## Follow-up (not in this PR)
Historical `audit_log.data` rows already contain leaked plaintext — a scrub of existing rows + downstream exports should be done separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents plaintext secrets from being stored in audit logs. Closes a confirmed leak where users with `app:read` could read secret values via `GET /v1/audit-logs`.

- **Bug Fixes**
  - Skip body diffing for the `secret` resource; log the action only.
  - Redact credential-like keys via regex (e.g., `clientSecret`, `secretAccessKey`, `apiKey`, `privateKey`, `totp`) in both global and admin audit interceptors.
  - Summarize object elements inside arrays as `[Object]`; keep primitive arrays unchanged.
  - Apply `@SkipAuditLog` to internal email send endpoints to avoid logging `html` and attachments.
  - Add tests for regex redaction (including admin path), array summarization, nested object hiding, and interceptor behavior.

<sup>Written for commit d54c8dd0a391ce37b882850e7a74b37783474f6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

