### PR TITLE
fix(app): prompt to connect when creating a browser automation with no connection

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/BrowserAutomations.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/BrowserAutomations.tsx
@@ -392,32 +392,38 @@ export function BrowserAutomations({ taskId, isManualTask = false }: BrowserAuto
   // connects here, `justConnected` advances to the "add your first automation"
   // state. Connections are org-level and reused, so connecting an already-connected
   // vendor simply reuses the saved session.
-  // A pending draft means the task is mid-setup — don't drop back to first-run.
-  if (
-    !isManualTask &&
-    automations.automations.length === 0 &&
-    !justConnected &&
-    drafts.length === 0
-  ) {
-    return (
-      <BrowserEvidenceEmptyState
-        isStartingAuth={context.isStartingAuth}
-        onConnect={() => setConnectOpen(true)}
+  // No saved automations yet.
+  if (!isManualTask && automations.automations.length === 0) {
+    // An automation can only be built on an existing connection — the composer
+    // opens on one. With no connection (and none just made — the profile list
+    // refetches a beat after connecting), "Create" would silently no-op because
+    // there's nothing to open the composer on, so prompt to connect first.
+    // Drafts are still surfaced above so they can be resumed either way.
+    const hasConnection = profiles.length > 0;
+    const draftsStrip = drafts.length > 0 && (
+      <DraftsStrip
+        drafts={drafts}
+        profiles={profiles}
+        onContinue={handleContinueDraft}
+        onDelete={handleDeleteDraft}
       />
     );
-  }
 
-  // No saved automations yet, but a connection and/or a draft exists — prompt to
-  // create the first one, with any drafts pinned above to resume.
-  if (!isManualTask && automations.automations.length === 0) {
+    if (!hasConnection && !justConnected) {
+      return (
+        <>
+          {draftsStrip}
+          <BrowserEvidenceEmptyState
+            isStartingAuth={context.isStartingAuth}
+            onConnect={() => setConnectOpen(true)}
+          />
+        </>
+      );
+    }
+
     return (
       <>
-        <DraftsStrip
-          drafts={drafts}
-          profiles={profiles}
-          onContinue={handleContinueDraft}
-          onDelete={handleDeleteDraft}
-        />
+        {draftsStrip}
         <EmptyWithContextState
           onCreateClick={() => setComposer({ open: true, mode: 'create' })}
         />


### PR DESCRIPTION
## The bug
On an evidence task with **no connections** (e.g. after deleting them), the Browser Automations section still showed **"Create Browser Automation"** — but clicking it did nothing.

## Root cause
The button sets `composer.open = true`, but the composer only renders when `composer.open && composerConnection` (`BrowserAutomations.tsx:365`). With no connections, `composerConnection` resolves to **`null`** (`buildConnectionRef` falls through to `return null`), so the composer never opens and the screen falls back to itself — a silent no-op.

The deeper issue: an automation can only be built **on an existing connection**, but the empty-state offered "Create" regardless of whether one existed.

## The fix
Decide the no-automations empty state by whether a connection actually exists:
- **No connection** (and none just made — the profile list refetches a beat after connecting) → show **"Connect a vendor login"** first (clickable, correct next step).
- **Has a connection** → show "Create Browser Automation" as before.
- Drafts are still surfaced above either way, so nothing in progress is lost.

## Verification
Typecheck clean. No test harness exists for this orchestrator component (wires ~10 hooks); verified by tracing the render/composer conditions. Best confirmed live: on a task with zero connections, the section now shows the clickable "Connect a vendor login" instead of a dead "Create" card.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a dead "Create Browser Automation" button by prompting to connect a vendor login when the task has no connections. Drafts still show, and "Create" appears once a connection exists.

- **Bug Fixes**
  - If no connection exists, show "Connect a vendor login" instead of "Create Browser Automation".
  - Keep drafts visible via the drafts strip in both states.
  - Ensure the composer only opens when a connection exists, removing the no-op click.

<sup>Written for commit 2b1dcad809a707ed998b95e8602912f9fa90d6f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

