### PR TITLE
fix(app): let users start a new automation instead of being trapped in a half-finished connect

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/BrowserAutomations.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/BrowserAutomations.tsx
@@ -18,9 +18,11 @@ import {
 } from './browser-automations';
 import { BrowserEvidenceEmptyState } from './browser-automations/BrowserEvidenceEmptyState';
 import { DraftsStrip } from './browser-automations/DraftsStrip';
+import { ResumeConnectStrip } from './browser-automations/ResumeConnectStrip';
 import {
   clearConnectState,
   loadConnectState,
+  type PersistedConnectState,
 } from './browser-automations/connect-flow-storage';
 
 interface BrowserAutomationsProps {
@@ -58,6 +60,10 @@ export function BrowserAutomations({ taskId, isManualTask = false }: BrowserAuto
   // Whether the user just connected within THIS task — org-level connection
   // status must not make a fresh task look already set up.
   const [justConnected, setJustConnected] = useState(false);
+  // A half-finished connect the user started and left — surfaced as a resumable
+  // strip (below) so it never blocks creating a new automation.
+  const [pendingConnect, setPendingConnect] =
+    useState<PersistedConnectState | null>(null);
   const authHostname = hostnameFromUrl(authUrl);
 
   // Hooks
@@ -123,6 +129,7 @@ export function BrowserAutomations({ taskId, isManualTask = false }: BrowserAuto
         ? 'password'
         : 'sso';
       clearConnectState(taskId);
+      setPendingConnect(null);
       setReconnectSeed({ url, mode });
       setConnectOpen(true);
     },
@@ -151,6 +158,7 @@ export function BrowserAutomations({ taskId, isManualTask = false }: BrowserAuto
       setAuthUrl(url);
       setJustConnected(true);
       clearConnectState(taskId);
+      setPendingConnect(null);
       context.checkContextStatus();
       // Load the fresh connection before opening the composer so it resolves the
       // just-connected vendor (not a stale profile). Keep the connect view up
@@ -163,15 +171,28 @@ export function BrowserAutomations({ taskId, isManualTask = false }: BrowserAuto
     [taskId, context, automations, fetchProfiles],
   );
 
-  // Connect a brand-new vendor (a new connection) — start the connect flow fresh.
-  const handleConnectAnother = useCallback(() => {
+  // Start a brand-new connect from scratch — clears any half-finished one so the
+  // flow doesn't resume into a stale draft.
+  const startFreshConnect = useCallback(() => {
     clearConnectState(taskId);
+    setPendingConnect(null);
     setConnectOpen(true);
+  }, [taskId]);
+  // Connect a brand-new vendor (a new connection) — same as starting fresh.
+  const handleConnectAnother = startFreshConnect;
+
+  // Resume the half-finished connect (the flow reads its saved state); discard
+  // simply drops it. Neither blocks creating a new automation.
+  const handleResumeConnect = useCallback(() => setConnectOpen(true), []);
+  const handleDiscardConnect = useCallback(() => {
+    clearConnectState(taskId);
+    setPendingConnect(null);
   }, [taskId]);
 
   // A reconnect verified — refresh the connection list; don't open the composer.
   const handleReconnected = useCallback(() => {
     clearConnectState(taskId);
+    setPendingConnect(null);
     setConnectOpen(false);
     setReconnectSeed(null);
     context.checkContextStatus();
@@ -181,6 +202,7 @@ export function BrowserAutomations({ taskId, isManualTask = false }: BrowserAuto
 
   const handleCancelConnect = useCallback(() => {
     clearConnectState(taskId);
+    setPendingConnect(null);
     setConnectOpen(false);
     setReconnectSeed(null);
   }, [taskId]);
@@ -242,10 +264,12 @@ export function BrowserAutomations({ taskId, isManualTask = false }: BrowserAuto
     automations.fetchAutomations();
   }, [automations, deleteDraft]);
 
-  // If a background analysis was in flight when the user navigated away, reopen
-  // the connect flow on return so it can resume instead of forcing a restart.
+  // A half-finished connect (analysis / method choice saved before the user
+  // left) is surfaced as a resumable strip below — NOT auto-reopened full-screen,
+  // which would trap the user in it instead of letting them create a new
+  // automation. They choose: resume it, or start a new one.
   useEffect(() => {
-    if (loadConnectState(taskId)) setConnectOpen(true);
+    setPendingConnect(loadConnectState(taskId));
   }, [taskId]);
 
   // Refresh the connection list whenever a connect/reconnect verifies.
@@ -298,6 +322,17 @@ export function BrowserAutomations({ taskId, isManualTask = false }: BrowserAuto
       })),
     [profiles],
   );
+
+  // Resumable "finish connecting" band for the normal views (not manual tasks).
+  // Only appears in the states below — the full-screen flows return before here.
+  const resumeStrip =
+    !isManualTask && pendingConnect ? (
+      <ResumeConnectStrip
+        host={hostnameFromUrl(pendingConnect.url)}
+        onResume={handleResumeConnect}
+        onDiscard={handleDiscardConnect}
+      />
+    ) : null;
 
   // Execution live view
   if (execution.isExecuting && execution.liveViewUrl) {
@@ -412,10 +447,11 @@ export function BrowserAutomations({ taskId, isManualTask = false }: BrowserAuto
     if (!hasConnection && !justConnected) {
       return (
         <>
+          {resumeStrip}
           {draftsStrip}
           <BrowserEvidenceEmptyState
             isStartingAuth={context.isStartingAuth}
-            onConnect={() => setConnectOpen(true)}
+            onConnect={startFreshConnect}
           />
         </>
       );
@@ -423,6 +459,7 @@ export function BrowserAutomations({ taskId, isManualTask = false }: BrowserAuto
 
     return (
       <>
+        {resumeStrip}
         {draftsStrip}
         <EmptyWithContextState
           onCreateClick={() => setComposer({ open: true, mode: 'create' })}
@@ -434,7 +471,9 @@ export function BrowserAutomations({ taskId, isManualTask = false }: BrowserAuto
   // List of automations (disable creation for manual tasks, but allow editing).
   // Drafts render inside the section (under the header) so they clearly belong.
   return (
-    <BrowserAutomationsList
+    <>
+      {resumeStrip}
+      <BrowserAutomationsList
       automations={automations.automations}
       profiles={profiles}
       runningAutomationId={execution.runningAutomationId}
@@ -450,6 +489,7 @@ export function BrowserAutomations({ taskId, isManualTask = false }: BrowserAuto
       drafts={drafts}
       onContinueDraft={handleContinueDraft}
       onDeleteDraft={handleDeleteDraft}
-    />
+      />
+    </>
   );
 }

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/browser-automations/ResumeConnectStrip.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/browser-automations/ResumeConnectStrip.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@trycompai/design-system', () => ({
+  Button: ({ children, onClick }: { children?: ReactNode; onClick?: () => void }) => (
+    <button onClick={onClick}>{children}</button>
+  ),
+}));
+vi.mock('@trycompai/design-system/icons', () => ({
+  Renew: () => <span />,
+  TrashCan: () => <span />,
+}));
+vi.mock('@/components/VendorLogo', () => ({
+  VendorLogo: () => <span data-testid="vendor-logo" />,
+}));
+
+import { ResumeConnectStrip } from './ResumeConnectStrip';
+
+describe('ResumeConnectStrip', () => {
+  it('names the vendor and offers resume + discard', () => {
+    const onResume = vi.fn();
+    const onDiscard = vi.fn();
+    render(
+      <ResumeConnectStrip host="github.com" onResume={onResume} onDiscard={onDiscard} />,
+    );
+
+    expect(screen.getByText(/Finish connecting to github\.com/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Resume'));
+    expect(onResume).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByLabelText(/discard in-progress connection/i));
+    expect(onDiscard).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/browser-automations/ResumeConnectStrip.tsx
+++ b/apps/app/src/app/(app)/[orgId]/tasks/[taskId]/components/browser-automations/ResumeConnectStrip.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { VendorLogo } from '@/components/VendorLogo';
+import { Button } from '@trycompai/design-system';
+import { Renew, TrashCan } from '@trycompai/design-system/icons';
+
+interface ResumeConnectStripProps {
+  /** Vendor host of the in-progress connection (derived from the saved URL). */
+  host: string;
+  onResume: () => void;
+  onDiscard: () => void;
+}
+
+/**
+ * A vendor connection the user started signing in to and left unfinished.
+ * Surfaced as a resumable band (mirroring DraftsStrip) instead of hijacking the
+ * whole panel, so the user can finish it OR ignore it and create a new
+ * automation — the choice is theirs.
+ */
+export function ResumeConnectStrip({
+  host,
+  onResume,
+  onDiscard,
+}: ResumeConnectStripProps) {
+  return (
+    <div className="mb-4 rounded-lg border border-dashed border-border bg-muted/30 p-3">
+      <div className="mb-2 text-[11px] font-bold uppercase tracking-[0.08em] text-muted-foreground">
+        Connection in progress
+      </div>
+      <div className="flex items-center gap-3 rounded-md border border-border bg-background px-3 py-2">
+        <VendorLogo hostname={host} size={20} />
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-[12.5px] text-foreground">
+            Finish connecting to {host}
+          </div>
+          <div className="truncate text-[10.5px] text-muted-foreground">
+            You started signing in but didn’t finish — resume it, or start a new one.
+          </div>
+        </div>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={onResume}
+          iconLeft={<Renew size={12} />}
+        >
+          Resume
+        </Button>
+        <button
+          type="button"
+          aria-label="Discard in-progress connection"
+          onClick={onDiscard}
+          className="grid h-7 w-7 flex-none cursor-pointer place-items-center rounded-sm text-muted-foreground hover:text-destructive"
+        >
+          <TrashCan size={13} />
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Problem

If you started connecting a vendor and left, returning to the task **auto-reopened that sign-in full-screen** — the whole Browser Automations panel became the connect flow, with only *Finish* or *Cancel (×)*. There was no way to **create a new (or different) automation** without cancelling out. The connect resume was a forced modal, unlike automation *drafts*, which are surfaced as a resumable strip and never block anything.

## Fix

Make the half-finished connect behave like a draft: surface it as a resumable band instead of hijacking the panel.

- On task open, you **land on your automations** (list / Create / Connect-another) — not the forced sign-in.
- The unfinished connect shows as a **"Finish connecting to {vendor}"** strip with **Resume** and **Discard** (mirrors the existing `DraftsStrip`).
- You decide: **Resume** to finish it, **Discard** to drop it, or ignore it and **Create / Connect a new one**.
- Starting a fresh connect clears any half-finished one, so the flow never resumes into a stale draft.

Same resumable steps as before (the connect flow still resumes at analysis / method-choice — a live sign-in session never survived a reload anyway). Only the forced full-screen takeover is removed.

## Scope
- `BrowserAutomations.tsx` — replace the auto-reopen effect with a resumable-strip state; clear it wherever connect state is cleared; render the strip on the empty states + list; empty-state "Connect" now starts fresh.
- New `ResumeConnectStrip` + test.

## Tests
96 browser-automations tests green (incl. the new strip test); app typecheck clean; no legacy UI/lucide imports.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let users return to their automations and choose to resume, discard, or start a new vendor connect instead of being forced into the full-screen connect flow. This removes the blocking experience and makes unfinished connects behave like drafts.

- **Bug Fixes**
  - Unfinished connects show as a “Finish connecting to {vendor}” strip with Resume and Discard; no full-screen takeover.
  - Starting a new connect always clears saved connect state; empty-state “Connect” starts fresh.
  - Resume reopens the flow using the saved state; Discard removes it.
  - Added `ResumeConnectStrip` and tests.

<sup>Written for commit 57c1d40bb1209b9fd4ca1dc23002dcfb101b864d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

