### PR TITLE
fix(api): only classify a passkey as switchable when a code method exists

### DIFF
--- a/apps/api/src/browserbase/browser-login-classifier.ts
+++ b/apps/api/src/browserbase/browser-login-classifier.ts
@@ -122,15 +122,15 @@ export async function classifyTwoFactorMethod(
         'user to verify, and whether another method can be chosen. Return exactly one:\n' +
         '"code" — a one-time / authenticator / SMS / email verification CODE can be ' +
         'entered right now (a code field is visible);\n' +
-        '"passkey" — it is asking for a passkey or security key, AND there is a way to ' +
-        "switch to another method (a 'More options', 'Try another way', or 'use a code' control);\n" +
-        '"passkey_only" — it is asking for a passkey or security key and NO other method ' +
-        'is offered;\n' +
-        '"other" — a different verification (a device approval/notification, a CAPTCHA, ' +
-        'or an email/SMS link to click).\n' +
-        'Only choose "passkey" or "passkey_only" when the page explicitly asks for a ' +
-        'passkey or security key; a device approval, push notification, or email/SMS ' +
-        'link is "other".',
+        '"passkey" — it is asking for a passkey or security key, AND a CODE-based method ' +
+        '(an authenticator app, SMS, or email code) can be chosen instead;\n' +
+        '"passkey_only" — it is asking for a passkey or security key with no usable ' +
+        'alternative;\n' +
+        '"other" — anything else, INCLUDING a passkey / security-key prompt whose only ' +
+        'alternative is a device approval, push notification, or email/SMS LINK (not a ' +
+        'code), and standalone CAPTCHA / device-approval / link steps.\n' +
+        'Only "code" and "passkey" imply a code the user can enter; do not pick them ' +
+        'unless a code can actually be entered.',
       z.object({
         method: z.enum(['code', 'passkey', 'passkey_only', 'other']),
       }),


### PR DESCRIPTION
## What

Follow-up to the review on the sign-in classifier (the earlier fixes merged in #3527). This closes the remaining nuance on the passkey finding.

Previously `passkey` meant "a passkey prompt with *any* other method available." But if that other method is a **device approval / push / email-link** (not a code), the take-over panel would still tell the user to "choose an authenticator/SMS/email code and enter it" — even though no code method exists.

Now the classifier is precise:
- **`passkey`** — a passkey/security-key prompt **AND** a code-based method (authenticator app, SMS, or email code) can be chosen instead.
- **`passkey_only`** — a passkey/security key with no usable alternative.
- **`other`** — anything else, **including** a passkey prompt whose only alternative is a device approval / push / email link (so it routes to the generic "finish sign-in yourself" panel, not the code panel).

## Scope
Prompt wording only in `browser-login-classifier.ts` (`classifyTwoFactorMethod`). No contract/type change.

## Note
This is LLM-prompt hardening — behavior isn't 100% guaranteed — but it removes a misleading-guidance edge case, and take-over stays interactive so it degrades gracefully.

## Tests
12 classifier tests green (they assert the return-value contract; mocked `extract`), typecheck clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix sign-in 2FA classification so "passkey" is only returned when a code-based alternative (authenticator app, SMS, or email code) is available. Passkey prompts that only offer device approval/push/email link are now "other," preventing code-entry guidance when no code exists.

<sup>Written for commit a9b4f0c923248d89264b6141b354c7048138ea2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

