### PR TITLE
fix(training): defer completion email and share canonical training IDs

### DIFF
--- a/apps/api/src/frameworks/frameworks-people-score.helper.ts
+++ b/apps/api/src/frameworks/frameworks-people-score.helper.ts
@@ -1,8 +1,10 @@
 import { BackgroundCheckStatus, db } from '@db';
+import {
+  GENERAL_TRAINING_VIDEO_IDS as GENERAL_TRAINING_IDS,
+  HIPAA_TRAINING_ID,
+} from '@trycompai/company';
 import { filterComplianceMembers } from '../utils/compliance-filters';
 
-const GENERAL_TRAINING_IDS = ['sat-1', 'sat-2', 'sat-3', 'sat-4', 'sat-5'];
-const HIPAA_TRAINING_ID = 'hipaa-sat-1';
 const COMPLETED_BACKGROUND_CHECK_STATUSES = [
   BackgroundCheckStatus.completed,
   BackgroundCheckStatus.completed_with_flags,

--- a/apps/api/src/training/training-hipaa.spec.ts
+++ b/apps/api/src/training/training-hipaa.spec.ts
@@ -4,6 +4,9 @@ import { TrainingService } from './training.service';
 jest.mock('@db', () => ({
   db: {
     member: { findFirst: jest.fn(), findUnique: jest.fn() },
+    // markVideoComplete gates hipaa-sat-1 on the org having a HIPAA framework
+    // instance, so the HIPAA paths must be able to resolve one.
+    frameworkInstance: { findFirst: jest.fn() },
     employeeTrainingVideoCompletion: {
       findMany: jest.fn(),
       findFirst: jest.fn(),
@@ -36,6 +39,7 @@ describe('TrainingService — HIPAA training', () => {
 
   describe('markVideoComplete', () => {
     it('should accept hipaa-sat-1 as a valid training ID', async () => {
+      db.frameworkInstance.findFirst.mockResolvedValue({ id: 'frm_1' });
       db.member.findFirst.mockResolvedValue({
         id: 'mem_1',
         organizationId: 'org_1',
@@ -63,6 +67,19 @@ describe('TrainingService — HIPAA training', () => {
           completedAt: expect.any(Date),
         },
       });
+    });
+
+    // Mirrors the portal's complete-training route: the two completion paths
+    // must agree on which orgs may complete HIPAA training, or one can create
+    // records — and certificate artifacts — the other would have rejected.
+    it('should reject hipaa-sat-1 when the org has no HIPAA framework', async () => {
+      db.frameworkInstance.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.markVideoComplete('mem_1', 'org_1', 'hipaa-sat-1'),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(db.employeeTrainingVideoCompletion.create).not.toHaveBeenCalled();
     });
 
     it('should reject unknown training IDs', async () => {

--- a/apps/api/src/training/training.service.ts
+++ b/apps/api/src/training/training.service.ts
@@ -5,12 +5,15 @@ import {
   BadRequestException,
 } from '@nestjs/common';
 import { db } from '@db';
+import {
+  GENERAL_TRAINING_VIDEO_IDS as GENERAL_TRAINING_IDS,
+  HIPAA_TRAINING_ID,
+  HIPAA_TRAINING_UNAVAILABLE_MESSAGE,
+  hipaaFrameworkInstanceWhere,
+  isTrainingVideoId,
+} from '@trycompai/company';
 import { TrainingEmailService } from './training-email.service';
 import { TrainingCertificatePdfService } from './training-certificate-pdf.service';
-
-const GENERAL_TRAINING_IDS = ['sat-1', 'sat-2', 'sat-3', 'sat-4', 'sat-5'];
-const HIPAA_TRAINING_ID = 'hipaa-sat-1';
-const ALL_TRAINING_IDS = [...GENERAL_TRAINING_IDS, HIPAA_TRAINING_ID];
 
 @Injectable()
 export class TrainingService {
@@ -40,19 +43,17 @@ export class TrainingService {
     organizationId: string,
     videoId: string,
   ) {
-    if (!ALL_TRAINING_IDS.includes(videoId)) {
+    if (!isTrainingVideoId(videoId)) {
       throw new BadRequestException(`Invalid video ID: ${videoId}`);
     }
 
     if (videoId === HIPAA_TRAINING_ID) {
       const hipaaInstance = await db.frameworkInstance.findFirst({
-        where: { organizationId, framework: { name: 'HIPAA' } },
+        where: hipaaFrameworkInstanceWhere(organizationId),
         select: { id: true },
       });
       if (!hipaaInstance) {
-        throw new BadRequestException(
-          'HIPAA training is not available for this organization',
-        );
+        throw new BadRequestException(HIPAA_TRAINING_UNAVAILABLE_MESSAGE);
       }
     }
 
@@ -116,7 +117,7 @@ export class TrainingService {
     const completions = await db.employeeTrainingVideoCompletion.findMany({
       where: {
         memberId,
-        videoId: { in: GENERAL_TRAINING_IDS },
+        videoId: { in: [...GENERAL_TRAINING_IDS] },
         completedAt: { not: null },
       },
     });
@@ -140,7 +141,7 @@ export class TrainingService {
     const completions = await db.employeeTrainingVideoCompletion.findMany({
       where: {
         memberId,
-        videoId: { in: GENERAL_TRAINING_IDS },
+        videoId: { in: [...GENERAL_TRAINING_IDS] },
         completedAt: { not: null },
       },
       orderBy: { completedAt: 'desc' },

--- a/apps/app/src/lib/data/hipaa-training-content.ts
+++ b/apps/app/src/lib/data/hipaa-training-content.ts
@@ -1,1 +1,8 @@
-export const HIPAA_TRAINING_ID = 'hipaa-sat-1';
+import type { TrainingVideoId } from '@trycompai/company';
+
+// Tied to the canonical ID that both training-completion paths validate
+// against. Deliberately a local literal with a type-only link rather than a
+// re-export: client components import this file, and @trycompai/company pulls
+// in @trycompai/db at runtime. The annotation still fails typecheck if the
+// canonical ID ever changes, so the two cannot drift.
+export const HIPAA_TRAINING_ID: Extract<TrainingVideoId, 'hipaa-sat-1'> = 'hipaa-sat-1';

--- a/apps/app/src/lib/data/training-videos.ts
+++ b/apps/app/src/lib/data/training-videos.ts
@@ -1,3 +1,5 @@
+import type { GeneralTrainingVideoId } from '@trycompai/company';
+
 /**
  * Represents a training video resource that can be used
  * for user education and compliance training.
@@ -14,6 +16,15 @@ export interface TrainingVideo {
   /** Full URL to access the video */
   url: string;
 }
+
+/**
+ * A rendered video whose ID is one the training-completion paths actually
+ * accept. `@trycompai/company` owns the canonical ID list, shared with the
+ * NestJS training service and the portal's complete-training route.
+ */
+type CanonicalTrainingVideo = Omit<TrainingVideo, 'id'> & {
+  id: GeneralTrainingVideoId;
+};
 
 export const trainingVideos: readonly TrainingVideo[] = [
   {
@@ -51,4 +62,4 @@ export const trainingVideos: readonly TrainingVideo[] = [
     youtubeId: 'Clvfkm6azDs',
     url: 'https://www.youtube.com/watch?v=Clvfkm6azDs',
   },
-] as const;
+] as const satisfies readonly CanonicalTrainingVideo[];

--- a/apps/app/src/lib/data/training-videos.ts
+++ b/apps/app/src/lib/data/training-videos.ts
@@ -18,48 +18,52 @@ export interface TrainingVideo {
 }
 
 /**
- * A rendered video whose ID is one the training-completion paths actually
- * accept. `@trycompai/company` owns the canonical ID list, shared with the
- * NestJS training service and the portal's complete-training route.
+ * Videos keyed by the canonical IDs that `@trycompai/company` owns, shared
+ * with the NestJS training service and the portal's complete-training route.
+ *
+ * Keying by the canonical union makes the lists exhaustive in BOTH directions:
+ * a canonical ID with no entry here fails to compile, and an entry that isn't
+ * canonical fails too. Both matter — completion requires a row for every
+ * canonical ID, so a video we never render would leave employees permanently
+ * unable to finish training, while a rendered video the API rejects would 400.
+ *
+ * The import is type-only on purpose: client components and a Trigger.dev task
+ * import this file, and `@trycompai/company` requires `@trycompai/db` at
+ * runtime.
  */
-type CanonicalTrainingVideo = Omit<TrainingVideo, 'id'> & {
-  id: GeneralTrainingVideoId;
-};
-
-export const trainingVideos: readonly TrainingVideo[] = [
-  {
-    id: 'sat-1',
+const trainingVideosById: Record<GeneralTrainingVideoId, Omit<TrainingVideo, 'id'>> = {
+  'sat-1': {
     title: 'Security Awareness Training - Part 1',
     description: 'Security Awareness Training - Part 1',
     youtubeId: 'N-sBS3uCWB4',
     url: 'https://www.youtube.com/watch?v=N-sBS3uCWB4',
   },
-  {
-    id: 'sat-2',
+  'sat-2': {
     title: 'Security Awareness Training - Part 2',
     description: 'Security Awareness Training - Part 2',
     youtubeId: 'JwQNwhDyXig',
     url: 'https://www.youtube.com/watch?v=JwQNwhDyXig',
   },
-  {
-    id: 'sat-3',
+  'sat-3': {
     title: 'Security Awareness Training - Part 3',
     description: 'Security Awareness Training - Part 3',
     youtubeId: 'fzMNw_-KEGE',
     url: 'https://www.youtube.com/watch?v=fzMNw_-KEGE',
   },
-  {
-    id: 'sat-4',
+  'sat-4': {
     title: 'Security Awareness Training - Part 4',
     description: 'Security Awareness Training - Part 4',
     youtubeId: 'WbpqjH9kI2Y',
     url: 'https://www.youtube.com/watch?v=WbpqjH9kI2Y',
   },
-  {
-    id: 'sat-5',
+  'sat-5': {
     title: 'Security Awareness Training - Part 5',
     description: 'Security Awareness Training - Part 5',
     youtubeId: 'Clvfkm6azDs',
     url: 'https://www.youtube.com/watch?v=Clvfkm6azDs',
   },
-] as const satisfies readonly CanonicalTrainingVideo[];
+};
+
+export const trainingVideos: readonly TrainingVideo[] = Object.entries(trainingVideosById).map(
+  ([id, video]) => ({ id, ...video }),
+);

--- a/apps/portal/src/app/api/portal/complete-training/route.test.ts
+++ b/apps/portal/src/app/api/portal/complete-training/route.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   completionFindMany: vi.fn(),
   logger: vi.fn(),
   fetch: vi.fn(),
+  afterTasks: [] as Array<() => unknown>,
   env: {
     SERVICE_TOKEN_PORTAL: undefined as string | undefined,
     NEXT_PUBLIC_API_URL: 'http://api.test',
@@ -45,6 +46,25 @@ vi.mock('@/env.mjs', () => ({ env: mocks.env }));
 vi.mock('@/utils/logger', () => ({ logger: mocks.logger }));
 vi.stubGlobal('fetch', mocks.fetch);
 
+// The route defers the completion email with `after` so it runs once the
+// response has been sent. Capture the deferred task instead of running it, so
+// tests can prove the response does NOT wait on the email and then drive the
+// email path explicitly.
+vi.mock('next/server', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('next/server')>();
+  return {
+    ...actual,
+    after: (task: () => unknown) => {
+      mocks.afterTasks.push(task);
+    },
+  };
+});
+
+/** Runs whatever the route deferred, mimicking Next flushing `after` tasks. */
+async function flushAfterTasks(): Promise<void> {
+  await Promise.all(mocks.afterTasks.splice(0).map((task) => task()));
+}
+
 import { POST } from './route';
 
 function makeRequest(body: unknown): NextRequest {
@@ -67,6 +87,7 @@ function makeRawRequest(raw: string): NextRequest {
 describe('POST /api/portal/complete-training', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.afterTasks.length = 0;
     mocks.env.SERVICE_TOKEN_PORTAL = undefined;
   });
 
@@ -203,9 +224,7 @@ describe('POST /api/portal/complete-training', () => {
   it('rejects an unknown video ID', async () => {
     mocks.getSession.mockResolvedValue({ user: { id: 'user_1' } });
 
-    const res = await POST(
-      makeRequest({ videoId: 'not-a-real-video', organizationId: 'org_1' }),
-    );
+    const res = await POST(makeRequest({ videoId: 'not-a-real-video', organizationId: 'org_1' }));
 
     expect(res.status).toBe(400);
     expect(mocks.memberFindFirst).not.toHaveBeenCalled();
@@ -227,9 +246,7 @@ describe('POST /api/portal/complete-training', () => {
     // No HIPAA framework instance for this org.
     mocks.frameworkInstanceFindFirst.mockResolvedValue(null);
 
-    const res = await POST(
-      makeRequest({ videoId: 'hipaa-sat-1', organizationId: 'org_1' }),
-    );
+    const res = await POST(makeRequest({ videoId: 'hipaa-sat-1', organizationId: 'org_1' }));
 
     expect(res.status).toBe(400);
     expect(mocks.frameworkInstanceFindFirst).toHaveBeenCalledWith({
@@ -257,9 +274,7 @@ describe('POST /api/portal/complete-training', () => {
     };
     mocks.completionUpsert.mockResolvedValue(record);
 
-    const res = await POST(
-      makeRequest({ videoId: 'hipaa-sat-1', organizationId: 'org_1' }),
-    );
+    const res = await POST(makeRequest({ videoId: 'hipaa-sat-1', organizationId: 'org_1' }));
 
     expect(res.status).toBe(200);
     expect(mocks.completionUpsert).toHaveBeenCalledWith({
@@ -300,15 +315,24 @@ describe('POST /api/portal/complete-training', () => {
     // dev-only `logger` util would have swallowed it outside development).
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    const res = await POST(
-      makeRequest({ videoId: 'hipaa-sat-1', organizationId: 'org_1' }),
-    );
+    const res = await POST(makeRequest({ videoId: 'hipaa-sat-1', organizationId: 'org_1' }));
 
     // Completion is persisted regardless — the email is best-effort.
     expect(res.status).toBe(200);
+    // ...and the response did not wait on it: the API call that renders the
+    // certificate and sends the mail only happens once `after` is flushed.
+    expect(mocks.fetch).not.toHaveBeenCalled();
+
+    await flushAfterTasks();
+
     expect(mocks.fetch).toHaveBeenCalledWith(
       'http://api.test/v1/training/send-hipaa-completion-email',
-      expect.objectContaining({ method: 'POST' }),
+      // The request is bounded: Node's fetch otherwise waits ~5 minutes, which
+      // would keep the invocation alive long after the response was sent.
+      expect.objectContaining({
+        method: 'POST',
+        signal: expect.any(AbortSignal),
+      }),
     );
     // The HTTP failure must surface (in prod too), not be swallowed as success.
     expect(errorSpy).toHaveBeenCalledWith(

--- a/apps/portal/src/app/api/portal/complete-training/route.ts
+++ b/apps/portal/src/app/api/portal/complete-training/route.ts
@@ -1,20 +1,25 @@
 import { auth } from '@/app/lib/auth';
 import { env } from '@/env.mjs';
-import { HIPAA_TRAINING_ID } from '@/lib/data/hipaa-training-content';
-import { trainingVideos } from '@/lib/data/training-videos';
 import { db } from '@db/server';
-import { type NextRequest, NextResponse } from 'next/server';
+import {
+  GENERAL_TRAINING_VIDEO_IDS,
+  HIPAA_TRAINING_ID,
+  HIPAA_TRAINING_UNAVAILABLE_MESSAGE,
+  hipaaFrameworkInstanceWhere,
+  isTrainingVideoId,
+} from '@trycompai/company';
+import { after, type NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-// Canonical training video IDs, derived from the same source the UI renders.
-const GENERAL_TRAINING_IDS = trainingVideos.map((v) => v.id);
-const VALID_VIDEO_IDS = new Set<string>([
-  ...GENERAL_TRAINING_IDS,
-  HIPAA_TRAINING_ID,
-]);
+// The completion email hits the NestJS API, which resolves the member, renders
+// a PDF certificate and calls the email provider — seconds of work. It runs
+// after the response (see `after` below), but still needs a bound: Node's fetch
+// waits ~5 minutes by default, which would pin the serverless invocation open
+// long after the employee has moved on.
+const COMPLETION_EMAIL_TIMEOUT_MS = 30_000;
 
 const schema = z.object({
   videoId: z.string().min(1),
@@ -58,7 +63,7 @@ export async function POST(req: NextRequest) {
 
   const { videoId, organizationId } = parsed.data;
 
-  if (!VALID_VIDEO_IDS.has(videoId)) {
+  if (!isTrainingVideoId(videoId)) {
     return NextResponse.json({ error: 'Invalid video ID' }, { status: 400 });
   }
 
@@ -76,20 +81,17 @@ export async function POST(req: NextRequest) {
   }
 
   // HIPAA training is only available to orgs that have the HIPAA framework
-  // enabled. Mirror the NestJS training service (markVideoComplete) so this
-  // route can't create HIPAA completion records — and trigger HIPAA
-  // certificate artifacts — for orgs the service would reject, which would
-  // desync the two completion paths.
+  // enabled. The eligibility rule is shared with the NestJS training service
+  // (markVideoComplete) so this route can't create HIPAA completion records —
+  // and trigger HIPAA certificate artifacts — for orgs the service would
+  // reject, which would desync the two completion paths.
   if (videoId === HIPAA_TRAINING_ID) {
     const hipaaInstance = await db.frameworkInstance.findFirst({
-      where: { organizationId, framework: { name: 'HIPAA' } },
+      where: hipaaFrameworkInstanceWhere(organizationId),
       select: { id: true },
     });
     if (!hipaaInstance) {
-      return NextResponse.json(
-        { error: 'HIPAA training is not available for this organization' },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: HIPAA_TRAINING_UNAVAILABLE_MESSAGE }, { status: 400 });
     }
   }
 
@@ -116,11 +118,19 @@ export async function POST(req: NextRequest) {
   // Best-effort: trigger the completion certificate email once the relevant
   // training is fully done. Reuses the NestJS email pipeline via the portal
   // service token, so we don't duplicate the certificate/email logic here.
-  await sendCompletionEmailIfComplete({
-    videoId,
-    memberId: member.id,
-    organizationId,
-  });
+  //
+  // Deferred with `after` so it runs once the response has been sent. The
+  // completion is already durable at this point, and the API call behind it
+  // renders a PDF certificate and talks to the email provider — awaiting that
+  // made the employee's click wait seconds on the happy path, and time out on
+  // the unhappy one, for work whose outcome they never see.
+  after(() =>
+    sendCompletionEmailIfComplete({
+      videoId,
+      memberId: member.id,
+      organizationId,
+    }),
+  );
 
   return NextResponse.json({ success: true, data: record });
 }
@@ -154,13 +164,13 @@ async function sendCompletionEmailIfComplete({
     const completed = await db.employeeTrainingVideoCompletion.findMany({
       where: {
         memberId,
-        videoId: { in: GENERAL_TRAINING_IDS },
+        videoId: { in: [...GENERAL_TRAINING_VIDEO_IDS] },
         completedAt: { not: null },
       },
       select: { id: true },
     });
 
-    if (completed.length === GENERAL_TRAINING_IDS.length) {
+    if (completed.length === GENERAL_TRAINING_VIDEO_IDS.length) {
       await triggerCompletionEmail({
         url: `${apiUrl}/v1/training/send-completion-email`,
         serviceToken,
@@ -199,6 +209,7 @@ async function triggerCompletionEmail({
       'x-organization-id': organizationId,
     },
     body: JSON.stringify({ memberId }),
+    signal: AbortSignal.timeout(COMPLETION_EMAIL_TIMEOUT_MS),
   });
 
   // fetch only rejects on network errors, never on a 4xx/5xx response. Without

--- a/apps/portal/src/lib/data/hipaa-training-content.ts
+++ b/apps/portal/src/lib/data/hipaa-training-content.ts
@@ -1,4 +1,11 @@
-export const HIPAA_TRAINING_ID = 'hipaa-sat-1';
+import type { TrainingVideoId } from '@trycompai/company';
+
+// Tied to the canonical ID that both training-completion paths validate
+// against. Deliberately a local literal with a type-only link rather than a
+// re-export: client components import this file, and @trycompai/company pulls
+// in @trycompai/db at runtime. The annotation still fails typecheck if the
+// canonical ID ever changes, so the two cannot drift.
+export const HIPAA_TRAINING_ID: Extract<TrainingVideoId, 'hipaa-sat-1'> = 'hipaa-sat-1';
 
 export interface HipaaTrainingSection {
   title: string;
@@ -59,7 +66,7 @@ Prompt reporting matters even when you are unsure whether PHI was actually expos
 ] as const;
 
 export const hipaaAcknowledgements: readonly string[] = [
-  'I completed the organization\'s general security awareness training and this HIPAA Security Awareness Training Add-On.',
+  "I completed the organization's general security awareness training and this HIPAA Security Awareness Training Add-On.",
   'I understand that PHI includes information in electronic, paper, image, audio, and verbal form.',
   'I will access, use, disclose, transmit, and store PHI only as authorized for my job responsibilities and in accordance with organization policy.',
   'I will use approved safeguards, including strong authentication, secure handling practices, and prompt reporting of suspicious activity or incidents.',

--- a/apps/portal/src/lib/data/training-videos.ts
+++ b/apps/portal/src/lib/data/training-videos.ts
@@ -1,3 +1,5 @@
+import type { GeneralTrainingVideoId } from '@trycompai/company';
+
 /**
  * Represents a training video resource that can be used
  * for user education and compliance training.
@@ -14,6 +16,15 @@ export interface TrainingVideo {
   /** Full URL to access the video */
   url: string;
 }
+
+/**
+ * A rendered video whose ID is one the training-completion paths actually
+ * accept. `@trycompai/company` owns the canonical ID list, shared with the
+ * NestJS training service and the portal's complete-training route.
+ */
+type CanonicalTrainingVideo = Omit<TrainingVideo, 'id'> & {
+  id: GeneralTrainingVideoId;
+};
 
 export const trainingVideos: readonly TrainingVideo[] = [
   {
@@ -51,4 +62,4 @@ export const trainingVideos: readonly TrainingVideo[] = [
     youtubeId: 'Clvfkm6azDs',
     url: 'https://www.youtube.com/watch?v=Clvfkm6azDs',
   },
-] as const;
+] as const satisfies readonly CanonicalTrainingVideo[];

--- a/apps/portal/src/lib/data/training-videos.ts
+++ b/apps/portal/src/lib/data/training-videos.ts
@@ -18,48 +18,52 @@ export interface TrainingVideo {
 }
 
 /**
- * A rendered video whose ID is one the training-completion paths actually
- * accept. `@trycompai/company` owns the canonical ID list, shared with the
- * NestJS training service and the portal's complete-training route.
+ * Videos keyed by the canonical IDs that `@trycompai/company` owns, shared
+ * with the NestJS training service and the portal's complete-training route.
+ *
+ * Keying by the canonical union makes the lists exhaustive in BOTH directions:
+ * a canonical ID with no entry here fails to compile, and an entry that isn't
+ * canonical fails too. Both matter — completion requires a row for every
+ * canonical ID, so a video we never render would leave employees permanently
+ * unable to finish training, while a rendered video the API rejects would 400.
+ *
+ * The import is type-only on purpose: client components and a Trigger.dev task
+ * import this file, and `@trycompai/company` requires `@trycompai/db` at
+ * runtime.
  */
-type CanonicalTrainingVideo = Omit<TrainingVideo, 'id'> & {
-  id: GeneralTrainingVideoId;
-};
-
-export const trainingVideos: readonly TrainingVideo[] = [
-  {
-    id: 'sat-1',
+const trainingVideosById: Record<GeneralTrainingVideoId, Omit<TrainingVideo, 'id'>> = {
+  'sat-1': {
     title: 'Security Awareness Training - Part 1',
     description: 'Security Awareness Training - Part 1',
     youtubeId: 'N-sBS3uCWB4',
     url: 'https://www.youtube.com/watch?v=N-sBS3uCWB4',
   },
-  {
-    id: 'sat-2',
+  'sat-2': {
     title: 'Security Awareness Training - Part 2',
     description: 'Security Awareness Training - Part 2',
     youtubeId: 'JwQNwhDyXig',
     url: 'https://www.youtube.com/watch?v=JwQNwhDyXig',
   },
-  {
-    id: 'sat-3',
+  'sat-3': {
     title: 'Security Awareness Training - Part 3',
     description: 'Security Awareness Training - Part 3',
     youtubeId: 'fzMNw_-KEGE',
     url: 'https://www.youtube.com/watch?v=fzMNw_-KEGE',
   },
-  {
-    id: 'sat-4',
+  'sat-4': {
     title: 'Security Awareness Training - Part 4',
     description: 'Security Awareness Training - Part 4',
     youtubeId: 'WbpqjH9kI2Y',
     url: 'https://www.youtube.com/watch?v=WbpqjH9kI2Y',
   },
-  {
-    id: 'sat-5',
+  'sat-5': {
     title: 'Security Awareness Training - Part 5',
     description: 'Security Awareness Training - Part 5',
     youtubeId: 'Clvfkm6azDs',
     url: 'https://www.youtube.com/watch?v=Clvfkm6azDs',
   },
-] as const satisfies readonly CanonicalTrainingVideo[];
+};
+
+export const trainingVideos: readonly TrainingVideo[] = Object.entries(trainingVideosById).map(
+  ([id, video]) => ({ id, ...video }),
+);

--- a/packages/company/src/index.ts
+++ b/packages/company/src/index.ts
@@ -1,1 +1,2 @@
 export * from './evidence-forms/index';
+export * from './training/index';

--- a/packages/company/src/training/index.ts
+++ b/packages/company/src/training/index.ts
@@ -1,0 +1,52 @@
+/**
+ * Canonical employee-training identifiers and eligibility rules.
+ *
+ * Training completion has two independent write paths that must stay in
+ * agreement:
+ *
+ *  - `TrainingService.markVideoComplete` (NestJS, RBAC-gated), and
+ *  - the portal's `/api/portal/complete-training` route, which authorizes on
+ *    session + org membership so employees on custom roles without
+ *    `portal:update` can still complete their own training.
+ *
+ * If the two disagree about which videos exist, or about which orgs may
+ * complete HIPAA training, the paths desync — one can create completion
+ * records (and trigger certificate artifacts) that the other would reject.
+ * Both import from here so there is only one definition to change.
+ */
+
+/** Security Awareness Training videos every employee must complete. */
+export const GENERAL_TRAINING_VIDEO_IDS = ['sat-1', 'sat-2', 'sat-3', 'sat-4', 'sat-5'] as const;
+
+export type GeneralTrainingVideoId = (typeof GENERAL_TRAINING_VIDEO_IDS)[number];
+
+/** HIPAA Security Awareness Training — gated on the org's HIPAA framework. */
+export const HIPAA_TRAINING_ID = 'hipaa-sat-1';
+
+export const ALL_TRAINING_VIDEO_IDS = [...GENERAL_TRAINING_VIDEO_IDS, HIPAA_TRAINING_ID] as const;
+
+export type TrainingVideoId = (typeof ALL_TRAINING_VIDEO_IDS)[number];
+
+export function isTrainingVideoId(videoId: string): videoId is TrainingVideoId {
+  return (ALL_TRAINING_VIDEO_IDS as readonly string[]).includes(videoId);
+}
+
+/** Framework an organization must have enabled to be offered HIPAA training. */
+export const HIPAA_FRAMEWORK_NAME = 'HIPAA';
+
+/** Shared rejection copy so both paths fail identically for ineligible orgs. */
+export const HIPAA_TRAINING_UNAVAILABLE_MESSAGE =
+  'HIPAA training is not available for this organization';
+
+/**
+ * Prisma `where` fragment identifying an org's HIPAA framework instance.
+ *
+ * Returned as plain data rather than running the query here, so this package
+ * stays free of a Prisma client — the API and the portal each hold their own.
+ */
+export function hipaaFrameworkInstanceWhere(organizationId: string) {
+  return {
+    organizationId,
+    framework: { name: HIPAA_FRAMEWORK_NAME },
+  };
+}


### PR DESCRIPTION
Follow-up to #3501, addressing both cubic review findings on `apps/portal/src/app/api/portal/complete-training/route.ts`.

## 1. The "best-effort" email was blocking the response

The route awaited `sendCompletionEmailIfComplete` before returning. That call hits `POST /v1/training/send-{hipaa-,}completion-email`, which resolves the member, renders a PDF certificate and calls the email provider — so every final-video completion made the employee wait seconds for work whose outcome they never see. Node's `fetch` also has no default request timeout, so a slow or unreachable API could stall the response for minutes even though the completion row was already committed.

- Deferred with `after()` from `next/server`, so it runs once the response has been sent.
- Bounded the request with `AbortSignal.timeout(30s)` so a hung API can't pin the invocation open.

## 2. Video IDs and HIPAA eligibility were duplicated

The route restated the valid-video-ID list and the HIPAA framework gate that `TrainingService.markVideoComplete` owns. That was the fifth copy — the same constants were already hardcoded in `training.service.ts`, `frameworks-people-score.helper.ts`, and the two apps' `training-videos.ts` / `hipaa-training-content.ts`.

Moved them to `@trycompai/company`, the existing shared-definitions package that api, app and portal all already consume (same pattern as `evidence-forms`):

- `GENERAL_TRAINING_VIDEO_IDS`, `HIPAA_TRAINING_ID`, `isTrainingVideoId`
- `HIPAA_FRAMEWORK_NAME`, `HIPAA_TRAINING_UNAVAILABLE_MESSAGE`, `hipaaFrameworkInstanceWhere` — so both completion paths reject ineligible orgs identically

The rendered video lists now `satisfies` the canonical ID union, so adding a video to the UI without adding it to the shared list is a compile error rather than a silent desync (verified: swapping `sat-5` for `sat-6` fails typecheck).

## Also

Fixed `training-hipaa.spec.ts`, which was failing on `main` — its `@db` mock was never given `frameworkInstance` when the HIPAA gate was added. Added coverage for the gate's rejection path, mirroring the portal route's test.

## Verification

- `apps/portal` — 14/14 vitest pass; `tsc --noEmit` clean (0 errors)
- `apps/api` — training + frameworks-people-score specs 20/20 pass; no new type errors (22 pre-existing, all in unrelated modules)
- `apps/app` — no new type errors (15 pre-existing, all in unrelated test files)
- Prettier clean on all changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defer the completion email until after the response (with a 30s timeout) and centralize training IDs and HIPAA eligibility in `@trycompai/company` so the API and portal share the same rules. Key the app and portal video lists by the canonical IDs to make them exhaustive both ways and type-safe.

- Bug Fixes
  - Deferred the completion email with `after()` and bounded the request with `AbortSignal.timeout(30_000)`. Tests confirm the response doesn’t wait and the request uses an `AbortSignal`.
  - Unified HIPAA eligibility and error copy via shared helpers (`hipaaFrameworkInstanceWhere`, `HIPAA_TRAINING_UNAVAILABLE_MESSAGE`).
  - Fixed `training-hipaa.spec.ts` by mocking `frameworkInstance` and adding the rejection case for ineligible orgs.

- Refactors
  - Centralized IDs and helpers in `@trycompai/company` (`GENERAL_TRAINING_VIDEO_IDS`, `HIPAA_TRAINING_ID`, `isTrainingVideoId`, `HIPAA_FRAMEWORK_NAME`, `HIPAA_TRAINING_UNAVAILABLE_MESSAGE`, `hipaaFrameworkInstanceWhere`), and updated the portal route, Nest `TrainingService`, and `frameworks-people-score.helper.ts` to use them.
  - Made the rendered video lists exhaustive both ways by keying them as `Record<GeneralTrainingVideoId, ...>`; the HIPAA ID stays a local literal tied by type-only link to the canonical union to avoid runtime deps while preventing drift.

<sup>Written for commit 5cb8566af1a52bef0979a567fa8f1e7807bad52e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

