### PR TITLE
fix(pentest): request full provider page so customer history isn't truncated

### DIFF
--- a/apps/api/src/security-penetration-tests/security-penetration-tests.service.spec.ts
+++ b/apps/api/src/security-penetration-tests/security-penetration-tests.service.spec.ts
@@ -7,7 +7,10 @@ import type { BillingEntitlementsService } from '../billing/billing-entitlements
 import type { CredentialVaultService } from '../integration-platform/services/credential-vault.service';
 import { CreatePenetrationTestDto } from './dto/create-penetration-test.dto';
 import type { PentestCreditsService } from './pentest-credits.service';
-import { SecurityPenetrationTestsService } from './security-penetration-tests.service';
+import {
+  PROVIDER_LIST_LIMIT,
+  SecurityPenetrationTestsService,
+} from './security-penetration-tests.service';
 
 const mockCredentialVaultService: jest.Mocked<
   Pick<CredentialVaultService, 'getDecryptedCredentials'>
@@ -238,13 +241,34 @@ describe('SecurityPenetrationTestsService', () => {
 
     const result = await service.listReports('org_123');
 
-    expect(getRequestUrl()).toBe('https://api.maced.ai/v1/pentests');
+    expect(getRequestUrl()).toBe(
+      `https://api.maced.ai/v1/pentests?limit=${PROVIDER_LIST_LIMIT}`,
+    );
     expect(result).toEqual([
       expect.objectContaining({
         id: 'run_123',
         status: 'completed',
       }),
     ]);
+  });
+
+  // Regression (CS-803 / CS-827 / CS-831). Every Comp customer shares one Maced
+  // API key, so the provider's list endpoint is scoped to Comp as a whole, not
+  // to the requesting org — and it defaults to the 50 newest runs across that
+  // entire shared bucket. Runs outside the window were dropped by the
+  // `if (!report) continue` join in listReports and vanished from the
+  // customer's history. Asking for no limit is what made that window 50.
+  it('asks the provider for more than its default page so older runs survive the join', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify([]), { status: 200 }),
+    );
+
+    await service.listReports('org_123');
+
+    const requestedLimit = Number(
+      new URL(getRequestUrl()).searchParams.get('limit'),
+    );
+    expect(requestedLimit).toBeGreaterThan(50);
   });
 
   it('creates report payload with resolved webhook URL', async () => {

--- a/apps/api/src/security-penetration-tests/security-penetration-tests.service.ts
+++ b/apps/api/src/security-penetration-tests/security-penetration-tests.service.ts
@@ -186,6 +186,29 @@ const ORIGINAL_RUN_LINEAGE: RunLineage = {
   retryOfProviderRunId: null,
 };
 
+/**
+ * TEMPORARY — remove once the provider can scope a list to one Comp org.
+ *
+ * Every Comp organization shares a single MACED_API_KEY, so Maced's
+ * `GET /v1/pentests` is scoped to Comp as a whole rather than to the
+ * requesting org, and it pages at 50 by default. That made `listReports`
+ * intersect each org's rows against the 50 newest runs ACROSS THE ENTIRE
+ * customer base; anything older was dropped by the `if (!report) continue`
+ * join and disappeared from the customer's history (CS-803, CS-827, CS-831 —
+ * 180 of 230 runs and 84 orgs were affected when this was found).
+ *
+ * Asking for a page far larger than the total run count restores full history
+ * without touching the provider. This is a stopgap, not a fix: it fails again
+ * once Comp exceeds this many lifetime runs, and Convex over-fetches
+ * `limit * 4` documents to serve it, so do NOT raise this much further.
+ *
+ * The real fix is provider-side: `metadata.compOrganizationId` is already
+ * persisted on every run but lives in an unindexed JSON string. Promote it to
+ * an indexed column, filter the list by it, and this constant goes away along
+ * with the whole intersect-against-a-global-list approach.
+ */
+export const PROVIDER_LIST_LIMIT = 1000;
+
 @Injectable()
 export class SecurityPenetrationTestsService {
   private readonly logger = new Logger(SecurityPenetrationTestsService.name);
@@ -316,8 +339,11 @@ export class SecurityPenetrationTestsService {
       }
     }
 
+    // TEMPORARY: an explicit page size is required here — the provider's
+    // default of 50 is applied across ALL Comp orgs, not this one. See
+    // PROVIDER_LIST_LIMIT.
     const reports = await this.callMaced(
-      () => this.macedClient.pentests.list(),
+      () => this.macedClient.pentests.list({ limit: PROVIDER_LIST_LIMIT }),
       'listing penetration tests',
     );
     const reportById = new Map(reports.map((report) => [report.id, report]));


### PR DESCRIPTION

## Summary by cubic
Request the full provider page when listing pentest reports so customer history isn’t truncated. Restores missing runs across orgs and resolves Linear CS-831.

- **Bug Fixes**
  - Pass an explicit limit to Maced’s `GET /v1/pentests` via `PROVIDER_LIST_LIMIT = 1000` in `listReports`.
  - Add/adjust tests to assert the limit in the request URL and enforce limit > 50.
  - No backfill needed; data wasn’t lost—runs now appear once requested.
  - Temporary stopgap; real fix is provider-side scoping by `metadata.compOrganizationId` (index and filter per org).

<sup>Written for commit a5e2cc02fcb106571f9351674f1961c15f382972. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

