### PR TITLE
fix(trust): copy '@' for TXT record name in custom domain settings

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/TrustPortalDomain.tsx
+++ b/apps/app/src/app/(app)/[orgId]/trust/portal-settings/components/TrustPortalDomain.tsx
@@ -340,9 +340,7 @@ export function TrustPortalDomain({
                                     variant="ghost"
                                     size="icon"
                                     type="button"
-                                    onClick={() =>
-                                      handleCopy(`compai-domain-verification=${orgId}`, 'Name')
-                                    }
+                                    onClick={() => handleCopy('@', 'Name')}
                                     className="h-6 w-6 shrink-0"
                                   >
                                     <Copy size={16} />
@@ -478,9 +476,7 @@ export function TrustPortalDomain({
                                 variant="ghost"
                                 size="icon"
                                 type="button"
-                                onClick={() =>
-                                  handleCopy(`compai-domain-verification=${orgId}`, 'Name')
-                                }
+                                onClick={() => handleCopy('@', 'Name')}
                                 className="h-6 w-6 shrink-0"
                               >
                                 <Copy size={16} />


### PR DESCRIPTION
## Summary
- The TXT record **Name** copy button in `TrustPortalDomain.tsx` copied `compai-domain-verification=<orgId>` (the value) instead of `@`.
- Fixed in both the desktop table and the mobile layout. Value copy buttons are unchanged.

## Test plan
- [ ] Open Trust → Portal Settings with an unverified custom domain
- [ ] Click the copy icon next to `@` in the TXT row → clipboard contains `@`
- [ ] Verify on mobile width (<lg) as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiQAkKJwZQqmTnitpoNf3F

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the TXT record Name copy button in custom domain settings so it copies `@` instead of the verification value (`compai-domain-verification=<orgId>`). Applies to both the desktop table and mobile layout; value copy buttons are unchanged.

<sup>Written for commit 2bd3d51338d760278a71a3c0adb15a62c162303f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

