### PR TITLE
feat(integration-platform): add CybeDefend security scanning integration

### DIFF
--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/EmptyStateOnboarding.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/EmptyStateOnboarding.test.tsx
@@ -46,8 +46,7 @@ vi.mock('@trycompai/integration-platform', () => ({
   getAwsCloudShellUrl: () => 'https://console.aws.amazon.com/cloudshell',
   getAwsCloudShellScript: () => '',
   getAwsRemediationScript: () => '',
-  normalizeAwsEnvironment: (value: unknown) =>
-    value === 'aws-us-gov' ? 'aws-us-gov' : 'aws',
+  normalizeAwsEnvironment: (value: unknown) => (value === 'aws-us-gov' ? 'aws-us-gov' : 'aws'),
 }));
 
 vi.mock('sonner', () => ({
@@ -68,18 +67,20 @@ describe('EmptyStateOnboarding', () => {
 
     render(
       <EmptyStateOnboarding
-        provider={{
-          id: 'dynamic-security',
-          slug: 'dynamic-security',
-          name: 'Dynamic Security',
-          description: 'Dynamic integration',
-          category: 'Security',
-          logoUrl: '',
-          authType: 'custom',
-          capabilities: ['checks'],
-          isActive: true,
-          docsUrl: 'https://example.com/docs',
-        } as any}
+        provider={
+          {
+            id: 'dynamic-security',
+            slug: 'dynamic-security',
+            name: 'Dynamic Security',
+            description: 'Dynamic integration',
+            category: 'Security',
+            logoUrl: '',
+            authType: 'custom',
+            capabilities: ['checks'],
+            isActive: true,
+            docsUrl: 'https://example.com/docs',
+          } as any
+        }
         orgId="org_1"
         onConnected={onConnected}
       />,
@@ -99,17 +100,19 @@ describe('EmptyStateOnboarding', () => {
 
     render(
       <EmptyStateOnboarding
-        provider={{
-          id: 'dynamic-api',
-          slug: 'dynamic-api',
-          name: 'Dynamic API',
-          description: 'Dynamic API integration',
-          category: 'Security',
-          logoUrl: '',
-          authType: 'api_key',
-          capabilities: ['checks'],
-          isActive: true,
-        } as any}
+        provider={
+          {
+            id: 'dynamic-api',
+            slug: 'dynamic-api',
+            name: 'Dynamic API',
+            description: 'Dynamic API integration',
+            category: 'Security',
+            logoUrl: '',
+            authType: 'api_key',
+            capabilities: ['checks'],
+            isActive: true,
+          } as any
+        }
         orgId="org_1"
         onConnected={vi.fn()}
       />,
@@ -185,15 +188,20 @@ describe('EmptyStateOnboarding', () => {
   });
 
   it('does not block submission on a hidden required field', async () => {
-    // A required field the operator cannot see must never gate the form.
+    // Tenant name is required but hidden on a public region, so the form must
+    // submit without it rather than gate on an error pointing at nothing.
     mockCreateConnection.mockResolvedValue({ success: true });
 
     render(
       <EmptyStateOnboarding provider={conditionalProvider} orgId="org_1" onConnected={vi.fn()} />,
     );
 
+    fireEvent.change(screen.getByLabelText('Region'), { target: { value: 'eu' } });
     fireEvent.click(screen.getByRole('button', { name: /connect account/i }));
 
+    await waitFor(() => {
+      expect(mockCreateConnection).toHaveBeenCalledWith('cybedefend', { region: 'eu' });
+    });
     expect(screen.queryByText('Tenant name is required')).not.toBeInTheDocument();
   });
 });

--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/EmptyStateOnboarding.test.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/EmptyStateOnboarding.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { IntegrationProviderResponse } from '@trycompai/integration-platform';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { EmptyStateOnboarding } from './EmptyStateOnboarding';
 
@@ -125,5 +126,74 @@ describe('EmptyStateOnboarding', () => {
       expect(mockCreateConnection).toHaveBeenCalledWith('dynamic-api', { api_key: 'secret' });
     });
   });
-});
 
+  const conditionalProvider = {
+    id: 'cybedefend',
+    slug: 'cybedefend',
+    name: 'CybeDefend',
+    description: 'Security scanning',
+    category: 'Security',
+    logoUrl: '',
+    authType: 'custom',
+    capabilities: ['checks'],
+    isActive: true,
+    credentialFields: [
+      {
+        id: 'region',
+        label: 'Region',
+        type: 'select',
+        required: true,
+        options: [
+          { value: 'eu', label: 'Europe' },
+          { value: 'dedicated', label: 'Dedicated tenant' },
+        ],
+      },
+      {
+        id: 'tenant',
+        label: 'Tenant name',
+        type: 'text',
+        required: true,
+        showIf: { field: 'region', equals: 'dedicated' },
+      },
+    ],
+  } satisfies IntegrationProviderResponse;
+
+  it('does not submit a hidden field whose value was typed then hidden again', async () => {
+    // The value survives in component state, so without filtering it would be
+    // encrypted and stored even though the operator took it back off screen.
+    render(
+      <EmptyStateOnboarding provider={conditionalProvider} orgId="org_1" onConnected={vi.fn()} />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Region'), { target: { value: 'dedicated' } });
+    fireEvent.change(screen.getByLabelText('Tenant name'), { target: { value: 'acme' } });
+    fireEvent.change(screen.getByLabelText('Region'), { target: { value: 'eu' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /connect account/i }));
+
+    await waitFor(() => {
+      expect(mockCreateConnection).toHaveBeenCalledWith('cybedefend', { region: 'eu' });
+    });
+  });
+
+  it('hides a conditional field until its controlling value is chosen', () => {
+    render(
+      <EmptyStateOnboarding provider={conditionalProvider} orgId="org_1" onConnected={vi.fn()} />,
+    );
+
+    expect(screen.queryByLabelText('Tenant name')).not.toBeInTheDocument();
+  });
+
+  it('does not block submission on a hidden required field', async () => {
+    // A required field the operator cannot see must never gate the form.
+    mockCreateConnection.mockResolvedValue({ success: true });
+
+    render(
+      <EmptyStateOnboarding provider={conditionalProvider} orgId="org_1" onConnected={vi.fn()} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /connect account/i }));
+
+    expect(screen.queryByText('Tenant name is required')).not.toBeInTheDocument();
+  });
+});

--- a/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/EmptyStateOnboarding.tsx
+++ b/apps/app/src/app/(app)/[orgId]/integrations/[slug]/components/EmptyStateOnboarding.tsx
@@ -2,6 +2,7 @@
 
 import { CloudShellSetup } from '@/components/integrations/CloudShellSetup';
 import { CredentialInput } from '@/components/integrations/CredentialInput';
+import { visibleCredentialFields } from '@/components/integrations/credential-field-visibility';
 import type { IntegrationProvider } from '@/hooks/use-integration-platform';
 import { useIntegrationMutations } from '@/hooks/use-integration-platform';
 import { Button, Label } from '@trycompai/design-system';
@@ -363,7 +364,13 @@ function CredentialSetup({
 
     return configuredFields;
   }, [provider.authType, provider.credentialFields]);
-  const hasConfigurableFields = fields.length > 0;
+
+  const visibleFields = useMemo(
+    () => visibleCredentialFields(fields, credentials),
+    [fields, credentials],
+  );
+
+  const hasConfigurableFields = visibleFields.length > 0;
 
   const updateCredential = (fieldId: string, value: string | string[]) => {
     setCredentials((prev) => ({ ...prev, [fieldId]: value }));
@@ -378,7 +385,7 @@ function CredentialSetup({
 
   const handleConnect = useCallback(async () => {
     const newErrors: Record<string, string> = {};
-    for (const field of fields) {
+    for (const field of visibleFields) {
       const value = credentials[field.id];
       const isMissing =
         field.type === 'multi-select'
@@ -393,9 +400,14 @@ function CredentialSetup({
       return;
     }
 
+    // Only what the operator could actually see.
+    const visibleCredentials = Object.fromEntries(
+      Object.entries(credentials).filter(([id]) => visibleFields.some((field) => field.id === id)),
+    );
+
     setConnecting(true);
     try {
-      const result = await createConnection(provider.id, credentials);
+      const result = await createConnection(provider.id, visibleCredentials);
       if (!result.success) {
         toast.error(result.error || 'Failed to connect');
         return;
@@ -407,7 +419,7 @@ function CredentialSetup({
     } finally {
       setConnecting(false);
     }
-  }, [fields, credentials, createConnection, provider, onConnected]);
+  }, [visibleFields, credentials, createConnection, provider, onConnected]);
 
   return (
     <div className="py-6 space-y-6">
@@ -423,7 +435,7 @@ function CredentialSetup({
         <div className="rounded-xl border bg-background shadow-sm">
           <div className="p-6 space-y-4">
             {hasConfigurableFields ? (
-              fields.map((field) => (
+              visibleFields.map((field) => (
                 <FieldRow
                   key={field.id}
                   field={field}
@@ -505,9 +517,7 @@ function CloudSetup({
   // AWS only — which scan engine the customer is choosing for this
   // connection. Sent in createConnection's credentials payload as the
   // `awsScanMode` variable, then read on every scan in cloud-security.service.
-  const [awsScanMode, setAwsScanMode] = useState<AwsScanModeChoice>(
-    DEFAULT_AWS_SCAN_MODE_CHOICE,
-  );
+  const [awsScanMode, setAwsScanMode] = useState<AwsScanModeChoice>(DEFAULT_AWS_SCAN_MODE_CHOICE);
 
   const allFields = provider.credentialFields ?? [];
   const visibleFields = allFields.filter(
@@ -597,9 +607,7 @@ function CloudSetup({
         )
       : regionOptions;
   const setupScript =
-    provider.id === 'aws'
-      ? getAwsCloudShellScript(awsEnvironment)
-      : (provider.setupScript ?? '');
+    provider.id === 'aws' ? getAwsCloudShellScript(awsEnvironment) : (provider.setupScript ?? '');
   const remediationScript = getAwsRemediationScript(awsEnvironment);
   const cloudShellUrl = getAwsCloudShellUrl(awsEnvironment);
 

--- a/apps/app/src/components/integrations/ConnectionVariablesForm.test.tsx
+++ b/apps/app/src/components/integrations/ConnectionVariablesForm.test.tsx
@@ -10,8 +10,10 @@ vi.mock('@trycompai/design-system', () => ({
     <label htmlFor={htmlFor}>{children}</label>
   ),
   Spinner: () => <span data-testid="spinner" />,
-  Select: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="ds-select">{children}</div>
+  Select: ({ children, value }: { children: React.ReactNode; value?: string }) => (
+    <div data-testid="ds-select" data-value={value}>
+      {children}
+    </div>
   ),
   SelectTrigger: ({ children, id }: { children: React.ReactNode; id?: string }) => (
     <div data-trigger-id={id}>{children}</div>
@@ -76,6 +78,36 @@ function renderFields(
     />,
   );
 }
+
+describe('ConnectionVariablesFields default preselection', () => {
+  const thresholdVariable = {
+    id: 'severity_threshold',
+    label: 'Fail at or above severity',
+    type: 'select',
+    required: false,
+    default: 'high',
+    options: [
+      { value: 'critical', label: 'Critical only' },
+      { value: 'high', label: 'High and above (default)' },
+      { value: 'low', label: 'Low and above' },
+    ],
+  } satisfies ConnectionVariable;
+
+  it('preselects a select variable default when no value is stored yet', () => {
+    // The boolean branch already falls back to `variable.default`; the select
+    // branch did not, so every defaulted dropdown rendered empty and the
+    // operator could not tell which value would be applied.
+    renderFields([thresholdVariable]);
+
+    expect(screen.getByTestId('ds-select')).toHaveAttribute('data-value', 'high');
+  });
+
+  it('leaves a select with no default empty', () => {
+    renderFields([{ ...thresholdVariable, default: undefined }]);
+
+    expect(screen.getByTestId('ds-select')).toHaveAttribute('data-value', '');
+  });
+});
 
 describe('ConnectionVariablesFields dropdown clickability inside a modal', () => {
   const modalSelectContentOptions = {

--- a/apps/app/src/components/integrations/ConnectionVariablesForm.tsx
+++ b/apps/app/src/components/integrations/ConnectionVariablesForm.tsx
@@ -163,7 +163,7 @@ export function ConnectionVariablesFields({
               />
             ) : variable.type === 'select' ? (
               <Select
-                value={String(variableValues[variable.id] ?? '')}
+                value={String(variableValues[variable.id] ?? variable.default ?? '')}
                 onValueChange={(value) => {
                   if (value === null) return;
                   setVariableValues((prev) => ({ ...prev, [variable.id]: value }));

--- a/apps/app/src/components/integrations/ManageIntegrationDialog.tsx
+++ b/apps/app/src/components/integrations/ManageIntegrationDialog.tsx
@@ -250,15 +250,6 @@ export function ManageIntegrationDialog({
   const handleSaveCredentials = async () => {
     if (!connectionId || !orgId) return;
 
-    // Check if any credentials were actually entered
-    const hasValues = Object.values(credentialValues).some((value) =>
-      Array.isArray(value) ? value.length > 0 : value.trim() !== '',
-    );
-    if (!hasValues) {
-      toast.error('Please enter at least one credential value to update');
-      return;
-    }
-
     // Only non-empty values, and only from fields the operator could see.
     const visibleIds = new Set(
       visibleCredentialFields(credentialFields, credentialValues).map((field) => field.id),
@@ -273,6 +264,11 @@ export function ManageIntegrationDialog({
       } else if (value.trim()) {
         credentialsToSave[key] = value.trim();
       }
+    }
+
+    if (Object.keys(credentialsToSave).length === 0) {
+      toast.error('Please enter at least one credential value to update');
+      return;
     }
 
     setSavingCredentials(true);

--- a/apps/app/src/components/integrations/ManageIntegrationDialog.tsx
+++ b/apps/app/src/components/integrations/ManageIntegrationDialog.tsx
@@ -37,6 +37,7 @@ import Image from 'next/image';
 import { useParams } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
+import { visibleCredentialFields } from './credential-field-visibility';
 
 interface VariableWithValue extends ConnectionVariable {
   currentValue?: string | number | boolean | string[];
@@ -258,9 +259,13 @@ export function ManageIntegrationDialog({
       return;
     }
 
-    // Only send non-empty values
+    // Only non-empty values, and only from fields the operator could see.
+    const visibleIds = new Set(
+      visibleCredentialFields(credentialFields, credentialValues).map((field) => field.id),
+    );
     const credentialsToSave: Record<string, string | string[]> = {};
     for (const [key, value] of Object.entries(credentialValues)) {
+      if (!visibleIds.has(key)) continue;
       if (Array.isArray(value)) {
         if (value.length > 0) {
           credentialsToSave[key] = value;
@@ -505,7 +510,7 @@ function ConfigurationContent({
           <span>Your credentials are encrypted at rest using AES-256-GCM encryption.</span>
         </p>
       </div>
-      {credentialFields.map((field) => (
+      {visibleCredentialFields(credentialFields, credentialValues).map((field) => (
         <div key={field.id} className="space-y-2">
           <Label htmlFor={`cred-${field.id}`}>
             {field.label}

--- a/apps/app/src/components/integrations/credential-field-visibility.test.ts
+++ b/apps/app/src/components/integrations/credential-field-visibility.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { isCredentialFieldVisible, visibleCredentialFields } from './credential-field-visibility';
+
+const region = { id: 'region', label: 'Region', type: 'select', required: true } as const;
+const tenant = {
+  id: 'tenant',
+  label: 'Tenant name',
+  type: 'text',
+  required: true,
+  showIf: { field: 'region', equals: 'dedicated' },
+} as const;
+
+describe('isCredentialFieldVisible', () => {
+  it('shows a field that declares no condition', () => {
+    expect(isCredentialFieldVisible(region, {})).toBe(true);
+  });
+
+  it('hides a conditional field while its controlling value differs', () => {
+    expect(isCredentialFieldVisible(tenant, { region: 'eu' })).toBe(false);
+  });
+
+  it('shows a conditional field once its controlling value matches', () => {
+    expect(isCredentialFieldVisible(tenant, { region: 'dedicated' })).toBe(true);
+  });
+
+  it('hides a conditional field when the controlling value is missing', () => {
+    expect(isCredentialFieldVisible(tenant, {})).toBe(false);
+  });
+
+  it('does not match a controlling value held as an array', () => {
+    // Multi-select fields hold arrays; an array never equals a scalar, and
+    // coercing it would make ['dedicated'] silently satisfy the condition.
+    expect(isCredentialFieldVisible(tenant, { region: ['dedicated'] })).toBe(false);
+  });
+});
+
+describe('visibleCredentialFields', () => {
+  it('keeps only the fields the operator can see', () => {
+    expect(visibleCredentialFields([region, tenant], { region: 'eu' })).toEqual([region]);
+    expect(visibleCredentialFields([region, tenant], { region: 'dedicated' })).toEqual([
+      region,
+      tenant,
+    ]);
+  });
+});

--- a/apps/app/src/components/integrations/credential-field-visibility.ts
+++ b/apps/app/src/components/integrations/credential-field-visibility.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared by every surface that renders credential fields, so a field hidden on
+ * the connect screen cannot reappear in the reconfigure dialog.
+ */
+
+export interface ConditionalCredentialField {
+  id: string;
+  showIf?: { field: string; equals: string };
+}
+
+/** An array controlling value never matches: `['dedicated']` is not `'dedicated'`. */
+export const isCredentialFieldVisible = (
+  field: ConditionalCredentialField,
+  values: Record<string, string | string[] | undefined>,
+): boolean => {
+  if (!field.showIf) return true;
+
+  const controlling = values[field.showIf.field];
+  if (typeof controlling !== 'string') return false;
+
+  return controlling === field.showIf.equals;
+};
+
+export const visibleCredentialFields = <T extends ConditionalCredentialField>(
+  fields: T[],
+  values: Record<string, string | string[] | undefined>,
+): T[] => fields.filter((field) => isCredentialFieldVisible(field, values));

--- a/packages/integration-platform/src/manifests/cybedefend/auth.test.ts
+++ b/packages/integration-platform/src/manifests/cybedefend/auth.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from 'bun:test';
+import { exchangePersonalAccessToken } from './auth';
+import type { FetchImpl } from './client';
+import { at, rejectionOf } from './test-support';
+
+const PAT = 'pat_secret_value_that_must_never_escape';
+const APP_ID = '7tx9q19tn1teq88ml18gc';
+
+interface RecordedRequest {
+  url: string;
+  headers?: Record<string, string>;
+  body?: string;
+}
+
+const fakeLogto = ({
+  tokenStatus = 200,
+  clientAppsStatus = 200,
+}: { tokenStatus?: number; clientAppsStatus?: number } = {}) => {
+  const requests: RecordedRequest[] = [];
+
+  const fetchImpl: FetchImpl = async (url, init) => {
+    requests.push({ url, headers: init?.headers, body: init?.body });
+
+    if (url.includes('/client-apps')) {
+      return {
+        ok: clientAppsStatus === 200,
+        status: clientAppsStatus,
+        json: async () => ({ cli: { appId: APP_ID }, vscode: { appId: 'x' } }),
+        text: async () => '',
+      };
+    }
+
+    return {
+      ok: tokenStatus === 200,
+      status: tokenStatus,
+      json: async () => ({ access_token: 'issued-access-token', expires_in: 900 }),
+      text: async () => 'invalid_grant',
+    };
+  };
+
+  return { fetchImpl, requests };
+};
+
+const options = (fetchImpl: FetchImpl) => ({
+  apiBaseUrl: 'https://api-eu.cybedefend.com',
+  logtoEndpoint: 'https://auth-eu.cybedefend.com',
+  personalAccessToken: PAT,
+  fetchImpl,
+});
+
+describe('exchangePersonalAccessToken', () => {
+  test('returns the issued access token', async () => {
+    const { fetchImpl } = fakeLogto();
+
+    expect(await exchangePersonalAccessToken(options(fetchImpl))).toBe('issued-access-token');
+  });
+
+  test('discovers the CLI app id from the public client-apps endpoint', async () => {
+    const { fetchImpl, requests } = fakeLogto();
+
+    await exchangePersonalAccessToken(options(fetchImpl));
+
+    expect(at(requests, 0).url).toBe('https://api-eu.cybedefend.com/client-apps');
+  });
+
+  test('exchanges against the region Logto endpoint', async () => {
+    const { fetchImpl, requests } = fakeLogto();
+
+    await exchangePersonalAccessToken(options(fetchImpl));
+
+    expect(at(requests, 1).url).toBe('https://auth-eu.cybedefend.com/oidc/token');
+  });
+
+  test('uses the token-exchange grant with the personal access token subject type', async () => {
+    const { fetchImpl, requests } = fakeLogto();
+
+    await exchangePersonalAccessToken(options(fetchImpl));
+
+    const body = new URLSearchParams(at(requests, 1).body);
+    expect(body.get('grant_type')).toBe('urn:ietf:params:oauth:grant-type:token-exchange');
+    expect(body.get('subject_token_type')).toBe('urn:logto:token-type:personal_access_token');
+    expect(body.get('client_id')).toBe(APP_ID);
+  });
+
+  test('sets the resource to the region API base URL', async () => {
+    // A resource from another region yields a token the API refuses.
+    const { fetchImpl, requests } = fakeLogto();
+
+    await exchangePersonalAccessToken(options(fetchImpl));
+
+    expect(new URLSearchParams(at(requests, 1).body).get('resource')).toBe(
+      'https://api-eu.cybedefend.com',
+    );
+  });
+});
+
+describe('exchangePersonalAccessToken: token handling', () => {
+  test('never puts the personal access token in a URL', async () => {
+    const { fetchImpl, requests } = fakeLogto();
+
+    await exchangePersonalAccessToken(options(fetchImpl));
+
+    for (const request of requests) {
+      expect(request.url).not.toContain(PAT);
+    }
+  });
+
+  test('never leaks the personal access token when the exchange fails', async () => {
+    const { fetchImpl } = fakeLogto({ tokenStatus: 400 });
+
+    const error = await rejectionOf(exchangePersonalAccessToken(options(fetchImpl)));
+
+    expect(error.message).not.toContain(PAT);
+  });
+
+  test('reports a failed exchange rather than returning an empty token', async () => {
+    const { fetchImpl } = fakeLogto({ tokenStatus: 400 });
+
+    await expect(exchangePersonalAccessToken(options(fetchImpl))).rejects.toThrow(
+      /personal access token/i,
+    );
+  });
+
+  test('reports an unreachable client-apps endpoint distinctly', async () => {
+    const { fetchImpl } = fakeLogto({ clientAppsStatus: 503 });
+
+    await expect(exchangePersonalAccessToken(options(fetchImpl))).rejects.toThrow(/client app/i);
+  });
+});

--- a/packages/integration-platform/src/manifests/cybedefend/auth.test.ts
+++ b/packages/integration-platform/src/manifests/cybedefend/auth.test.ts
@@ -113,6 +113,32 @@ describe('exchangePersonalAccessToken: token handling', () => {
     expect(error.message).not.toContain(PAT);
   });
 
+  test('reports a 200 whose body is not JSON as an exchange failure', async () => {
+    // A proxy or captive portal can answer 200 with HTML; the raw SyntaxError
+    // that follows tells the operator nothing about the region or the token.
+    const fetchImpl: FetchImpl = async (url) =>
+      url.includes('/client-apps')
+        ? {
+            ok: true,
+            status: 200,
+            json: async () => ({ cli: { appId: APP_ID } }),
+            text: async () => '',
+          }
+        : {
+            ok: true,
+            status: 200,
+            json: async () => {
+              throw new SyntaxError('Unexpected token <');
+            },
+            text: async () => '<html>gateway</html>',
+          };
+
+    const error = await rejectionOf(exchangePersonalAccessToken(options(fetchImpl)));
+
+    expect(error.message).toMatch(/personal access token/i);
+    expect(error.message).not.toContain(PAT);
+  });
+
   test('reports a failed exchange rather than returning an empty token', async () => {
     const { fetchImpl } = fakeLogto({ tokenStatus: 400 });
 

--- a/packages/integration-platform/src/manifests/cybedefend/auth.ts
+++ b/packages/integration-platform/src/manifests/cybedefend/auth.ts
@@ -1,0 +1,86 @@
+import type { FetchImpl } from './client';
+
+const TOKEN_EXCHANGE_GRANT = 'urn:ietf:params:oauth:grant-type:token-exchange';
+const PERSONAL_ACCESS_TOKEN_TYPE = 'urn:logto:token-type:personal_access_token';
+
+export interface ExchangePersonalAccessTokenOptions {
+  /** Region API base URL. Doubles as the OAuth resource indicator. */
+  apiBaseUrl: string;
+  /** Region Logto endpoint. */
+  logtoEndpoint: string;
+  personalAccessToken: string;
+  fetchImpl?: FetchImpl;
+}
+
+/** Public endpoint: the region's published list of client applications. */
+const fetchCliAppId = async ({
+  apiBaseUrl,
+  fetchImpl,
+}: {
+  apiBaseUrl: string;
+  fetchImpl: FetchImpl;
+}): Promise<string> => {
+  const response = await fetchImpl(`${apiBaseUrl}/client-apps`, {
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Could not read the CybeDefend client apps registry (HTTP ${response.status}). Check the region.`,
+    );
+  }
+
+  const registry = (await response.json()) as { cli?: { appId?: unknown } };
+  const appId = registry?.cli?.appId;
+
+  if (typeof appId !== 'string' || !appId) {
+    throw new Error('The CybeDefend client apps registry did not advertise a CLI client app.');
+  }
+
+  return appId;
+};
+
+/**
+ * The API token lives for minutes: obtained once per run, never cached beyond
+ * it. No message below carries the personal access token: they are persisted
+ * on the integration result and displayed.
+ */
+export const exchangePersonalAccessToken = async ({
+  apiBaseUrl,
+  logtoEndpoint,
+  personalAccessToken,
+  fetchImpl = globalThis.fetch as unknown as FetchImpl,
+}: ExchangePersonalAccessTokenOptions): Promise<string> => {
+  const clientId = await fetchCliAppId({ apiBaseUrl, fetchImpl });
+
+  const body = new URLSearchParams({
+    client_id: clientId,
+    grant_type: TOKEN_EXCHANGE_GRANT,
+    subject_token: personalAccessToken,
+    subject_token_type: PERSONAL_ACCESS_TOKEN_TYPE,
+    resource: apiBaseUrl,
+  });
+
+  const response = await fetchImpl(`${logtoEndpoint}/oidc/token`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Accept: 'application/json',
+    },
+    body: body.toString(),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `CybeDefend rejected the personal access token (HTTP ${response.status}). It may be expired, or issued for a different region.`,
+    );
+  }
+
+  const payload = (await response.json()) as { access_token?: unknown };
+
+  if (typeof payload?.access_token !== 'string' || !payload.access_token) {
+    throw new Error('CybeDefend returned no access token for the personal access token.');
+  }
+
+  return payload.access_token;
+};

--- a/packages/integration-platform/src/manifests/cybedefend/auth.ts
+++ b/packages/integration-platform/src/manifests/cybedefend/auth.ts
@@ -76,10 +76,12 @@ export const exchangePersonalAccessToken = async ({
     );
   }
 
-  const payload = (await response.json()) as { access_token?: unknown };
+  const payload = (await response.json().catch(() => null)) as { access_token?: unknown } | null;
 
   if (typeof payload?.access_token !== 'string' || !payload.access_token) {
-    throw new Error('CybeDefend returned no access token for the personal access token.');
+    throw new Error(
+      `CybeDefend returned no usable access token for the personal access token (HTTP ${response.status}).`,
+    );
   }
 
   return payload.access_token;

--- a/packages/integration-platform/src/manifests/cybedefend/checks/__tests__/project-findings-check.test.ts
+++ b/packages/integration-platform/src/manifests/cybedefend/checks/__tests__/project-findings-check.test.ts
@@ -1,0 +1,422 @@
+import { describe, expect, it } from 'bun:test';
+import type { CheckContext, CheckResult, CheckVariableValues } from '../../../../types';
+import type { CybeDefendFinding } from '../../types';
+import { createProjectFindingsCheck } from '../project-findings-check';
+
+const PAT = 'pat_secret_value_that_must_never_escape';
+
+interface Emitted {
+  passed: Array<{ resourceId: string; resourceType: string; title: string; evidence: unknown }>;
+  failed: Array<{
+    resourceId: string;
+    resourceType: string;
+    title: string;
+    severity: CheckResult['severity'];
+    remediation?: string;
+    evidence?: unknown;
+  }>;
+}
+
+const finding = ({
+  id,
+  projectId,
+  projectName = 'proj',
+  findingType = 'sast',
+  severity = 'high',
+}: {
+  id: string;
+  projectId: string;
+  projectName?: string;
+  findingType?: string;
+  severity?: string;
+}): CybeDefendFinding =>
+  ({
+    id,
+    title: 'Rule',
+    description: '',
+    remediation: '',
+    severity,
+    status: 'confirmed',
+    finding_type: findingType,
+    project_id: projectId,
+    project_name: projectName,
+    first_detected_at: null,
+    last_detected_at: null,
+    triaged_at: null,
+    resolved_at: null,
+    triaged_by: null,
+    triaged_by_type: null,
+    dismissal_reason: null,
+    updated_at: '2026-08-06T08:26:17.000Z',
+    url: 'https://eu.cybedefend.com/x',
+    details: { path: 'src/a.py', line: 1 },
+  }) satisfies CybeDefendFinding;
+
+const run = async ({
+  findings,
+  projects,
+  variables = {},
+  collectLogs,
+}: {
+  findings: CybeDefendFinding[];
+  projects: Array<{ projectId: string; projectName: string }>;
+  variables?: CheckVariableValues;
+  collectLogs?: string[];
+}): Promise<Emitted> => {
+  const emitted: Emitted = { passed: [], failed: [] };
+
+  const ctx = {
+    accessToken: '',
+    credentials: {
+      region: 'eu',
+      organizationId: '00000000-0000-4000-8000-000000000000',
+      personalAccessToken: PAT,
+    },
+    variables,
+    connectionId: 'conn_1',
+    organizationId: 'org_1',
+    metadata: {},
+    log: (m: string) => collectLogs?.push(m),
+    warn: (m: string) => collectLogs?.push(m),
+    error: (m: string) => collectLogs?.push(m),
+    pass: (r: Parameters<CheckContext['pass']>[0]) => {
+      emitted.passed.push({
+        resourceId: r.resourceId,
+        resourceType: r.resourceType,
+        title: r.title,
+        evidence: r.evidence,
+      });
+    },
+    fail: (f: Parameters<CheckContext['fail']>[0]) => {
+      emitted.failed.push({
+        resourceId: f.resourceId,
+        resourceType: f.resourceType,
+        title: f.title,
+        severity: f.severity,
+        remediation: f.remediation,
+        evidence: f.evidence,
+      });
+    },
+    addPassingResult: () => {},
+    addFinding: () => {},
+  } as unknown as CheckContext;
+
+  const check = createProjectFindingsCheck({
+    id: 'cybedefend_sast',
+    name: 'SAST',
+    description: 'desc',
+    service: 'code-scanning',
+    findingType: 'sast',
+    fetchImpl: async (url: string) => {
+      if (url.includes('/client-apps')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ cli: { appId: 'app' } }),
+          text: async () => '',
+        };
+      }
+      if (url.includes('/oidc/token')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ access_token: 'issued' }),
+          text: async () => '',
+        };
+      }
+      if (url.includes('/user/profile')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            myAccessibleProjects: projects.map((p) => ({
+              ...p,
+              organizationId: '00000000-0000-4000-8000-000000000000',
+            })),
+          }),
+          text: async () => '',
+        };
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          success: true,
+          data: { findings, next_cursor: null, has_more: false, next_since: null },
+        }),
+        text: async () => '',
+      };
+    },
+  });
+
+  await check.run(ctx);
+  return emitted;
+};
+
+describe('createProjectFindingsCheck: one result per project', () => {
+  it('emits a single result per project, not one per finding', async () => {
+    const emitted = await run({
+      findings: [
+        finding({ id: 'a', projectId: 'p1' }),
+        finding({ id: 'b', projectId: 'p1' }),
+        finding({ id: 'c', projectId: 'p1' }),
+      ],
+      projects: [{ projectId: 'p1', projectName: 'vulpy' }],
+    });
+
+    expect(emitted.passed.length + emitted.failed.length).toBe(1);
+  });
+
+  it('keys the result on the project, as a project resource', async () => {
+    const emitted = await run({
+      findings: [finding({ id: 'a', projectId: 'p1' })],
+      projects: [{ projectId: 'p1', projectName: 'vulpy' }],
+    });
+
+    expect(emitted.failed[0]?.resourceId).toBe('p1');
+    expect(emitted.failed[0]?.resourceType).toBe('project');
+  });
+
+  it('passes a project that has no findings of this type', async () => {
+    // A clean project never appears in the findings feed, so it has to come
+    // from the project list, otherwise clean repositories are invisible.
+    const emitted = await run({
+      findings: [],
+      projects: [{ projectId: 'p1', projectName: 'clean' }],
+    });
+
+    expect(emitted.passed.map((p) => p.resourceId)).toEqual(['p1']);
+    expect(emitted.failed).toHaveLength(0);
+  });
+
+  it('ignores findings belonging to another scan type', async () => {
+    const emitted = await run({
+      findings: [finding({ id: 'a', projectId: 'p1', findingType: 'sca' })],
+      projects: [{ projectId: 'p1', projectName: 'vulpy' }],
+    });
+
+    expect(emitted.passed).toHaveLength(1);
+    expect(emitted.failed).toHaveLength(0);
+  });
+});
+
+describe('createProjectFindingsCheck: severity threshold', () => {
+  it('fails a project whose findings reach the threshold', async () => {
+    const emitted = await run({
+      findings: [finding({ id: 'a', projectId: 'p1', severity: 'critical' })],
+      projects: [{ projectId: 'p1', projectName: 'vulpy' }],
+      variables: { severity_threshold: 'high' },
+    });
+
+    expect(emitted.failed).toHaveLength(1);
+  });
+
+  it('passes a project whose findings all sit below the threshold', async () => {
+    const emitted = await run({
+      findings: [finding({ id: 'a', projectId: 'p1', severity: 'low' })],
+      projects: [{ projectId: 'p1', projectName: 'vulpy' }],
+      variables: { severity_threshold: 'high' },
+    });
+
+    expect(emitted.passed).toHaveLength(1);
+    expect(emitted.failed).toHaveLength(0);
+  });
+
+  it('reports the per-severity counts as evidence', async () => {
+    const emitted = await run({
+      findings: [
+        finding({ id: 'a', projectId: 'p1', severity: 'low' }),
+        finding({ id: 'b', projectId: 'p1', severity: 'low' }),
+      ],
+      projects: [{ projectId: 'p1', projectName: 'vulpy' }],
+      variables: { severity_threshold: 'critical' },
+    });
+
+    expect(emitted.passed[0]?.evidence).toMatchObject({
+      counts: { critical: 0, high: 0, medium: 0, low: 2, unknown: 0 },
+      total: 2,
+    });
+  });
+});
+
+describe('createProjectFindingsCheck: unrecognised severity', () => {
+  // CybeDefend severities are critical/high/medium/low. Anything else is a
+  // provider-side anomaly: it must stay visible rather than be folded into the
+  // weakest level, which is how 19 real findings once went unreported.
+  it('counts a finding whose severity it cannot read', async () => {
+    const emitted = await run({
+      findings: [finding({ id: 'a', projectId: 'p1', severity: '' })],
+      projects: [{ projectId: 'p1', projectName: 'vulpy' }],
+    });
+
+    expect(emitted.passed[0]?.evidence).toMatchObject({ counts: { unknown: 1 }, total: 1 });
+  });
+
+  it('does not let an unreadable severity breach the threshold', async () => {
+    const emitted = await run({
+      findings: [finding({ id: 'a', projectId: 'p1', severity: 'catastrophic' })],
+      projects: [{ projectId: 'p1', projectName: 'vulpy' }],
+    });
+
+    expect(emitted.failed).toHaveLength(0);
+  });
+
+  it('does not let an unreadable severity breach even the lowest threshold', async () => {
+    // The edge case behind the claim: `low` is rank 0 and unknown is -1, so the
+    // comparison has to stay strict. A fallback to rank 0 would breach here.
+    const emitted = await run({
+      findings: [finding({ id: 'a', projectId: 'p1', severity: '' })],
+      projects: [{ projectId: 'p1', projectName: 'vulpy' }],
+      variables: { severity_threshold: 'low' },
+    });
+
+    expect(emitted.failed).toHaveLength(0);
+    expect(emitted.passed[0]?.evidence).toMatchObject({ counts: { unknown: 1 } });
+  });
+
+  it('warns so the anomaly is visible without a database query', async () => {
+    const lines: string[] = [];
+    await run({
+      findings: [finding({ id: 'a', projectId: 'p1', severity: 'catastrophic' })],
+      projects: [{ projectId: 'p1', projectName: 'vulpy' }],
+      collectLogs: lines,
+    });
+
+    expect(lines.join('\n')).toMatch(/1 finding\(s\) with an unrecognised severity/i);
+  });
+
+  it('stays silent when every severity is readable', async () => {
+    const lines: string[] = [];
+    await run({
+      findings: [finding({ id: 'a', projectId: 'p1', severity: 'high' })],
+      projects: [{ projectId: 'p1', projectName: 'vulpy' }],
+      collectLogs: lines,
+    });
+
+    expect(lines.join('\n')).not.toMatch(/unrecognised severity/i);
+  });
+});
+
+describe('createProjectFindingsCheck: threshold variable', () => {
+  const threshold = () => {
+    const check = createProjectFindingsCheck({
+      id: 'cybedefend_sast',
+      name: 'SAST',
+      description: 'desc',
+      service: 'code-scanning',
+      findingType: 'sast',
+    });
+    return (check.variables ?? []).find((v) => v.id === 'severity_threshold');
+  };
+
+  it('declares the default the code actually applies', async () => {
+    // Without this the connection form shows an empty selector, and the
+    // operator cannot tell which threshold will be used.
+    expect(threshold()?.default).toBe('high');
+  });
+
+  it('marks the default option in its label', async () => {
+    const option = threshold()?.options?.find((o) => o.value === 'high');
+
+    expect(option?.label).toContain('default');
+  });
+
+  it('applies that same default when the variable is unset', async () => {
+    const emitted = await run({
+      findings: [finding({ id: 'a', projectId: 'p1', severity: 'high' })],
+      projects: [{ projectId: 'p1', projectName: 'vulpy' }],
+      variables: {},
+    });
+
+    expect(emitted.failed).toHaveLength(1);
+  });
+});
+
+describe('createProjectFindingsCheck: remediation wording', () => {
+  const failing = async () =>
+    (
+      await run({
+        findings: [
+          finding({ id: 'a', projectId: 'p1', projectName: 'vulpy', severity: 'critical' }),
+        ],
+        projects: [{ projectId: 'p1', projectName: 'vulpy' }],
+      })
+    ).failed[0];
+
+  it('names the project rather than pasting a raw URL', async () => {
+    const result = await failing();
+
+    expect(result?.remediation).toContain('vulpy');
+    expect(result?.remediation).not.toContain('http');
+  });
+
+  it('still carries the deep link in the evidence', async () => {
+    // Dropping the URL from the prose must not lose the way back to the finding.
+    const result = await failing();
+
+    expect(result?.evidence).toMatchObject({
+      projectUrl: 'https://eu.cybedefend.com/project/p1',
+      projectName: 'vulpy',
+    });
+  });
+});
+
+describe('createProjectFindingsCheck: diagnostics', () => {
+  const logsOf = async (args: Parameters<typeof run>[0]): Promise<string[]> => {
+    const lines: string[] = [];
+    await run({ ...args, collectLogs: lines });
+    return lines;
+  };
+
+  it('reports which region and organization it is querying', async () => {
+    const lines = await logsOf({
+      findings: [],
+      projects: [{ projectId: 'p1', projectName: 'vulpy' }],
+    });
+
+    expect(lines.join('\n')).toContain('region eu');
+  });
+
+  it('reports how many projects and findings it saw', async () => {
+    const lines = await logsOf({
+      findings: [finding({ id: 'a', projectId: 'p1' }), finding({ id: 'b', projectId: 'p1' })],
+      projects: [{ projectId: 'p1', projectName: 'vulpy' }],
+    });
+
+    const joined = lines.join('\n');
+    expect(joined).toContain('1 project');
+    expect(joined).toContain('2 open finding');
+  });
+
+  it('reports the pass and fail tally it emitted', async () => {
+    const lines = await logsOf({
+      findings: [finding({ id: 'a', projectId: 'p1', severity: 'critical' })],
+      projects: [
+        { projectId: 'p1', projectName: 'vulpy' },
+        { projectId: 'p2', projectName: 'clean' },
+      ],
+    });
+
+    expect(lines.join('\n')).toContain('1 failed, 1 passed');
+  });
+
+  it('never writes the personal access token to the logs', async () => {
+    const lines = await logsOf({
+      findings: [finding({ id: 'a', projectId: 'p1' })],
+      projects: [{ projectId: 'p1', projectName: 'vulpy' }],
+    });
+
+    expect(lines.join('\n')).not.toContain(PAT);
+  });
+});
+
+describe('createProjectFindingsCheck: secrets', () => {
+  it('never puts the personal access token in an emitted result', async () => {
+    const emitted = await run({
+      findings: [finding({ id: 'a', projectId: 'p1' })],
+      projects: [{ projectId: 'p1', projectName: 'vulpy' }],
+    });
+
+    expect(JSON.stringify(emitted)).not.toContain(PAT);
+  });
+});

--- a/packages/integration-platform/src/manifests/cybedefend/checks/__tests__/project-findings-check.test.ts
+++ b/packages/integration-platform/src/manifests/cybedefend/checks/__tests__/project-findings-check.test.ts
@@ -261,6 +261,19 @@ describe('createProjectFindingsCheck: unrecognised severity', () => {
     expect(emitted.failed).toHaveLength(0);
   });
 
+  it('survives a severity the export did not send as a string', async () => {
+    const emitted = await run({
+      findings: [
+        finding({ id: 'a', projectId: 'p1', severity: null as unknown as string }),
+        finding({ id: 'b', projectId: 'p1', severity: 'critical' }),
+      ],
+      projects: [{ projectId: 'p1', projectName: 'vulpy' }],
+    });
+
+    expect(emitted.failed).toHaveLength(1);
+    expect(emitted.failed[0]?.evidence).toMatchObject({ counts: { unknown: 1, critical: 1 } });
+  });
+
   it('does not let an unreadable severity breach even the lowest threshold', async () => {
     // The edge case behind the claim: `low` is rank 0 and unknown is -1, so the
     // comparison has to stay strict. A fallback to rank 0 would breach here.

--- a/packages/integration-platform/src/manifests/cybedefend/checks/index.ts
+++ b/packages/integration-platform/src/manifests/cybedefend/checks/index.ts
@@ -1,0 +1,36 @@
+import { TASK_TEMPLATES } from '../../../task-mappings';
+import { createProjectFindingsCheck } from './project-findings-check';
+
+/**
+ * Static application security testing.
+ *
+ * Bound to "Sanitized Inputs": the control asks for input validation and
+ * sanitization, which is what SAST findings evidence.
+ */
+export const sastCheck = createProjectFindingsCheck({
+  id: 'cybedefend_sast_findings',
+  name: 'CybeDefend Code Scanning',
+  description:
+    'Checks each CybeDefend project for open static-analysis findings on its reference branch.',
+  service: 'code-scanning',
+  findingType: 'sast',
+  taskMapping: TASK_TEMPLATES.sanitizedInputs,
+});
+
+/**
+ * Software composition analysis.
+ *
+ * Bound to "Secure Code", the task that asks for "dependabot or its
+ * equivalent", dependency vulnerability detection.
+ */
+export const scaCheck = createProjectFindingsCheck({
+  id: 'cybedefend_sca_findings',
+  name: 'CybeDefend Dependency Scanning',
+  description:
+    'Checks each CybeDefend project for open dependency vulnerabilities on its reference branch.',
+  service: 'dependency-scanning',
+  findingType: 'sca',
+  taskMapping: TASK_TEMPLATES.secureCode,
+});
+
+export { createProjectFindingsCheck };

--- a/packages/integration-platform/src/manifests/cybedefend/checks/project-findings-check.ts
+++ b/packages/integration-platform/src/manifests/cybedefend/checks/project-findings-check.ts
@@ -19,8 +19,10 @@ const UNKNOWN_RANK = -1;
  * Deliberately not "unknown falls back to the weakest level": that fold is how
  * findings with an empty severity once sat below every threshold, unreported.
  */
-const rank = (severity: string): number =>
-  SEVERITIES.indexOf(severity.trim().toLowerCase() as CybeDefendSeverity);
+const rank = (severity: unknown): number =>
+  typeof severity === 'string'
+    ? SEVERITIES.indexOf(severity.trim().toLowerCase() as CybeDefendSeverity)
+    : UNKNOWN_RANK;
 
 const resolveThreshold = (value: unknown): CybeDefendSeverity =>
   typeof value === 'string' && SEVERITIES.includes(value.toLowerCase() as CybeDefendSeverity)

--- a/packages/integration-platform/src/manifests/cybedefend/checks/project-findings-check.ts
+++ b/packages/integration-platform/src/manifests/cybedefend/checks/project-findings-check.ts
@@ -1,0 +1,249 @@
+import type { TaskTemplateId } from '../../../task-mappings';
+import type { CheckContext, FindingSeverity, IntegrationCheck } from '../../../types';
+import { exchangePersonalAccessToken } from '../auth';
+import { fetchFindingsPages, type FetchImpl } from '../client';
+import { resolveRegion } from '../regions';
+import type { CybeDefendFinding } from '../types';
+
+/** CybeDefend severities, weakest first. */
+const SEVERITIES = ['low', 'medium', 'high', 'critical'] as const;
+
+type CybeDefendSeverity = (typeof SEVERITIES)[number];
+
+const DEFAULT_THRESHOLD: CybeDefendSeverity = 'high';
+
+/** Rank of an unreadable severity. Below every threshold, and never silent. */
+const UNKNOWN_RANK = -1;
+
+/**
+ * Deliberately not "unknown falls back to the weakest level": that fold is how
+ * findings with an empty severity once sat below every threshold, unreported.
+ */
+const rank = (severity: string): number =>
+  SEVERITIES.indexOf(severity.trim().toLowerCase() as CybeDefendSeverity);
+
+const resolveThreshold = (value: unknown): CybeDefendSeverity =>
+  typeof value === 'string' && SEVERITIES.includes(value.toLowerCase() as CybeDefendSeverity)
+    ? (value.toLowerCase() as CybeDefendSeverity)
+    : DEFAULT_THRESHOLD;
+
+/** Highest severity present, used to grade the finding Comp AI records. */
+const toCheckSeverity = (findings: CybeDefendFinding[]): FindingSeverity => {
+  const highest = findings.reduce((worst, f) => Math.max(worst, rank(f.severity)), 0);
+  return (SEVERITIES[highest] ?? 'low') as FindingSeverity;
+};
+
+type SeverityCounts = Record<CybeDefendSeverity | 'unknown', number>;
+
+const countBySeverity = (findings: CybeDefendFinding[]): SeverityCounts => {
+  const counts: SeverityCounts = { low: 0, medium: 0, high: 0, critical: 0, unknown: 0 };
+  for (const finding of findings) {
+    const key = SEVERITIES[rank(finding.severity)];
+    counts[key ?? 'unknown'] += 1;
+  }
+  return counts;
+};
+
+interface AccessibleProject {
+  projectId: string;
+  projectName: string;
+  organizationId: string;
+}
+
+const readString = (value: string | string[] | undefined): string =>
+  (Array.isArray(value) ? value[0] : value)?.trim() ?? '';
+
+export interface ProjectFindingsCheckOptions {
+  id: string;
+  name: string;
+  description: string;
+  service: string;
+  /** CybeDefend scan type this check reports on, e.g. `sast` or `sca`. */
+  findingType: string;
+  taskMapping?: TaskTemplateId;
+  /** Injectable for tests. Defaults to the platform's own fetch. */
+  fetchImpl?: FetchImpl;
+}
+
+/**
+ * One result per project: it passes when no open finding of this scan type
+ * reaches the configured severity. Clean projects come from the account's
+ * project list, since a project with no findings never appears in the feed.
+ *
+ * The export has no scan-type filter, so each check narrows locally.
+ */
+export const createProjectFindingsCheck = ({
+  id,
+  name,
+  description,
+  service,
+  findingType,
+  taskMapping,
+  fetchImpl,
+}: ProjectFindingsCheckOptions): IntegrationCheck => ({
+  id,
+  name,
+  description,
+  service,
+  taskMapping,
+  defaultSeverity: 'high',
+
+  variables: [
+    {
+      id: 'severity_threshold',
+      label: 'Fail at or above severity',
+      type: 'select',
+      required: false,
+      // Declaring it is what pre-selects the value in the form.
+      default: DEFAULT_THRESHOLD,
+      helpText: 'A project fails when it has an open finding at or above this severity.',
+      options: [
+        { value: 'critical', label: 'Critical only' },
+        { value: 'high', label: 'High and above (default)' },
+        { value: 'medium', label: 'Medium and above' },
+        { value: 'low', label: 'Low and above' },
+      ],
+    },
+  ],
+
+  run: async (ctx: CheckContext) => {
+    const region = readString(ctx.credentials.region);
+    const organizationId = readString(ctx.credentials.organizationId);
+    const personalAccessToken = readString(ctx.credentials.personalAccessToken);
+
+    const tenant = readString(ctx.credentials.tenant);
+    const { apiBaseUrl, logtoEndpoint, appBaseUrl } = resolveRegion({ region, tenant });
+
+    ctx.log(
+      `Querying CybeDefend region ${region} (${apiBaseUrl}) for organization ${organizationId}`,
+    );
+
+    const accessToken = await exchangePersonalAccessToken({
+      apiBaseUrl,
+      logtoEndpoint,
+      personalAccessToken,
+      fetchImpl,
+    });
+    ctx.log(`Exchanged the personal access token for a short-lived API token`);
+
+    const projects = await listProjects({
+      apiBaseUrl,
+      organizationId,
+      accessToken,
+      fetchImpl,
+    });
+    ctx.log(`Found ${projects.length} project(s) visible to this token`);
+
+    const { findings } = await fetchFindingsPages({
+      apiBaseUrl,
+      organizationId,
+      accessToken,
+      fetchImpl,
+    });
+
+    const relevant = findings.filter(
+      (finding) => finding.finding_type?.toLowerCase() === findingType,
+    );
+    ctx.log(
+      `Fetched ${findings.length} open finding(s), of which ${relevant.length} are ${findingType.toUpperCase()}`,
+    );
+
+    // Unrankable, so below every threshold. Surfaced rather than dropped.
+    const unreadable = relevant.filter((finding) => rank(finding.severity) === UNKNOWN_RANK);
+    if (unreadable.length > 0) {
+      ctx.warn(
+        `${unreadable.length} finding(s) with an unrecognised severity are counted but cannot breach the threshold`,
+        { severities: [...new Set(unreadable.map((f) => f.severity))] },
+      );
+    }
+
+    const byProject = new Map<string, CybeDefendFinding[]>();
+    for (const finding of relevant) {
+      const bucket = byProject.get(finding.project_id) ?? [];
+      bucket.push(finding);
+      byProject.set(finding.project_id, bucket);
+    }
+
+    const threshold = resolveThreshold(ctx.variables.severity_threshold);
+    const thresholdRank = rank(threshold);
+
+    // Union with the feed, so a project the token cannot enumerate is still reported.
+    const projectNames = new Map(projects.map((p) => [p.projectId, p.projectName]));
+    for (const finding of relevant) {
+      if (!projectNames.has(finding.project_id)) {
+        projectNames.set(finding.project_id, finding.project_name);
+      }
+    }
+
+    let passedCount = 0;
+    let failedCount = 0;
+
+    for (const [projectId, projectName] of projectNames) {
+      const projectFindings = byProject.get(projectId) ?? [];
+      const breaching = projectFindings.filter((f) => rank(f.severity) >= thresholdRank);
+      const counts = countBySeverity(projectFindings);
+      const projectUrl = `${appBaseUrl}/project/${projectId}`;
+
+      const evidence = {
+        counts,
+        total: projectFindings.length,
+        scanType: findingType,
+        threshold,
+        projectName,
+        projectUrl,
+        checkedAt: new Date().toISOString(),
+      };
+
+      if (breaching.length === 0) {
+        ctx.pass({
+          title: `${projectName}: no ${findingType.toUpperCase()} findings at or above ${threshold}`,
+          description: `${projectFindings.length} open ${findingType.toUpperCase()} finding(s), none at or above ${threshold}.`,
+          resourceType: 'project',
+          resourceId: projectId,
+          evidence,
+        });
+        passedCount += 1;
+        continue;
+      }
+
+      failedCount += 1;
+      ctx.fail({
+        title: `${projectName}: ${breaching.length} ${findingType.toUpperCase()} finding(s) at or above ${threshold}`,
+        description: `CybeDefend reports ${breaching.length} open ${findingType.toUpperCase()} finding(s) at or above ${threshold} on this project's reference branch.`,
+        resourceType: 'project',
+        resourceId: projectId,
+        severity: toCheckSeverity(breaching),
+        remediation: `Open the ${projectName} project in CybeDefend and remediate its ${findingType.toUpperCase()} findings.`,
+        evidence,
+      });
+    }
+
+    ctx.log(
+      `Reported ${projectNames.size} project(s) at threshold ${threshold}: ${failedCount} failed, ${passedCount} passed`,
+    );
+  },
+});
+
+/** Never fails the run: losing the clean projects beats reporting nothing. */
+const listProjects = async ({
+  apiBaseUrl,
+  organizationId,
+  accessToken,
+  fetchImpl = globalThis.fetch as unknown as FetchImpl,
+}: {
+  apiBaseUrl: string;
+  organizationId: string;
+  accessToken: string;
+  fetchImpl?: FetchImpl;
+}): Promise<AccessibleProject[]> => {
+  const response = await fetchImpl(`${apiBaseUrl}/user/profile`, {
+    headers: { Authorization: `Bearer ${accessToken}`, Accept: 'application/json' },
+  });
+
+  if (!response.ok) return [];
+
+  const payload = (await response.json()) as { myAccessibleProjects?: AccessibleProject[] };
+  const projects = Array.isArray(payload?.myAccessibleProjects) ? payload.myAccessibleProjects : [];
+
+  return projects.filter((project) => project.organizationId === organizationId);
+};

--- a/packages/integration-platform/src/manifests/cybedefend/client.test.ts
+++ b/packages/integration-platform/src/manifests/cybedefend/client.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, test } from 'bun:test';
+import { fetchFindingsPages, type FetchImpl } from './client';
+import { rejectionOf } from './test-support';
+import type { CybeDefendFinding, CybeDefendFindingsPage } from './types';
+
+const finding = (id: string): CybeDefendFinding =>
+  ({
+    id,
+    title: 'Rule',
+    description: '',
+    remediation: '',
+    severity: 'medium',
+    status: 'confirmed',
+    finding_type: 'sast',
+    project_id: 'p',
+    project_name: 'p',
+    first_detected_at: null,
+    last_detected_at: null,
+    triaged_at: null,
+    resolved_at: null,
+    triaged_by: null,
+    triaged_by_type: null,
+    dismissal_reason: null,
+    updated_at: '2026-08-06T08:26:17.000Z',
+    url: '',
+    details: {},
+  }) satisfies CybeDefendFinding;
+
+const ACCESS_TOKEN = 'test-access-token';
+
+/** Serves the given pages in order and records every request it was asked for. */
+const fakeServer = (pages: CybeDefendFindingsPage[]) => {
+  const requests: string[] = [];
+  const headers: Array<Record<string, string> | undefined> = [];
+  let call = 0;
+
+  const fetchImpl: FetchImpl = async (url, init) => {
+    requests.push(url);
+    headers.push(init?.headers);
+    const page = pages[call];
+    call += 1;
+    if (!page) throw new Error(`fake server ran out of pages after ${call} calls`);
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, data: page }),
+      text: async () => '',
+    };
+  };
+
+  return { fetchImpl, requests, headers, callCount: () => call };
+};
+
+/** Serves a single failing response with the given status. */
+const failingServer =
+  (status: number): FetchImpl =>
+  async () => ({
+    ok: false,
+    status,
+    json: async () => ({}),
+    text: async () => 'denied',
+  });
+
+const options = (fetchImpl: FetchImpl) => ({
+  apiBaseUrl: 'https://api-eu.cybedefend.com',
+  organizationId: '00000000-0000-4000-8000-000000000000',
+  accessToken: ACCESS_TOKEN,
+  fetchImpl,
+});
+
+describe('fetchFindingsPages: cursor pagination', () => {
+  test('walks three pages and returns every finding', async () => {
+    const { fetchImpl } = fakeServer([
+      {
+        findings: [finding('a'), finding('b')],
+        next_cursor: 'c1',
+        has_more: true,
+        next_since: null,
+      },
+      { findings: [finding('c')], next_cursor: 'c2', has_more: true, next_since: null },
+      {
+        findings: [finding('d')],
+        next_cursor: null,
+        has_more: false,
+        next_since: '2026-08-06T00:00:00Z',
+      },
+    ]);
+
+    const result = await fetchFindingsPages(options(fetchImpl));
+
+    expect(result.findings.map((f) => f.id)).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  test('passes the cursor of the previous page to the next request', async () => {
+    const { fetchImpl, requests } = fakeServer([
+      { findings: [finding('a')], next_cursor: 'cursor-one', has_more: true, next_since: null },
+      { findings: [finding('b')], next_cursor: null, has_more: false, next_since: null },
+    ]);
+
+    await fetchFindingsPages(options(fetchImpl));
+
+    expect(requests[0]).not.toContain('cursor=');
+    expect(requests[1]).toContain('cursor=cursor-one');
+  });
+
+  test('stops on has_more false even though the last page still has findings', async () => {
+    // A "loop while the page is non-empty" reader would ask for one more page
+    // with a null cursor, i.e. restart from page one, and never terminate.
+    const { fetchImpl, callCount } = fakeServer([
+      { findings: [finding('a')], next_cursor: null, has_more: false, next_since: null },
+    ]);
+
+    await fetchFindingsPages(options(fetchImpl));
+
+    expect(callCount()).toBe(1);
+  });
+
+  test('keeps walking through an empty page while has_more is true', async () => {
+    const { fetchImpl } = fakeServer([
+      { findings: [], next_cursor: 'c1', has_more: true, next_since: null },
+      { findings: [finding('a')], next_cursor: null, has_more: false, next_since: null },
+    ]);
+
+    const result = await fetchFindingsPages(options(fetchImpl));
+
+    expect(result.findings.map((f) => f.id)).toEqual(['a']);
+  });
+});
+
+describe('fetchFindingsPages: incremental sync marker', () => {
+  test('returns the last non-null next_since', async () => {
+    const { fetchImpl } = fakeServer([
+      {
+        findings: [finding('a')],
+        next_cursor: 'c1',
+        has_more: true,
+        next_since: '2026-08-01T00:00:00Z',
+      },
+      {
+        findings: [finding('b')],
+        next_cursor: null,
+        has_more: false,
+        next_since: '2026-08-02T00:00:00Z',
+      },
+    ]);
+
+    const result = await fetchFindingsPages(options(fetchImpl));
+
+    expect(result.nextSince).toBe('2026-08-02T00:00:00Z');
+  });
+
+  test('keeps the previous marker when the last page reports a null next_since', async () => {
+    // Overwriting the marker with null re-pulls the whole history next run.
+    const { fetchImpl } = fakeServer([
+      {
+        findings: [finding('a')],
+        next_cursor: 'c1',
+        has_more: true,
+        next_since: '2026-08-01T00:00:00Z',
+      },
+      { findings: [], next_cursor: null, has_more: false, next_since: null },
+    ]);
+
+    const result = await fetchFindingsPages(options(fetchImpl));
+
+    expect(result.nextSince).toBe('2026-08-01T00:00:00Z');
+  });
+
+  test('falls back to the caller marker when no page reports one', async () => {
+    const { fetchImpl } = fakeServer([
+      { findings: [], next_cursor: null, has_more: false, next_since: null },
+    ]);
+
+    const result = await fetchFindingsPages({
+      ...options(fetchImpl),
+      updatedSince: '2026-07-01T00:00:00Z',
+    });
+
+    expect(result.nextSince).toBe('2026-07-01T00:00:00Z');
+  });
+});
+
+describe('fetchFindingsPages: request shape', () => {
+  test('requests only the open statuses', async () => {
+    const { fetchImpl, requests } = fakeServer([
+      { findings: [], next_cursor: null, has_more: false, next_since: null },
+    ]);
+
+    await fetchFindingsPages(options(fetchImpl));
+
+    expect(requests[0]).toContain('status=to_verify%2Cconfirmed');
+  });
+
+  test('sends updated_since when the caller supplies a marker', async () => {
+    const { fetchImpl, requests } = fakeServer([
+      { findings: [], next_cursor: null, has_more: false, next_since: null },
+    ]);
+
+    await fetchFindingsPages({ ...options(fetchImpl), updatedSince: '2026-07-01T00:00:00Z' });
+
+    expect(requests[0]).toContain('updated_since=2026-07-01T00%3A00%3A00Z');
+  });
+
+  test('omits updated_since entirely on a first sync', async () => {
+    const { fetchImpl, requests } = fakeServer([
+      { findings: [], next_cursor: null, has_more: false, next_since: null },
+    ]);
+
+    await fetchFindingsPages(options(fetchImpl));
+
+    expect(requests[0]).not.toContain('updated_since');
+  });
+
+  test('authenticates with a bearer token', async () => {
+    const { fetchImpl, headers } = fakeServer([
+      { findings: [], next_cursor: null, has_more: false, next_since: null },
+    ]);
+
+    await fetchFindingsPages(options(fetchImpl));
+
+    expect(headers[0]?.Authorization).toBe(`Bearer ${ACCESS_TOKEN}`);
+  });
+
+  test('never puts the token in the query string', async () => {
+    const { fetchImpl, requests } = fakeServer([
+      { findings: [], next_cursor: null, has_more: false, next_since: null },
+    ]);
+
+    await fetchFindingsPages(options(fetchImpl));
+
+    expect(requests[0]).not.toContain(ACCESS_TOKEN);
+  });
+});
+
+describe('fetchFindingsPages: untrusted organization id', () => {
+  // The id is typed into a connection form and lands in a URL path. The host is
+  // pinned by the region so this cannot reach another domain, but an
+  // unvalidated value would still walk to other endpoints of the CybeDefend API
+  // carrying the caller's bearer token.
+  test.each([
+    ['path traversal', '../../user/profile'],
+    ['a nested path', 'abc/def'],
+    ['a query injection', 'abc?admin=true'],
+    ['a non-uuid value', 'not-an-organization'],
+    ['an empty value', ''],
+  ])('refuses %s', async (_label: string, organizationId: string) => {
+    const { fetchImpl } = fakeServer([
+      { findings: [], next_cursor: null, has_more: false, next_since: null },
+    ]);
+
+    await expect(fetchFindingsPages({ ...options(fetchImpl), organizationId })).rejects.toThrow(
+      /organization id/i,
+    );
+  });
+
+  test('never reaches the network with an invalid organization id', async () => {
+    const { fetchImpl, requests } = fakeServer([
+      { findings: [], next_cursor: null, has_more: false, next_since: null },
+    ]);
+
+    await fetchFindingsPages({
+      ...options(fetchImpl),
+      organizationId: '../../user/profile',
+    }).catch(() => undefined);
+
+    expect(requests).toHaveLength(0);
+  });
+});
+
+describe('fetchFindingsPages: failures', () => {
+  test('separates a credentials problem from a permission problem', async () => {
+    await expect(fetchFindingsPages(options(failingServer(401)))).rejects.toThrow(/401/);
+    await expect(fetchFindingsPages(options(failingServer(403)))).rejects.toThrow(
+      /export_findings/,
+    );
+  });
+
+  test.each([401, 403, 500])(
+    'never leaks the token into the error message for HTTP %i',
+    async (status: number) => {
+      // This message is logged and stored on the integration result, so the
+      // assertion has to read the real message, an asymmetric matcher passed
+      // to toThrow() is silently ignored and would pass no matter what.
+      const error = await rejectionOf(fetchFindingsPages(options(failingServer(status))));
+
+      expect(error.message).not.toContain(ACCESS_TOKEN);
+    },
+  );
+
+  test('refuses to restart from page one when the server reports more but sends no cursor', async () => {
+    const { fetchImpl } = fakeServer([
+      { findings: [finding('a')], next_cursor: null, has_more: true, next_since: null },
+    ]);
+
+    await expect(fetchFindingsPages(options(fetchImpl))).rejects.toThrow(/no cursor/i);
+  });
+});

--- a/packages/integration-platform/src/manifests/cybedefend/client.ts
+++ b/packages/integration-platform/src/manifests/cybedefend/client.ts
@@ -1,0 +1,161 @@
+import type { CybeDefendFinding, CybeDefendFindingsPage } from './types';
+
+/** Live vulnerabilities only. Never empty, the API rejects an empty filter with a 400. */
+const OPEN_STATUSES = ['to_verify', 'confirmed'] as const;
+
+/** Maximum allowed by the API. Fewer round trips for the same data. */
+const PAGE_SIZE = 100;
+
+/** Backstop against a server that keeps reporting more pages: 100k findings. */
+const MAX_PAGES = 1000;
+
+const AUTH_FAILURE_HINT =
+  'Check the region, the organization ID, and that the personal access token is still valid.';
+
+const PERMISSION_FAILURE_HINT =
+  'The account behind the token needs the export_findings permission on this organization.';
+
+/** Minimal shape of a fetch response, so tests can serve pages without a socket. */
+export interface HttpResponse {
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+  text: () => Promise<string>;
+}
+
+export interface RequestInitLike {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+}
+
+export type FetchImpl = (url: string, init?: RequestInitLike) => Promise<HttpResponse>;
+
+export interface FetchFindingsPagesOptions {
+  apiBaseUrl: string;
+  organizationId: string;
+  accessToken: string;
+  /** Marker from the previous sync. Omit for a first, full pull. */
+  updatedSince?: string;
+  fetchImpl?: FetchImpl;
+}
+
+export interface FetchFindingsPagesResult {
+  findings: CybeDefendFinding[];
+  /** Marker to persist for the next incremental sync. */
+  nextSince: string | null;
+}
+
+/**
+ * The organization id is operator-supplied and lands in a URL path segment.
+ *
+ * The host is pinned by the region, so a bad value cannot reach another domain,
+ * but an unvalidated one would still walk to other endpoints of the CybeDefend
+ * API while carrying the caller's bearer token. Anything that is not a UUID is
+ * refused before a request is made.
+ */
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const assertOrganizationId = (organizationId: string): void => {
+  if (!UUID_PATTERN.test(organizationId)) {
+    throw new Error('CybeDefend organization ID must be a UUID.');
+  }
+};
+
+const buildUrl = ({
+  apiBaseUrl,
+  organizationId,
+  updatedSince,
+  cursor,
+}: {
+  apiBaseUrl: string;
+  organizationId: string;
+  updatedSince?: string;
+  cursor: string | null;
+}): string => {
+  const params = new URLSearchParams({
+    status: OPEN_STATUSES.join(','),
+    page_size: String(PAGE_SIZE),
+  });
+
+  if (updatedSince) params.set('updated_since', updatedSince);
+  if (cursor) params.set('cursor', cursor);
+
+  // Encoded as well as validated upstream: defence in depth, since this value
+  // originates from a settings form.
+  return `${apiBaseUrl}/organization/${encodeURIComponent(organizationId)}/findings?${params.toString()}`;
+};
+
+/** Hand-narrowed rather than zod: `details` is free-form and a schema would strip it. */
+const readPage = (payload: unknown): CybeDefendFindingsPage => {
+  const envelope = payload as { data?: unknown };
+  const page = (envelope?.data ?? payload) as Partial<CybeDefendFindingsPage>;
+
+  if (!Array.isArray(page?.findings) || typeof page?.has_more !== 'boolean') {
+    throw new Error('Unexpected response from the CybeDefend findings export.');
+  }
+
+  return {
+    findings: page.findings,
+    next_cursor: page.next_cursor ?? null,
+    has_more: page.has_more,
+    next_since: page.next_since ?? null,
+  };
+};
+
+const describeFailure = (status: number): string => {
+  if (status === 401) return `CybeDefend rejected the credentials (401). ${AUTH_FAILURE_HINT}`;
+  if (status === 403) return `CybeDefend denied the request (403). ${PERMISSION_FAILURE_HINT}`;
+  return `CybeDefend findings export failed with HTTP ${status}.`;
+};
+
+/**
+ * Pulls every page for an organization. Termination is driven by `has_more`,
+ * never by an empty page: stopping on emptiness would re-request with a null
+ * cursor, restarting at page one forever.
+ */
+export const fetchFindingsPages = async ({
+  apiBaseUrl,
+  organizationId,
+  accessToken,
+  updatedSince,
+  fetchImpl = globalThis.fetch as unknown as FetchImpl,
+}: FetchFindingsPagesOptions): Promise<FetchFindingsPagesResult> => {
+  assertOrganizationId(organizationId);
+
+  const findings: CybeDefendFinding[] = [];
+  let cursor: string | null = null;
+  // A page that reports no marker means "keep the one you have", not "start over".
+  let nextSince: string | null = updatedSince ?? null;
+
+  for (let page = 0; page < MAX_PAGES; page += 1) {
+    const url = buildUrl({ apiBaseUrl, organizationId, updatedSince, cursor });
+
+    const response = await fetchImpl(url, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(describeFailure(response.status));
+    }
+
+    const current = readPage(await response.json());
+    findings.push(...current.findings);
+    if (current.next_since) nextSince = current.next_since;
+
+    if (!current.has_more) return { findings, nextSince };
+
+    if (!current.next_cursor) {
+      throw new Error(
+        'CybeDefend reported more findings but returned no cursor; refusing to restart from the first page.',
+      );
+    }
+
+    cursor = current.next_cursor;
+  }
+
+  throw new Error(`CybeDefend findings export exceeded ${MAX_PAGES} pages; aborting.`);
+};

--- a/packages/integration-platform/src/manifests/cybedefend/credentials.ts
+++ b/packages/integration-platform/src/manifests/cybedefend/credentials.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { CYBEDEFEND_REGION_IDS, TENANT_PATTERN } from './regions';
+import { CYBEDEFEND_REGION_IDS, TENANT_PATTERN, TENANT_RULE } from './regions';
 
 /**
  * Connection form.
@@ -82,8 +82,7 @@ export const cybedefendCredentialSchema = z
       ctx.addIssue({
         code: 'custom',
         path: ['tenant'],
-        message:
-          'Tenant name may only contain lowercase letters, digits and hyphens, and cannot start or end with a hyphen.',
+        message: `Tenant name ${TENANT_RULE}.`,
       });
     }
   });

--- a/packages/integration-platform/src/manifests/cybedefend/credentials.ts
+++ b/packages/integration-platform/src/manifests/cybedefend/credentials.ts
@@ -1,0 +1,107 @@
+import { z } from 'zod';
+import { CYBEDEFEND_REGION_IDS } from './regions';
+
+/**
+ * Connection form.
+ *
+ * The region is a selector, never a free-text URL: CybeDefend is deployed per
+ * region and both the API and Logto endpoints are derived from the choice, so
+ * a US customer connects without a patch and no other host is reachable.
+ */
+export const cybedefendCredentialFields = [
+  {
+    id: 'region',
+    label: 'Region',
+    type: 'select' as const,
+    required: true,
+    placeholder: 'Select your CybeDefend region',
+    helpText:
+      'The region your CybeDefend organization lives in. Choosing the wrong one fails authentication.',
+    options: [
+      { value: 'eu', label: 'Europe (eu.cybedefend.com)' },
+      { value: 'us', label: 'United States (us.cybedefend.com)' },
+      { value: 'dedicated', label: 'Dedicated tenant' },
+    ],
+  },
+  {
+    id: 'tenant',
+    label: 'Tenant name',
+    type: 'text' as const,
+    required: true,
+    placeholder: 'acme',
+    helpText: 'The name in your CybeDefend URL. For acme.cybedefend.com, enter "acme".',
+    // Only asked for when the dedicated option is chosen.
+    showIf: { field: 'region', equals: 'dedicated' },
+  },
+  {
+    id: 'organizationId',
+    label: 'Organization ID',
+    type: 'text' as const,
+    required: true,
+    placeholder: '00000000-0000-0000-0000-000000000000',
+    helpText: 'Found in the CybeDefend URL when your organization is selected.',
+  },
+  {
+    id: 'personalAccessToken',
+    label: 'Personal Access Token',
+    type: 'password' as const,
+    required: true,
+    placeholder: 'pat_…',
+    helpText:
+      'Profile → Personal Access Tokens in CybeDefend. Shown once. Prefer a dedicated service account holding only the export_findings permission. A token issued to a person inherits every permission that person is later granted.',
+  },
+];
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Mirrors TENANT_PATTERN in regions.ts, a DNS label under cybedefend.com. */
+const TENANT = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+
+export const cybedefendCredentialSchema = z
+  .object({
+    region: z.enum(CYBEDEFEND_REGION_IDS),
+    tenant: z.string().trim().toLowerCase().optional(),
+    organizationId: z
+      .string()
+      .trim()
+      .regex(UUID, 'Organization ID must be a UUID, as shown in the CybeDefend URL.'),
+    personalAccessToken: z.string().trim().min(1, 'Personal access token is required.'),
+  })
+  // Caught at the form rather than mid-run: a dedicated tenant with no name has
+  // no URLs to derive, and a malformed one must never reach the interpolation.
+  .superRefine((value, ctx) => {
+    if (value.region !== 'dedicated') return;
+
+    if (!value.tenant) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['tenant'],
+        message: 'Tenant name is required for a dedicated tenant.',
+      });
+      return;
+    }
+
+    if (!TENANT.test(value.tenant)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['tenant'],
+        message:
+          'Tenant name may only contain lowercase letters, digits and hyphens, and cannot start or end with a hyphen.',
+      });
+    }
+  });
+
+export const cybedefendSetupInstructions = `To connect CybeDefend:
+
+1. Sign in to CybeDefend at eu.cybedefend.com, us.cybedefend.com, or your own
+   dedicated tenant.
+2. Open Profile → Personal Access Tokens and create a token. The value is shown once.
+3. Copy your Organization ID from the URL.
+4. Pick the matching region above, then paste both values.
+
+On a dedicated tenant, choose "Dedicated tenant" and enter its name: the part
+before .cybedefend.com in your URL. For acme.cybedefend.com, enter "acme".
+
+The account holding the token needs the export_findings permission on the
+organization. We recommend a dedicated service account rather than a personal
+one: a personal token silently gains write access if that person is promoted.`;

--- a/packages/integration-platform/src/manifests/cybedefend/credentials.ts
+++ b/packages/integration-platform/src/manifests/cybedefend/credentials.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { CYBEDEFEND_REGION_IDS } from './regions';
+import { CYBEDEFEND_REGION_IDS, TENANT_PATTERN } from './regions';
 
 /**
  * Connection form.
@@ -54,9 +54,6 @@ export const cybedefendCredentialFields = [
 
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-/** Mirrors TENANT_PATTERN in regions.ts, a DNS label under cybedefend.com. */
-const TENANT = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
-
 export const cybedefendCredentialSchema = z
   .object({
     region: z.enum(CYBEDEFEND_REGION_IDS),
@@ -81,7 +78,7 @@ export const cybedefendCredentialSchema = z
       return;
     }
 
-    if (!TENANT.test(value.tenant)) {
+    if (!TENANT_PATTERN.test(value.tenant)) {
       ctx.addIssue({
         code: 'custom',
         path: ['tenant'],

--- a/packages/integration-platform/src/manifests/cybedefend/index.ts
+++ b/packages/integration-platform/src/manifests/cybedefend/index.ts
@@ -1,0 +1,58 @@
+import type { IntegrationManifest } from '../../types';
+import { sastCheck, scaCheck } from './checks';
+import {
+  cybedefendCredentialFields,
+  cybedefendCredentialSchema,
+  cybedefendSetupInstructions,
+} from './credentials';
+
+export const manifest: IntegrationManifest = {
+  id: 'cybedefend',
+  name: 'CybeDefend',
+  description:
+    'Connect CybeDefend to evidence code scanning and dependency vulnerability management across your projects.',
+  category: 'Security',
+  /** Inlined: the logo lookup service returns a generic result for this domain. */
+  logoUrl:
+    'data:image/svg+xml;base64,PHN2ZyBpZD0iTWFzdGVyX0xvZ29zIiBkYXRhLW5hbWU9Ik1hc3RlciBMb2dvcyIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2aWV3Qm94PSIwIDAgOTYgOTYiPjxkZWZzPjxzdHlsZT4gLmNscy0xIHsgZmlsbDogIzdCNUJGRjsgfSA8L3N0eWxlPjwvZGVmcz48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0yNS43LDc2LjY0TDMuNjUsNTQuNThjLTQuODYtNC44Ni00Ljg2LTEyLjc1LDAtMTcuNjFMMjUuNywxNC45MmMxLjE3LTEuMTcsMi43NS0xLjgyLDQuNC0xLjgyaDIyLjM0cy03LjA1LDEwLjU3LTcuMDUsMTAuNTdjLTEuMTUsMS43My0zLjEsMi43Ny01LjE4LDIuNzdoLTMuNDljLTIuMzYsMC00LjYyLjk0LTYuMjksMi42aDBjLTkuMjQsOS4yNC05LjI0LDI0LjIzLDAsMzMuNDhoMGMxLjY3LDEuNjcsMy45MywyLjYsNi4yOSwyLjZoNS4yNmMuODYsMCwxLjU2LjcsMS41NiwxLjU2djExLjc4aC0xMy40NWMtMS42NSwwLTMuMjMtLjY2LTQuNC0xLjgyWiIvPjxwYXRoIGNsYXNzPSJjbHMtMSIgZD0iTTQzLjU1LDgyLjkxbDcuMDUtMTAuNTdjMS4xNS0xLjczLDMuMS0yLjc3LDUuMTgtMi43N2gzLjQ5YzIuMzYsMCw0LjYyLS45NCw2LjI5LTIuNmgwYzkuMjQtOS4yNCw5LjI0LTI0LjIzLDAtMzMuNDhoMGMtMS42Ny0xLjY3LTMuOTMtMi42LTYuMjktMi42aC0xNS43MXM3LjA1LTEwLjU3LDcuMDUtMTAuNTdjMS4xNS0xLjczLDMuMS0yLjc3LDUuMTgtMi43N2gxMC4xMmMxLjY1LDAsMy4yMy42Niw0LjQsMS44MmwyMi4wNiwyMi4wNmM0Ljg2LDQuODYsNC44NiwxMi43NSwwLDE3LjYxbC0yMi4wNiwyMi4wNmMtMS4xNywxLjE3LTIuNzUsMS44Mi00LjQsMS44MmgtMjIuMzRaIi8+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNNTcuODYsNDhjMCw1LjUxLTQuNzcsOS45LTEwLjQsOS4yOC00LjI3LS40Ny03Ljc1LTMuOTQtOC4yMi04LjIyLS42Mi01LjYzLDMuNzctMTAuNCw5LjI4LTEwLjQsMS4wOSwwLDIuMTQuMTksMy4xMS41MnYyLjU5YzAsMS43MiwxLjM5LDMuMTEsMy4xMSwzLjExaDIuNTljLjM0Ljk3LjUyLDIuMDIuNTIsMy4xMVoiLz48L3N2Zz4=',
+  docsUrl: 'https://docs.cybedefend.com',
+
+  /** Empty on purpose: each check derives its URLs from the chosen region. */
+  baseUrl: '',
+
+  auth: {
+    type: 'custom',
+    config: {
+      description:
+        'CybeDefend personal access token, exchanged for a short-lived API token on every run.',
+      credentialFields: cybedefendCredentialFields,
+      validationSchema: cybedefendCredentialSchema,
+      setupInstructions: cybedefendSetupInstructions,
+    },
+  },
+
+  capabilities: ['checks'],
+
+  services: [
+    {
+      id: 'code-scanning',
+      name: 'Code Scanning',
+      description: 'Static analysis findings per project',
+      enabledByDefault: true,
+      implemented: true,
+    },
+    {
+      id: 'dependency-scanning',
+      name: 'Dependency Scanning',
+      description: 'Software composition analysis findings per project',
+      enabledByDefault: true,
+      implemented: true,
+    },
+  ],
+
+  checks: [sastCheck, scaCheck],
+
+  isActive: true,
+};
+
+export default manifest;

--- a/packages/integration-platform/src/manifests/cybedefend/regions.test.ts
+++ b/packages/integration-platform/src/manifests/cybedefend/regions.test.ts
@@ -81,10 +81,21 @@ describe('resolveRegion: tenant names cannot smuggle a host', () => {
     expect(() => resolveRegion({ region: 'dedicated', tenant })).toThrow(/tenant name/i);
   });
 
-  test('refuses a name longer than a DNS label allows', () => {
-    expect(() => resolveRegion({ region: 'dedicated', tenant: 'a'.repeat(64) })).toThrow(
+  test('refuses a name that would overflow the auth- DNS label', () => {
+    // `auth-` prefixes the longest derived label, so 58 is the real ceiling.
+    expect(resolveRegion({ region: 'dedicated', tenant: 'a'.repeat(58) }).logtoEndpoint).toBe(
+      `https://auth-${'a'.repeat(58)}.cybedefend.com`,
+    );
+    expect(() => resolveRegion({ region: 'dedicated', tenant: 'a'.repeat(59) })).toThrow(
       /tenant name/i,
     );
+  });
+
+  test('every derived label stays within the 63-character DNS limit', () => {
+    const urls = resolveRegion({ region: 'dedicated', tenant: 'a'.repeat(58) });
+    for (const url of Object.values(urls)) {
+      expect(new URL(url).hostname.split('.')[0]!.length).toBeLessThanOrEqual(63);
+    }
   });
 
   test('every accepted tenant still resolves to a cybedefend.com host', () => {

--- a/packages/integration-platform/src/manifests/cybedefend/regions.test.ts
+++ b/packages/integration-platform/src/manifests/cybedefend/regions.test.ts
@@ -91,6 +91,12 @@ describe('resolveRegion: tenant names cannot smuggle a host', () => {
     );
   });
 
+  test('says why a name of legal characters is still too long', () => {
+    // Without the length in the message, a 59-letter name is told it may only
+    // contain letters, which is exactly what it is.
+    expect(() => resolveRegion({ region: 'dedicated', tenant: 'a'.repeat(59) })).toThrow(/58/);
+  });
+
   test('every derived label stays within the 63-character DNS limit', () => {
     const urls = resolveRegion({ region: 'dedicated', tenant: 'a'.repeat(58) });
     for (const url of Object.values(urls)) {

--- a/packages/integration-platform/src/manifests/cybedefend/regions.test.ts
+++ b/packages/integration-platform/src/manifests/cybedefend/regions.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from 'bun:test';
+import { CYBEDEFEND_REGION_IDS, resolveRegion } from './regions';
+
+describe('resolveRegion: public regions', () => {
+  test('derives every URL for the EU region', () => {
+    expect(resolveRegion({ region: 'eu' })).toEqual({
+      apiBaseUrl: 'https://api-eu.cybedefend.com',
+      logtoEndpoint: 'https://auth-eu.cybedefend.com',
+      appBaseUrl: 'https://eu.cybedefend.com',
+    });
+  });
+
+  test('derives every URL for the US region', () => {
+    expect(resolveRegion({ region: 'us' })).toEqual({
+      apiBaseUrl: 'https://api-us.cybedefend.com',
+      logtoEndpoint: 'https://auth-us.cybedefend.com',
+      appBaseUrl: 'https://us.cybedefend.com',
+    });
+  });
+
+  test('rejects an unknown region rather than guessing one', () => {
+    expect(() => resolveRegion({ region: 'elsewhere' })).toThrow(/unsupported cybedefend region/i);
+  });
+
+  test('rejects an empty region rather than falling back to a default', () => {
+    expect(() => resolveRegion({ region: '' })).toThrow(/unsupported cybedefend region/i);
+  });
+});
+
+describe('resolveRegion: dedicated tenants', () => {
+  test('derives the URLs from the tenant name, on the same pattern as a region', () => {
+    expect(resolveRegion({ region: 'dedicated', tenant: 'acme' })).toEqual({
+      apiBaseUrl: 'https://api-acme.cybedefend.com',
+      logtoEndpoint: 'https://auth-acme.cybedefend.com',
+      appBaseUrl: 'https://acme.cybedefend.com',
+    });
+  });
+
+  test('accepts hyphens and digits inside the tenant name', () => {
+    expect(resolveRegion({ region: 'dedicated', tenant: 'acme-corp2' }).apiBaseUrl).toBe(
+      'https://api-acme-corp2.cybedefend.com',
+    );
+  });
+
+  test('normalises case and surrounding spaces', () => {
+    expect(resolveRegion({ region: 'dedicated', tenant: '  ACME  ' }).apiBaseUrl).toBe(
+      'https://api-acme.cybedefend.com',
+    );
+  });
+
+  test('requires a tenant name when the dedicated option is chosen', () => {
+    expect(() => resolveRegion({ region: 'dedicated' })).toThrow(/tenant name is required/i);
+  });
+
+  test('ignores a tenant name supplied alongside a public region', () => {
+    expect(resolveRegion({ region: 'eu', tenant: 'acme' }).apiBaseUrl).toBe(
+      'https://api-eu.cybedefend.com',
+    );
+  });
+});
+
+describe('resolveRegion: tenant names cannot smuggle a host', () => {
+  // `https://api-${tenant}.cybedefend.com` is string interpolation: without a
+  // strict allowlist a crafted tenant relocates the host entirely. The middle
+  // case below resolves to evil.com, not cybedefend.com.
+  test.each([
+    ['userinfo and a path', 'x@evil.com/'],
+    ['a bare host', 'evil.com'],
+    ['a scheme', 'https://evil.com'],
+    ['a port', 'acme:8080'],
+    ['a path traversal', '../../evil'],
+    ['a query string', 'acme?x=1'],
+    ['a fragment', 'acme#evil.com'],
+    ['whitespace', 'acme corp'],
+    ['a leading hyphen', '-acme'],
+    ['a trailing hyphen', 'acme-'],
+    ['an underscore', 'acme_corp'],
+    ['an empty name', ''],
+    ['only whitespace', '   '],
+  ])('refuses %s', (_label: string, tenant: string) => {
+    expect(() => resolveRegion({ region: 'dedicated', tenant })).toThrow(/tenant name/i);
+  });
+
+  test('refuses a name longer than a DNS label allows', () => {
+    expect(() => resolveRegion({ region: 'dedicated', tenant: 'a'.repeat(64) })).toThrow(
+      /tenant name/i,
+    );
+  });
+
+  test('every accepted tenant still resolves to a cybedefend.com host', () => {
+    for (const tenant of ['acme', 'acme-corp2', 'tenant-1', 'a1']) {
+      for (const url of Object.values(resolveRegion({ region: 'dedicated', tenant }))) {
+        expect(new URL(url).hostname.endsWith('.cybedefend.com')).toBe(true);
+        expect(new URL(url).protocol).toBe('https:');
+      }
+    }
+  });
+});
+
+describe('shipped regions', () => {
+  test('exposes the two public regions plus the dedicated option', () => {
+    expect(CYBEDEFEND_REGION_IDS).toEqual(['eu', 'us', 'dedicated']);
+  });
+
+  test('every public region derives https CybeDefend hosts for itself', () => {
+    // Locks the delivery requirement: no internal environment and no local
+    // address can be reached through a region.
+    for (const region of ['eu', 'us'] as const) {
+      const { apiBaseUrl, logtoEndpoint, appBaseUrl } = resolveRegion({ region });
+
+      expect(apiBaseUrl).toMatch(new RegExp(`^https://api-${region}\\.cybedefend\\.com$`));
+      expect(logtoEndpoint).toMatch(new RegExp(`^https://auth-${region}\\.cybedefend\\.com$`));
+      expect(appBaseUrl).toMatch(new RegExp(`^https://${region}\\.cybedefend\\.com$`));
+    }
+  });
+});

--- a/packages/integration-platform/src/manifests/cybedefend/regions.ts
+++ b/packages/integration-platform/src/manifests/cybedefend/regions.ts
@@ -1,0 +1,67 @@
+/**
+ * CybeDefend is deployed per region and has no single global URL. Every URL is
+ * derived here, the form never accepts a host, so no other domain is reachable.
+ */
+export const CYBEDEFEND_REGION_IDS = ['eu', 'us', 'dedicated'] as const;
+
+export type CybeDefendRegion = (typeof CYBEDEFEND_REGION_IDS)[number];
+
+const PUBLIC_REGIONS = ['eu', 'us'] as const;
+
+/**
+ * Load-bearing, not cosmetic: the URLs are built by interpolation, so
+ * `x@evil.com/` would yield `https://api-x@evil.com/.cybedefend.com`, whose
+ * host is evil.com. The token would then be posted to an attacker.
+ */
+const TENANT_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+
+export interface CybeDefendRegionUrls {
+  /** Base URL of the deployment's API. Doubles as the OAuth resource indicator. */
+  apiBaseUrl: string;
+  /** Logto endpoint used to exchange the personal access token. */
+  logtoEndpoint: string;
+  /** Base URL of the web UI, used to build deep links. */
+  appBaseUrl: string;
+}
+
+export interface ResolveRegionOptions {
+  region: string;
+  /** Required when `region` is `dedicated`, ignored otherwise. */
+  tenant?: string;
+}
+
+export const isCybeDefendRegion = (value: unknown): value is CybeDefendRegion =>
+  typeof value === 'string' && (CYBEDEFEND_REGION_IDS as readonly string[]).includes(value);
+
+const urlsFor = (slug: string): CybeDefendRegionUrls => ({
+  apiBaseUrl: `https://api-${slug}.cybedefend.com`,
+  logtoEndpoint: `https://auth-${slug}.cybedefend.com`,
+  appBaseUrl: `https://${slug}.cybedefend.com`,
+});
+
+/** Derives a deployment's URLs, failing closed on anything unrecognised. */
+export const resolveRegion = ({ region, tenant }: ResolveRegionOptions): CybeDefendRegionUrls => {
+  if (!isCybeDefendRegion(region)) {
+    throw new Error(
+      `Unsupported CybeDefend region "${region}". Supported regions: ${CYBEDEFEND_REGION_IDS.join(', ')}.`,
+    );
+  }
+
+  if ((PUBLIC_REGIONS as readonly string[]).includes(region)) {
+    return urlsFor(region);
+  }
+
+  const slug = tenant?.trim().toLowerCase() ?? '';
+
+  if (!slug) {
+    throw new Error('A CybeDefend tenant name is required for a dedicated tenant.');
+  }
+
+  if (!TENANT_PATTERN.test(slug)) {
+    throw new Error(
+      'The CybeDefend tenant name may only contain lowercase letters, digits and hyphens, and cannot start or end with a hyphen.',
+    );
+  }
+
+  return urlsFor(slug);
+};

--- a/packages/integration-platform/src/manifests/cybedefend/regions.ts
+++ b/packages/integration-platform/src/manifests/cybedefend/regions.ts
@@ -16,7 +16,11 @@ const PUBLIC_REGIONS = ['eu', 'us'] as const;
  * Capped at 58 so the longest derived label, `auth-${tenant}`, stays within the
  * 63-character DNS limit.
  */
+export const MAX_TENANT_LENGTH = 58;
+
 export const TENANT_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,56}[a-z0-9])?$/;
+
+export const TENANT_RULE = `may only contain lowercase letters, digits and hyphens, cannot start or end with a hyphen, and must be at most ${MAX_TENANT_LENGTH} characters`;
 
 export interface CybeDefendRegionUrls {
   /** Base URL of the deployment's API. Doubles as the OAuth resource indicator. */
@@ -61,9 +65,7 @@ export const resolveRegion = ({ region, tenant }: ResolveRegionOptions): CybeDef
   }
 
   if (!TENANT_PATTERN.test(slug)) {
-    throw new Error(
-      'The CybeDefend tenant name may only contain lowercase letters, digits and hyphens, and cannot start or end with a hyphen.',
-    );
+    throw new Error(`The CybeDefend tenant name ${TENANT_RULE}.`);
   }
 
   return urlsFor(slug);

--- a/packages/integration-platform/src/manifests/cybedefend/regions.ts
+++ b/packages/integration-platform/src/manifests/cybedefend/regions.ts
@@ -12,8 +12,11 @@ const PUBLIC_REGIONS = ['eu', 'us'] as const;
  * Load-bearing, not cosmetic: the URLs are built by interpolation, so
  * `x@evil.com/` would yield `https://api-x@evil.com/.cybedefend.com`, whose
  * host is evil.com. The token would then be posted to an attacker.
+ *
+ * Capped at 58 so the longest derived label, `auth-${tenant}`, stays within the
+ * 63-character DNS limit.
  */
-const TENANT_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+export const TENANT_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,56}[a-z0-9])?$/;
 
 export interface CybeDefendRegionUrls {
   /** Base URL of the deployment's API. Doubles as the OAuth resource indicator. */

--- a/packages/integration-platform/src/manifests/cybedefend/test-support.ts
+++ b/packages/integration-platform/src/manifests/cybedefend/test-support.ts
@@ -1,0 +1,31 @@
+/**
+ * Helpers shared by the CybeDefend tests.
+ *
+ * They exist so the tests stay readable under `noUncheckedIndexedAccess` and
+ * `strict` without reaching for casts.
+ */
+
+/** Reads an element that the test expects to be there, failing loudly if not. */
+export const at = <T>(items: readonly T[], index: number): T => {
+  const item = items[index];
+
+  if (item === undefined) {
+    throw new Error(
+      `expected an element at index ${index}, but only ${items.length} were recorded`,
+    );
+  }
+
+  return item;
+};
+
+/** Awaits a promise that is expected to reject, and returns the rejection. */
+export const rejectionOf = async (promise: Promise<unknown>): Promise<Error> => {
+  try {
+    await promise;
+  } catch (thrown) {
+    if (thrown instanceof Error) return thrown;
+    throw thrown;
+  }
+
+  throw new Error('expected the call to reject, but it resolved');
+};

--- a/packages/integration-platform/src/manifests/cybedefend/types.ts
+++ b/packages/integration-platform/src/manifests/cybedefend/types.ts
@@ -1,0 +1,62 @@
+/**
+ * Shapes returned by the CybeDefend findings export API.
+ *
+ * Verified against a live response: the payload is wrapped in a
+ * `{ success, data, message }` envelope, and the documented fields live under
+ * `data`.
+ */
+
+/**
+ * Free-form per-finding metadata. Keys present depend on the scanner.
+ *
+ * Shapes confirmed against live data: `cwe` and `owasp` are arrays, not
+ * strings, and `owasp` is frequently empty.
+ */
+export interface CybeDefendFindingDetails {
+  cwe?: string[] | null;
+  line?: number | null;
+  path?: string | null;
+  owasp?: string[] | null;
+  branch?: string | null;
+  language?: string | null;
+  [key: string]: unknown;
+}
+
+export interface CybeDefendFinding {
+  /** Stable fingerprint. Survives refactors, and is the only reliable identity. */
+  id: string;
+  title: string;
+  description: string;
+  remediation: string;
+  severity: string;
+  status: string;
+  finding_type: string;
+  project_id: string;
+  project_name: string;
+  first_detected_at: string | null;
+  last_detected_at: string | null;
+  triaged_at: string | null;
+  resolved_at: string | null;
+  triaged_by: string | null;
+  triaged_by_type: string | null;
+  dismissal_reason: string | null;
+  updated_at: string;
+  /** Deep link to the vulnerability in the CybeDefend UI. */
+  url: string;
+  details: CybeDefendFindingDetails;
+}
+
+/** The `data` object inside the response envelope. */
+export interface CybeDefendFindingsPage {
+  findings: CybeDefendFinding[];
+  next_cursor: string | null;
+  has_more: boolean;
+  next_since: string | null;
+}
+
+/** The full response envelope. */
+export interface CybeDefendResponse<T> {
+  success: boolean;
+  data: T;
+  message?: string;
+}

--- a/packages/integration-platform/src/registry/index.ts
+++ b/packages/integration-platform/src/registry/index.ts
@@ -10,6 +10,7 @@ import type {
 import { manifest as aikidoManifest } from '../manifests/aikido';
 import { awsManifest } from '../manifests/aws';
 import { azureManifest } from '../manifests/azure';
+import { manifest as cybedefendManifest } from '../manifests/cybedefend';
 import { gcpManifest } from '../manifests/gcp';
 import { manifest as githubManifest } from '../manifests/github';
 import { githubAppManifest } from '../manifests/github-app';
@@ -151,6 +152,7 @@ const allManifests: IntegrationManifest[] = [
   ripplingManifest,
   vercelManifest,
   aikidoManifest,
+  cybedefendManifest,
 ];
 
 // Create and export the registry singleton

--- a/packages/integration-platform/src/types.ts
+++ b/packages/integration-platform/src/types.ts
@@ -156,6 +156,8 @@ export const CustomAuthConfigSchema = z.object({
         placeholder: z.string().optional(),
         helpText: z.string().optional(),
         options: z.array(z.object({ value: z.string(), label: z.string() })).optional(),
+        /** Show this field only when another field holds a given value. */
+        showIf: z.object({ field: z.string(), equals: z.string() }).optional(),
       }),
     )
     .optional(),
@@ -209,6 +211,8 @@ export const CredentialFieldSchema = z.object({
   pattern: z.string().optional(),
   /** Default value */
   defaultValue: z.string().optional(),
+  /** Show this field only when another field holds a given value. */
+  showIf: z.object({ field: z.string(), equals: z.string() }).optional(),
 });
 
 export type CredentialField = z.infer<typeof CredentialFieldSchema>;


### PR DESCRIPTION
## What & why

Adds **CybeDefend** as a code-based integration manifest, plus two fixes to the
shared credential-field machinery it depends on.

CybeDefend is an application security platform (SAST, SCA, container, IaC, CI/CD,
secrets). The integration pulls its findings export and reports **one result per
project per scan type**, so a project's security posture becomes evidence against
existing compliance tasks:

| Check | `taskMapping` | Task |
|---|---|---|
| Code Scanning (SAST) | `TASK_TEMPLATES.sanitizedInputs` | Sanitized Inputs |
| Dependency Scanning (SCA) | `TASK_TEMPLATES.secureCode` | Secure Code, the *"dependabot or its equivalent"* task |

Three commits, reviewable in order and independently revertable:

1. `fix(app): preselect a select variable's declared default`
2. `feat(integration-platform): let a credential field depend on another`
3. `feat(integration-platform): add CybeDefend security scanning integration`

No issue number: `CONTRIBUTING.md` asks feature requests to wait for
`🚨 needs approval`. Happy to open one and hold this PR. Commit 1 is a bug fix,
which the same section exempts.

## Commit 1, select variables ignored their declared default

A `select` variable declaring a `default` rendered as an empty dropdown, so the
operator could not tell which value the check would apply. The `boolean` branch
of the same component already fell back to `variable.default`; the `select`
branch did not:

```tsx
// select   (before)
value={String(variableValues[variable.id] ?? '')}
// boolean  (already correct)
value={String(variableValues[variable.id] ?? variable.default ?? 'false')}
```

This affects shipped integrations: GitHub's Dependabot `alert_severity_threshold`
declares `default: 'high'` and was showing empty.

## Commit 2, `showIf` on credential fields

Adds an optional `showIf` so a manifest can ask for input only some choices need.
A hidden field is **neither rendered, nor validated, nor submitted**. The last
one matters: a value typed into a field that was then hidden again is not part of
the operator's intent, yet would still be encrypted and stored.

Both surfaces share one predicate rather than a copy each (connect screen and
reconfigure dialog), since duplicating the rule is how they drift.

**No shipped manifest declares `showIf`, so this is inert for every existing
integration.**

## Commit 3, the manifest

CybeDefend is deployed per region, so the form takes a **region selector**
(`eu`, `us`, or a dedicated tenant) and derives every URL from it. There is no
free-text host field, and that is deliberate.

`api-${tenant}.cybedefend.com` is string interpolation, so a tenant carrying `@`
or `/` relocates the host entirely: `x@evil.com/` yields
`https://api-x@evil.com/.cybedefend.com`, whose host is `evil.com`, and the
integration would post the customer's access token there. Tenant names are
restricted to a DNS label, validated at the form and again before the
interpolation. The server does not enforce a manifest's `validationSchema`, so
that second check is the only real barrier.

Auth is a personal access token exchanged for a short-lived API token on every
run. Only the token is stored; it reaches no log, error message or emitted result.

Two behaviours worth knowing:

- A project with no findings never appears in the findings feed, so clean
  projects are read from the account's project list. Otherwise they would be
  invisible rather than green.
- A severity outside the known set is counted apart and warned about rather than
  folded into the weakest level. That fold is how findings arriving with an empty
  severity stayed below every threshold and went unreported.

## Explicitly NOT touched

- The legacy `packages/integrations` handler path
- Any existing manifest, check, or task mapping
- Auth, RBAC, API schemas, DB schema. No migration
- The dynamic-integration DSL and its runner

## Verification

- ✅ `packages/integration-platform`: 80 new tests for the manifest, covering
  region and tenant derivation (14 adversarial host-injection cases), the PAT
  exchange, cursor pagination across pages, and the check itself
- ✅ `apps/app`: 31 tests across the two shared fixes, including that a select
  with no default stays empty and that a hidden field's value is not submitted
- ✅ `bun run verify` in `packages/integration-platform` validates the manifest
- ✅ `@trycompai/integration-platform` and `@trycompai/app` build and typecheck
  clean; no file in this diff is reported by Prettier
- ✅ End to end against a real organization (17 projects, 2063 open findings):
  both checks return 17 results, covering 592 SAST and 1090 SCA findings

`bun run build` and `bun run lint` fail on `main` before this branch
(`packages/db` has an implicit `any` in `backfill-framework-versions.ts`;
`packages/analytics` and `packages/billing` are unformatted, including committed
`dist/` files), so I verified the touched packages instead.

## Impact

Additive. New integration, one shared bug fixed, one shared capability added that
no existing manifest uses. Existing connections and check results are untouched.

### Follow-ups, deliberately out of scope

- CybeDefend also reports `container`, `iac`, `cicd` and `secret` findings; only
  SAST and SCA map to tasks that exist today. `secret` would fit
  `TASK_TEMPLATES.secureSecrets`.
- The findings export has no server-side scan-type filter, so each check pulls
  the organization's open findings once and narrows locally, two passes per run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the CybeDefend security scanning integration and two improvements to shared integration machinery. CybeDefend reports one result per project for SAST and SCA findings, mapped to the Sanitized Inputs and Secure Code compliance tasks.

**What changed**
- Select variables now preselect their declared default instead of rendering empty; GitHub's Dependabot severity threshold was affected.
- Credential fields can declare `showIf`; hidden fields are not rendered, validated, or submitted. A credential save with nothing left to send is now rejected instead of falsely reporting success.
- Region selector derives all URLs; dedicated tenant names are validated as DNS labels to prevent host injection, capped at 58 characters so the derived `auth-` label stays valid.
- Personal access tokens are exchanged for short-lived API tokens on each run and never logged; a non-JSON or failed exchange reports a clear message.
- Clean projects come from the account project list since they don't appear in the findings feed.
- Unrecognized severities are counted and warned about, not folded into the weakest level; a non-string severity no longer aborts the run.

<sup>Written for commit 83c18cd0e7e1ea7c9473b1655fbe425e7775d1dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/comp/pull/3567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

